### PR TITLE
[Issue-45] Ensure error subtypes are caught by composable

### DIFF
--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -133,7 +133,7 @@ public class WorkerHandler {
                     payload.put(TRACE, metrics);
                     po.send(dt.setBody(payload));
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 log.error("Unable to send to {}", DistributedTrace.DISTRIBUTED_TRACING, e);
             }
         } else {
@@ -334,7 +334,7 @@ public class WorkerHandler {
             }
             return ps.setExecutionTime(diff).setInputOutput(inputOutput);
 
-        } catch (Exception e) {
+        } catch (Throwable e) {
             float diff = getExecTime(begin);
             final String replyTo = event.getReplyTo();
             final int status = getStatusFromException(e);

--- a/system/platform-core/src/test/java/org/platformlambda/core/system/WorkerHandlerTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/system/WorkerHandlerTest.java
@@ -1,0 +1,111 @@
+package org.platformlambda.core.system;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class WorkerHandlerTest extends TestBase {
+
+
+    @Test
+    void shouldReturn500_OnNoClassDefError() throws InterruptedException, ExecutionException {
+        long timeout = 5000;
+        String demoFunction = "test.v1.error.noclassdef";
+
+        TypedLambdaFunction<Object, Object> f = (headers, input, instance) -> {
+            throw new NoClassDefFoundError();
+        };
+
+        Platform platform = Platform.getInstance();
+        platform.registerPrivate(demoFunction, f, 1);
+
+        PostOffice po = new PostOffice("unit.test", "10", "TEST /function/" + demoFunction);
+        EventEnvelope res = po.request(new EventEnvelope().setTo(demoFunction)
+                .setBody(Map.of()), timeout)
+                .get();
+
+        assertNotNull(res);
+        assertEquals(500, res.getStatus());
+        assertNotNull(res.getException());
+        assertEquals(NoClassDefFoundError.class, res.getException().getClass());
+    }
+
+
+    @Test
+    void shouldReturn500_OnAssertionError() throws InterruptedException, ExecutionException {
+        long timeout = 5000;
+        String demoFunction = "test.v1.error.assertionError";
+
+        TypedLambdaFunction<Object, Object> f = (headers, input, instance) -> {
+            throw new AssertionError();
+        };
+
+        Platform platform = Platform.getInstance();
+        platform.registerPrivate(demoFunction, f, 1);
+
+        PostOffice po = new PostOffice("unit.test", "10", "TEST /function/" + demoFunction);
+        EventEnvelope res = po.request(new EventEnvelope().setTo(demoFunction)
+                        .setBody(Map.of()), timeout)
+                .get();
+
+        assertNotNull(res);
+        assertEquals(500, res.getStatus());
+        assertNotNull(res.getException());
+        assertEquals(AssertionError.class, res.getException().getClass());
+    }
+
+    @Test
+    void shouldReturn500_OnError() throws InterruptedException, ExecutionException {
+        long timeout = 5000;
+        String demoFunction = "test.v1.error";
+
+        TypedLambdaFunction<Object, Object> f = (headers, input, instance) -> {
+            throw new Error();
+        };
+
+        Platform platform = Platform.getInstance();
+        platform.registerPrivate(demoFunction, f, 1);
+
+        PostOffice po = new PostOffice("unit.test", "10", "TEST /function/" + demoFunction);
+        EventEnvelope res = po.request(new EventEnvelope().setTo(demoFunction)
+                        .setBody(Map.of()), timeout)
+                .get();
+
+        assertNotNull(res);
+        assertEquals(500, res.getStatus());
+        assertNotNull(res.getException());
+        assertEquals(Error.class, res.getException().getClass());
+    }
+
+    @Test
+    void shouldReturn500_OnAssertion() throws InterruptedException, ExecutionException {
+        long timeout = 5000;
+        String demoFunction = "test.v1.error";
+
+        TypedLambdaFunction<Object, Object> f = (headers, input, instance) -> {
+            assert false;
+
+            return true;
+        };
+
+        Platform platform = Platform.getInstance();
+        platform.registerPrivate(demoFunction, f, 1);
+
+        PostOffice po = new PostOffice("unit.test", "10", "TEST /function/" + demoFunction);
+        EventEnvelope res = po.request(new EventEnvelope().setTo(demoFunction)
+                        .setBody(Map.of()), timeout)
+                .get();
+
+        assertNotNull(res);
+        assertEquals(500, res.getStatus());
+        assertNotNull(res.getException());
+        assertEquals(AssertionError.class, res.getException().getClass());
+    }
+
+}


### PR DESCRIPTION
- Handle all error types by catching Throwable instead of Exception