### PR TITLE
Allow shared composable functions to be overridden

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,9 @@
     <name>Parent Mercury</name>
 
     <modules>
-    
+
+        <module>shared/shared</module>
+
         <!-- Core libraries -->
         <module>system/platform-core</module>
         <module>system/rest-spring-3</module>

--- a/shared/shared/pom.xml
+++ b/shared/shared/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.platformlambda</groupId>
+    <artifactId>shared</artifactId>
+    <packaging>jar</packaging>
+    <version>4.3.21</version>
+    <name>Library for Shared functionality</name>
+
+    
+</project>

--- a/shared/shared/src/main/java/com/accenture/utils/ComposableConstants.java
+++ b/shared/shared/src/main/java/com/accenture/utils/ComposableConstants.java
@@ -1,0 +1,7 @@
+package com.accenture.utils;
+
+public abstract class ComposableConstants {
+
+    public static final String ENV_INSTANCES_PREFIX = "com.accenture.instances.";
+
+}

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>shared</artifactId>
+            <version>4.3.21</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
             <version>5.13.4</version>

--- a/system/event-script-engine/src/main/java/com/accenture/adapters/HttpToFlow.java
+++ b/system/event-script-engine/src/main/java/com/accenture/adapters/HttpToFlow.java
@@ -29,13 +29,19 @@ import org.platformlambda.core.system.PostOffice;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.accenture.utils.ComposableConstants.ENV_INSTANCES_PREFIX;
+
 /**
  * This is reserved for system use.
  * DO NOT use this directly in your application code.
  */
 @EventInterceptor
-@PreLoad(route = "http.flow.adapter", instances = 200)
+@PreLoad(route = HttpToFlow.ROUTE, instances = 200, envInstances = HttpToFlow.ENV_INSTANCE_PROPERTY)
 public class HttpToFlow implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    public static final String ROUTE = "http.flow.adapter";
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + HttpToFlow.ROUTE;
+
     private static final String TYPE = "type";
     private static final String ERROR = "error";
     private static final String STATUS = "status";

--- a/system/event-script-engine/src/main/java/com/accenture/services/Resilience4Flow.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/Resilience4Flow.java
@@ -29,6 +29,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.accenture.utils.ComposableConstants.ENV_INSTANCES_PREFIX;
+
 /**
  * This is a generic resilience handler. It will retry, abort, use an alternative path or exercise a brief backoff.
  * <p>
@@ -69,8 +71,12 @@ import java.util.concurrent.atomic.AtomicLong;
  *     its result programmatically using the PostOffice.
  */
 @EventInterceptor
-@PreLoad(route = "resilience.handler", instances=500)
+@PreLoad(route = Resilience4Flow.ROUTE, instances=500, envInstances = Resilience4Flow.ENV_INSTANCE_PROPERTY)
 public class Resilience4Flow implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    public static final String ROUTE = "resilience.handler";
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + Resilience4Flow.ROUTE;
+
     private static final Utility util = Utility.getInstance();
     private static final String MAX_ATTEMPTS = "max_attempts";
     private static final String ATTEMPT = "attempt";

--- a/system/event-script-engine/src/main/java/com/accenture/services/SimpleExceptionHandler.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/SimpleExceptionHandler.java
@@ -27,9 +27,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-@PreLoad(route="simple.exception.handler", instances=250)
+import static com.accenture.utils.ComposableConstants.ENV_INSTANCES_PREFIX;
+
+@PreLoad(route=SimpleExceptionHandler.ROUTE, instances=250, envInstances = SimpleExceptionHandler.ENV_INSTANCE_PROPERTY)
 public class SimpleExceptionHandler implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
     private static final Logger log = LoggerFactory.getLogger(SimpleExceptionHandler.class);
+
+    public static final String ROUTE = "simple.exception.handler";
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + SimpleExceptionHandler.ROUTE;
 
     private static final String TYPE = "type";
     private static final String TASK = "task";

