### PR TITLE
add a feature to allow fork-n-join to fan out based on a dynamic list…

### DIFF
--- a/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
@@ -51,6 +51,7 @@ public class CompileFlows implements EntryPoint {
     private static final String OUTPUT = "output";
     private static final String DESCRIPTION = "description";
     private static final String EXECUTION = "execution";
+    private static final String SOURCE = "source";
     private static final String DATA_TYPE = "datatype";
     private static final String RESULT = "result";
     private static final String STATUS = "status";
@@ -215,6 +216,7 @@ public class CompileFlows implements EntryPoint {
                 String loopStatement = flow.getProperty(TASKS+"["+i+"]."+LOOP+"."+STATEMENT);
                 Object loopCondition = flow.get(TASKS+"["+i+"]."+LOOP+"."+CONDITION);
                 String uniqueTaskName = taskName == null? functionRoute : taskName;
+                String source = flow.getProperty(TASKS+"["+i+"]."+SOURCE);
                 if (input instanceof List && output instanceof List && uniqueTaskName != null &&
                         taskDesc instanceof String && execution instanceof String taskExecution &&
                         validExecutionType(taskExecution)) {
@@ -298,6 +300,15 @@ public class CompileFlows implements EntryPoint {
                                     log.error("Invalid {} task {} in {}. Expected one next task, Actual: {}",
                                             execution, uniqueTaskName, name, nextTasks.size());
                                     return;
+                                }
+                                if (nextTasks.size() > 1 &&
+                                        (source != null && !source.isEmpty())) {
+                                    log.error("Invalid {} task {} in {}. Expected one next task if dynamic model source is used, Actual: {}",
+                                            execution, uniqueTaskName, name, nextTasks.size());
+                                    return;
+                                }
+                                if (source != null && !source.isEmpty()) {
+                                    task.setSourceModelKey(source);
                                 }
                                 task.nextSteps.addAll(nextTasks);
                             } else {

--- a/system/event-script-engine/src/main/java/com/accenture/models/Task.java
+++ b/system/event-script-engine/src/main/java/com/accenture/models/Task.java
@@ -42,6 +42,7 @@ public class Task {
     private String exceptionTask = null;
     private String loopType = "none";
     private String whileModelKey = null;
+    private String sourceModelKey = null;
 
     /**
      * This is reserved for system use.
@@ -207,5 +208,13 @@ public class Task {
      */
     public void setWhileModelKey(String whileModelKey) {
         this.whileModelKey = whileModelKey;
+    }
+
+    public String getSourceModelKey() {
+        return sourceModelKey;
+    }
+
+    public void setSourceModelKey(String sourceModelKey) {
+        this.sourceModelKey = sourceModelKey;
     }
 }

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -863,8 +863,18 @@ class FlowTests extends TestBase {
         forkJoin("/api/fork-n-join-flows/", true);
     }
 
+    @Test
+    void forkJoinWithDynamicModeListTest() throws InterruptedException, ExecutionException {
+        PoJo pw = forkJoin("/api/fork-n-join-with-dynamic-model/", false);
+        // Additional assertion
+        assertNotNull(pw.list1);
+        assertEquals(3, pw.list1.size());
+        assertTrue(pw.list1.containsAll(List.of(1L,2L,3L)));
+        assertTrue(List.of(1L,2L,3L).containsAll(pw.list1));
+    }
+
     @SuppressWarnings("unchecked")
-    void forkJoin(String apiPath, boolean exception) throws InterruptedException, ExecutionException {
+    PoJo forkJoin(String apiPath, boolean exception) throws InterruptedException, ExecutionException {
         final int UNAUTHORIZED = 401;
         final long TIMEOUT = 8000;
         String USER = "test-user";
@@ -886,6 +896,7 @@ class FlowTests extends TestBase {
                     "type", "error",
                     "status", UNAUTHORIZED), res.getBody());
             assertEquals(UNAUTHORIZED, res.getStatus());
+            return null;
         } else {
             Map<String, Object> result = (Map<String, Object>) res.getBody();
             PoJo pw = SimpleMapper.getInstance().getMapper().readValue(result, PoJo.class);
@@ -893,6 +904,7 @@ class FlowTests extends TestBase {
             assertEquals(USER, pw.user);
             assertEquals("hello-world-one", pw.key1);
             assertEquals("hello-world-two", pw.key2);
+            return pw;
         }
     }
 

--- a/system/event-script-engine/src/test/java/com/accenture/models/PoJo.java
+++ b/system/event-script-engine/src/test/java/com/accenture/models/PoJo.java
@@ -19,6 +19,7 @@
 package com.accenture.models;
 
 import java.util.Date;
+import java.util.List;
 
 public class PoJo {
 
@@ -28,6 +29,7 @@ public class PoJo {
 
     public String key1;
     public String key2;
+    public List<?> list1;
 
     public PoJo(String user, int sequence) {
         this.user = user;

--- a/system/event-script-engine/src/test/resources/flows.yaml
+++ b/system/event-script-engine/src/test/resources/flows.yaml
@@ -33,6 +33,7 @@ flows:
   - 'externalize-put-key-value.yml'
   - 'externalize-get-key-value.yml'
   - 'fork-n-join-flows.yml'
+  - 'fork-n-join-with-dynamic-model-test.yml'
   - 'children/child-one.yml'
   - 'children/child-two.yml'
   - 'children/child-three.yml'

--- a/system/event-script-engine/src/test/resources/flows/fork-n-join-with-dynamic-model-test.yml
+++ b/system/event-script-engine/src/test/resources/flows/fork-n-join-with-dynamic-model-test.yml
@@ -1,0 +1,56 @@
+flow:
+  id: 'fork-n-join-with-dynamic-model-test'
+  description: 'Test fork-n-join flow'
+  ttl: 500000s
+
+first.task: 'my.first.task'
+
+tasks:
+  - name: 'my.first.task'
+    input:
+      - 'input.path_parameter.user -> user'
+      - 'input.query.seq -> sequence'
+      - 'int(1) -> model.intList[]'
+      - 'int(2) -> model.intList[]'
+      - 'int(3) -> model.intList[]'
+    process: 'sequential.one'
+    output:
+      - 'result -> model.pojo'
+    description: 'Pass a pojo to another task'
+    execution: fork
+    source: 'model.intList'
+    next:
+      - 'echo.me'
+    join: 'join.task'
+
+  - name: 'echo.me'
+    input:
+      - 'text(hello-world-one) -> key1'
+      - 'text(hello-world-two) -> key2'
+      - 'model.intList.current-item -> current-item'
+      - 'model.intList.current-index -> current-index'
+      - 'model.key:uuid -> uuid'
+    process: 'no.op'
+    output:
+      - 'result.key1 -> model.key1'
+      - 'result.key2 -> model.key2'
+      - 'result.current-item -> model.returnIntList[]'
+    description: 'Hello world'
+    execution: sink
+
+  #
+  # the "*" pojo mapping entry must be the first one in the input mapping
+  # so that the subsequent update to the pojo is possible.
+  #
+  - name: 'join.task'
+    input:
+      - 'model.pojo -> *'
+      - 'model.key1 -> key1'
+      - 'model.key2 -> key2'
+      - 'model.returnIntList -> list1'
+    process: 'no.op'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Return result'
+    execution: end

--- a/system/event-script-engine/src/test/resources/rest.yaml
+++ b/system/event-script-engine/src/test/resources/rest.yaml
@@ -159,6 +159,15 @@ rest:
     tracing: true
 
   - service: "http.flow.adapter"
+    methods: [ 'GET' ]
+    url: "/api/fork-n-join-with-dynamic-model/{user}?seq=_"
+    flow: 'fork-n-join-with-dynamic-model-test'
+    timeout: 10s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
+  - service: "http.flow.adapter"
     methods: ['GET']
     url: "/api/fork-n-join-flows/{user}?seq=_"
     flow: 'fork-n-join-flows'


### PR DESCRIPTION
Fork-n-join creates fan-out tasks based on the task list specified in next.  The execution of every task is in parallel.  However, the list of tasks cannot be changed at runtime as the list is configured in event script.
This PR enhances the fork-n-join feature by allowing the fan-out tasks to be based on a dynamic list at the runtime.  For every element of the dynamic list, a fan-out task is created.  The execution of every task remains in parallel.