--- a/system/event-script-engine/src/test/java/com/accenture/EnvInstanceOverrideTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/EnvInstanceOverrideTest.java
@@ -1,0 +1,69 @@
+package com.accenture;
+
+import com.accenture.adapters.HttpToFlow;
+import com.accenture.service.EchoEndpoint;
+import com.accenture.services.Resilience4Flow;
+import com.accenture.services.SimpleExceptionHandler;
+import com.accenture.setup.TestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.ServiceDef;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class EnvInstanceOverrideTest extends TestBase {
+
+    private AppConfigReader reader;
+    private Map<String, Integer> routeToInstancesMap;
+
+    @BeforeEach
+    void setupTest(){
+        Platform platform = Platform.getInstance();
+        this.reader = AppConfigReader.getInstance();
+
+        ConcurrentMap<String, ServiceDef> serviceDefinitions =  platform.getLocalRoutingTable();
+        this.routeToInstancesMap = serviceDefinitions.entrySet().stream()
+                .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> e.getValue().getConcurrency()
+                        )
+                );
+    }
+
+
+    @Test
+    void shouldReplaceInstancesFromOverride(){
+        assertEquals(
+                Integer.parseInt(reader.getProperty(Resilience4Flow.ENV_INSTANCE_PROPERTY)),
+                routeToInstancesMap.get(Resilience4Flow.ROUTE)
+        );
+
+        assertEquals(
+                Integer.parseInt(reader.getProperty(SimpleExceptionHandler.ENV_INSTANCE_PROPERTY)),
+                routeToInstancesMap.get(SimpleExceptionHandler.ROUTE)
+        );
+    }
+
+    @Test
+    void shouldNotReplaceInstanceIfNoOverride(){
+        assertFalse(reader.exists(HttpToFlow.ENV_INSTANCE_PROPERTY));
+        assertFalse(reader.exists(EchoEndpoint.ENV_INSTANCE_PROPERTY));
+
+        assertEquals(
+                200,
+                routeToInstancesMap.get(HttpToFlow.ROUTE)
+        );
+
+        assertEquals(
+                10,
+                routeToInstancesMap.get(EchoEndpoint.ROUTE)
+        );
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/service/EchoEndpoint.java
+++ b/system/event-script-engine/src/test/java/com/accenture/service/EchoEndpoint.java
@@ -24,8 +24,13 @@ import org.platformlambda.core.models.TypedLambdaFunction;
 
 import java.util.Map;
 
-@PreLoad(route="echo.endpoint", instances=10)
+import static com.accenture.utils.ComposableConstants.ENV_INSTANCES_PREFIX;
+
+@PreLoad(route=EchoEndpoint.ROUTE, instances=10, envInstances = EchoEndpoint.ENV_INSTANCE_PROPERTY)
 public class EchoEndpoint implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+
+    public static final String ROUTE = "echo.endpoint";
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + EchoEndpoint.ROUTE;
 
     @Override
     public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) throws Exception {

--- a/system/event-script-engine/src/test/resources/application.properties
+++ b/system/event-script-engine/src/test/resources/application.properties
@@ -75,3 +75,8 @@ app.id=A12
 #
 test.map3.hello=world
 test.map3.ping=pong
+
+
+
+com.accenture.instances.resilience.handler=1000
+com.accenture.instances.simple.exception.handler=500

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -46,6 +46,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>shared</artifactId>
+            <version>4.3.21</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
         </dependency>

--- a/system/platform-core/src/main/java/org/platformlambda/core/services/NoOpFunction.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/services/NoOpFunction.java
@@ -24,12 +24,17 @@ import org.platformlambda.core.models.TypedLambdaFunction;
 
 import java.util.Map;
 
+import static com.accenture.utils.ComposableConstants.ENV_INSTANCES_PREFIX;
+
 /**
  * This is a convenient no-operation function for event scripts.
  * It is effectively an echo function.
  */
-@PreLoad(route = "no.op", instances=500)
+@PreLoad(route = NoOpFunction.ROUTE, instances=500, envInstances = NoOpFunction.ENV_INSTANCE_PROPERTY)
 public class NoOpFunction implements TypedLambdaFunction<Map<String, Object>, EventEnvelope> {
+
+    public static final String ROUTE = "no.op";
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + NoOpFunction.ROUTE;
 
     @Override
     public EventEnvelope handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {

--- a/system/platform-core/src/test/java/org/platformlambda/core/EnvInstanceOverrideTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EnvInstanceOverrideTest.java
@@ -1,0 +1,45 @@
+package org.platformlambda.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.services.NoOpFunction;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.ServiceDef;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnvInstanceOverrideTest extends TestBase {
+
+    private AppConfigReader reader;
+    private Map<String, Integer> routeToInstancesMap;
+
+    @BeforeEach
+    void setupTest(){
+        Platform platform = Platform.getInstance();
+        this.reader = AppConfigReader.getInstance();
+
+        ConcurrentMap<String, ServiceDef> serviceDefinitions =  platform.getLocalRoutingTable();
+        this.routeToInstancesMap = serviceDefinitions.entrySet().stream()
+                .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> e.getValue().getConcurrency()
+                        )
+                );
+    }
+
+
+    @Test
+    void shouldReplaceInstancesFromOverride(){
+        assertEquals(
+                Integer.parseInt(reader.getProperty(NoOpFunction.ENV_INSTANCE_PROPERTY)),
+                routeToInstancesMap.get(NoOpFunction.ROUTE)
+        );
+    }
+
+}

--- a/system/platform-core/src/test/resources/application.properties
+++ b/system/platform-core/src/test/resources/application.properties
@@ -115,3 +115,6 @@ show.application.properties=rest.automation, snake.case.serialization
 # - the maximum number of lines in a stack trace
 #
 stack.trace.transport.size=5
+
+
+com.accenture.instances.no.op=750


### PR DESCRIPTION
- Allow no.op, resilience.handler, http.to.flow, and simple.exception.handler to be overridden if necessary