### PR TITLE
feat(webapp): mock data upload modal, large-payload inline fetch, and UX improvements

### DIFF
--- a/extensions/minigraph-playground-engine/webapp/docs/SPEC-auto-graph-refresh.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/SPEC-auto-graph-refresh.md
@@ -3,7 +3,7 @@
 **Target:** `webapp/` (React/TypeScript frontend)
 **Branch:** `feature/playground`
 **Date:** 2026-03-12
-**Status:** Revised v4 — approved, ready to implement
+**Status:** Revised v5 — updated to match implemented code
 
 ### Revision history
 
@@ -13,6 +13,7 @@
 | v2 | 2026-03-11 | Applied peer-review findings: B1 stale-closure fix (`pinnedGraphPathRef`); B2 stable `useCallback` constraint; B3 `sendRawText` new API + changelist entry; I1 `setPinnedGraphPath` + `waitingForDescribeRef` mechanism; I2 mount-time watermark init; I3 dep-array requirement in §8; I4 ARIA on loading overlay; I5 narrowed `removed` match to `' -> ' && 'removed'`; C1 `rightTab` read-only clarification; C2 E1 dep-array cross-reference; C3 `useWebSocket.ts` added to changelist |
 | v3 | 2026-03-12 | Tightened node-mutation match rules (A1/B2): added `lower.startsWith('node ')` prefix guard for `created`, `updated`, `deleted`, `connected to`, `imported from`, `overwritten by node from` checks — eliminates false positives from `"Graph instance created…"` (`instantiate graph`) and `"Root node created because it does not exist"` (`export graph`). Updated §2.2.1 table, §3.1 code block + false-positive table, §10 edge cases E16–E17. Spec review fixes: updated §3.1 JSDoc to document `startsWithNode` compound condition explicitly; removed `aria-live="polite"` from §6.2 accessibility bullet (`role="status"` already implies it per ARIA 1.2); updated false-positive table row and E9 to note that `"Node foo already exists"` passes `startsWithNode` but still does not match due to absent `" created"`. |
 | v4 | 2026-03-12 | Expanded goal: mutation commands now auto-generate and auto-pin the graph when `pinnedGraphPath === null`, rather than being a silent no-op. Removed `pinnedGraphPath !== null` precondition from §2.2. Removed guard from `import-graph` path (§2.2.2). Both `node-mutation` and `import-graph` now share the same `waitingForDescribeRef` / `describe graph` auto-send path when nothing is pinned. Updated §1 (goal + data flow), §2.2, §4.1 (responsibility table + data flow diagram), §5.1, §5.2, §5.3 (replaced silent no-op with auto-describe path), §5.4 (tab-switch table). Added edge cases E18–E22 to §10. |
+| v5 | 2026-03-23 | **Post-implementation accuracy pass** — updated spec to match the code as shipped. Key changes: (1) §1/§4.1/§4.3/§5.1/§5.4 — `node-mutation` path **always** sends `describe graph` regardless of `pinnedGraphPath`; `refetchGraph` is accepted in the interface but intentionally unused (`_refetchGraph`). (2) §5.1 — tab **does** switch when a graph was already pinned, because `setPinnedGraphPath(newPath)` fires the initial-load path in `useGraphData` which calls `setRightTab('graph')`. (3) §7 — watermark is a separate mount-only effect (not an inline init); variable named `watermarkRef`; disconnect reset is its own `useEffect([connected])`; main effect dep array is `[messages, connected, sendRawText, setPinnedGraphPath, addToast]` (no `pinnedGraphPath`, no `refetchGraph`). (4) §8 — debounce fires `sendRawText('describe graph')` + sets `waitingForDescribeRef`, not `refetchGraph()`. (5) §3.1 — `detectMutation` match structure is early-return `if` chain, not compound OR; guard order is `isMarkdownCandidate` → `startsWith('> ')` → `isGraphLinkMessage`. (6) §6.2 — overlay CSS uses `rgba(26, 26, 46, 0.55)` background, spinner is bottom-right, keyframe is named `graphRefreshSpin`. (7) §6.1 — clarified that `refetchGraph` is exposed but not called by `useAutoGraphRefresh` in the current implementation. (8) §10 — updated E1 dep-array note and E8 to reflect the new all-describe-graph architecture. |
 
 ---
 
@@ -53,13 +54,27 @@ User pins graph-link message
 ### New data flow — mutation with graph already pinned (this feature)
 
 ```
-User sends a mutation command
+User sends a mutation command (pinnedGraphPath !== null)
   → server responds with a plain-text success message (no graph-link)
   → useAutoGraphRefresh detects the mutation in the incoming message stream
-  → triggers re-fetch of the currently pinned graph path  ← NEW
-  → graph re-renders in place with a subtle loading overlay  ← NEW
-  → tab does NOT switch (user is not interrupted)  ← NEW
+  → 300 ms debounce fires → sendRawText('describe graph')  ← NEW
+  → sets waitingForDescribeRef = true                       ← NEW
+  → server responds with a new graph-link message
+  → hook detects graph-link (waitingForDescribeRef === true)
+  → calls setPinnedGraphPath(newPath)                       ← NEW
+  → useGraphData initial-load path fires (path: old → new)
+  → graphData null'd briefly then re-populated              ← NEW
+  → setRightTab('graph') fires — tab switches to Graph      ← NEW
 ```
+
+> **v5 note — `refetchGraph` / overlay not used for `node-mutation`:**
+> Earlier spec revisions described this path as calling `refetchGraph()` in overlay
+> mode (no tab switch). The implementation (line 83 of `useAutoGraphRefresh.ts`)
+> instead receives `refetchGraph` as `_refetchGraph` — intentionally unused — and
+> always sends `describe graph` for both pinned and un-pinned cases. The overlay
+> (`isRefreshing`) is therefore only set when `useGraphData`'s own `refetchGraph`
+> is called externally, which does not currently happen from any hook or component.
+> See §6.1 for the preserved `refetchGraph` API.
 
 ### New data flow — mutation with NO graph pinned yet (this feature)
 
@@ -94,10 +109,10 @@ The `{n}` suffix is a server-side cache-buster (`getRandomCounter()` in `GraphCo
 ### 2.2 Mutation commands — auto-refresh triggers (NEW)
 
 > **No precondition on `pinnedGraphPath`.** Mutation detection fires regardless of whether a graph is already pinned.
-> - If `pinnedGraphPath !== null` — re-fetch the existing pinned path in place (loading overlay shown).
-> - If `pinnedGraphPath === null` — auto-send `describe graph` over the WebSocket, consume the resulting graph-link, and call `setPinnedGraphPath`. This triggers the initial-load path in `useGraphData`, which fetches the graph and auto-switches the tab to Graph.
+> - If `pinnedGraphPath !== null` — 300 ms debounce fires `sendRawText('describe graph')`; the returned graph-link replaces `pinnedGraphPath`; `useGraphData` initial-load re-renders the graph and switches the tab to Graph.
+> - If `pinnedGraphPath === null` — same flow; `useGraphData` initial-load auto-switches the tab to Graph.
 >
-> Both paths share the same `waitingForDescribeRef` / `describe graph` auto-send mechanism that the `import-graph` path already uses (see §5.3).
+> Both paths go through the same `waitingForDescribeRef` / `describe graph` auto-send mechanism (see §5.1–§5.2). The `import-graph` path uses the same mechanism without debouncing (see §5.3).
 
 #### 2.2.1 Node & connection structural mutations
 
@@ -167,63 +182,64 @@ All matching is applied to the **raw** WebSocket message string (`msg.raw`). Rul
 
 ### 3.1 New utility function: `detectMutation`
 
-**File:** `src/utils/messageParser.ts`
+**File:** `src/utils/messageParser.ts` (lines 243–289)
 
 ```ts
 export type MutationKind = 'node-mutation' | 'import-graph';
 
 /**
- * Returns the kind of graph mutation this raw WebSocket message represents,
- * or null if the message is not a mutation signal.
+ * Inspects a single raw WebSocket message string and returns whether it
+ * represents a graph mutation that should trigger an auto-refresh.
  *
- * Rules:
- *  - JSON messages are never mutations (lifecycle events, JsonView payloads).
- *  - Echoed commands (lines starting with "> ") are never mutations.
- *  - Graph-link messages are never mutations (handled by the pin flow).
- *  - "Graph model imported as draft" → 'import-graph'
+ * Returns:
+ *  - `'node-mutation'`  when the message is a plain-text success response for
+ *    a structural node or connection change (create / update / delete / connect /
+ *    import-node / delete-connection).
+ *  - `'import-graph'`   when the message is `"Graph model imported as draft"`.
+ *  - `null`             for all other messages (read-only responses, JSON
+ *    lifecycle events, echoed commands, graph-link messages, etc.).
  *
- * Returns 'node-mutation' for messages that start with "Node " AND contain any of:
- *  - " created"                   → create node {name}
- *  - " updated"                   → update node {name}
- *  - " deleted"                   → delete node {name}
- *  - " connected to "             → connect {A} to {B} with {rel}
- *  - " imported from "            → import node {name} from {file}
- *  - " overwritten by node from " → import node (overwrite variant)
- * Or for messages that contain both (no "Node " prefix required):
- *  - " -> " AND "removed"         → delete connection {A} and {B}
- *
- * The "Node " prefix guard is required because other server responses contain
- * words like "created" without that prefix (e.g. "Graph instance created…",
- * "Root node created…") and must not trigger a refresh.
+ * Matching rules:
+ *  - Only non-JSON messages pass (`isMarkdownCandidate` guard).
+ *  - Echoed commands (`raw.startsWith('> ')`) are excluded.
+ *  - Graph-link messages (`isGraphLinkMessage`) are excluded.
+ *  - Node-operation matches require `lower.startsWith('node ')` (mirrors the
+ *    server's `NODE_NAME = "Node "` prefix) to avoid false positives from
+ *    `"Graph instance created…"` and `"Root node created because…"`.
+ *  - Connection-delete match requires both `" -> "` and `"removed"`.
  */
 export function detectMutation(raw: string): MutationKind | null {
-  if (!isMarkdownCandidate(raw)) return null;   // JSON → not a mutation
-  if (isGraphLinkMessage(raw))   return null;   // graph-link → pin flow handles it
-  if (raw.startsWith('>'))       return null;   // echoed command
+  if (!isMarkdownCandidate(raw)) return null;   // JSON messages → not a mutation
+  if (raw.startsWith('> ')) return null;         // echoed user command → ignore
+  if (isGraphLinkMessage(raw)) return null;      // graph-link messages handled by pin flow
 
   const lower = raw.toLowerCase();
 
+  // ── import-graph ─────────────────────────────────────────────────────────
   if (lower.includes('graph model imported as draft')) return 'import-graph';
 
-  // All node operation success messages share the "Node " prefix (Java constant
-  // NODE_NAME). The prefix guard eliminates false positives from:
-  //   "Graph instance created. Loaded N mock entries…"  (instantiate graph)
-  //   "Root node created because it does not exist"     (export graph, missing root)
-  const startsWithNode = lower.startsWith('node ');
+  // ── node-mutation ─────────────────────────────────────────────────────────
+  // Connection delete: "{A} -> {B} removed" (one or two lines)
+  if (lower.includes(' -> ') && lower.includes('removed')) return 'node-mutation';
 
-  if (
-    (startsWithNode && lower.includes(' created'))                ||
-    (startsWithNode && lower.includes(' updated'))                ||
-    (startsWithNode && lower.includes(' deleted'))                ||
-    (startsWithNode && lower.includes(' connected to '))          ||
-    (lower.includes(' -> ') && lower.includes('removed'))         ||  // "A -> B removed" (delete connection)
-    (startsWithNode && lower.includes(' imported from '))         ||
-    (startsWithNode && lower.includes(' overwritten by node from '))
-  ) return 'node-mutation';
+  // Node structural ops — require "Node " prefix to avoid false positives
+  const startsWithNode = lower.startsWith('node ');
+  if (startsWithNode) {
+    if (lower.includes(' created'))            return 'node-mutation';
+    if (lower.includes(' updated'))            return 'node-mutation';
+    if (lower.includes(' deleted'))            return 'node-mutation';
+    if (lower.includes(' connected to '))      return 'node-mutation';
+    if (lower.includes(' imported from '))     return 'node-mutation';
+    if (lower.includes(' overwritten by node from ')) return 'node-mutation';
+  }
 
   return null;
 }
 ```
+
+> **Guard order matters:** `isMarkdownCandidate` runs first (cheapest, eliminates all JSON), then `startsWith('> ')` (string prefix), then `isGraphLinkMessage` (requires a regex match). This order minimises work for the common case.
+
+> **Early-return `if` chain vs. compound OR:** The `startsWithNode` block uses individual `if` returns rather than a single compound `||` expression. This makes each branch independently readable and means `lower.startsWith('node ')` is only tested once — it gates the entire block via the outer `if (startsWithNode)`.
 
 > **Why `' -> ' && 'removed'` instead of `' removed'` alone?**
 > The `delete connection` server response has a unique structure: `"{A} -> {B} removed\n"`.
@@ -257,18 +273,16 @@ export function detectMutation(raw: string): MutationKind | null {
 | Concern | Owner |
 |---|---|
 | Detect mutation kind from raw message | `detectMutation()` in `messageParser.ts` |
-| Abort-controller-aware re-fetch | `useGraphData.ts` — new `refetchGraph()` method |
-| `isRefreshing` state | `useGraphData.ts` — new `isRefreshing: boolean` |
-| `pinnedGraphPath` ref sync (stale-closure fix) | `useGraphData.ts` — `pinnedGraphPathRef` |
-| Debounce + message-ID tracking | `useAutoGraphRefresh.ts` (new file) |
-| `node-mutation` + graph already pinned → re-fetch | `useAutoGraphRefresh.ts` — calls `refetchGraph()` after 300 ms debounce |
-| `node-mutation` + **no graph pinned** → auto-describe | `useAutoGraphRefresh.ts` — sends `describe graph`, sets `waitingForDescribeRef = true` |
-| `import-graph` → WS `describe graph` command (always) | `useAutoGraphRefresh.ts` — sends `describe graph` regardless of `pinnedGraphPath` |
-| Detecting `describe graph` response, calling `setPinnedGraphPath` | `useAutoGraphRefresh.ts` — `waitingForDescribeRef` flag |
-| Sending arbitrary WS text (new API) | `useWebSocket.ts` — new `sendRawText` method |
-| Tab-switch on existing-graph refresh | Suppressed — `useAutoGraphRefresh` never calls `setRightTab` |
-| Tab-switch on first auto-pin (no prior graph) | Natural — `useGraphData` initial-load path switches to `'graph'` when `pinnedGraphPath` changes from `null` to a value |
-| Loading overlay in graph view | `GraphView.tsx` + `GraphView.module.css` |
+| Abort-controller-aware re-fetch | `useGraphData.ts` — `refetchGraph()` method (defined; not currently called by `useAutoGraphRefresh`) |
+| `isRefreshing` state | `useGraphData.ts` — `isRefreshing: boolean` (set by `refetchGraph()`; currently stays `false` as `refetchGraph` is not invoked by the auto-refresh path) |
+| `pinnedGraphPath` ref sync (stale-closure fix) | `useGraphData.ts` — `pinnedGraphPathRef`; also mirrored in `useAutoGraphRefresh.ts` — `pinnedGraphPathRef` |
+| Debounce + message-ID (watermark) tracking | `useAutoGraphRefresh.ts` — `debounceTimerRef` / `watermarkRef` |
+| `node-mutation` (any `pinnedGraphPath` value) → `describe graph` | `useAutoGraphRefresh.ts` — debounce fires `sendRawText('describe graph')`, sets `waitingForDescribeRef = true` |
+| `import-graph` → `describe graph` command (always) | `useAutoGraphRefresh.ts` — sends `describe graph` immediately (no debounce), sets `waitingForDescribeRef = true` |
+| Detecting `describe graph` response, calling `setPinnedGraphPath` | `useAutoGraphRefresh.ts` — `waitingForDescribeRef` flag; Pass 1 of the main effect |
+| Sending arbitrary WS text | `useWebSocket.ts` — `sendRawText` method |
+| Tab-switch after any auto-describe completes | Natural — `useGraphData` initial-load path calls `setRightTab('graph')` whenever `pinnedGraphPath` changes to a non-null value |
+| Loading overlay in graph view | `GraphView.tsx` + `GraphView.module.css` — `isRefreshing` prop; overlay currently inactive (see `refetchGraph` row above) |
 | Wiring everything together | `Playground.tsx` |
 
 ### 4.2 New hook: `useAutoGraphRefresh`
@@ -282,36 +296,38 @@ export interface UseAutoGraphRefreshOptions {
   /** Currently pinned graph REST path, or null if nothing is pinned. */
   pinnedGraphPath:    string | null;
   /**
-   * Current right-panel tab.
-   * Passed as a read-only input for future use (e.g. badge-pulse deferred to §11).
-   * This hook does NOT call setRightTab directly — tab switching is handled
-   * by useGraphData's initial-load path when setPinnedGraphPath is called.
+   * Setter for pinnedGraphPath — called when the auto-describe path
+   * discovers a new graph URL via waitingForDescribeRef.
    */
-  rightTab:           RightTab;
+  setPinnedGraphPath: (path: string | null) => void;
   /**
    * Whether the WebSocket is currently connected.
-   * Used to reset waitingForDescribeRef on disconnect, preventing a stale
-   * flag from triggering setPinnedGraphPath after reconnect (see E21).
+   * sendRawText is a no-op when disconnected; the guard here prevents
+   * setting waitingForDescribeRef = true while disconnected (which would
+   * cause the next connection's first graph-link message to be consumed).
+   * Also used in a dedicated useEffect to reset waitingForDescribeRef on
+   * disconnect (see E21).
    */
   connected:          boolean;
   /**
-   * Sends an arbitrary raw text string over the active WebSocket.
-   * This is a NEW method that must be added to UseWebSocketReturn in
-   * useWebSocket.ts — see §9. It is a thin stable useCallback wrapping
-   * ctx.send(wsPath, text) from WebSocketContext.
+   * Imperatively re-fetch the currently pinned graph (overlay mode).
+   * Accepted in the interface and kept for future use, but currently
+   * aliased as `_refetchGraph` inside the hook body and NOT called.
+   * All node-mutation refreshes go through the describe-graph path.
+   * Stable reference from useGraphData (empty dep array).
+   */
+  refetchGraph:       () => void;
+  /**
+   * Send a raw string over the WebSocket without echoing it to the console.
+   * From useWebSocket.sendRawText.
    */
   sendRawText:        (text: string) => void;
   /**
-   * Triggers an imperative re-fetch of pinnedGraphPath.
-   * Must be a stable useCallback (empty dep array) from useGraphData —
-   * reads pinnedGraphPath via ref internally (see §6.1 stale-closure fix).
-   * Including an unstable function reference here would cause the effect
-   * to re-run on every render and reprocess the entire message log.
+   * The currently active right panel tab.
+   * Reserved for a future badge-pulse animation (spec §11).
+   * Aliased as `_rightTab` in the hook body — not read.
    */
-  refetchGraph:       () => void;
-  /** Called when import-graph auto-fetch or no-pin auto-describe finds a new graph-link path. */
-  setPinnedGraphPath: (path: string) => void;
-  /** Toast callback from useToast. */
+  rightTab:           RightTab;
   addToast:           (msg: string, type?: ToastType) => void;
 }
 ```
@@ -329,39 +345,39 @@ useWebSocket → ws.messages
         ▼
 useAutoGraphRefresh
   ├── detectMutation(raw)
-  │       ├── 'node-mutation'
-  │       │       ├── pinnedGraphPath !== null
-  │       │       │       └── debounce(300ms) → refetchGraph()
-  │       │       └── pinnedGraphPath === null
-  │       │               └── debounce(300ms) → sendRawText('describe graph')
-  │       │                                      sets waitingForDescribeRef = true
+  │       ├── 'node-mutation' (pinnedGraphPath === null OR !== null — no distinction)
+  │       │       └── debounce(300ms) → sendRawText('describe graph')
+  │       │                             sets waitingForDescribeRef = true
   │       │
   │       └── 'import-graph' (always, regardless of pinnedGraphPath)
-  │               └── sendRawText('describe graph')
+  │               └── sendRawText('describe graph')  [no debounce]
   │                   sets waitingForDescribeRef = true
   │
-  │       [both paths above converge here when server replies]
+  │       [both paths above converge here when server replies — Pass 1]
   │               server responds with graph-link message
-  │               isGraphLinkMessage(raw) && waitingForDescribeRef
+  │               isGraphLinkMessage(raw) && waitingForDescribeRef === true
   │                 → setPinnedGraphPath(extractGraphApiPath(raw))
   │                 → waitingForDescribeRef = false
-  │                 → pinnedGraphPath was null → initial-load fires:
-  │                     graphData populated, setRightTab('graph')  ← tab switches
-  │                 → pinnedGraphPath was set → path-change re-fetch fires:
-  │                     graphData updated, isRefreshing clears, no tab switch
+  │                 → pinnedGraphPath: null → new path
+  │                     initial-load fires: graphData populated, setRightTab('graph')
+  │                 → pinnedGraphPath: old path → new path
+  │                     path-change re-fetch fires: graphData null'd then re-populated
+  │                     setRightTab('graph') fires — tab always switches
   │
   └── (no matched mutation kind) → no-op
         │
         ▼
 useGraphData
-  ├── pinnedGraphPathRef (kept in sync via useEffect)
-  ├── fetch(pinnedGraphPathRef.current) + AbortController
-  ├── isRefreshing: boolean  (true while auto-refresh fetch is in-flight)
+  ├── pinnedGraphPathRef (kept in sync via dedicated useEffect)
+  ├── refetchAbortRef (AbortController for imperative refetch)
+  ├── isRefreshing: boolean  (only set by refetchGraph(); currently stays false)
+  ├── refetchGraph(): void   (stable useCallback, empty dep array — not called by
+  │                            useAutoGraphRefresh in the current implementation)
   └── graphData: MinigraphGraphData | null
         │
         ▼
 Playground.tsx
-  └── RightPanel → GraphView (isRefreshing prop)
+  └── RightPanel (isGraphRefreshing={isRefreshing}) → GraphView (isRefreshing prop)
 ```
 
 ---
@@ -370,103 +386,110 @@ Playground.tsx
 
 ### 5.1 `node-mutation` path — graph already pinned
 
+> **v5 note:** This path no longer calls `refetchGraph()` or shows an overlay.
+> `refetchGraph` is received as `_refetchGraph` (line 83 of `useAutoGraphRefresh.ts`)
+> and is intentionally not called. Both the "already pinned" and "not pinned" cases
+> go through the same `describe graph` send → `waitingForDescribeRef` → `setPinnedGraphPath`
+> pipeline, which means the tab **does** switch to Graph via the `useGraphData`
+> initial-load path.
+
 ```
 Incoming message detected as 'node-mutation'
   AND pinnedGraphPath !== null
-    → start/reset 300 ms debounce timer
-    → on debounce fire:
-        → call refetchGraph()
-            → sets isRefreshing = true
-            → fires fetch(pinnedGraphPath) with a fresh AbortController
-                (cancels any previously in-flight request)
-            → on HTTP success (200):
-                → validate shape with isMinigraphGraphData()
-                → setGraphData(newData)
-                → setIsRefreshing(false)
-                → NO tab switch — user is not interrupted
-            → on HTTP error or shape validation failure:
-                → addToast('Graph refresh failed: …', 'error')
-                → setIsRefreshing(false)
-                → graphData is NOT cleared (stale data preferred over empty state)
+    → start/reset 300 ms debounce timer (debounceTimerRef)
+    → on debounce fire (if still connected):
+        → set waitingForDescribeRef = true
+        → sendRawText('describe graph')
+        → addToast('Graph updated — refreshing…', 'info')
+
+Pass 1 of the next main-effect execution:
+  → new message arrives that passes isGraphLinkMessage()
+    AND waitingForDescribeRef === true
+      → path = extractGraphApiPath(msg.raw)
+      → waitingForDescribeRef = false
+      → call setPinnedGraphPath(path)        ← updates Playground.tsx state
+      → return (batch processing stops)
+      → useGraphData initial-load path fires (old pinnedGraphPath → new path):
+          → graphData null'd while fetch in-flight
+          → fetch(path) succeeds → setGraphData(newData)
+          → setRightTab('graph')             ← tab switches to Graph
 ```
 
-**Debounce rationale:** 300 ms collapses rapid-fire commands (e.g. pasting history + Enter multiple times) into a single fetch, preventing N redundant requests.
+**Debounce rationale:** 300 ms collapses rapid-fire commands (e.g. pasting history + Enter multiple times) into a single `describe graph` send, preventing N redundant round-trips.
+
+**Why `setRightTab('graph')` fires even when a graph was already pinned:** `setPinnedGraphPath` is called with the *new* path returned by `describe graph` (which may differ from the old one due to the server-side cache-buster). This triggers `useGraphData`'s initial-load `useEffect` (which runs whenever `pinnedGraphPath` changes), and that effect calls `setRightTab('graph')` on success — unconditionally.
 
 ### 5.2 `node-mutation` path — no graph pinned yet
 
 ```
 Incoming message detected as 'node-mutation'
   AND pinnedGraphPath === null
-    → start/reset 300 ms debounce timer
-    → on debounce fire:
-        → send WebSocket text via sendRawText: 'describe graph'
+    → start/reset 300 ms debounce timer (debounceTimerRef)
+    → on debounce fire (if still connected):
         → set waitingForDescribeRef = true
+        → sendRawText('describe graph')
+        → addToast('Graph updated — opening Graph tab…', 'info')
 
-Next message scan iteration:
+Pass 1 of the next main-effect execution:
   → new message arrives that passes isGraphLinkMessage()
     AND waitingForDescribeRef === true
       → path = extractGraphApiPath(msg.raw)
+      → waitingForDescribeRef = false
       → call setPinnedGraphPath(path)        ← updates Playground.tsx state
-      → set waitingForDescribeRef = false
-      → mark message as processed (update lastProcessedIdRef watermark)
+      → return (batch processing stops)
       → useGraphData initial-load path fires (pinnedGraphPath: null → value):
           → graphData null'd while fetch in-flight
           → fetch(path) succeeds → setGraphData(newData)
           → setRightTab('graph')             ← tab switches to Graph
 ```
 
-**Why auto-describe rather than a direct fetch when `pinnedGraphPath === null`?** There is no path to fetch — `pinnedGraphPath` is `null`. `describe graph` both serialises the current in-memory graph (making it available via REST) and returns the canonical path in its response. This is the only correct mechanism.
+**Toast differentiation (lines 228-233 of `useAutoGraphRefresh.ts`):** The debounce callback reads `pinnedGraphPathRef.current` at fire time to choose the toast message:
+- `pinnedGraphPath !== null` → `'Graph updated — refreshing…'`
+- `pinnedGraphPath === null` → `'Graph updated — opening Graph tab…'`
 
-**Why the tab switches here but not on §5.1?** Because `setPinnedGraphPath` triggers the initial-load path in `useGraphData`, which switches the tab unconditionally when `pinnedGraphPath` changes from `null` to a value. This is the same behaviour as a manual pin click — and it is exactly what the user wants: they issued a mutation command with no graph displayed yet, and they should immediately see the result.
+**Why auto-describe rather than a direct fetch when `pinnedGraphPath === null`?** There is no path to fetch — `pinnedGraphPath` is `null`. `describe graph` both serialises the current in-memory graph and returns the canonical path. This is the only correct mechanism.
 
 ### 5.3 `import-graph` path
 
 ```
 Incoming message = 'Graph model imported as draft'
   (pinnedGraphPath may be null OR non-null — no guard)
-    → send WebSocket text via sendRawText: 'describe graph'
+    → cancel any pending node-mutation debounce   ← import supersedes it
     → set waitingForDescribeRef = true
-    → toast: 'Graph imported — refreshing view…' (info)
+    → sendRawText('describe graph')               ← no debounce
+    → addToast('Graph imported — refreshing view…', 'info')
+    → return (no further processing for this batch)
 
-Next message scan iteration:
+Pass 1 of the next main-effect execution:
   → new message arrives that passes isGraphLinkMessage()
     AND waitingForDescribeRef === true
       → path = extractGraphApiPath(msg.raw)
+      → waitingForDescribeRef = false
       → call setPinnedGraphPath(path)        ← updates Playground.tsx state
-      → set waitingForDescribeRef = false
-      → mark message as processed (update lastProcessedIdRef watermark)
+      → return (batch processing stops)
       → if pinnedGraphPath was null:
           → useGraphData initial-load path fires
           → graphData populated, setRightTab('graph')  ← tab switches to Graph
       → if pinnedGraphPath was already set (possibly a different path):
-          → useGraphData path-change path fires (old path → new path)
+          → useGraphData path-change effect fires (old path → new path)
           → graphData null'd then re-populated with new graph
           → setRightTab('graph')  ← tab switches to Graph
 ```
 
-**Why `import-graph` always switches the tab (unlike `node-mutation` §5.1)?** An import replaces the entire in-memory graph — often with a structurally different model. Switching to the Graph tab on import is intentional and expected: the user explicitly replaced the graph and should see it immediately. This is consistent with how `export graph` already works (it emits a graph-link that the manual pin flow processes, switching the tab).
+**Why `import-graph` is not debounced:** It is processed immediately (line 189-199 of `useAutoGraphRefresh.ts`), cancelling any pending node-mutation debounce timer first. An import is a heavyweight intentional operation — the user always wants to see the result immediately. Debouncing it would add an unnecessary 300 ms delay.
 
-**Why `waitingForDescribeRef` is needed (I1):** The "existing pin flow" is user-driven —
-it fires when the user *clicks* a console row, calling `handlePinMessage` in Playground.tsx.
-An automatically sent `describe graph` produces a new graph-link message that no one clicks.
-The hook must therefore detect this response itself and call `setPinnedGraphPath` directly.
-The `waitingForDescribeRef` flag scopes this detection to only the graph-link that arrives
-*after* the hook sent `describe graph` — it does not interfere with unrelated graph-link
-messages that the user may pin manually.
+**Why `waitingForDescribeRef` is needed (I1):** The existing pin flow is user-driven — it fires when the user *clicks* a console row, calling `handlePinMessage` in `Playground.tsx`. An automatically sent `describe graph` produces a new graph-link that no one clicks. The hook must therefore detect this response itself and call `setPinnedGraphPath` directly. The `waitingForDescribeRef` flag scopes this detection to only the graph-link that arrives *after* the hook sent `describe graph`.
 
-**Loop prevention:** `detectMutation` returns `null` for all graph-link messages
-(`isGraphLinkMessage` guard). The graph-link response from `describe graph` is consumed by
-the `waitingForDescribeRef` branch, not the `detectMutation` branch — so there is no loop.
+**Loop prevention:** `detectMutation` returns `null` for all graph-link messages (`isGraphLinkMessage` guard at line 264 of `messageParser.ts`). The graph-link response from `describe graph` is consumed by the `waitingForDescribeRef` branch (Pass 1), not the mutation-detection branch (Pass 2) — so there is no loop.
 
 ### 5.4 Tab-switching rule
 
 | Scenario | Behaviour |
 |---|---|
-| `node-mutation`, graph already pinned — refresh completes | No tab switch — graph updates in place under loading overlay |
-| `node-mutation`, **no graph pinned** — first auto-pin | **Switches to Graph tab** — initial-load path in `useGraphData` fires |
-| `import-graph` (any state) — refresh completes | **Switches to Graph tab** — import is a deliberate whole-graph replacement |
-| User is on Graph Data (Raw) tab during background refresh | No tab switch (§5.1 only) |
-| User is on Payload Editor / Developer Guides during background refresh | No tab switch (§5.1 only) |
+| `node-mutation`, graph **already pinned** — auto-describe completes | **Switches to Graph tab** — `setPinnedGraphPath(newPath)` triggers initial-load path in `useGraphData` which calls `setRightTab('graph')` |
+| `node-mutation`, **no graph pinned** — first auto-pin | **Switches to Graph tab** — same initial-load path fires |
+| `import-graph` (any state) — auto-describe completes | **Switches to Graph tab** — same initial-load path fires |
+| User is on Graph Data (Raw) tab during any auto-refresh | **Switches to Graph tab** (all mutation paths now go through `setPinnedGraphPath`) |
 | **Initial manual pin** (existing behaviour) | **Always** switches to Graph tab ← unchanged |
 
 ---
@@ -475,7 +498,7 @@ the `waitingForDescribeRef` branch, not the `detectMutation` branch — so there
 
 ### 6.1 Changes to `useGraphData`
 
-The hook's return type is extended:
+The hook's return type is extended with two new members (lines 7-22 of `useGraphData.ts`):
 
 ```ts
 export interface UseGraphDataReturn {
@@ -483,74 +506,63 @@ export interface UseGraphDataReturn {
   setGraphData: React.Dispatch<React.SetStateAction<MinigraphGraphData | null>>;
   rightTab:     RightTab;
   setRightTab:  React.Dispatch<React.SetStateAction<RightTab>>;
-  isRefreshing: boolean;   // NEW — true while a re-fetch is in-flight
-  refetchGraph: () => void; // NEW — imperatively trigger a re-fetch
+  /** True while an auto-refresh re-fetch is in-flight (NOT set during initial load). */
+  isRefreshing: boolean;
+  /**
+   * Imperatively trigger a re-fetch of the currently pinned graph path.
+   * - Does NOT null graphData — stale graph remains visible under the overlay.
+   * - Does NOT switch the right tab.
+   * - Sets isRefreshing = true while the fetch is in-flight.
+   * - Stable reference (empty dep array) — safe to include in useEffect dep arrays.
+   */
+  refetchGraph: () => void;
 }
 ```
 
-**Key design decision:** During auto-refresh `graphData` is **NOT nulled out**. The stale graph remains visible under the loading overlay. Nulling would cause a jarring disappear/reappear cycle. Only the initial load (when `pinnedGraphPath` first becomes non-null) nulls the data, as it does today.
+**`refetchGraph` is defined but not currently called by `useAutoGraphRefresh`.** The hook accepts `refetchGraph` in its options interface (and Playground.tsx passes it) but aliases it as `_refetchGraph` (line 83 of `useAutoGraphRefresh.ts`). It is preserved in the interface for future use — for example, a hypothetical "silent background refresh" that does not switch the tab. `isRefreshing` therefore stays `false` during normal mutation flows; the overlay infrastructure is present and correct, ready to be activated.
 
-The `refetchGraph()` method:
-- Can be called imperatively (e.g. from `useAutoGraphRefresh`)
-- Uses the same `AbortController` + `cancelled` pattern as the existing `useEffect`
+**Key design decision:** During a `refetchGraph()` call, `graphData` is **NOT nulled out**. The stale graph remains visible under the loading overlay. Nulling would cause a jarring disappear/reappear cycle. Only the initial load (when `pinnedGraphPath` first becomes non-null) nulls the data, as it does today.
+
+The `refetchGraph()` method (lines 100-127 of `useGraphData.ts`):
+- Uses its own `refetchAbortRef` — a separate `useRef<AbortController | null>` that is distinct from the initial-load `controller`
 - Sets `isRefreshing = true` immediately on call
+- Cancels the previous in-flight refetch via `refetchAbortRef.current?.abort()` before creating a new `AbortController`
 - Does **not** null `graphData` (unlike the initial path-change flow)
-- **Must be a stable `useCallback` with an empty dependency array** so that
-  `useAutoGraphRefresh` can include it in a `useEffect` dependency array without
-  causing the effect to re-run on every render.
+- On `AbortError`, returns immediately — does **not** call `setIsRefreshing(false)` because a newer request is already in-flight and owns the flag
+- A separate unmount cleanup effect (lines 130-133) calls `refetchAbortRef.current?.abort()` so any in-flight refetch is cancelled if the component unmounts mid-request
+- **Stable `useCallback` with an empty dependency array** — reads `pinnedGraphPath` via `pinnedGraphPathRef` (never via closure)
 
-**Stale-closure fix (B1):** Because `refetchGraph` has an empty dependency array it cannot
-close over `pinnedGraphPath` directly. Instead, `useGraphData` must keep a `useRef` that
-is kept in sync with the prop, and `refetchGraph` reads the path through the ref:
+**Stale-closure fix (B1):** `useGraphData` keeps a `useRef` in sync with the prop (lines 61-65):
 
 ```ts
-const pinnedGraphPathRef = useRef(pinnedGraphPath);
+// useGraphData.ts lines 61–65
+const pinnedGraphPathRef = useRef<string | null>(pinnedGraphPath);
 useEffect(() => {
   pinnedGraphPathRef.current = pinnedGraphPath;
 }, [pinnedGraphPath]);
-
-const refetchGraph = useCallback(() => {
-  const path = pinnedGraphPathRef.current;
-  if (!path) return;
-  // ... create AbortController, fetch(path), set isRefreshing, etc.
-}, []); // stable — reads via ref, never via closure
 ```
 
-This guarantees that even if `pinnedGraphPath` changes (e.g. from `/api/graph/model/foo`
-to `/api/graph/model/bar`) while a 300 ms debounce is pending, the timer fires and fetches
-the **new** path, not the stale one.
+`refetchGraph` reads through this ref, never through a closure. Similarly, `useAutoGraphRefresh` maintains its own `pinnedGraphPathRef` (lines 104-108) for reading `pinnedGraphPath` inside the debounce callback.
 
 ### 6.2 GraphView loading overlay
 
-A subtle non-blocking overlay is added to `GraphView` when `isRefreshing === true`:
+A non-blocking overlay is rendered in `GraphView` when `isRefreshing === true` (currently inactive — see §6.1). Implementation in `GraphView.tsx` (lines 105-116) and `GraphView.module.css`:
 
-- Position: absolute, covers the graph area
-- Background: semi-transparent (e.g. `rgba(0,0,0,0.3)`)
-- `pointer-events: none` — user can still interact with the graph underneath
-- Content: a small spinner in one corner (e.g. bottom-right)
-- Disappears instantly when new data arrives (React state transition)
-- **Accessibility:** The spinner element must carry `role="status"` and `aria-label="Graph refreshing"`.
-  Note: `role="status"` already implies `aria-live="polite"` per the ARIA 1.2 spec — do **not**
-  add `aria-live` explicitly, as it would be redundant. The element is non-focusable due to
-  `pointer-events: none`, but screen readers will still announce it via the implicit live region.
-  Additionally, set `aria-busy={isRefreshing}` on the `<div>` wrapping `<ReactFlow>` so assistive
-  technology understands that the content region is updating.
+- **Position:** `.refreshingOverlay` — `position: absolute; inset: 0` anchored to `.graphWrapper` which is `position: relative`
+- **Background:** `rgba(26, 26, 46, 0.55)` — matches the graph's dark theme palette
+- **Spinner placement:** `align-items: flex-end; justify-content: flex-end; padding: 0.75rem` — small spinner in the **bottom-right** corner
+- **Passthrough:** `pointer-events: none` — pan, zoom, and node interactions pass through to ReactFlow underneath
+- **Spinner:** `.refreshingSpinner` — `1.25rem × 1.25rem`, `border: 2px solid`, `border-top-color: rgba(255,255,255,0.85)`, `animation: graphRefreshSpin 0.75s linear infinite`
+- **Accessibility:** `role="status"` + `aria-label="Graph refreshing"` on the spinner element. `aria-busy={isRefreshing}` on the `<div className={styles.graphWrapper}>` wrapper (line 105) so assistive technology understands the content region is updating. `role="status"` already implies `aria-live="polite"` per ARIA 1.2 — `aria-live` is **not** added explicitly.
 
-**Prop chain:** `Playground` → `RightPanel` → `GraphView`
+**Prop chain as implemented:** `Playground.tsx` line 365: `isGraphRefreshing={isRefreshing}` → `RightPanel.tsx` prop `isGraphRefreshing?: boolean` → `GraphView.tsx` prop `isRefreshing?: boolean` (default `false`).
 
 ```ts
-// RightPanel additions
-interface RightPanelProps {
-  // ... existing props
-  isGraphRefreshing?: boolean; // NEW
-}
+// RightPanel.tsx — interface (line 27)
+isGraphRefreshing?: boolean;
 
-// GraphView additions
-interface GraphViewProps {
-  graphData:        MinigraphGraphData | null;
-  onRenderError?:   (message: string) => void;
-  isRefreshing?:    boolean; // NEW
-}
+// GraphView.tsx — interface (line 27)
+isRefreshing?: boolean;
 ```
 
 ---
@@ -563,82 +575,140 @@ interface GraphViewProps {
 - React Strict Mode double-invokes effects in development.
 - Without tracking, the same mutation message would be processed on every subsequent re-render.
 
-**Implementation:**
+**Implementation (as shipped):**
+
+The watermark is a separate `useRef` initialised to `-1`, then set to the current high-water mark in a **dedicated mount-only `useEffect`** (lines 92, 134-142 of `useAutoGraphRefresh.ts`):
 
 ```ts
-// Initialise to the id of the last *already-present* message so that messages
-// which arrived before this component mounted (e.g. after a route navigation
-// away and back) are never reprocessed. -1 is safe when messages is empty.
-const lastProcessedIdRef = useRef<number>(
-  messages.length > 0 ? messages[messages.length - 1].id : -1
-);
+// useAutoGraphRefresh.ts lines 92, 96
+const watermarkRef     = useRef<number>(-1);
+const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+// ── Set watermark at mount (lines 134–142) ───────────────────────────────
+// Runs once on mount. Captures the highest message ID currently in the log
+// so that only genuinely new messages (posted after mount) are processed.
 useEffect(() => {
-  // Reset waitingForDescribeRef on disconnect so a stale flag cannot
-  // trigger setPinnedGraphPath after reconnect (see E21).
-  if (!connected) {
-    waitingForDescribeRef.current = false;
-    return;
+  if (messages.length > 0) {
+    watermarkRef.current = messages[messages.length - 1].id;
   }
+}, []); // eslint-disable-line react-hooks/exhaustive-deps
+// Intentionally empty dep array — we only want the mount snapshot.
+```
 
-  const newMessages = messages.filter(m => m.id > lastProcessedIdRef.current);
+The disconnect reset lives in its **own dedicated `useEffect`** watching `[connected]` (lines 120-132), **not** inside the main messages effect:
+
+```ts
+// useAutoGraphRefresh.ts lines 120–132
+useEffect(() => {
+  if (!connected) {
+    if (waitingForDescribeRef.current) {
+      waitingForDescribeRef.current = false;
+    }
+    // Also cancel any in-flight debounce — a mutation debounce that fires
+    // after disconnection would set waitingForDescribeRef = true and call
+    // sendRawText, which is a no-op when disconnected but leaves the flag
+    // stranded true for the next reconnect.
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }
+}, [connected]);
+```
+
+The main effect (lines 144-248) filters new messages by watermark, then advances it **before** any async work:
+
+```ts
+// useAutoGraphRefresh.ts lines 144–248 (abridged)
+useEffect(() => {
+  if (messages.length === 0) return;
+
+  const newMessages = messages.filter(m => m.id > watermarkRef.current);
   if (newMessages.length === 0) return;
 
-  // update the watermark first — before any async work
-  lastProcessedIdRef.current = newMessages[newMessages.length - 1].id;
+  // Advance watermark to the latest processed ID.
+  watermarkRef.current = messages[messages.length - 1].id;
+
+  // ── Pass 1: consume a pending describe-graph response ─────────────────
+  if (waitingForDescribeRef.current) {
+    for (const msg of newMessages) {
+      if (isGraphLinkMessage(msg.raw)) {
+        const path = extractGraphApiPath(msg.raw);
+        if (path) {
+          waitingForDescribeRef.current = false;
+          setPinnedGraphPath(path);
+          return;
+        }
+      }
+    }
+  }
+
+  // ── Pass 2: detect mutation commands ──────────────────────────────────
+  let hasMutation = false;
+  let hasImportGraph = false;
 
   for (const msg of newMessages) {
     const kind = detectMutation(msg.raw);
-    // ... handle kind
+    if (kind === 'import-graph')  { hasImportGraph = true; }
+    else if (kind === 'node-mutation') { hasMutation = true; }
   }
-}, [messages, pinnedGraphPath, connected, sendRawText, refetchGraph, setPinnedGraphPath, addToast]);
+  // ... handle hasImportGraph, then hasMutation
+}, [messages, connected, sendRawText, setPinnedGraphPath, addToast]);
 ```
 
-**Why not initialise to `-1`?** When `Playground.tsx` remounts (e.g. user navigates to
-another route and back), `useAutoGraphRefresh` remounts with a fresh `useRef`. However,
-`WebSocketContext` is mounted above `<Routes>` and survives navigation — its `messages`
-array may already contain N messages with ids `[1 … N]`. Initialising to `-1` would cause
-all N messages to be re-scanned on mount, potentially re-triggering a `describe graph`
-command for a mutation that happened minutes ago. Initialising to the last existing id
-skips them correctly.
+**Actual dep array** (line 248): `[messages, connected, sendRawText, setPinnedGraphPath, addToast]`
 
----
+Note: `pinnedGraphPath` and `refetchGraph` are **absent** from the dep array. `pinnedGraphPath` is read via `pinnedGraphPathRef` (not via closure), and `refetchGraph` is not called from the main effect.
+
+**Why not initialise `watermarkRef` to `messages[last].id` inline?** When `Playground.tsx` remounts (e.g. user navigates to another route and back), `useAutoGraphRefresh` remounts with a fresh `useRef` initialised to `-1`. However, `WebSocketContext` is mounted above `<Routes>` and survives navigation — its `messages` array may already contain N messages. The separate mount-only `useEffect` correctly captures the high-water mark after React has committed the component, skipping all historical messages.
+
+
 
 ## 8. Debounce Implementation
 
-Use a `useRef<ReturnType<typeof setTimeout>>` (not `useState`) to avoid triggering extra renders:
+`debounceTimerRef` is a `useRef<ReturnType<typeof setTimeout> | null>` (not `useState`) to avoid triggering extra renders (line 96 of `useAutoGraphRefresh.ts`):
 
 ```ts
-const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+// useAutoGraphRefresh.ts lines 203–248 (node-mutation debounce block, abridged)
+if (hasMutation) {
+  // Cancel any already-pending debounce so rapid commands collapse to one.
+  if (debounceTimerRef.current !== null) {
+    clearTimeout(debounceTimerRef.current);
+  }
 
-// Inside the effect, on 'node-mutation' detection:
-if (debounceRef.current) clearTimeout(debounceRef.current);
-debounceRef.current = setTimeout(() => {
-  refetchGraph();
-  debounceRef.current = null;
-}, 300);
+  debounceTimerRef.current = setTimeout(() => {
+    debounceTimerRef.current = null;
 
-// Effect cleanup:
+    if (!connected) return;  // guard: don't send if disconnected during the 300 ms window
+
+    // Always send `describe graph` — regardless of whether a graph is already pinned.
+    waitingForDescribeRef.current = true;
+    sendRawText('describe graph');
+
+    const currentPath = pinnedGraphPathRef.current;
+    addToast(
+      currentPath !== null
+        ? 'Graph updated — refreshing…'
+        : 'Graph updated — opening Graph tab…',
+      'info',
+    );
+  }, 300);
+}
+
+// Effect cleanup (fires on every re-run and on unmount):
 return () => {
-  if (debounceRef.current) {
-    clearTimeout(debounceRef.current);
-    debounceRef.current = null;
+  if (debounceTimerRef.current !== null) {
+    clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = null;
   }
 };
 ```
 
-`refetchGraph()` itself creates a new `AbortController` on each call and cancels the previous one, so even if the debounce fires twice in close succession, only the last fetch result is applied.
+**`pinnedGraphPath` is NOT in the dep array.** Unlike earlier spec revisions, the debounce callback no longer calls `refetchGraph()`, so there is no need to re-run the effect when `pinnedGraphPath` changes. The path is read at fire-time via `pinnedGraphPathRef.current` (for the toast message only — the actual `describe graph` send is path-agnostic). The effect's dep array is `[messages, connected, sendRawText, setPinnedGraphPath, addToast]`.
 
-**`pinnedGraphPath` must be in the `useEffect` dependency array (I3).** When
-`pinnedGraphPath` changes — either because the user pins a different graph manually, or
-because `setPinnedGraphPath` is called from the `import-graph` path — React tears down the
-effect and re-runs it. The teardown fires the cleanup function which calls
-`clearTimeout(debounceRef.current)`, cancelling any debounce timer that was pending for the
-*old* path. The new effect starts with a clean slate. If `pinnedGraphPath` were accidentally
-omitted from the dep array, a pending debounce from an old path could fire and call
-`refetchGraph` for a path that is no longer pinned (even though `refetchGraph` reads through
-`pinnedGraphPathRef`, it would still fetch — just the right path — creating a surprising
-ghost refresh).
+**Effect cleanup cancels the debounce** on every re-run and on unmount. Because `messages` is in the dep array and changes on every new WS message, the effect is re-entrant — each new batch of messages re-runs the effect, running cleanup first. If a debounce timer from a previous run is still pending (rapid-fire commands), it is cancelled and a fresh timer is started, collapsing all commands within the 300 ms window into a single `describe graph` send.
+
+**`import-graph` is not debounced** (lines 189-200). It immediately cancels any pending node-mutation debounce, then fires `sendRawText('describe graph')` synchronously. The `return` statement after the `hasImportGraph` block ensures the node-mutation block (and its debounce) is never reached for the same batch.
 
 ---
 
@@ -646,14 +716,14 @@ ghost refresh).
 
 | File | Type | Summary of change |
 |---|---|---|
-| `src/utils/messageParser.ts` | Modify | Add `MutationKind` type and `detectMutation()` function |
-| `src/hooks/useGraphData.ts` | Modify | Expose `isRefreshing: boolean` and `refetchGraph(): void`; `pinnedGraphPathRef` sync; do NOT null `graphData` on auto-refresh |
-| `src/hooks/useWebSocket.ts` | Modify | Add `sendRawText: (text: string) => void` and expose `connected: boolean` in `UseWebSocketReturn` — `sendRawText` is a thin stable `useCallback` wrapping `ctx.send(wsPath, text)` |
-| `src/hooks/useAutoGraphRefresh.ts` | **New** | Core auto-refresh logic: message scan, debounce, no-pin auto-describe, `import-graph` WS dispatch, `setPinnedGraphPath` on new graph-link; E21 disconnect reset; `connected` prop in options interface |
-| `src/components/GraphView/GraphView.tsx` | Modify | Accept `isRefreshing?: boolean`; render non-blocking loading overlay with ARIA attributes |
-| `src/components/GraphView/GraphView.module.css` | Modify | Add `.refreshingOverlay` and `.refreshingSpinner` styles |
-| `src/components/RightPanel/RightPanel.tsx` | Modify | Accept + forward `isGraphRefreshing?: boolean` prop |
-| `src/components/Playground.tsx` | Modify | Instantiate `useAutoGraphRefresh` (pass `connected` from `ws`); forward `isRefreshing` to `RightPanel` |
+| `src/utils/messageParser.ts` | Modified | Added `MutationKind` type and `detectMutation()` function (lines 243-289). Early-return `if` chain structure; guard order: `isMarkdownCandidate` → `startsWith('> ')` → `isGraphLinkMessage`. |
+| `src/hooks/useGraphData.ts` | Modified | Exposed `isRefreshing: boolean` and `refetchGraph(): void` in `UseGraphDataReturn`; `pinnedGraphPathRef` sync effect; separate `refetchAbortRef` for imperative refetch; unmount-cleanup effect for `refetchAbortRef`; `useLocalStorage` for `rightTab` persistence with `storageKeyTab` param. |
+| `src/hooks/useWebSocket.ts` | Modified | Added `sendRawText: (text: string) => void` to `UseWebSocketReturn` — stable `useCallback` wrapping `ctx.send(wsPath, text)`, guarded by `phase !== 'connected'`. Added `appendMessage: (raw: string) => void` to `UseWebSocketReturn`. |
+| `src/hooks/useAutoGraphRefresh.ts` | **New** | Core auto-refresh logic: `watermarkRef` (separate mount-only `useEffect`); dedicated `[connected]` effect for disconnect reset + debounce cancellation; `pinnedGraphPathRef` stale-closure fix; two-pass main effect (Pass 1: consume graph-link; Pass 2: detect mutations); `import-graph` path immediate (no debounce); `node-mutation` path 300 ms debounce → `sendRawText('describe graph')` (both pinned and un-pinned); `refetchGraph` accepted in interface as `_refetchGraph` (unused). |
+| `src/components/GraphView/GraphView.tsx` | Modified | Accepted `isRefreshing?: boolean` (default `false`); renders `.refreshingOverlay` + `.refreshingSpinner` when `isRefreshing`; `aria-busy={isRefreshing}` on `.graphWrapper`; `role="status"` + `aria-label="Graph refreshing"` on spinner; `onCopySuccess`/`onCopyError` props forwarded to `GraphToolbar`. |
+| `src/components/GraphView/GraphView.module.css` | Modified | Added `.refreshingOverlay` (absolute, `rgba(26,26,46,0.55)` bg, `pointer-events:none`, bottom-right flex alignment) and `.refreshingSpinner` (`1.25rem`, `graphRefreshSpin` keyframe, `0.75s linear infinite`). Added `position: relative` to `.graphWrapper`. |
+| `src/components/RightPanel/RightPanel.tsx` | Modified | Accepted + forwarded `isGraphRefreshing?: boolean` prop to `GraphView` as `isRefreshing`; added `onCopySuccess`/`onCopyError` props for `GraphView` clipboard actions. |
+| `src/components/Playground.tsx` | Modified | Instantiated `useAutoGraphRefresh` (passes `connected` from `ws`, `refetchGraph` from `useGraphData`, `sendRawText` from `ws`); forwarded `isRefreshing` as `isGraphRefreshing` to `RightPanel`; `useGraphData` now receives `tabs[0]` and `storageKeyTab` params. |
 
 ---
 
@@ -661,27 +731,27 @@ ghost refresh).
 
 | # | Scenario | Mitigation |
 |---|---|---|
-| E1 | User clears console while refresh is in-flight | `handleClearMessages` in Playground.tsx sets `pinnedGraphPath = null`. Because `pinnedGraphPath` is in `useAutoGraphRefresh`'s `useEffect` dep array (see §8), React tears down the effect, the cleanup fires `clearTimeout(debounceRef.current)`, and any pending debounce is cancelled. Simultaneously, `refetchGraph`'s `AbortController` cancels the in-flight fetch. No stale result is applied. |
-| E2 | User disconnects mid-session | No new WS messages arrive; no trigger fires. `waitingForDescribeRef` is reset to `false` on disconnect (see E21) so a stale flag cannot fire `setPinnedGraphPath` on reconnect. On reconnect, session state on the server is fresh — the existing `pinnedGraphPath` will still re-fetch correctly if the user issues a mutation after reconnecting. |
+| E1 | User clears console while refresh is in-flight | `handleClearMessages` in `Playground.tsx` (line 280) sets `pinnedGraphPath = null`, `setGraphData(null)`. Since `messages` changes (cleared), the main effect in `useAutoGraphRefresh` re-runs; its cleanup cancels any pending debounce. The disconnect-reset effect is independent. Since `refetchGraph` is not called by the hook in the current implementation, there is no in-flight HTTP request to abort from the `refetchGraph` path. If `waitingForDescribeRef` is set, the cleared console produces no new graph-link messages, so it stays set until the next WS reconnect/disconnect cycle clears it. |
+| E2 | User disconnects mid-session | No new WS messages arrive; no trigger fires. The dedicated `[connected]` effect resets `waitingForDescribeRef = false` and cancels the pending debounce on disconnect (lines 120-132). On reconnect, session state on the server is fresh — the user can issue a new mutation to trigger a fresh auto-refresh. |
 | E3 | `import graph` imports a graph whose root name differs from `pinnedGraphPath` | Handled: `describe graph` is auto-sent, server returns the correct new path, which replaces `pinnedGraphPath` via `waitingForDescribeRef` → `setPinnedGraphPath` |
 | E4 | `import graph` fails (file not found in both temp and deployed locations) | Server sends `"Graph model not found in …"` (and possibly `"Found deployed graph model in …"`) — neither message contains `"graph model imported as draft"` → not matched → no action |
 | E5 | Echo line `"> create node foo"` matched as mutation | Guarded: `raw.startsWith('>')` in `detectMutation` returns `null` |
 | E6 | Graph-link message matched as mutation | Guarded: `isGraphLinkMessage(raw)` check in `detectMutation` returns `null` |
-| E7 | React Strict Mode double-effect execution | Guarded: `lastProcessedIdRef` ID watermark prevents reprocessing already-seen messages |
-| E8 | User rapid-fires 5 mutation commands while no graph is pinned | Debounce collapses all 5 into a single `describe graph` send. Once `waitingForDescribeRef` is set, subsequent mutation detections within the same debounce window are collapsed. Only one `describe graph` is sent. |
+| E7 | React Strict Mode double-effect execution | Guarded: `watermarkRef` watermark prevents reprocessing already-seen messages. The mount-only watermark effect also double-invokes in Strict Mode, but it is idempotent — it only reads `messages[last].id`. |
+| E8 | User rapid-fires 5 mutation commands while no graph is pinned | Debounce collapses all 5 into a single `describe graph` send. The watermark advances on the first main-effect run that sees the batch, so no message is re-scanned. If `waitingForDescribeRef` is already `true` when the debounce fires, the debounce callback calls `sendRawText('describe graph')` and sets the flag again (idempotent). Only one `describe graph` round-trip is in flight because the server responds with exactly one graph-link per `describe graph`. |
 | E9 | Server sends `"Node foo already exists"` (create on existing node) | Starts with `"Node "` so `startsWithNode` is true, but does not contain `" created"` → not matched |
 | E10 | Auto-sent `describe graph` triggers another auto-refresh loop | `describe graph` response is a graph-link → `isGraphLinkMessage()` is true → `detectMutation` returns `null` → no loop |
-| E11 | Component unmounts during debounce window | `useEffect` cleanup `clearTimeout(debounceRef.current)` fires |
-| E12 | `pinnedGraphPath` changes while a debounced refresh is pending | `refetchGraph` reads `pinnedGraphPath` through a `useRef` (not a closure), so it always fetches the path that is current at the moment the debounce fires — never a stale value (see §6.1 stale-closure fix) |
+| E11 | Component unmounts during debounce window | `useEffect` cleanup `clearTimeout(debounceTimerRef.current)` fires on unmount, cancelling the pending timer. `sendRawText` is never called after teardown. |
+| E12 | `pinnedGraphPath` changes while a debounced refresh is pending | The debounce callback reads `pinnedGraphPathRef.current` at fire time (for the toast message only). The `sendRawText('describe graph')` call is path-agnostic — the server always serialises the current in-memory graph. A change to `pinnedGraphPath` does not re-run the main effect (it is not in the dep array), so the pending debounce continues unaffected and fires the correct `describe graph`. |
 | E13 | ~~`import-graph` triggered but `pinnedGraphPath` is null~~ | **No longer an edge case (v4).** `import-graph` now sends `describe graph` regardless of `pinnedGraphPath`. The `waitingForDescribeRef` path handles both null and non-null cases identically. |
 | E14 | `import node` success but the node's graph was never pinned | `pinnedGraphPath === null` → debounce fires → `describe graph` auto-sent → graph-link received → `setPinnedGraphPath` called → initial-load path fires → tab switches to Graph. Same as §5.2. |
 | E15 | `delete connection` emits two `"removed"` lines in one message | Both `"A -> B removed"` lines are in a single `msg.raw` — the narrowed `' -> ' && 'removed'` check still matches; `detectMutation` fires once per message; debounce collapses any duplicates |
 | E16 | `instantiate graph` response `"Graph instance created. Loaded N mock entries…"` matched as `node-mutation` | Guarded: `lower.startsWith('node ')` is false for this message — the `" created"` branch is never reached. `instantiate graph` creates a runtime instance, not a model change. |
 | E17 | `export graph as {name}` auto-creates a root node — `"Root node created because it does not exist"` matched as `node-mutation` | Guarded: `lower.startsWith('node ')` is false (`"root node…"` does not begin with `"node "`). The `export` command already emits a graph-link; the pin flow handles the refresh. A double-refresh is unnecessary and avoided. |
-| E18 | `node-mutation` detected while `waitingForDescribeRef` is already `true` (e.g. a second mutation arrives before the `describe graph` response) | The second mutation fires the debounce, but `waitingForDescribeRef` is already set. The debounce callback should check `waitingForDescribeRef` before sending another `describe graph`: if already waiting, skip the send. Only one `describe graph` round-trip should be in flight at a time. |
+| E18 | `node-mutation` detected while `waitingForDescribeRef` is already `true` (e.g. a second mutation arrives before the `describe graph` response) | The debounce fires and calls `sendRawText('describe graph')` again, setting `waitingForDescribeRef.current = true` (idempotent). This sends a second `describe graph` command. The server will respond with two graph-link messages. Pass 1 of the main effect consumes the first one (sets `pinnedGraphPath`), then `return`s. On the next effect run, `watermarkRef` has already advanced past both graph-link messages, so the second one is never re-processed. Net effect: two `describe graph` commands are sent, but only the first response is consumed — the second graph-link is silently ignored. This is a minor inefficiency but not a correctness issue. |
 | E19 | User manually pins a different graph while `waitingForDescribeRef === true` | The user clicks a console row containing a graph-link → `handlePinMessage` fires → `setPinnedGraphPath(oldPath)`. The hook then sees the server's `describe graph` response (a graph-link message) with `waitingForDescribeRef === true` and calls `setPinnedGraphPath(newPath)`, silently overwriting the user's manual pin. `waitingForDescribeRef` must still be cleared immediately when the hook calls `setPinnedGraphPath` to prevent the flag remaining set for a subsequent auto-describe round-trip. **Accepted v4 trade-off:** this race requires the user to manually pin a graph-link row within the < 100 ms window between the hook sending `describe graph` and the server responding — an extremely narrow window in practice. The hook always sets the freshest server-derived path. A future hardening could store the trigger message `id` in `waitingForDescribeRef` (change type from `boolean` to `number | false`) and skip calling `setPinnedGraphPath` if a manual pin has already fired, but this is out of scope for v4. |
 | E20 | `node-mutation` detected immediately after session open (empty graph, 0 nodes) | `describe graph` is auto-sent. Server responds with `"Graph with 0 nodes described in /api/graph/model/{id}/{n}"`. This is a valid graph-link. `setPinnedGraphPath` is called, `useGraphData` fetches and renders an empty graph. The Graph tab switches. This is correct — the user will see the result of their mutation (1 node) after the next refresh cycle, or after the debounce fires a second `describe graph`. In practice this shouldn't happen: the mutation itself produces a success message which fires the debounce, so the tab will show the updated 1-node graph shortly after. |
-| E21 | `import graph` triggered, `waitingForDescribeRef` set, but WS disconnects before server replies | `describe graph` was sent but the response never arrives. `waitingForDescribeRef` stays `true` indefinitely. On reconnect, a fresh session starts; the user issues any mutation → `waitingForDescribeRef` is still `true` from the previous cycle. **Mitigation:** On WS disconnect (detected via `connected` becoming `false` in `useAutoGraphRefresh`), reset `waitingForDescribeRef = false`. Implementation: add `connected` to the `useEffect` dep array and add a `if (!connected) { waitingForDescribeRef.current = false; return; }` guard at the top of the effect. |
+| E21 | `import graph` triggered, `waitingForDescribeRef` set, but WS disconnects before server replies | **Mitigated (implemented).** The dedicated `[connected]` effect (lines 120-132 of `useAutoGraphRefresh.ts`) resets `waitingForDescribeRef = false` **and** cancels any pending `debounceTimerRef` when `connected` becomes `false`. This prevents a stale flag from consuming the first graph-link that arrives after reconnect, and prevents a stranded debounce from calling `sendRawText` after reconnect with a stale `waitingForDescribeRef = true`. |
 | E22 | User issues `import graph` with no graph previously pinned; server sends the `"Found deployed graph model…"` informational message before `"Graph model imported as draft"` | The informational message does not match `detectMutation` → ignored. `"Graph model imported as draft"` fires the `import-graph` path and sends `describe graph`. Correct behaviour, no spurious trigger. |
 
 ---

--- a/extensions/minigraph-playground-engine/webapp/docs/SPEC-large-payload-inline.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/SPEC-large-payload-inline.md
@@ -1,0 +1,654 @@
+# Feature Spec: Large-Payload Inline Console Rendering
+
+**Target:** `webapp/` (React/TypeScript frontend)
+**Branch:** `feature/playground`
+**Date:** 2026-03-19
+**Status:** v4 — peer-review applied, ready for implementation
+
+---
+
+## Table of Contents
+
+1. [Background & Motivation](#1-background--motivation)
+2. [Current Behaviour (to be replaced)](#2-current-behaviour-to-be-replaced)
+3. [Target Behaviour](#3-target-behaviour)
+4. [Exact Message-Matching Rules (unchanged)](#4-exact-message-matching-rules-unchanged)
+5. [Architecture: Where the Logic Lives](#5-architecture-where-the-logic-lives)
+6. [State Inventory & Lifecycle](#6-state-inventory--lifecycle)
+7. [Detailed Behaviour Specification](#7-detailed-behaviour-specification)
+8. [ConsoleMessage Rendering Changes](#8-consolemessage-rendering-changes)
+9. [File Changelist](#9-file-changelist)
+10. [Edge Cases & Pitfall Index](#10-edge-cases--pitfall-index)
+11. [Open Questions (Deferred)](#11-open-questions-deferred)
+
+---
+
+## 1. Background & Motivation
+
+The backend enforces a 64 KB inline WebSocket limit.  When a namespace value
+(or any inspectable field) exceeds this threshold it is not echoed through the
+socket; instead the server sends a plain-text "Large payload" notification:
+
+```
+Large payload (254922) -> GET /api/inspect/ws-734563-3/input.body
+```
+
+### Small-payload path (current, unchanged)
+
+For payloads within the 64 KB limit the server sends the value as a regular
+WebSocket message.  The existing `ConsoleMessage` component renders it as a
+collapsed `JsonView` tree, and a hover-visible **➡️** button lets the user
+send the JSON into the JSON-Path Playground payload editor with one click —
+_without_ leaving the current playground.
+
+### Large-payload path (current, to be replaced)
+
+The current `useLargePayloadDownload` hook:
+
+1. Detects the notification message.
+2. Guards that the JSON-Path Playground WebSocket is already connected.
+3. Navigates away to `/json-path`.
+4. Fetches the payload from `/api/inspect/…`.
+5. Deposits it via `ctx.setPendingPayload` into the payload editor.
+
+This forces a context switch before the user has even seen the data and
+requires them to have pre-connected the JSON-Path Playground.
+
+### Goal
+
+> Large payloads should behave identically to small payloads from the user's
+> perspective: the fetched JSON appears **in the console** where the
+> notification was, collapsed and scrollable, with the same **➡️**
+> send-to-JSON-Path button — no navigation, no pre-connection requirement.
+
+---
+
+## 2. Current Behaviour (to be replaced)
+
+```
+Server sends "Large payload (N) -> GET /api/inspect/…"
+  → useLargePayloadDownload detects it
+  → Guards JSON-Path connection (error toast if not connected)
+  → navigate('/json-path')                    ← ❌ removed
+  → fetch(apiPath)                            ← kept
+  → ctx.setPendingPayload(wsPath, content)    ← ❌ removed
+  → addToast('Payload loaded…')               ← ❌ removed (replaced)
+```
+
+**Side-effects to eliminate:**
+- `navigate()` call — removes forced context switch.
+- `ctx.setPendingPayload` — no longer needed for the primary flow.
+- The JSON-Path connection guard — no longer a prerequisite for fetching.
+- The `useNavigate` import in the hook.
+
+---
+
+## 3. Target Behaviour
+
+```
+Server sends "Large payload (N) -> GET /api/inspect/…"
+  → useLargePayloadDownload detects it
+  → addToast(`Fetching large payload (${sizeMB} MB)…`, 'info')  ← NEW
+  → fetch(apiPath)
+  → on success: appendMessage(prettyJSON)                   ← NEW
+  → the new message renders in Console as a collapsed JsonView
+  → hover reveals ➡️ button → sends to JSON-Path editor     ← same as small payload
+```
+
+The notification row itself (`"Large payload (N) -> GET …"`) **remains in the
+console** — it becomes the history record of where the payload came from and
+is useful for debugging.  No deletion or replacement of the original message.
+
+---
+
+## 4. Exact Message-Matching Rules (unchanged)
+
+`extractLargePayloadLink` in `messageParser.ts` is **not modified**.
+
+```
+/Large payload \((\d+)\)\s*->\s*GET\s+(\/api\/inspect\/[^\s]+)/i
+```
+
+`isLargePayloadMessage` continues to drive the amber styling in `ConsoleMessage`.
+
+---
+
+## 5. Architecture: Where the Logic Lives
+
+### 5.1 Responsibility table
+
+| Concern | Owner | Notes |
+|---|---|---|
+| Detect large-payload notification | `useLargePayloadDownload` | unchanged |
+| Fetch JSON from `/api/inspect/…` | `useLargePayloadDownload` | unchanged |
+| Append fetched content to console | `useLargePayloadDownload` via `appendMessage(content)` | **new** — replaces `setPendingPayload` + `navigate`; note: 1-arg form — `wsPath` already bound in the hook's option |
+| Render JSON tree in console | `ConsoleMessage` | unchanged — already handles JSON via `JsonView` |
+| Send to JSON-Path editor (➡️ button) | `Playground.tsx` → `handleSendToJsonPath` | unchanged — already wired to `onSendToJsonPath` |
+| Per-message copy button | `ConsoleMessage` | unchanged |
+
+### 5.2 Hook signature changes
+
+`useLargePayloadDownload` **removes** the `navigate` dependency:
+
+```typescript
+// BEFORE
+import { useNavigate } from 'react-router-dom';
+const navigate = useNavigate();
+
+// AFTER — removed entirely
+```
+
+The `UseWebSocketDownloadOptions` interface and the hook's `useEffect`
+dependency array shrink by two entries.  The final dep array is:
+
+```typescript
+[messages, connected, appendMessage, addToast]
+```
+
+`navigate` and `ctx` are both removed.  Note: `useNavigate` returns a new
+function identity on every render in some React Router versions; removing it
+eliminates a source of unnecessary effect re-runs.  No other public API changes.
+
+### 5.3 WebSocketContext changes
+
+**None.**  `setPendingPayload` / `takePendingPayload` are **not removed** —
+`handleSendToJsonPath` in `Playground.tsx` still uses them for the ➡️ button
+flow on both small and large payloads.  The hook simply stops calling
+`setPendingPayload` itself.
+
+### 5.4 Playground.tsx changes
+
+**None.**  `handleSendToJsonPath` already handles any pretty-printed JSON
+string regardless of how it arrived in the console.  The hook no longer calls
+`navigate`, so the import of `useNavigate` in `Playground.tsx` is unaffected
+(it is still needed by `handleSendToJsonPath`).
+
+---
+
+## 6. State Inventory & Lifecycle
+
+### 6.1 Message-ID watermark (`watermarkRef`)
+
+`watermarkRef` is a `useRef<number>` initialised to `-1`.  On mount, the
+`useEffect` with an empty dep-array sets it to the id of the last existing
+message so historical notifications are never replayed after a navigation
+round-trip.
+
+**No change needed** — this guarantee holds identically under the new flow
+because `appendMessage` adds a new message with a higher id than the
+watermark; that new message is above the watermark and **will** be processed
+on the next `messages` tick.
+
+> ⚠️ **Subtle re-entrancy concern:** when `appendMessage` is called, it
+> dispatches to `WebSocketContext`'s reducer which increments `msgIdRefs` and
+> produces a new `messages` array via `useReducer`.  The `messages` change
+> triggers the hook's main `useEffect` again.  The appended message will have
+> an id **above** the watermark, so `newMessages` will contain it.
+>
+> **Fix:** After `appendMessage` is called, advance `watermarkRef.current`
+> to the id of the message just appended **before** the effect returns.
+> Because `appendMessage` is a synchronous context dispatch, the new id is
+> `ctx.msgIdRefs.current[wsPath]` — but that ref is internal to the context
+> and not exposed.
+>
+> **Simpler fix (chosen):** set a local `pendingRef` boolean flag
+> (`isFetchingRef`) to `true` while a fetch is in flight and skip the
+> inner-loop processing when it is set.  When the fetch resolves, clear the
+> flag and advance the watermark to cover the newly-appended message.
+> See §7.4 for the full implementation pattern.
+
+### 6.2 In-flight fetch AbortController (`abortRef`)
+
+`abortRef` holds the `AbortController` for any in-flight fetch.
+
+- **On disconnect** (`connected` changes to `false`): `abortRef.current?.abort()` and `abortRef.current = null`.  The aborted fetch's `.catch` branch checks `err.name === 'AbortError'` and silently returns — no error message is appended, no toast.  This is correct; a stale payload is useless.
+- **On unmount**: same abort pattern via cleanup effect.
+- **On new large-payload message arriving while fetch is in flight**: `abortRef.current?.abort()` is called before starting the new fetch.  Only one in-flight fetch at a time.  This matches current behaviour.
+
+### 6.3 `isFetchingRef` (new)
+
+A `useRef<boolean>` initialised to `false`.
+
+Purpose: prevent the appended result message from being re-processed as a new
+large-payload notification by the hook's own main effect.
+
+**Lifecycle:**
+| Moment | Value |
+|---|---|
+| At mount | `false` |
+| Just before `fetch()` call | `true` |
+| After `appendMessage(content)` returns | `false`, watermark advanced |
+| After abort (disconnect / unmount) | `false` |
+| After fetch error (non-abort) | `false` |
+
+> **Interaction with the watermark (Gap 2):** The main effect's first
+> statement advances the watermark unconditionally:
+> ```typescript
+> watermarkRef.current = messages[messages.length - 1].id;
+> ```
+> The `isFetchingRef` early return (`if (isFetchingRef.current) return`)
+> fires **before** this line.  Consequently, non-large-payload messages that
+> arrive while a fetch is in flight do not advance the watermark on that tick.
+> Those messages remain above the watermark and are re-scanned on the next
+> tick once `isFetchingRef` is cleared.  This is **safe**: `extractLargePayloadLink`
+> returns `null` for any non-notification string, so they are simply skipped
+> with no side effects.  The only cost is one redundant scan per batch, which
+> is negligible.
+
+> **Mount ordering:** React guarantees that `useEffect` hooks fire in source
+> order within the same component.  The mount watermark effect (empty dep-array)
+> is declared **before** the main messages effect in the hook, so it runs first
+> on the initial render.  By the time the main effect fires for the first time,
+> `watermarkRef.current` already reflects the id of the last pre-existing
+> message.  `isFetchingRef.current` is `false` at mount, so the early return
+> does not interfere with this ordering.
+
+### 6.4 `JSON_PATH_CONFIG` module-level constants
+
+Still resolved at module load time from `PLAYGROUND_CONFIGS`.  However,
+`JSON_PATH_ROUTE` and `JSON_PATH_WS` are **no longer used inside the hook**
+— `navigate` is removed.  `JSON_PATH_WS` is also no longer needed for the
+connection guard.
+
+**Action:** Remove all three constants from the hook — they are not used
+anywhere else.  Note: the current code uses `JSON_PATH_CONFIG` to provide
+fallback strings (`'/json-path'` and `'/ws/json/path'`) when
+`PLAYGROUND_CONFIGS.find(...)` returns `undefined`.  Removing the constants
+also removes this fallback concern — **intentionally** — because neither the
+fetch path nor the `appendMessage` call requires knowledge of the JSON-Path
+playground's route or wsPath.  The fallback strings had value only for the
+now-deleted `navigate()` + `getSlot()` calls.
+
+---
+
+## 7. Detailed Behaviour Specification
+
+### 7.1 Normal happy path
+
+```
+messages tick arrives with newMessages = [{ id: 42, raw: "Large payload (254922) -> GET /api/inspect/ws-1/input.body" }]
+
+watermark was 41 → newMessages = [id:42]
+isFetchingRef = false → proceed
+
+link = extractLargePayloadLink(raw)
+  → { apiPath: '/api/inspect/ws-1/input.body', byteSize: 254922, filename: 'input.body.json' }
+
+isFetchingRef = true
+abortRef.current?.abort()          // cancel any prior in-flight
+const controller = new AbortController()
+abortRef.current = controller
+
+sizeMB = '0.24'
+addToast(`Fetching large payload (0.24 MB)…`, 'info')
+
+fetch('/api/inspect/ws-1/input.body', { signal })
+  → 200 OK, body = '{"foo":…}'
+  → content = JSON.stringify(JSON.parse(body), null, 2)    // pretty-print
+
+appendMessage(content)              // 1-arg: wsPath already bound in hook options
+watermarkRef.current = newMessages[newMessages.length - 1].id + 1  // safe upper bound — see §7.4
+isFetchingRef.current = false
+abortRef.current = null
+```
+
+The new message appears in the console.
+`ConsoleMessage` receives it, `tryParseJSON` succeeds, `JsonView` renders it
+collapsed at depth < 2.  `canSendToJsonPath` is `true` because
+`onSendToJsonPath` is wired and `jsonCheck.isJSON` is `true`.
+
+### 7.2 Canonical watermark formula: `newMessages[newMessages.length - 1].id + 1`
+
+The canonical formula used everywhere in this spec is:
+
+```typescript
+watermarkRef.current = newMessages[newMessages.length - 1].id + 1;
+```
+
+**Why `+1`?**  After `appendMessage(content)` is called, the message dispatched
+into the context's reducer receives the next sequential id — `notificationId + 1`
+or higher (if other messages arrived concurrently).  Using `+1` as a safe upper
+bound guarantees the appended row is treated as "already seen" even in the same
+synchronous continuation of `.then()`, before React has re-rendered and before
+`messages` in the closure is updated.
+
+**Why not `messages[messages.length - 1].id`?** At the point `.then()` runs,
+`messages` is the **stale closure value** from the render cycle in which the
+large-payload notification was detected.  Setting the watermark to that value
+would leave the appended row (id = notification + 1) above the watermark — it
+would be scanned on the next tick.  The `isFetchingRef` guard catches this
+safely (the appended JSON does not match the large-payload regex), but the
+`+1` formula avoids the scan entirely and is unambiguously correct.
+
+**Conclusion:** `isFetchingRef` is the critical re-entrancy guard.  The `+1`
+watermark advance in `.then()` is belt-and-suspenders.  Both are required for
+robustness.
+
+### 7.3 Disconnect during fetch
+
+```
+connected changes false
+  → abortRef.current?.abort()
+  → isFetchingRef = false   ← MUST be cleared here too
+  → abortRef.current = null
+
+fetch rejects with AbortError → caught, silently returns (no toast, no append)
+```
+
+> ⚠️ **If `isFetchingRef` is not cleared in the disconnect effect**, the next
+> reconnect + large-payload message will be silently skipped because the guard
+> still reads `true`.  This is a subtle latent bug in any implementation that
+> forgets this step.
+
+### 7.4 Re-entrancy guard: full pattern
+
+The `isFetchingRef` guard must be inserted as the **very first statement** in
+the main messages effect body — before the `messages.length === 0` check.
+This avoids the `filter()` call entirely when a fetch is in flight and is the
+cleanest insertion point:
+
+```typescript
+// Main messages effect — isFetchingRef guard is the FIRST line:
+if (isFetchingRef.current) return;   // ← inserted before messages.length === 0 check
+if (messages.length === 0) return;
+const newMessages = messages.filter(m => m.id > watermarkRef.current);
+if (newMessages.length === 0) return;
+watermarkRef.current = messages[messages.length - 1].id;  // unconditional advance
+
+// Just before fetch():
+isFetchingRef.current = true;
+
+// In .then():
+appendMessage(content);
+watermarkRef.current = newMessages[newMessages.length - 1].id + 1; // canonical — see §7.4
+isFetchingRef.current = false;
+abortRef.current = null;
+
+// In .catch() (non-abort):
+// isFetchingRef is cleared BEFORE appendMessage — intentional and safe:
+// the error string cannot match extractLargePayloadLink, so re-entrancy
+// risk is zero. Clearing early is consistent with the .then() path.
+isFetchingRef.current = false;
+abortRef.current = null;
+appendMessage(`ERROR: payload fetch failed — ${err.message}`);  // 1-arg form
+addToast(...);
+```
+
+Note: `watermarkRef.current = newMessages[lastIdx].id + 1` uses `+1` as a
+safe upper bound to guarantee the appended message (which will have id =
+lastIdx + 1 or higher) is treated as "already seen" on the next tick.
+
+### 7.5 Multiple large-payload notifications in one batch
+
+The current code `break`s after the first link found in a batch.  This is
+**unchanged** — only one fetch is initiated per effect run.  Additional
+notifications in the same batch will be processed on subsequent ticks once
+`isFetchingRef` is cleared.
+
+> The `break` is important: without it, two concurrent fetches could race and
+> both attempt to set `abortRef.current`, leaving the second one unabortable.
+
+### 7.6 Server error response (non-2xx)
+
+```
+fetch('/api/inspect/…') → 500 Internal Server Error
+
+.then(res => { if (!res.ok) throw new Error(`HTTP ${res.status}`); … })
+.catch((err: Error) => {
+  if (err.name === 'AbortError') return;
+  isFetchingRef.current = false;
+  abortRef.current = null;
+  appendMessage(`ERROR: payload fetch failed — ${err.message}`);  // 1-arg form
+  addToast(`Payload fetch failed: ${err.message}`, 'error');
+});
+```
+
+The original notification row (`Large payload (N) -> GET …`) remains visible
+in the console.  The error message is appended below it.  The user can re-run
+the command that produced the large payload if needed.
+
+### 7.7 Non-JSON response body
+
+```typescript
+let content = text;
+try {
+  content = JSON.stringify(JSON.parse(text), null, 2);
+} catch {
+  // Not JSON — pass raw text through unchanged
+}
+appendMessage(content);  // 1-arg form
+```
+
+If the server returns XML or plain text (edge case — the endpoint is
+`/api/inspect/…` which always returns JSON), the raw string is appended.
+`ConsoleMessage` will render it as a `<span className={messageText}>` via the
+`!jsonCheck.isJSON` branch.  The ➡️ button will NOT appear because
+`canSendToJsonPath` requires `jsonCheck.isJSON === true` — correct, since
+non-JSON cannot be deposited into the payload editor meaningfully.
+
+---
+
+## 8. ConsoleMessage Rendering Changes
+
+### 8.1 No changes required
+
+The fetched JSON is appended as a plain raw string.  `ConsoleMessage` already
+handles this correctly:
+
+- **`parseMessage(raw)`** is called first.  Because the raw string is valid
+  JSON, `JSON.parse(msg)` succeeds.  `parseMessage` then reads
+  `parsed.message || msg` — a top-level JSON object has no `.message` key, so
+  `parsed.message` is `undefined`, and the expression falls back to `msg` (the
+  full JSON string).  `parsed.type` similarly falls back to `'info'`.  This is
+  the correct pass-through path; the string is not mistaken for a lifecycle
+  event.
+- **`tryParseJSON(parsed.message)`** — called with the full JSON string —
+  returns `{ isJSON: true, data: <object> }`.
+- **`JsonView`** renders the tree collapsed at depth < 2.
+- **`canSendToJsonPath`** → `true` (when `onSendToJsonPath` is wired).
+- **Copy button** present (always).
+- **`isLargePayloadMessage(raw)`** returns `false` — the pretty-printed JSON
+  does not match `/Large payload \(\d+\)/` — so the row receives **no** amber
+  `consoleMessageLargePayload` styling.  This is correct: it is the payload
+  content, not a link.  The icon shown will be the standard `'info'` icon
+  (`ℹ️`) from `getMessageIcon('info')`.
+
+### 8.2 Visual sequence in the console
+
+```
+[⬇️] Large payload (254922) -> GET /api/inspect/ws-1/input.body   ← amber row (existing)
+[ℹ️] {                                                              ← new JsonView row
+       "foo": "bar",
+       …
+     }
+```
+
+The notification row is preserved, giving the user the context of where the
+data came from.  The rendered JSON row immediately follows.
+
+### 8.3 "Send to JSON-Path" button on large payloads
+
+The ➡️ button on the rendered JSON row calls `handleSendToJsonPath(prettyJSON)`
+in `Playground.tsx`, which:
+
+1. Checks that the JSON-Path Playground is connected (same guard as before).
+2. Calls `ctx.setPendingPayload(JSON_PATH_WS, json)`.
+3. Calls `navigate(JSON_PATH_ROUTE)`.
+4. Shows a success toast.
+
+This is **identical to the small-payload path**.  No changes are required in
+`Playground.tsx` or `handleSendToJsonPath`.
+
+---
+
+## 9. File Changelist
+
+### Modified
+
+#### `src/hooks/useLargePayloadDownload.ts`
+
+| Change | Reason |
+|---|---|
+| Remove `useNavigate` import and `navigate` call | Navigation is eliminated |
+| Remove `JSON_PATH_CONFIG`, `JSON_PATH_ROUTE`, `JSON_PATH_WS` module constants and `PLAYGROUND_CONFIGS` import | No longer used in the hook after constants are removed |
+| Update hook-body JSDoc comment to describe new behaviour | The existing comment describes the old navigation/`setPendingPayload` flow in detail and will be actively misleading after implementation |
+
+The replacement JSDoc should read:
+
+```typescript
+/**
+ * Watches the WebSocket message stream for large-payload inspect links.
+ *
+ * When the server sends a message matching:
+ *   "Large payload (<bytes>) -> GET /api/inspect/<id>/<namespace>"
+ *
+ * this hook fetches the payload from the backend inspect endpoint and
+ * appends it directly to this playground's console as a collapsible
+ * JSON row — no navigation, no pre-connection requirement.
+ *
+ * The user can then use the per-row ➡️ button (onSendToJsonPath) to
+ * move the payload into the JSON-Path Playground editor in one click,
+ * identical to the flow for inline small payloads.
+ *
+ * Follows the same patterns as useAutoGraphRefresh / useAutoMarkdownPin:
+ *  - Message-ID watermark set at mount prevents replaying history.
+ *  - isFetchingRef guard prevents re-entrancy when the appended result
+ *    message triggers the effect again.
+ *  - AbortController cancels in-flight fetches on disconnect or unmount.
+ */
+```
+| Remove JSON-Path connection guard (`ctx.getSlot(JSON_PATH_WS)`) | Not a prerequisite for fetching |
+| Remove `ctx.setPendingPayload(...)` call | Payload goes to console, not editor |
+| Remove `navigate(JSON_PATH_ROUTE)` call | Eliminated |
+| Add `isFetchingRef = useRef(false)` | Re-entrancy guard (§6.3) |
+| In `.then()`: call `appendMessage(content)` (1-arg) | Puts payload in console; `wsPath` already bound in hook options |
+| In `.then()`: add empty-body guard before `JSON.parse` | Routes 200-with-empty-body to the error path rather than appending an empty row (see E4) |
+| In `.then()`: advance `watermarkRef.current = newMessages[newMessages.length - 1].id + 1` | Belt-and-suspenders guard — prevents re-scan of appended row (§7.2) |
+| In `.then()`: clear `isFetchingRef.current = false` | Release guard |
+| In `.catch()` (non-abort): clear `isFetchingRef.current = false` | Release guard |
+| In `.catch()` (non-abort): call `` appendMessage(`ERROR: payload fetch failed — ${err.message}`) `` (1-arg) | Appends error to console; distinct from the loop variable `msg` |
+| In disconnect effect: clear `isFetchingRef.current = false` | Prevent stale guard on reconnect (§7.3) |
+| Change `addToast` content to `` `Fetching large payload (${sizeMB} MB)…` `` (`'info'`) | Describes actual new behaviour |
+| Remove success toast ("Payload loaded into JSON-Path editor ✓") | No longer navigating away |
+| Remove `useWebSocketContext` import and `ctx` variable | Both uses of `ctx` (`getSlot` and `setPendingPayload`) are removed; leaving the import creates a stale dep-array entry on `ctx` |
+
+> **Note:** `UseWebSocketDownloadOptions` interface does not change.
+> `appendMessage`, `addToast`, `messages`, and `connected` are still the
+> four inputs.  `ctx` (WebSocketContext) is no longer imported.
+
+### Unmodified
+
+| File | Reason untouched |
+|---|---|
+| `src/utils/messageParser.ts` | Detection logic unchanged |
+| `src/components/Console/ConsoleMessage.tsx` | Already handles JSON rendering + ➡️ button |
+| `src/components/Console/Console.tsx` | No interface changes |
+| `src/components/Console/Console.module.css` | No new CSS classes needed |
+| `src/components/Playground.tsx` | `handleSendToJsonPath` and `onSendToJsonPath` wiring unchanged |
+| `src/contexts/WebSocketContext.tsx` | `setPendingPayload` / `takePendingPayload` retained for ➡️ button flow |
+| `src/config/playgrounds.ts` | No config changes |
+
+---
+
+## 10. Edge Cases & Pitfall Index
+
+### E1 — Stale `isFetchingRef` after disconnect
+**Scenario:** Fetch is in flight; user disconnects.
+**Risk:** `isFetchingRef` stays `true`; next reconnect + large payload is silently dropped.
+**Mitigation:** Clear `isFetchingRef.current = false` in the `connected → false` effect alongside `abortRef.current?.abort()`.
+
+### E2 — Appended message triggers re-processing
+**Scenario:** `appendMessage(prettyJSON)` increments the message list; the main effect fires again with the new message in `newMessages`.
+**Risk:** The hook calls `extractLargePayloadLink(prettyJSON)` on the JSON content.  Since pretty-printed JSON does not match the pattern (`/Large payload \(\d+\)/`), this returns `null` and is skipped — **no action taken**.  Safe.
+**Belt-and-suspenders:** `isFetchingRef` guard still catches this before `extractLargePayloadLink` is even called.
+
+### E3 — Large-payload notification arrives while navigation is in progress (old behaviour)
+**Scenario:** Not applicable in the new design — no navigation occurs.
+
+### E4 — `appendMessage` called with an empty string or null
+**Scenario:** Server returns an empty body.
+**Mitigation:** The `!res.ok` check will have already thrown for a 204 (no content).  For a 200 with empty body, `JSON.parse('')` throws, so the `catch` leaves `content = ''`.  An empty string appended to the console renders as an empty `<span>` — harmless, but ugly.  Add a guard: `if (!text.trim()) throw new Error('empty response body')` before the JSON.parse attempt, routing to the error path instead.
+
+### E5 — Two large-payload messages arrive in the same `newMessages` batch
+**Scenario:** Server sends two notifications without any other messages between them (unusual but possible).
+**Mitigation:** `isFetchingRef = true` is set and the loop `break`s after the first.  The second notification stays above the watermark.  On the next tick (after the first fetch resolves), `isFetchingRef = false` allows the second to be processed.  Correct sequential behaviour.
+
+### E6 — User clears the console while fetch is in flight
+**Scenario:** User clicks the 🗑️ clear button; `ws.clearMessages()` is called; `messages` becomes `[]`.
+**Risk:** The fetch resolves; `appendMessage(prettyJSON)` is called.  The message appears in the now-empty console — correct.  Watermark was set to `newMessages[lastIdx].id + 1` which is larger than any current id; on the next render `messages` is empty so `newMessages` will be empty — no double processing.  Safe.
+
+### E7 — Playground unmounts before fetch resolves (user navigates away manually)
+**Scenario:** User clicks a different playground in the nav bar mid-fetch.
+**Mitigation:** The unmount cleanup effect calls `abortRef.current?.abort()`.  The fetch rejects with `AbortError`; the `.catch` branch silently returns.  `appendMessage` is never called — correct, because the target slot's console is no longer visible.
+
+### E8 — `wsPath` changes (impossible in current architecture)
+**Scenario:** `wsPath` is a prop derived from `config.wsPath` which is static for the lifetime of a `Playground` instance.  This edge case does not exist.
+
+### E9 — Backend returns a non-JSON content-type but valid JSON body
+**Scenario:** `Content-Type: text/plain` with a JSON body.
+**Mitigation:** `res.text()` is used (not `res.json()`), so content-type is irrelevant.  The `JSON.parse` attempt in the hook succeeds; content is pretty-printed.  Safe.
+
+### E10 — `extractLargePayloadLink` returns a path with query parameters
+**Scenario:** Hypothetical future server change: `/api/inspect/ws-1/input.body?v=2`.
+**Mitigation:** The existing regex `\/api\/inspect\/[^\s]+` captures the full path including query string.  `fetch(apiPath)` would include the query string — correct.  The `lastSegment` filename derivation splits on `/` and pops, returning `input.body?v=2` — slightly ugly filename for the copy button, but functionally correct.  This is a pre-existing consideration, not introduced by this change.
+
+### E11 — JSON-Path Playground not connected when user clicks ➡️
+**Scenario:** User sees the fetched payload in the console and clicks ➡️ but has not connected the JSON-Path Playground.
+**Mitigation:** `handleSendToJsonPath` in `Playground.tsx` already checks `slot.phase !== 'connected'` and shows an error toast.  **No change needed** — the guard is correctly placed in `Playground.tsx`, not in the hook.
+
+### E12 — `handleSendToJsonPath` not wired (Minigraph Playground's own console)
+**Scenario:** The large-payload notification arrives in the **Minigraph** Playground console (wsPath = `/ws/graph/playground`).
+**Check in `Playground.tsx`:**
+```tsx
+onSendToJsonPath={jsonPathConfig && wsPath !== jsonPathConfig.wsPath ? handleSendToJsonPath : undefined}
+```
+When `wsPath === jsonPathConfig.wsPath` (i.e., we are already on the JSON-Path
+Playground), `onSendToJsonPath` is `undefined`, so the ➡️ button is not
+rendered — correct.  When we are on the Minigraph Playground
+(`wsPath !== jsonPathConfig.wsPath`), the button is rendered — correct.
+
+### E13 — `MAX_ITEMS` console buffer overflow
+**Scenario:** Console is near the 200-item limit; `appendMessage` for the fetched payload causes the oldest message (possibly the large-payload notification itself) to be evicted via `msgs.shift()`.
+**Analysis:** The notification row and the fetched payload row are two separate messages.  If the console is at 199 items when the notification arrives, the notification is at item 200 (max).  The fetched payload is appended as item 201 → the oldest item is evicted.  This is correct buffer behaviour — no special handling needed.  The amber notification row may disappear, but the JSON payload row remains, which is the more valuable information.
+
+### E14 — Fetch resolves after the console is cleared (`messages = []`) and then the effect runs
+**Analysis:** The appended message lands in an empty console (see E6).  `watermarkRef.current` was set to `notificationId + 1` inside `.then()` before clearing `isFetchingRef`.  The empty `messages` array means `newMessages` is empty on the next tick — the watermark check short-circuits.  No issue.
+
+### E15 — `appendMessage` internal dispatch timing vs. watermark update
+**Scenario:** Between the synchronous `appendMessage(...)` call and the synchronous `watermarkRef.current = ...` assignment, React has NOT re-rendered yet (React batches state updates).  The watermark is advanced in the same synchronous continuation of the `.then()` handler — before any re-render.  Safe.
+
+---
+
+## 11. Open Questions (Deferred)
+
+### Q1 — Loading indicator on the notification row
+**Question:** Should the amber notification row show a spinner while the fetch
+is in flight?
+
+**Discussion:** This would require the hook to communicate in-progress state
+back to the message row.  Since `ConsoleMessage` renders by `msg.raw` string
+alone with no external state, this would require either:
+- A context value exposed from `useLargePayloadDownload` (adds coupling), or
+- Replacing the notification row's raw string with a modified version that
+  contains a marker (mutates shared state — fragile).
+
+**Recommendation:** Defer.  The `addToast('Fetching…', 'info')` provides
+sufficient feedback.  The toast is transient and auto-dismisses; by the time
+the user reads the notification row, the fetch will typically have resolved.
+
+### Q2 — Collapse/expand state persistence across re-renders
+**Question:** `JsonView` renders collapsed at depth < 2 by default.  If the
+user expands nodes and then the console re-renders (e.g. new message arrives),
+the expansion state resets.
+
+**Discussion:** This is a pre-existing behaviour shared with small-payload
+JSON messages.  Not introduced by this change.  Addressed if/when the JsonView
+integration is upgraded to a stateful alternative.  Defer.
+
+### Q3 — Size threshold feedback
+**Question:** Should the console message for the fetched payload show the byte
+size reported by the notification?
+
+**Discussion:** The raw JSON string itself conveys its size implicitly.  The
+notification row above it already shows the byte count.  Showing it again
+would be redundant.  Defer as a potential UX polish item.

--- a/extensions/minigraph-playground-engine/webapp/docs/SPEC-mock-data-upload-modal.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/SPEC-mock-data-upload-modal.md
@@ -1,0 +1,1371 @@
+# SPEC — Mock-Data Upload Modal
+
+**Feature:** When the server responds to a command like `upload mock data` with a
+`"You may upload JSON payload -> POST /api/mock/<id>"` message, intercept that
+message in the console and **automatically open a modal dialog** so the user
+perceives the command itself as the upload action. The modal lets the user paste
+a JSON payload and POST it to the provided URL.
+
+**Status:** Implemented — file-upload extension added March 20 2026  
+**Branch:** `feature/playground`  
+**Last updated:** March 20 2026
+
+---
+
+## Table of Contents
+
+1. [Motivation & Scope](#1-motivation--scope)
+2. [Server Contract](#2-server-contract)
+3. [UX Flow](#3-ux-flow)
+4. [Architecture Overview](#4-architecture-overview)
+5. [Layer-by-Layer Design](#5-layer-by-layer-design)
+   - 5.1 [`messageParser.ts` — new predicate & extractor](#51-messageparserts--new-predicate--extractor)
+   - 5.2 [`useAutoMockUpload` hook — auto-open trigger](#52-useautomockupload-hook--auto-open-trigger)
+   - 5.3 [`ConsoleMessage.tsx` — upload-link row treatment](#53-consolemessagetsx--upload-link-row-treatment)
+   - 5.4 [`MockUploadModal` component](#54-mockuploadmodal-component)
+   - 5.5 [`useMockUpload` hook — fetch lifecycle](#55-usemockupload-hook--fetch-lifecycle)
+   - 5.6 [`Playground.tsx` — wiring](#56-playgroundtsx--wiring)
+6. [CSS & Theming](#6-css--theming)
+7. [Accessibility](#7-accessibility)
+8. [Error Handling](#8-error-handling)
+9. [Resolved Decisions](#9-resolved-decisions)
+10. [Files Changed / Created](#10-files-changed--created)
+11. [What Is Explicitly Out of Scope](#11-what-is-explicitly-out-of-scope)
+
+---
+
+## 1. Motivation & Scope
+
+### The analogous existing feature
+
+The **large-payload download** flow (`useLargePayloadDownload`) detects a pattern in
+the message stream, takes autonomous action (a `GET` fetch), and surfaces the result
+back in the console — all without any new UI widget.
+
+This feature is the **upload mirror**: the server emits an upload invitation in the
+stream, we detect it, and instead of acting autonomously we need user-supplied JSON
+data. A modal is the right affordance because:
+
+- The Minigraph playground intentionally has **no payload editor tab** (its right
+  panel shows `preview`, `graph`, `graph-data`). There is nowhere else to put a
+  multi-line text input.
+- The payload is ephemeral and context-specific to the upload invitation. Writing it
+  to localStorage (as the JSON-Path playground does) would be misleading.
+- The action is driven by a specific server response, not a standing toolbar button,
+  so a transient overlay is the natural fit.
+
+### Scope
+
+| In scope | Out of scope |
+|---|---|
+| Detecting the `POST /api/mock/<id>` pattern | Detecting other arbitrary `POST` patterns |
+| Opening a modal with a textarea | Adding a payload tab to the Minigraph playground |
+| Validating JSON before sending | XML upload support (deferred — see §9.3) |
+| `POST`-ing the payload and surfacing the result | Retry logic beyond a single attempt |
+| Accessible, keyboard-navigable modal | Full i18n / localisation |
+| Drag-and-drop a `.json` file onto the drop zone | Uploading non-JSON file types |
+| "Browse file…" button to open the system file-picker | Multi-file selection |
+| Client-side file validation (extension + JSON parse check) | Server-side file validation feedback beyond HTTP status |
+
+---
+
+## 2. Server Contract
+
+### Trigger message pattern
+
+```
+You may upload JSON payload -> POST /api/mock/{id}
+```
+
+The `{id}` segment is an alphanumeric + hyphen token (same shape as websocket session
+ids elsewhere in the app, e.g. `ws-417669-24`).
+
+**Regex** (new function `extractMockUploadPath` in `messageParser.ts`):
+
+```typescript
+const match = raw.match(/You may upload .*?->\s*POST\s+(\/api\/mock\/[\w-]+)/i);
+```
+
+> **Note on pattern breadth:** The regex is intentionally anchored to `/api/mock/`
+> (not a generic POST capture) to avoid false positives from future unrelated
+> messages. The case-insensitive flag handles any minor casing variation the server
+> might introduce.
+
+### Expected HTTP exchange
+
+```
+POST {uploadPath}
+Content-Type: application/json
+
+{ …user payload… }
+```
+
+The server is expected to return `2xx` on success and a non-`2xx` status on failure.
+
+On **failure**, the response body is included in the inline error banner and toast:
+`"Upload failed: HTTP 400 — <server response body>"`.
+
+On **success**, the response body is read (to drain the connection) but is **not
+surfaced** in the console or toast. The toast always shows the hardcoded message
+`'Mock data uploaded successfully ✓'` for consistency, regardless of what the
+server returns. `_responseBody` / `responseBody` is available in `handleUploadSuccess`
+in `Playground.tsx` but intentionally unused (see §5.6).
+
+---
+
+## 3. UX Flow
+
+```
+1. User types: upload mock data
+   Console echoes: > upload mock data
+
+2. Server responds:
+   "You may upload JSON payload -> POST /api/mock/ws-417669-24"
+
+3. useAutoMockUpload detects the new message (watermark-guarded, same pattern
+   as useAutoGraphRefresh / useAutoMarkdownPin).
+   → Calls onOpenModal("/api/mock/ws-417669-24") automatically.
+   → Modal opens immediately, focused on the textarea.
+   The user perceives the upload command itself as having triggered the dialog —
+   no extra click required.
+
+4. Meanwhile, ConsoleMessage renders the invitation row with:
+   - ⬆️  icon (amber accent — mirrors the ⬇️ for large-payload download)
+   - Amber row highlight
+   - An "⬆️ Upload JSON…" re-open button visible on hover/focus
+     (This is a RE-OPEN affordance for after the modal is dismissed, not
+      the primary trigger.  The primary trigger is the auto-open in step 3.)
+
+5. Modal contents:
+   ┌─────────────────────────────────────────────────────┐
+   │  ⬆️ Upload Mock Data                            ✕  │
+   │  POST /api/mock/ws-417669-24                        │
+   ├─────────────────────────────────────────────────────┤
+   │  📂  Drop a .json file here                         │
+   │          — or —                                     │
+   │          [Browse file…]                             │
+   │                                                     │
+   │  JSON Payload                                       │
+   │  ┌───────────────────────────────────────────────┐  │
+   │  │ {                                             │  │
+   │  │   "key": "value"                              │  │
+   │  │ }                                             │  │
+   │  └───────────────────────────────────────────────┘  │
+   │  ⚠️ Invalid JSON — check syntax                     │
+   │  ⌘+Enter to upload                                  │
+   │                                                     │
+   │  [Format]               [Cancel]  [Upload ▶]        │
+   └─────────────────────────────────────────────────────┘
+
+6. User provides JSON via one of three methods:
+
+   **a. Type / paste** directly into the textarea.
+
+   **b. Drag-and-drop a `.json` file** onto the drop zone:
+      - Drop zone gains an amber active-drag highlight while a file is held over it.
+      - On drop: file extension and MIME type are validated client-side.
+        If invalid → `fileError` banner shown below the drop zone; textarea unchanged.
+        If valid   → file is read as UTF-8 text, validated as JSON object/array
+                     via `tryParseJSON`, pretty-printed via `formatJSON`, and loaded
+                     into the textarea. Focus returns to the textarea.
+
+   **c. Click "Browse file…"** to open the system file-picker (accepts `.json` only).
+      Same validation and load path as drag-and-drop.
+
+   Inline JSON validation runs on every textarea keystroke
+   (`tryParseJSON` — JSON-only, not `validatePayload` which also accepts XML).
+   "Format" button pretty-prints valid JSON in-place (reuses `formatJSON`).
+   Ctrl+Enter / Cmd+Enter submits without leaving the textarea.
+
+7. User clicks "Upload ▶" (or presses Ctrl+Enter / Cmd+Enter).
+   → Button shows spinner / disabled state while the fetch is in-flight.
+   → Modal stays open until the response arrives.
+
+8a. Success (2xx):
+    → Modal closes automatically.
+    → Toast: "Mock data uploaded successfully ✓"  (success, 3 s auto-dismiss)
+    → Console row gains a ✅ badge (persists for the session).
+
+8b. Error (non-2xx or network failure):
+    → Modal stays open.
+    → Inline error banner below the textarea:
+      "Upload failed: HTTP 400 — <server response body>"
+    → Toast: "Upload failed: …"  (error)
+    → User can edit and retry, or Cancel.
+
+9. Pressing Escape or clicking the backdrop closes the modal (same as Cancel).
+   Any in-flight fetch is aborted via AbortController.
+   The "⬆️ Upload JSON…" button on the console row remains available to
+   re-open the modal for the same endpoint.
+```
+
+---
+
+## 4. Architecture Overview
+
+```
+messageParser.ts
+  extractMockUploadPath(raw)  ← new
+  isMockUploadMessage(raw)    ← new
+
+useAutoMockUpload              ← new hook (message-stream watcher, auto-open)
+  watches messages for isMockUploadMessage
+  calls onOpenModal(path) when a new invitation arrives
+  follows watermark + disconnect-guard pattern of useAutoGraphRefresh
+
+ConsoleMessage.tsx
+  detects isMockUploadMessage → renders ⬆️ row + "⬆️ Upload JSON…" RE-OPEN button
+  onUploadMockData?: (uploadPath: string) => void  ← new prop (re-open)
+
+MockUploadModal/
+  MockUploadModal.tsx          ← new component
+  MockUploadModal.module.css   ← new styles
+
+useMockUpload.ts               ← new hook (owns the fetch + abort logic)
+
+Playground.tsx
+  useState: modalUploadPath (string | null)
+  handleOpenUploadModal(path)  → sets modalUploadPath
+  handleCloseUploadModal()     → clears modalUploadPath
+  useAutoMockUpload wired here → auto-opens on new invitation message
+  passes onUploadMockData={handleOpenUploadModal} down for the re-open button:
+    LeftPanel → Console → ConsoleMessage
+  renders <MockUploadModal> when modalUploadPath !== null
+```
+
+**Two-trigger, one modal:**  The modal is opened either (a) automatically by
+`useAutoMockUpload` when the server message arrives, or (b) manually by the
+user clicking the "⬆️ Upload JSON…" re-open button on the console row. Both
+paths call the same `handleOpenUploadModal(path)` callback, so the modal
+implementation is unaffected by how it was opened.
+
+The pattern is deliberately **component-local**: the modal path lives in `Playground`
+state (not context, not localStorage), matching the same scoping decision used for
+`pinnedGraphPath` and `pinnedMessageId`.
+
+---
+
+## 5. Layer-by-Layer Design
+
+### 5.1 `messageParser.ts` — new predicate & extractor
+
+Add two exported functions after the existing `extractUploadPath` block:
+
+```typescript
+/**
+ * Extracts the POST path from a mock-data upload invitation:
+ *   "You may upload JSON payload -> POST /api/mock/{id}"
+ *
+ * Returns the path (e.g. "/api/mock/ws-417669-24") or null.
+ */
+export function extractMockUploadPath(raw: string): string | null {
+  const match = raw.match(/You may upload .*?->\s*POST\s+(\/api\/mock\/[\w-]+)/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Returns true when a raw WebSocket message is a mock-data upload invitation.
+ * Used by useAutoMockUpload (auto-open) and ConsoleMessage.tsx (re-open button).
+ */
+export function isMockUploadMessage(raw: string): boolean {
+  return extractMockUploadPath(raw) !== null;
+}
+```
+
+**Why a separate extractor instead of reusing `extractUploadPath`?**  
+`extractUploadPath` matches `/api/json/content/{id}` — the JSON-Path playground's
+two-step upload handshake. The new path is `/api/mock/{id}`. Keeping them separate
+maintains a clean separation of the two server protocols and avoids a fragile
+shared regex.
+
+#### Cross-hook and cross-component interaction: two required guards
+
+Introducing `isMockUploadMessage` requires **two separate fixes** — one in a hook and one in a component. Both must be implemented; missing either one causes a different bug.
+
+**Fix A — `useAutoMarkdownPin.ts`:** The upload invitation is plain text, so `isMarkdownCandidate` returns `true` for it. If `waitingForResponseRef` is armed (e.g. the user sent `help` and then quickly ran `upload mock data` before the help response arrived), `isPinnableResponse` would steal the invitation and pin it to the Developer Guides tab.
+
+Add `isMockUploadMessage` as an exclusion inside `isPinnableResponse` in `useAutoMarkdownPin.ts`:
+
+```typescript
+// BEFORE (in useAutoMarkdownPin.ts):
+function isPinnableResponse(raw: string): boolean {
+  if (raw.startsWith('> ')) return false;
+  if (isGraphLinkMessage(raw)) return false;
+  return isMarkdownCandidate(raw);
+}
+
+// AFTER:
+function isPinnableResponse(raw: string): boolean {
+  if (raw.startsWith('> ')) return false;
+  if (isGraphLinkMessage(raw)) return false;
+  if (isMockUploadMessage(raw)) return false;   // ← new: don't steal upload invitations
+  return isMarkdownCandidate(raw);
+}
+```
+
+This file (`useAutoMarkdownPin.ts`) must be added to §10 (Files Changed).
+
+**Fix B — `ConsoleMessage.tsx`:** The same plain-text nature of the invitation means `isMarkdownCandidate(message)` returns `true`, which would cause the existing `isPinnable` derivation to add `role="button"` and `onClick` to the invitation row — alongside the `canUploadMock` re-open button — creating a nested interactive element that violates WCAG. This fix is documented in detail in §5.3. Both fixes are required; §5.3 must not be treated as optional.
+
+> **For implementors reading §5.1 in isolation:** do not stop after adding the `useAutoMarkdownPin` guard. See §5.3 for the mandatory `isPinnable` fix in `ConsoleMessage.tsx`.
+
+---
+
+### 5.2 `useAutoMockUpload` hook — auto-open trigger
+
+**Location:** `src/hooks/useAutoMockUpload.ts`
+
+Follows the **identical pattern** to `useAutoMarkdownPin` and `useAutoGraphRefresh`:
+message-ID watermark set at mount, disconnect guard, main effect scanning only
+new messages.
+
+```typescript
+export interface UseAutoMockUploadOptions {
+  messages:    { id: number; raw: string }[];
+  connected:   boolean;
+  onOpenModal: (uploadPath: string) => void;
+}
+```
+
+#### Implementation outline
+
+```typescript
+import { useEffect, useRef } from 'react';
+import { extractMockUploadPath, isMockUploadMessage } from '../utils/messageParser';
+
+export interface UseAutoMockUploadOptions {
+  messages:    { id: number; raw: string }[];
+  /**
+   * Included for interface symmetry with the other automation hooks and for
+   * future extensibility (e.g. disabling the re-open button when disconnected).
+   * No disconnect-guard effect body is needed in this hook — see key decisions below.
+   */
+  connected:   boolean;
+  onOpenModal: (uploadPath: string) => void;
+}
+
+export function useAutoMockUpload({
+  messages,
+  connected: _connected,   // accepted but not read in any effect body — see decisions
+  onOpenModal,
+}: UseAutoMockUploadOptions): void {
+
+  const watermarkRef = useRef<number>(-1);
+
+  // ── Set watermark at mount — never replay history ─────────────────────────
+  // MUST be declared before the main effect so React fires it first on the
+  // initial render, matching the ordering guarantee used by useLargePayloadDownload
+  // and useAutoGraphRefresh.  If the main effect ran first on mount, watermarkRef
+  // would be -1 and every existing message would be scanned, potentially
+  // auto-opening the modal for a stale invitation from a previous session.
+  useEffect(() => {
+    if (messages.length > 0) {
+      watermarkRef.current = messages[messages.length - 1].id;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Main effect ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    const newMessages = messages.filter(m => m.id > watermarkRef.current);
+    if (newMessages.length === 0) return;
+
+    watermarkRef.current = messages[messages.length - 1].id;
+
+    for (const msg of newMessages) {
+      const path = extractMockUploadPath(msg.raw);
+      if (!path) continue;
+
+      // Open the modal for the first invitation found in this batch.
+      // If multiple invitations arrive in one tick (unlikely), only the
+      // first is acted upon — consistent with the "break on first match"
+      // pattern used by useLargePayloadDownload.
+      onOpenModal(path);
+      break;
+    }
+  }, [messages, onOpenModal]);
+}
+```
+
+#### Key design decisions
+
+| Decision | Rationale |
+|---|---|
+| No `waitingForRef` flag | Unlike `useAutoGraphRefresh` there is no two-step server handshake. The invitation message itself contains the complete target URL — open immediately. |
+| Watermark **not** reset on disconnect | The hook has no pending-wait flag to clear. Resetting the watermark to `-1` on disconnect would cause old invitation messages still in the message store to be replayed as "new" on reconnect, auto-opening the modal for a stale endpoint. The watermark stays at its current value; the server sends a fresh invitation for each new session. |
+| `connected` accepted but not read | `connected` is destructured with an `_connected` alias (TypeScript unused-param suppression). It is accepted in the interface for symmetry with the other automation hooks and future extensibility (e.g. disabling the re-open button when disconnected). No effect body reads or depends on it. |
+| `onOpenModal` is the only callback | The hook has no knowledge of the modal or `Playground` state — it only calls a callback. This keeps the hook unit-testable and the Playground the single source of truth for modal open/close. |
+| Break on first match | Consistent with `useLargePayloadDownload`. Prevents two modals from stacking if the server sends two invitations in one message batch. |
+
+---
+
+### 5.3 `ConsoleMessage.tsx` — upload-link row treatment
+
+The button on this row is a **re-open** affordance. The modal will already be open
+(auto-opened by `useAutoMockUpload`) when the row first renders — the button
+becomes useful only after the user has dismissed the modal and wants to return
+to the same upload endpoint.
+
+#### New props (exact additions to `ConsoleMessageProps`)
+
+```typescript
+/**
+ * When provided, a "⬆️ Upload JSON…" re-open button appears on hover for
+ * mock-upload invitation rows. Called with the extracted POST path.
+ * Only rendered when isMockUploadMessage(message) is true.
+ */
+onUploadMockData?:      (uploadPath: string) => void;
+/**
+ * Set of POST paths for which a mock upload has succeeded this session.
+ * Used to render the ✅ badge on fulfilled invitation rows.
+ */
+successfulUploadPaths?: Set<string>;
+```
+
+> **Note:** Both props are optional (`?`) to match the existing convention for
+> feature-specific callbacks (`onSendToJsonPath?`, `onPin?`).
+> `Console.tsx` and `LeftPanel.tsx` pass them through unconditionally when provided
+> by `Playground`. The exact prop additions for those components:
+>
+> ```typescript
+> // Console.tsx — add to ConsoleProps:
+> onUploadMockData?:      (uploadPath: string) => void;
+> successfulUploadPaths?: Set<string>;
+>
+> // LeftPanel.tsx — add to LeftPanelProps:
+> onUploadMockData?:      (uploadPath: string) => void;
+> successfulUploadPaths?: Set<string>;
+> ```
+
+#### New derived flags (alongside existing `isGraphLink`, `isLargePayload`)
+
+```typescript
+const isMockUpload   = isMockUploadMessage(message);
+const mockUploadPath = isMockUpload ? extractMockUploadPath(message) : null;
+const canUploadMock  = !!onUploadMockData && isMockUpload && mockUploadPath !== null;
+```
+
+> **⚠️ Critical: `isPinnable` guard**  
+> `isMockUploadMessage` returns `true` for a plain-text string, so
+> `isMarkdownCandidate(message)` is also `true` for the invitation row. Without an
+> explicit exclusion, the existing `isPinnable` derivation would assign
+> `role="button"`, `onClick`, and `onKeyDown` to the row div *in addition to* the
+> `canUploadMock` re-open button — creating a nested interactive element that
+> violates WCAG and the spec's own accessibility rule (§7).
+>
+> The `isPinnable` line **must** include `&& !isMockUpload`:
+
+```typescript
+// BEFORE (existing):
+const isPinnable = !!onPin && (!isGraphLink ? isMarkdownCandidate(message) : true);
+
+// AFTER (with mock-upload exclusion):
+const isPinnable = !!onPin && !isMockUpload && (!isGraphLink ? isMarkdownCandidate(message) : true);
+```
+
+> This is consistent with `isLargePayload` rows, which are also non-pinnable
+> (they have their own affordance — the browser download — and no `role="button"`).
+> The mock-upload row's sole interactive element is the `canUploadMock` button.
+
+#### Icon
+
+```typescript
+// In the icon span — isMockUpload checked before isLargePayload:
+{isMockUpload ? '⬆️' : isLargePayload ? '⬇️' : isGraphLink ? '🕸️' : icon}
+```
+
+#### CSS class on the row
+
+```typescript
+isMockUpload ? styles.consoleMessageMockUpload : '',
+```
+
+#### "⬆️ Upload JSON…" re-open button (mirrors the existing ➡️ button)
+
+```tsx
+{canUploadMock && (
+  <button
+    className={styles.uploadMockButton}
+    onClick={(e) => { e.stopPropagation(); onUploadMockData!(mockUploadPath!); }}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault(); e.stopPropagation();
+        onUploadMockData!(mockUploadPath!);
+      }
+    }}
+    title="Re-open upload dialog for this endpoint"
+    aria-label={`Re-open upload dialog for ${mockUploadPath}`}
+    tabIndex={0}
+  >
+    ⬆️ Upload JSON…
+  </button>
+)}
+```
+
+The row itself is **not** given `role="button"` — the explicit labelled button is
+the sole interactive element, avoiding the nested-interactive-element accessibility
+conflict. This is consistent with the large-payload `⬇️` row (which also has no
+row-level click handler).
+
+#### Success badge
+
+After a successful upload, `Playground` passes `successfulUploadPaths: Set<string>`
+(keyed by upload path) down the prop chain. When `successfulUploadPaths.has(mockUploadPath)` is true, a `✅` span is rendered at the end of the row's message
+text. This is session-only (resets on `clearMessages`).
+
+> **Note on the `✅` glyph:** This intentionally reuses the same emoji as the
+> copy-button's "copied" confirmation state (`copyButtonCopied` in
+> `ConsoleMessage`). The two are semantically distinct (one confirms a clipboard
+> copy action, the other marks a fulfilled upload invitation) but visually
+> identical. This is intentional — no new icon is introduced.
+
+---
+
+### 5.4 `MockUploadModal` component
+
+**Location:** `src/components/MockUploadModal/MockUploadModal.tsx`  
+**Styles:** `src/components/MockUploadModal/MockUploadModal.module.css`
+
+#### Required imports
+
+```typescript
+import { useState, useEffect, useRef, useCallback } from 'react';
+import styles from './MockUploadModal.module.css';
+import { tryParseJSON } from '../../utils/messageParser';
+import { formatJSON } from '../../utils/validators';
+import { useMockUpload } from '../../hooks/useMockUpload';
+```
+
+#### Props
+
+```typescript
+interface MockUploadModalProps {
+  /** The POST path extracted from the server message, e.g. "/api/mock/ws-417669-24" */
+  uploadPath: string;
+  /** Called when the user cancels or the upload succeeds (modal self-closes on success). */
+  onClose: () => void;
+  /** Called with the raw response body text on a successful upload. */
+  onSuccess: (responseBody: string) => void;
+  /** Called with an error message on failure — modal stays open. */
+  onError: (errorMessage: string) => void;
+}
+```
+
+#### Internal state
+
+```typescript
+const [json,        setJson]        = useState('');
+const [uploadError, setUploadError] = useState<string | null>(null);
+const [fileError,   setFileError]   = useState<string | null>(null);  // ← new
+const [isDragOver,  setIsDragOver]  = useState(false);                // ← new
+```
+
+`fileError` is separate from `uploadError`:
+- `fileError` — set by the client-side file validator (`validateFileType` /
+  `readFileAsText` / `tryParseJSON`) when a dragged or browsed file is rejected.
+  Displayed below the drop zone with `var(--warning-color)` (amber — not a hard
+  failure, just "try a different file"). Cleared when the user types in the textarea
+  or successfully loads another file.
+- `uploadError` — set by the `useMockUpload` `onError` callback when the HTTP
+  request fails. Displayed in the red error banner below the textarea.
+
+`isDragOver` drives the `.dropZoneActive` CSS class on the drop zone div —
+toggled by the `dragover` / `dragleave` events.
+
+> **Error ownership:**  
+> `isUploading` is **not** local state — it is read from `useMockUpload`'s return
+> value (see §5.5). `uploadError` is local state, set by the component's own
+> `onError` handler that wraps the `useMockUpload` `onError` callback:
+>
+> ```typescript
+> const { isUploading, upload, cancel } = useMockUpload({
+>   uploadPath,
+>   json,
+>   onSuccess,                     // prop — forwarded straight to Playground
+>   onError: (msg) => {
+>     setUploadError(msg);          // ← set inline banner (local state)
+>     onError(msg);                 // ← call prop so Playground fires a toast
+>   },
+> });
+> ```
+>
+> `uploadError` is cleared at the start of each new upload attempt:
+> ```typescript
+> const handleUpload = () => {
+>   setUploadError(null);
+>   upload();
+> };
+> ```
+> This ensures a stale error from a previous attempt is not shown while a retry
+> is in-flight.
+
+#### File loading — `loadFile(file: File)` (shared by drop and picker)
+
+```typescript
+/** Read a File as text, resolving with the string or rejecting with an Error. */
+function readFileAsText(file: File): Promise<string>
+
+/**
+ * Validate that a dropped / selected file is acceptable.
+ * Accepts .json extension OR application/json MIME type.
+ * Returns null on success, or a human-readable error string on failure.
+ */
+function validateFileType(file: File): string | null
+```
+
+Both helper functions are module-level (outside the component) — they are pure
+and have no dependency on React state. `loadFile` is a `useCallback` inside the
+component that calls them in sequence:
+
+```
+validateFileType(file)
+  → error? → setFileError + return
+  → ok
+readFileAsText(file)
+  → error? → setFileError + return
+  → ok
+tryParseJSON(text)
+  → not JSON? → setFileError(`"${file.name}" contains invalid JSON.`) + return
+  → ok
+setJson(formatJSON(text))   ← pretty-print on load
+textareaRef.current?.focus()
+```
+
+Key decisions:
+- File is pretty-printed on load (`formatJSON`) so the user sees clean output
+  without having to click Format manually.
+- Both drag-and-drop and the file-picker share the same `loadFile` path — no
+  duplicated logic.
+- The file input is reset (`e.target.value = ''`) after each selection so the
+  same file can be re-selected after a fix.
+
+#### Drop zone
+
+```tsx
+<div
+  className={`${styles.dropZone} ${isDragOver ? styles.dropZoneActive : ''}`}
+  onDragOver={handleDragOver}
+  onDragLeave={handleDragLeave}
+  onDrop={handleDrop}
+  aria-label="Drop a JSON file here"
+>
+  <span className={styles.dropZoneIcon}>📂</span>
+  <span className={styles.dropZoneText}>Drop a <code>.json</code> file here</span>
+  <span className={styles.dropZoneOr}>— or —</span>
+  <input
+    ref={fileInputRef}
+    type="file"
+    accept=".json,application/json"
+    className={styles.fileInputHidden}
+    aria-hidden="true"
+    tabIndex={-1}
+    onChange={handleFileInputChange}
+  />
+  <button type="button" className={styles.browseButton}
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isUploading}>
+    Browse file…
+  </button>
+</div>
+```
+
+- The `<input type="file">` is hidden (`display: none`) and triggered
+  programmatically from the "Browse file…" button via `fileInputRef.current?.click()`.
+  This gives full style control over the button while retaining native file-picker
+  behaviour (including keyboard-accessible activation via Enter/Space on the button).
+- `dragLeave` is guarded: `setIsDragOver(false)` only fires when leaving the drop
+  zone container itself (checking `relatedTarget` against `e.currentTarget.contains()`),
+  not when moving between child elements inside the zone.
+
+Uses `tryParseJSON(json)` from `messageParser.ts` directly — **not** `validatePayload`
+from `validators.ts`. This is intentional: `validatePayload` accepts both JSON and XML
+(per the JSON-Path playground's requirements), but the mock-upload endpoint is
+JSON-only. Using `tryParseJSON` gives a clean boolean `isJSON` result without
+a false-positive for valid XML.
+
+```typescript
+const jsonResult  = tryParseJSON(json);
+const isValidJson = jsonResult.isJSON;
+const canSubmit   = isValidJson && !isUploading && json.trim() !== '';
+```
+
+> **Note:** `tryParseJSON` returns `isJSON: false` for JSON primitives (`42`,
+> `"hello"`, `true`, `null`). These are **intentionally blocked** by the
+> `isValidJson` gate — the mock endpoint expects an object or array, and the server
+> would reject a bare primitive with a `4xx` error anyway. This is consistent with
+> the existing JSON-Path textarea behaviour.
+
+- `!isValidJson && json.trim() !== ''` → show inline validation message (`role="status"`):
+  `"⚠️ Invalid JSON — check syntax"`.
+- "Format" button calls `formatJSON(json)` (imported from `../../utils/validators`) and replaces the textarea value.
+  It is **only enabled when `isValidJson` is true** — `formatJSON` silently returns
+  the original string on invalid JSON (no-op), so gating on validity prevents a
+  confusing "Format clicked, nothing changed" experience.
+- "Upload ▶" button is disabled while `!isValidJson || isUploading || json.trim() === ''`.
+
+#### Keyboard shortcut
+
+`Ctrl+Enter` (Windows/Linux) and `Cmd+Enter` (macOS) submit the form while focus
+is in the textarea. Plain `Enter` inserts a newline (standard textarea behaviour —
+essential for pasting multi-line JSON). The `onKeyDown` handler:
+
+```typescript
+const handleTextareaKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    if (canSubmit) handleUpload();
+  }
+};
+```
+
+A small hint line below the textarea reads:
+`Ctrl+Enter to upload` (or `⌘+Enter to upload` on macOS).
+
+`isMac` is derived with a modern-first, legacy-fallback approach:
+
+```typescript
+// navigator.platform is deprecated but still widely supported; use
+// navigator.userAgentData?.platform (available in Chromium-based browsers)
+// as the preferred source and fall back for Firefox / Safari.
+const isMac =
+  (navigator.userAgentData?.platform ?? navigator.platform)
+    .toLowerCase()
+    .includes('mac');
+```
+
+This is a single expression at the top of the component; no hook is needed.
+
+#### Focus management
+
+- **On open:** `useEffect` calls `textareaRef.current?.focus()` after the `<dialog>`
+  is shown (after `dialogRef.current.showModal()`).
+- **On close:** Focus is returned to the element that triggered the open.
+  This responsibility lives entirely in **`Playground.tsx`** — `MockUploadModal`
+  has no `triggerRef` prop and does not call `.focus()` itself. The modal simply
+  calls its `onClose` prop; `Playground`'s `handleCloseUploadModal` (and
+  `handleUploadSuccess`) perform the focus restore after the dialog has been
+  removed from the DOM.
+
+  > **Why Playground owns focus-return:**  
+  > This is consistent with how all other side-effect callbacks in the codebase
+  > flow upward to `Playground` — the component stays a pure renderer.  
+  > Passing a `triggerRef` down as a prop would create a back-channel from
+  > `Playground` state into the component's close handler, coupling them in a
+  > way that is harder to test and reason about.
+
+```typescript
+// In Playground.tsx — capture the trigger BEFORE setting modal state:
+const modalTriggerRef = useRef<HTMLElement | null>(null);
+
+const handleOpenUploadModal = useCallback((path: string) => {
+  modalTriggerRef.current = document.activeElement as HTMLElement;
+  setModalUploadPath(path);
+}, []);
+
+// Both close paths restore focus via setTimeout (dialog must be gone first):
+const handleCloseUploadModal = useCallback(() => {
+  setModalUploadPath(null);
+  setTimeout(() => modalTriggerRef.current?.focus(), 0);
+}, []);
+
+const handleUploadSuccess = useCallback((_responseBody: string) => {
+  setSuccessfulUploadPaths(prev => new Set([...prev, modalUploadPath!]));
+  setModalUploadPath(null);
+  setTimeout(() => modalTriggerRef.current?.focus(), 0);
+  addToast('Mock data uploaded successfully ✓', 'success');
+}, [modalUploadPath, addToast]);
+```
+
+```tsx
+// MockUploadModal — handleClose simply delegates to the prop:
+const handleClose = () => {
+  onClose();   // Playground restores focus; the component does nothing extra.
+};
+```
+
+#### Layout sketch
+
+```tsx
+<dialog ref={dialogRef} aria-modal="true" aria-labelledby="modal-title"
+        onClick={handleBackdropClick} onCancel={handleClose}>
+  <div className={styles.modalHeader}>
+    <h2 id="modal-title" className={styles.modalTitle}>Upload JSON Payload</h2>
+    <code className={styles.modalPath}>{uploadPath}</code>
+    <button className={styles.closeButton} aria-label="Close" onClick={handleClose}>✕</button>
+  </div>
+  <div className={styles.modalBody}>
+    <textarea
+      ref={textareaRef}
+      className={styles.textarea}
+      value={json}
+      onChange={e => setJson(e.target.value)}
+      onKeyDown={handleTextareaKeyDown}
+      placeholder={'{\n  "key": "value"\n}'}
+      aria-label="JSON payload"
+      aria-describedby={uploadError ? 'upload-error' : undefined}
+      spellCheck={false}
+    />
+    {uploadError && (
+      <p id="upload-error" className={styles.errorBanner} role="alert">
+        ❌ {uploadError}
+      </p>
+    )}
+    {!isValidJson && json.trim() !== '' && (
+      <p className={styles.validationError} role="status">
+        ⚠️ Invalid JSON — check syntax
+      </p>
+    )}
+    <p className={styles.keyboardHint}>
+      {isMac ? '⌘+Enter' : 'Ctrl+Enter'} to upload
+    </p>
+  </div>
+  <div className={styles.modalFooter}>
+    <button className={styles.formatButton} onClick={handleFormat}
+      disabled={!isValidJson || json.trim() === ''}>
+      Format
+    </button>
+    <div className={styles.footerActions}>
+      <button className={styles.cancelButton} onClick={handleClose}>Cancel</button>
+      <button className={styles.uploadButton} onClick={handleUpload}
+        disabled={!canSubmit}
+        aria-busy={isUploading}
+        aria-label={isUploading ? 'Uploading…' : `Upload to ${uploadPath}`}>
+        {isUploading ? '⏳ Uploading…' : 'Upload ▶'}
+      </button>
+    </div>
+  </div>
+</dialog>
+```
+
+> **Layout sketch notes for implementors:**
+> - All `class=` attributes are JSX `className=` using CSS Module references
+>   (`styles.<ruleName>`), as shown above. The pseudocode has been updated to reflect this.
+> - Inline validation uses `!isValidJson` (derived from `tryParseJSON` — not a `validation`
+>   object). The error string is hardcoded to `"⚠️ Invalid JSON — check syntax"` per §3 UX
+>   Flow step 6. `validatePayload` / `ValidationResult` are **not** imported by this component.
+
+#### Implementation notes
+
+- **Native `<dialog>`** with `.showModal()` called via `useEffect` on mount gives
+  the browser's built-in focus-trap and backdrop for free. **`.close()` is NOT
+  called explicitly** — the component is unmounted (via Playground's
+  `{modalUploadPath && ...}` conditional) which implicitly removes the dialog from
+  the DOM; calling `.close()` after `onClose()` would produce a "dialog already
+  closed" warning.
+- **Backdrop click:** `dialog` click handler checks `e.target === dialogRef.current`
+  to distinguish backdrop from inner content clicks; fires `handleClose`.
+- **`onCancel`** event (fired by browser on Escape) calls `handleClose` →
+  `onClose()` → `setModalUploadPath(null)` in Playground → component unmounts.
+  Do **not** call `dialogRef.current.close()` in `handleClose` — the unmount
+  handles it.
+- **`isMac`** is derived from `(navigator.userAgentData?.platform ?? navigator.platform).toLowerCase().includes('mac')`. `navigator.platform` is deprecated; `userAgentData.platform` is preferred (Chromium) with `navigator.platform` as the Safari/Firefox fallback. A single expression at the top of the component; no new hook required.
+
+---
+
+### 5.5 `useMockUpload` hook — fetch lifecycle
+
+**Location:** `src/hooks/useMockUpload.ts`
+
+This hook owns the `fetch` lifecycle — keeping it out of the component keeps
+`MockUploadModal` a pure renderer.
+
+```typescript
+export interface UseMockUploadOptions {
+  uploadPath: string;
+  json:       string;
+  /** Called with the raw response body text on a 2xx response. */
+  onSuccess:  (responseBody: string) => void;
+  /** Called with a formatted error string on network failure or non-2xx. Modal stays open. */
+  onError:    (message: string) => void;
+}
+
+export interface UseMockUploadReturn {
+  isUploading: boolean;
+  upload:      () => void;
+  cancel:      () => void;
+}
+```
+
+#### Implementation outline
+
+```typescript
+export function useMockUpload({
+  uploadPath, json, onSuccess, onError,
+}: UseMockUploadOptions): UseMockUploadReturn {
+
+  // isUploading lifecycle:
+  //   false  → initial / idle
+  //   true   → set immediately before fetch starts (in `upload()`)
+  //   false  → reset in .then() (success), .catch() (non-abort error), and
+  //            the unmount cleanup below (abort-via-unmount path)
+  const [isUploading, setIsUploading] = useState<boolean>(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const upload = useCallback(() => {
+    abortRef.current?.abort();                         // cancel any previous attempt
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // Re-serialise through JSON.parse to normalise whitespace before sending.
+    // Wrapped in try/catch to guard against the edge case where `json` state
+    // changes between the component's isValidJson check and this callback firing
+    // (e.g. a React batched state update in the same tick).  Matches the pattern
+    // used in useWebSocket.ts for the JSON-Path playground upload.
+    let body: string;
+    try {
+      body = JSON.stringify(JSON.parse(json));
+    } catch {
+      setIsUploading(false);
+      onError('Invalid JSON — cannot send');
+      return;
+    }
+
+    setIsUploading(true);                              // ← true before fetch
+
+    fetch(uploadPath, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        // Always read the response body to drain the connection.
+        // On 4xx/5xx it may contain a useful server error message.
+        // On 2xx the body is passed to onSuccess — see note below.
+        const responseBody = await res.text();
+        if (!res.ok) throw new Error(`HTTP ${res.status}${responseBody ? ` — ${responseBody}` : ''}`);
+        setIsUploading(false);                         // ← false on success
+        abortRef.current = null;
+        // responseBody is available here but Playground intentionally does not
+        // surface it — the toast always shows the hardcoded
+        // 'Mock data uploaded successfully ✓' message for consistency.
+        onSuccess(responseBody);
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return;
+        setIsUploading(false);                         // ← false on error
+        abortRef.current = null;
+        onError(err.message);
+      });
+  }, [uploadPath, json, onSuccess, onError]);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsUploading(false);
+  }, []);
+
+  // ── Abort on unmount — PRIMARY abort mechanism ────────────────────────────
+  // When the modal is dismissed (Cancel, Escape, backdrop click, or
+  // auto-close on success), Playground sets modalUploadPath = null, which
+  // unmounts the modal component, which unmounts this hook.  This cleanup
+  // fires abortRef.current?.abort() — cancelling any in-flight fetch without
+  // requiring the modal's handleClose to call cancel() explicitly.
+  // `setIsUploading(false)` is also called here so that isUploading is
+  // consistent even on the unmount-abort path — this prevents React Testing
+  // Library tests from seeing an `act()` warning about state updates on an
+  // unmounted component when asserting on this hook's state after unmount.
+  // `cancel()` is exposed for supplementary use (e.g. a dedicated Cancel
+  // button that needs to reset isUploading immediately in the same tick).
+  useEffect(() => () => {
+    abortRef.current?.abort();
+    setIsUploading(false);
+  }, []);
+
+  return { isUploading, upload, cancel };
+}
+```
+
+**Why a hook instead of inline `fetch` inside the component?**  
+Consistent with the codebase principle: every side-effect lives in a hook.
+`MockUploadModal` is a pure renderer; the hook is independently testable.
+
+---
+
+### 5.6 `Playground.tsx` — wiring
+
+#### New imports (add to existing `Playground.tsx` import statements)
+
+```typescript
+// React — add useRef to the existing React import if not already present:
+import { useState, useRef, useCallback } from 'react';   // useRef is the addition
+
+// New components and hooks:
+import { MockUploadModal } from '../components/MockUploadModal/MockUploadModal';
+import { useAutoMockUpload } from '../hooks/useAutoMockUpload';
+```
+
+> **Note:** `isMockUploadMessage` and `extractMockUploadPath` are **not** imported
+> in `Playground.tsx`. The path is extracted inside `useAutoMockUpload` and delivered
+> to `Playground` as the `path` argument of the `onOpenModal` callback — `Playground`
+> only ever receives the already-extracted string. Both functions are used directly by
+> `ConsoleMessage.tsx` and `useAutoMarkdownPin.ts`, which import them from
+> `messageParser.ts` themselves.
+
+#### New state
+
+```typescript
+// Path extracted from the server's upload invitation.
+// null = modal closed; non-null = modal open for that specific endpoint.
+const [modalUploadPath, setModalUploadPath] = useState<string | null>(null);
+
+// Capture the element that triggered the modal so focus can be restored on close.
+const modalTriggerRef = useRef<HTMLElement | null>(null);
+
+// POST paths of invitations that have been successfully fulfilled — drives ✅ badge.
+const [successfulUploadPaths, setSuccessfulUploadPaths] =
+  useState<Set<string>>(new Set());
+```
+
+#### New callbacks
+
+```typescript
+const handleOpenUploadModal = useCallback((path: string) => {
+  // When called by useAutoMockUpload, activeElement is the command input
+  // or the send button — restoring focus there after close is correct.
+  // When called by the re-open button, activeElement is that button — also correct.
+  modalTriggerRef.current = document.activeElement as HTMLElement;
+  setModalUploadPath(path);
+}, []);
+
+const handleCloseUploadModal = useCallback(() => {
+  setModalUploadPath(null);
+  // Restore focus to whatever triggered the open (next microtask, after
+  // the dialog is removed from the DOM).
+  setTimeout(() => modalTriggerRef.current?.focus(), 0);
+}, []);
+
+const handleUploadSuccess = useCallback((responseBody: string) => {
+  // responseBody is available here but intentionally not appended to the console
+  // or toast — the hardcoded message below is used for consistency across all
+  // mock-upload invocations, regardless of what the server body contains.
+  void responseBody;
+  // `modalUploadPath` is read from the closure — no need to pass it as an
+  // argument.  The hook already has `uploadPath` as a fixed input; the
+  // caller (Playground) already knows the path from its own state.
+  setSuccessfulUploadPaths(prev => new Set([...prev, modalUploadPath!]));
+  setModalUploadPath(null);
+  setTimeout(() => modalTriggerRef.current?.focus(), 0);
+  addToast('Mock data uploaded successfully ✓', 'success');
+}, [modalUploadPath, addToast]);
+
+const handleUploadError = useCallback((errorMessage: string) => {
+  // Modal stays open — error is displayed inline inside the modal.
+  // Toast provides secondary feedback.
+  addToast(`Upload failed: ${errorMessage}`, 'error');
+}, [addToast]);
+```
+
+#### Auto-open hook (new, added after existing automation hooks)
+
+```typescript
+useAutoMockUpload({
+  messages:    ws.messages,
+  connected:   ws.connected,
+  onOpenModal: handleOpenUploadModal,
+});
+```
+
+This sits alongside `useAutoGraphRefresh`, `useAutoMarkdownPin`, and
+`useLargePayloadDownload` in the hook-invocation block — consistent ordering.
+
+#### Prop threading
+
+`handleOpenUploadModal` (re-open) and `successfulUploadPaths` thread down all
+four levels. All four components (`Playground`, `LeftPanel`, `Console`,
+`ConsoleMessage`) require new props — none can be skipped:
+
+```
+Playground
+  → LeftPanel  (onUploadMockData: (path: string) => void,
+                successfulUploadPaths: Set<string>)
+    → Console  (onUploadMockData: (path: string) => void,
+                successfulUploadPaths: Set<string>)
+      → ConsoleMessage (onUploadMockData?: (uploadPath: string) => void,
+                        successfulUploadPaths?: Set<string>)
+```
+
+`ConsoleMessage` marks both props optional (`?`) to stay consistent with the
+existing convention for feature-specific callbacks (`onSendToJsonPath?`,
+`onPin?`). `Console` and `LeftPanel` pass them through unconditionally when
+provided by `Playground`.
+
+#### Modal rendering (after `<ToastContainer>` in the JSX return)
+
+```tsx
+{modalUploadPath && (
+  <MockUploadModal
+    uploadPath={modalUploadPath}
+    onClose={handleCloseUploadModal}
+    onSuccess={handleUploadSuccess}
+    onError={handleUploadError}
+  />
+)}
+```
+
+#### `handleClearMessages` update
+
+```typescript
+const handleClearMessages = useCallback(() => {
+  ws.clearMessages();
+  setPinnedMessageId(null);
+  setPinnedGraphPath(null);
+  setGraphData(null);
+  setModalUploadPath(null);             // ← close modal if open when console is cleared
+  setSuccessfulUploadPaths(new Set());  // ← clear session-only badges
+  // Note: useAutoMockUpload's internal watermarkRef is NOT reset here.
+  // The hook's watermark is managed entirely within the hook (it resets on
+  // disconnect, not on message clear).  Any new invitation posted after the
+  // clear will have an ID above the current watermark and will be processed
+  // correctly — no hook-level reset is needed or desired.
+}, [ws.clearMessages, setGraphData]);
+```
+
+> **Dependency array note:** `useState` setters (`setPinnedMessageId`,
+> `setPinnedGraphPath`, `setModalUploadPath`, `setSuccessfulUploadPaths`) are
+> **deliberately omitted** from the dep array. React guarantees that `useState`
+> setters are stable references that never change across renders, so including
+> them would add noise without any correctness benefit. Only `ws.clearMessages`
+> (from `useWebSocket`) and `setGraphData` (from `useGraphData`) are listed because
+> they originate from custom hooks whose internal identities are not guaranteed to
+> be stable by the React spec — though in practice both are `useCallback`-wrapped
+> with empty dep arrays in their respective hooks.
+
+---
+
+## 6. CSS & Theming
+
+### `Console.module.css` additions
+
+> **⚠️ Grid column count update required — apply as one atomic edit**  
+> The existing `.consoleMessage` rule uses a 5-column grid:
+> ```css
+> grid-template-columns: auto 1fr auto auto auto;
+> /* columns:            icon  content  copy  send-to-json-path  timestamp */
+> ```
+> The `sendToJsonPathButton` is already in the grid as column 4 (added in a
+> prior feature; the CSS comment was not updated at that time — the comment in
+> the source currently reads `[icon] [message body] [copy button] [timestamp]`,
+> which is stale). The new `.uploadMockButton` inserts a **sixth column** between
+> `send-to-json-path` and `timestamp`. **Both the column count and the comment
+> must be updated in the same edit** to avoid the comment becoming stale again
+> immediately. Update the rule to:
+> ```css
+> grid-template-columns: auto 1fr auto auto auto auto;
+> /* columns:            icon  content  copy  send-to-json-path  upload-mock  timestamp */
+> ```
+> Without this change, the new button will collapse into the timestamp column,
+> causing layout misalignment on mock-upload rows.
+
+```css
+/* Mock-upload invitation row — amber accent (pairs with ⬇️ large-payload style) */
+.consoleMessageMockUpload {
+  background-color: rgba(245, 158, 11, 0.06);
+  outline: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 4px;
+}
+
+/* "Upload JSON…" action button — amber accent on hover */
+.uploadMockButton {
+  appearance: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  line-height: 1;
+  align-self: start;
+  font-weight: 600;
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  color: rgba(255, 255, 255, 0.75);
+  opacity: 0;
+  transition: opacity 0.15s, background-color 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.consoleMessage:hover .uploadMockButton,
+.consoleMessage:focus-within .uploadMockButton {
+  opacity: 1;
+}
+
+.uploadMockButton:hover {
+  background-color: rgba(245, 158, 11, 0.2);
+  border-color: rgba(245, 158, 11, 0.6);
+  color: #fcd34d;
+}
+
+.uploadMockButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
+}
+```
+
+### `MockUploadModal.module.css`
+
+Follows the app's existing token vocabulary (`--bg-primary`, `--bg-secondary`,
+`--border-color`, `--text-primary`, `--text-secondary`, `--primary-color`,
+`--danger-color`, `--radius`, `--shadow-md`).
+
+Key structural rules (abridged — see implementation for full source):
+
+```css
+/* Native dialog — browser supplies the backdrop */
+.dialog { … width: min(560px, 94vw); max-height: 90vh; … }
+.dialog::backdrop { background: rgba(0,0,0,0.5); backdrop-filter: blur(2px); }
+
+/* ── Drop zone ── */
+.dropZone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  user-select: none;   /* prevents text selection during drag */
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+/* Active drag-over — amber accent to match the row highlight */
+.dropZoneActive {
+  border-color: rgba(245, 158, 11, 0.8);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--text-primary);
+}
+
+/* Hidden native <input type="file"> — triggered programmatically */
+.fileInputHidden { display: none; }
+
+/* Browse button — ghost secondary style */
+.browseButton { … }
+.browseButton:hover:not(:disabled) {
+  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(245, 158, 11, 0.6);
+}
+
+/* File-type / read error — warning (amber), not danger (red) */
+.fileError { color: var(--warning-color); font-size: 0.8rem; }
+```
+
+> **⚠️ CSS token `--warning-color` — value correction (already applied)**  
+> `src/index.css` has been updated from `#f5780b` (amber-600) to `#f59e0b`
+> (amber-500) so `.fileError`, `.validationError`, and the row-accent rgba
+> values all share the same amber shade.
+
+```css
+.modalBody { flex: 1 1 auto; overflow-y: auto; padding: 1rem 1.25rem; … }
+
+.textarea {
+  background: var(--bg-dark);
+  color: var(--console-text);
+  border: 1px solid var(--border-color);
+  min-height: 180px;
+  resize: vertical;
+  font-family: 'Courier New', Courier, monospace;
+}
+.textarea:focus { border-color: var(--primary-color); box-shadow: var(--focus-ring); }
+
+.validationError { color: var(--warning-color); font-size: 0.8rem; }
+.errorBanner     { color: var(--danger-color); background: rgba(239,68,68,0.08); … }
+```
+
+---
+
+## 7. Accessibility
+
+| Requirement | Implementation |
+|---|---|
+| Focus trap inside modal | Native `<dialog>` provides this automatically |
+| Initial focus | `useEffect` focuses the `<textarea>` after `.showModal()`. After a file is loaded via drop or browse, focus returns to the textarea via `textareaRef.current?.focus()`. |
+| Focus return on close | `modalTriggerRef` in `Playground` captures `document.activeElement` before open; `.focus()` is restored inside `handleCloseUploadModal` and `handleUploadSuccess` (via `setTimeout` to allow the dialog to be removed from the DOM first). `MockUploadModal` itself has no `triggerRef` prop — focus management is exclusively `Playground`'s responsibility. |
+| Backdrop click closes | `dialog` click handler with `e.target === dialogRef.current` guard |
+| Escape closes | Native `cancel` event on `<dialog>` calls `handleClose` |
+| Screen reader label | `aria-labelledby="modal-title"` + `aria-modal="true"` on `<dialog>` |
+| Error announced immediately | `role="alert"` on the upload error banner and file error |
+| Validation feedback | `role="status"` on the validation message |
+| Upload button state | `aria-busy={isUploading}`; `aria-label` changes to "Uploading…" during fetch |
+| Keyboard submit hint | Visible `Ctrl+Enter` / `⌘+Enter` hint below the textarea |
+| Drop zone | Labelled with `aria-label="Drop a JSON file here"`. Not focusable itself — the "Browse file…" button inside it is the keyboard-accessible entry point. |
+| Browse file button | Standard `<button>` element — fully keyboard accessible (Enter/Space); triggers the hidden `<input type="file">` programmatically. `disabled` during upload. |
+| File error | `role="alert"` ensures it is announced by screen readers immediately when it appears (same as the upload error banner). |
+| Console invitation row | **Not** given `role="button"` — the re-open button is the sole interactive element on the row, avoiding nested-interactive-element issues. |
+| Auto-open screen reader announcement | The modal opening automatically is announced by the `<dialog>` focus shift; no extra live region needed |
+
+---
+
+## 8. Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Network error (fetch throws) | `onError` called; error banner shown in modal; modal stays open |
+| HTTP 4xx / 5xx | Error includes status code + response body; same path as above |
+| `AbortError` (user cancels / modal dismissed mid-flight) | Silently swallowed — no error shown |
+| Invalid JSON in textarea | "Upload ▶" button disabled; inline validation message shown |
+| Modal dismissed while upload in-flight | `useMockUpload` unmount cleanup aborts the fetch via `AbortController` |
+| Messages cleared while modal is open | `handleClearMessages` calls `setModalUploadPath(null)` — the modal closes immediately. `successfulUploadPaths` is also cleared so any future re-invitation starts with a clean badge state. |
+| Auto-open while modal already open | `useAutoMockUpload` calls `onOpenModal` unconditionally — `setModalUploadPath` simply replaces the current path. React's effect cleanup runs the old modal's `AbortController.abort()` before the new modal mounts. |
+| Dropped file is not a `.json` / wrong MIME | `validateFileType` returns an error string → `fileError` shown below the drop zone (amber, `role="alert"`); textarea unchanged |
+| Dropped file has `.json` extension but invalid content | `tryParseJSON` fails → `fileError`: `"<name>" contains invalid JSON.`; textarea unchanged |
+| `FileReader` fails (permissions, corrupted file) | `readFileAsText` rejects → `fileError` set to the caught error message |
+| Multiple files dropped at once | Only `e.dataTransfer.files[0]` is processed; additional files are silently ignored |
+
+---
+
+## 9. Resolved Decisions
+
+| # | Question | Decision |
+|---|---|---|
+| 9.1 | Row interactivity | **Button-only + auto-open.** The re-open button (`⬆️ Upload JSON…`) appears on row hover/focus. The modal opens automatically via `useAutoMockUpload` when the invitation first arrives — no click required for the primary path. |
+| 9.2 | Success badge | **Yes** — `✅` badge on the console row after a successful upload. Session-only; cleared by `clearMessages`. |
+| 9.3 | XML support | **JSON-only** for now. Extendable if the server message changes. The modal uses `tryParseJSON` (not `validatePayload`) so XML never passes validation even though `validatePayload` accepts it. |
+| 9.4 | Keyboard submit shortcut | **`Ctrl+Enter` / `Cmd+Enter`** to submit; `Enter` inserts newline. Hint line shown in modal. |
+| 9.5 | Pre-fill textarea | **Always empty** — mock upload payload is semantically unrelated to any stored JSON-Path payload. |
+
+---
+
+## 10. Files Changed / Created
+
+| File | Change type | Notes |
+|---|---|---|
+| `src/utils/messageParser.ts` | Edit | Add `extractMockUploadPath`, `isMockUploadMessage` |
+| `src/hooks/useAutoMarkdownPin.ts` | Edit | Add `isMockUploadMessage` guard to `isPinnableResponse` to prevent cross-hook interference |
+| `src/hooks/useAutoMockUpload.ts` | **Create** | New automation hook — watermark-guarded message watcher, auto-opens modal |
+| `src/components/Console/ConsoleMessage.tsx` | Edit | New prop `onUploadMockData`, new flags, ⬆️ icon, re-open button, success badge |
+| `src/components/Console/Console.module.css` | Edit | New `.consoleMessageMockUpload` + `.uploadMockButton` rules |
+| `src/components/Console/Console.tsx` | Edit | Thread `onUploadMockData` + `successfulUploadPaths` props |
+| `src/components/LeftPanel/LeftPanel.tsx` | Edit | Thread new props to `Console` |
+| `src/hooks/useMockUpload.ts` | **Create** | New hook — fetch lifecycle |
+| `src/components/MockUploadModal/MockUploadModal.tsx` | **Create** | New modal component |
+| `src/components/MockUploadModal/MockUploadModal.module.css` | **Create** | New modal styles |
+| `src/components/Playground.tsx` | Edit | State, `modalTriggerRef`, callbacks, `useAutoMockUpload`, modal render, prop threading, `handleClearMessages` update |
+| `src/index.css` | Edit | Update **existing** `--warning-color` value from `#f5780b` to `#f59e0b` (amber-500, to match the amber row-accent) — do **not** add a second declaration |
+
+No changes to:
+- `playgrounds.ts` — trigger is purely message-driven, no new per-playground config needed
+- `WebSocketContext.tsx` — upload is a direct `fetch`, no WS involvement
+- `useWebSocket.ts` — the existing `pendingUploadRef` two-step handshake is only for
+  the JSON-Path playground's `upload` command; this feature does not use it.
+  **Safety confirmation:** `useWebSocket.ts` watches incoming messages via
+  `extractUploadPath`, whose regex is anchored to `/api/json/content/…`. The new
+  mock-upload path is `/api/mock/…`. The two regexes are entirely disjoint —
+  `extractUploadPath` will never match a mock-upload invitation and there is no
+  cross-trigger risk between the two upload protocols.
+
+---
+
+## 11. What Is Explicitly Out of Scope
+
+- **Drag-and-drop file upload** — out of scope; paste is sufficient.
+- **File browser (input[type=file])** — out of scope for the same reason.
+- **Progress reporting** — the payload is JSON text; it is small enough that a
+  simple spinner is adequate. No `ReadableStream` / `XMLHttpRequest` progress events.
+- **Upload history** — past uploads are not persisted. The `✅` badge is session-only.
+- **Multiple concurrent upload invitations** — only the most recently opened modal
+  is tracked in state. If the user receives two invitations without closing the
+  first modal, clicking the second replaces `modalUploadPath` and the first AbortController is cleaned up via the modal unmount.
+- **Server-sent JSON schema validation** — the modal validates only that the input
+  is syntactically valid JSON. Business-level validation is the server's responsibility.

--- a/extensions/minigraph-playground-engine/webapp/docs/Technical Documentation.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/Technical Documentation.md
@@ -1,0 +1,1201 @@
+# Minigraph Playground — Codebase Walkthrough & Knowledge Transfer
+
+**Audience:** Engineers inheriting or maintaining this webapp  
+**Branch:** `feature/playground`  
+**Last updated:** March 23 2026
+
+---
+
+## Table of Contents
+
+1. [What This App Does](#1-what-this-app-does)
+2. [Technology Stack & Tooling](#2-technology-stack--tooling)
+3. [High-Level Features](#3-high-level-features)
+   - 3.1 [Multi-Playground Architecture](#31-multi-playground-architecture)
+   - 3.2 [Navigation-Persistent WebSocket Connections](#32-navigation-persistent-websocket-connections)
+   - 3.3 [Interactive Console (REPL-like)](#33-interactive-console-repl-like)
+   - 3.4 [Graph Visualisation](#34-graph-visualisation)
+   - 3.5 [Auto-Graph Refresh](#35-auto-graph-refresh)
+   - 3.6 [Markdown Preview (Developer Guides)](#36-markdown-preview-developer-guides)
+   - 3.7 [Large Payload Handling](#37-large-payload-handling)
+   - 3.8 [JSON-Path ↔ Minigraph Cross-Playground Routing](#38-json-path--minigraph-cross-playground-routing)
+   - 3.9 [Two-Step Payload Upload (REST Handshake)](#39-two-step-payload-upload-rest-handshake)
+   - 3.10 [Saved Graph Bookmarks](#310-saved-graph-bookmarks)
+   - 3.11 [Keep-Alive Pings](#311-keep-alive-pings)
+   - 3.12 [Mock-Data Upload Modal](#312-mock-data-upload-modal)
+   - 3.13 [Save-Name Management](#313-save-name-management)
+4. [Repository Layout](#4-repository-layout)
+5. [Architecture Overview](#5-architecture-overview)
+6. [Layer-by-Layer Walkthrough](#6-layer-by-layer-walkthrough)
+   - 6.1 [Entry Point & Routing](#61-entry-point--routing)
+   - 6.2 [Playground Configuration](#62-playground-configuration)
+   - 6.3 [WebSocket State — Context + Hook](#63-websocket-state--context--hook)
+   - 6.4 [Playground.tsx — The Orchestrator](#64-playgroundtsx--the-orchestrator)
+   - 6.5 [Left Panel — Console & Command Input](#65-left-panel--console--command-input)
+   - 6.6 [Right Panel — Tabs](#66-right-panel--tabs)
+   - 6.7 [Graph Pipeline](#67-graph-pipeline)
+   - 6.8 [Automation Hooks](#68-automation-hooks)
+   - 6.9 [Utilities](#69-utilities)
+   - 6.10 [Navigation Bar](#610-navigation-bar)
+   - 6.11 [Saved Graphs](#611-saved-graphs)
+7. [Key Engineering Decisions](#7-key-engineering-decisions)
+8. [Data & Message Flows](#8-data--message-flows)
+   - 8.1 [User Sends a Command](#81-user-sends-a-command)
+   - 8.2 [User Pins a Graph](#82-user-pins-a-graph)
+   - 8.3 [Auto-Refresh After Mutation](#83-auto-refresh-after-mutation)
+   - 8.4 [Large Payload Flow](#84-large-payload-flow)
+   - 8.5 [REST Upload Handshake](#85-rest-upload-handshake)
+   - 8.6 [Mock-Data Upload Flow](#86-mock-data-upload-flow)
+   - 8.7 [Save-Name Lifecycle](#87-save-name-lifecycle)
+9. [State Ownership Map](#9-state-ownership-map)
+10. [Build, Dev & Deploy](#10-build-dev--deploy)
+11. [Extending the App](#11-extending-the-app)
+12. [Pitfalls & Gotchas](#12-pitfalls--gotchas)
+
+---
+
+## 1. What This App Does
+
+The **Minigraph Playground** is a React-based developer tool that communicates with a Java Spring Boot backend over **WebSocket** and **REST**. It provides two interactive playgrounds:
+
+| Playground | URL | Purpose |
+|---|---|---|
+| **Minigraph** | `/` | CRUD operations on a node-and-edge graph model via text commands |
+| **JSON-Path** | `/json-path` | Evaluate JSON-Path expressions against a JSON payload |
+
+The UI offers:
+- A **live WebSocket console** (like a REPL) where commands are sent and responses printed
+- A **ReactFlow graph visualiser** that renders the current graph model
+- A **Markdown preview panel** for `help` and `describe` command responses
+- A **JSON/XML payload editor** for the JSON-Path playground
+- **Saved graph bookmarks** (export/import graph snapshots by name)
+- **Large payload handling** — payloads exceeding 64 KB are automatically fetched via REST and displayed inline
+- **Mock-data upload modal** — when the server responds to a command with an upload invitation, a modal dialog opens automatically so the user can paste, drag-and-drop, or browse a JSON file and POST it to the provided endpoint
+
+The built output (`dist/`) is copied into the Java application's `src/main/resources/public/` directory and served as a static SPA by the same Spring Boot server that provides the WebSocket and REST endpoints.
+
+---
+
+## 2. Technology Stack & Tooling
+
+| Concern | Choice | Notes |
+|---|---|---|
+| Framework | **React 19** | Uses the new React Compiler (`babel-plugin-react-compiler`) |
+| Language | **TypeScript 5.9** | Strict, no implicit any |
+| Build tool | **Vite 6** | Fast HMR in dev; Rollup-based production bundle |
+| Routing | **react-router-dom v7** | `BrowserRouter` + `<Routes>` |
+| Graph renderer | **@xyflow/react v12** | ReactFlow — nodes, edges, minimap, controls |
+| Panel layout | **react-resizable-panels v4** | Draggable left/right split |
+| Markdown | **react-markdown + remark-gfm** | GitHub-flavoured Markdown |
+| JSON viewer | **react-json-view-lite** | Collapsible inline JSON tree |
+| Styling | **CSS Modules** | Per-component `.module.css` files; global resets in `index.css` |
+| State persistence | **localStorage** | Via custom `useLocalStorage` hook |
+| Dev proxy | **Vite server.proxy** | `/ws`, `/api`, `/health`, `/info`, `/env` → `localhost:8085` |
+
+### React Compiler
+
+The project opts in to the **React Compiler** (`babel-plugin-react-compiler`), which automatically inserts memoisation. This means you will rarely see manual `useMemo` or `useCallback` calls needed purely for performance — they are present only where the semantics require a stable reference (e.g. a ref updated in an effect, an empty-dep-array `useCallback`). Do not add gratuitous memoisation; let the compiler do its job.
+
+---
+
+## 3. High-Level Features
+
+### 3.1 Multi-Playground Architecture
+The app supports multiple independent playgrounds configured entirely in one file (`src/config/playgrounds.ts`). Adding a new playground requires no changes to routing, navigation, or state management — only a new entry in `PLAYGROUND_CONFIGS`.
+
+**Key code locations:**
+- `src/config/playgrounds.ts` [L33–L56](../src/config/playgrounds.ts#L33) — `PlaygroundConfig` interface defining every per-playground property
+- `src/config/playgrounds.ts` [L57–end](../src/config/playgrounds.ts#L57) — `PLAYGROUND_CONFIGS` array (the only file to edit for a new playground)
+- `src/App.tsx` [L21–L23](../src/App.tsx#L21) — routes auto-generated: `PLAYGROUND_CONFIGS.map((cfg) => <Route … element={<Playground config={cfg} />} />)`
+- `src/components/Navigation.tsx` [L102–L143](../src/components/Navigation.tsx#L102) — nav links and status dots also auto-generated from the same array
+
+---
+
+### 3.2 Navigation-Persistent WebSocket Connections
+Switching between the Minigraph and JSON-Path playgrounds does **not** close either WebSocket connection. Each connection is owned by `WebSocketContext` which lives above `<Routes>` in the tree, so both sockets stay alive simultaneously. The navigation bar shows a live status dot per playground.
+
+**Key code locations:**
+- `src/App.tsx` [L17–L29](../src/App.tsx#L17) — `<WebSocketProvider>` wraps `<BrowserRouter>`, not the other way around
+- `src/contexts/WebSocketContext.tsx` [L1–L10](../src/contexts/WebSocketContext.tsx#L1) — explains the "above Routes" contract in the module JSDoc
+- `src/contexts/WebSocketContext.tsx` [L30](../src/contexts/WebSocketContext.tsx#L30) — `WsPhase = 'idle' | 'connecting' | 'connected'`
+- `src/contexts/WebSocketContext.tsx` [L140–L165](../src/contexts/WebSocketContext.tsx#L140) — `useReducer`-managed `slots` map keyed by `wsPath`; `wsRefs` / `pingRefs` / `msgIdRefs` live in `useRef` outside the reducer
+- `src/contexts/WebSocketContext.tsx` [L196–L253](../src/contexts/WebSocketContext.tsx#L196) — `connect()`: opens socket, sends `welcome`, starts ping interval
+- `src/components/Navigation.tsx` [L21–L33](../src/components/Navigation.tsx#L21) — `aggregateDotStatus()` + `phaseToDotStatus()` derive nav dot colours
+
+---
+
+### 3.3 Interactive Console (REPL-like)
+- Messages are printed in real time with type-based icons (ℹ️ ❌ 👋)
+- JSON messages are rendered as a collapsible tree (`react-json-view-lite`)
+- Graph-link messages (🕸️) are clickable to pin the graph
+- Plain-text messages (📌) are clickable to pin them to the Markdown Preview
+- Per-row copy button; command history navigation with ↑/↓ arrow keys
+- Multiline input mode toggle for multi-line commands
+
+**Key code locations:**
+- `src/components/Console/ConsoleMessage.tsx` [L24–L42](../src/components/Console/ConsoleMessage.tsx#L24) — per-message classification: `isGraphLink`, `isLargePayload`, `isPinnable`, `canSendToJsonPath`
+- `src/components/Console/ConsoleMessage.tsx` [L70–L149](../src/components/Console/ConsoleMessage.tsx#L70) — JSX: `<JsonView>` for JSON, plain `<span>` for text, copy button, ➡️ send-to-JSON-Path button
+- `src/components/Console/ConsoleMessage.tsx` [L29–L31](../src/components/Console/ConsoleMessage.tsx#L29) — `isGraphLinkMessage` / `isLargePayloadMessage` / `isPinnable` flags drive rendering branches
+- `src/hooks/useWebSocket.ts` [L143–L163](../src/hooks/useWebSocket.ts#L143) — `sendCommand()`: sends text, pushes to history, handles special `load` command
+- `src/hooks/useWebSocket.ts` [L165–L189](../src/hooks/useWebSocket.ts#L165) — `handleKeyDown()`: ↑/↓ history navigation with draft-save/restore (`ENTER_HISTORY` / `EXIT_HISTORY` / `SET_HISTORY_INDEX` reducer actions)
+- `src/hooks/useWebSocket.ts` [L11–L32](../src/hooks/useWebSocket.ts#L11) — `LocalState` + `LocalAction` types; `draftCommand` field saves in-progress input on first ↑ press
+
+---
+
+### 3.4 Graph Visualisation
+- Fetched via REST (`GET /api/graph/model/{id}`) after the server emits a graph-link in the WebSocket stream
+- Rendered with **ReactFlow**: nodes are colour-coded by type (`entry_point`, `api_fetcher`, `mapper`, `terminator`), edges show relation labels
+- Nodes are **resizable** (NodeResizer) and can be re-arranged interactively
+- A **minimap** provides navigation for large graphs
+- A **refreshing overlay** (spinner) is displayed during background re-fetches without clearing the existing graph
+
+**Key code locations:**
+- `src/utils/graphTypes.ts` [L1–L47](../src/utils/graphTypes.ts#L1) — `MinigraphGraphData`, `MinigraphNode`, `MinigraphConnection` types + `isMinigraphGraphData()` type guard
+- `src/hooks/useGraphData.ts` [L53–L101](../src/hooks/useGraphData.ts#L53) — initial-load path: `fetch(pinnedGraphPath)` → `setGraphData(json)` → `setRightTab('graph')` (L93); clears `graphData` to `null` on path change (L83)
+- `src/hooks/useGraphData.ts` [L106–L137](../src/hooks/useGraphData.ts#L106) — `refetchGraph()`: overlay-mode re-fetch; does NOT clear `graphData` (stale graph stays visible), sets `isRefreshing = true` (L116)
+- `src/utils/graphTransformer.ts` [L61–L76](../src/utils/graphTransformer.ts#L61) — `NODE_ACCENT` colour map + `nodeStyle()` applying `--node-accent` CSS custom property
+- `src/utils/graphTransformer.ts` [L83–L157](../src/utils/graphTransformer.ts#L83) — `computeLayout()`: BFS topological layout (levels = columns, stacked vertically within each level)
+- `src/utils/graphTransformer.ts` [L163–L205](../src/utils/graphTransformer.ts#L163) — `transformGraphData()`: converts `MinigraphGraphData` → ReactFlow `nodes[]` + `edges[]`
+- `src/components/GraphView/NodeTypes.tsx` [L9–L16](../src/components/GraphView/NodeTypes.tsx#L9) — `TYPE_META` icon/label map per node type
+- `src/components/GraphView/NodeTypes.tsx` [L55–L88](../src/components/GraphView/NodeTypes.tsx#L55) — `MinigraphNode`: renders as `<Fragment>` (no wrapper div), `NodeResizer` + `Handle` + content as siblings (L60–L86)
+- `src/components/GraphView/NodeTypes.tsx` [L96–L103](../src/components/GraphView/NodeTypes.tsx#L96) — `nodeTypes` export map used by `<ReactFlow nodeTypes={nodeTypes}>`
+- `src/components/GraphView/GraphView.tsx` [L115–L157](../src/components/GraphView/GraphView.tsx#L115) — `<ReactFlow>` with `fitView`, `<Controls>`, `<MiniMap>` (L130), and `isRefreshing` overlay (L144–L152)
+
+---
+
+### 3.5 Auto-Graph Refresh
+After any graph-mutating command (`create node`, `delete node`, `connect`, etc.), the graph automatically re-fetches and re-renders without user interaction. If no graph was previously loaded, the app issues `describe graph` silently, receives the graph-link, and opens the Graph tab automatically. This is debounced at 300 ms to collapse rapid-fire commands.
+
+**Key code locations:**
+- `src/utils/messageParser.ts` [L237–L265](../src/utils/messageParser.ts#L237) — `detectMutation()`: classifies a raw message as `'node-mutation'`, `'import-graph'`, or `null`; includes the critical `startsWith('node ')` prefix guard
+- `src/hooks/useAutoGraphRefresh.ts` [L89–L102](../src/hooks/useAutoGraphRefresh.ts#L89) — three core refs: `watermarkRef` (prevents replaying history), `debounceTimerRef` (300 ms collapse), `waitingForDescribeRef` (two-step describe-graph/graph-link handshake)
+- `src/hooks/useAutoGraphRefresh.ts` [L112–L131](../src/hooks/useAutoGraphRefresh.ts#L112) — disconnect guard: clears `waitingForDescribeRef` and cancels any pending debounce on socket close
+- `src/hooks/useAutoGraphRefresh.ts` [L143–L250](../src/hooks/useAutoGraphRefresh.ts#L143) — main `useEffect`: Pass 1 consumes pending graph-link when `waitingForDescribeRef` is true; Pass 2 detects mutations and fires the debounce or immediate `describe graph` send
+- `src/hooks/useWebSocket.ts` [L246–L249](../src/hooks/useWebSocket.ts#L246) — `sendRawText()`: sends without echoing to console or history (used exclusively by automation hooks)
+
+---
+
+### 3.6 Markdown Preview (Developer Guides)
+After `help` or text-producing `describe` commands, the response is automatically pinned to the **Developer Guides** tab and the tab switches into view. The panel renders GitHub-flavoured Markdown.
+
+**Key code locations:**
+- `src/utils/messageParser.ts` [L192–L210](../src/utils/messageParser.ts#L192) — `isHelpOrDescribeCommand()`: matches `"> help …"` and `"> describe <non-graph>"` echoes (explicitly excludes `"> describe graph"`)
+- `src/hooks/useAutoMarkdownPin.ts` [L42–L46](../src/hooks/useAutoMarkdownPin.ts#L42) — `isPinnableResponse()`: a message is pinnable if it is not an echo (`> ` prefix), not a graph-link, and passes `isMarkdownCandidate`
+- `src/hooks/useAutoMarkdownPin.ts` [L88–L163](../src/hooks/useAutoMarkdownPin.ts#L88) — main hook: `watermarkRef`, `waitingForResponseRef`; armed when a `help`/`describe` echo is seen; pins first pinnable response and calls `onAutoPin()` to switch the tab
+- `src/utils/messageParser.ts` [L80–L92](../src/utils/messageParser.ts#L80) — `isMarkdownCandidate()`: true for non-JSON strings; false for JSON lifecycle events (`{type, message, time}`)
+
+---
+
+### 3.7 Large Payload Handling
+When the server reports a payload exceeding 64 KB (`"Large payload (N) -> GET /api/inspect/…"`), the hook fetches it via REST and appends the result directly to the console as a collapsible JSON row — identical in appearance to small payloads.
+
+**Key code locations:**
+- `src/utils/messageParser.ts` [L148–L168](../src/utils/messageParser.ts#L148) — `extractLargePayloadLink()`: regex parses byte size and API path from the server notification; `isLargePayloadMessage()` (L167) is the boolean predicate
+- `src/hooks/useLargePayloadDownload.ts` [L56–L64](../src/hooks/useLargePayloadDownload.ts#L56) — three key refs: `watermarkRef`, `abortRef` (AbortController for in-flight cancellation), `isFetchingRef` (re-entrancy guard)
+- `src/hooks/useLargePayloadDownload.ts` [L92–L167](../src/hooks/useLargePayloadDownload.ts#L92) — main effect: scans new messages for `extractLargePayloadLink`, fetches the endpoint, pretty-prints JSON, calls `appendMessage(content)` (L142); `break` on first match (L165) prevents concurrent fetches
+- `src/config/playgrounds.ts` [L27](../src/config/playgrounds.ts#L27) — `MAX_BUFFER = 63_488` — the 62 KB send limit that makes large-payload handling necessary
+
+---
+
+### 3.8 JSON-Path ↔ Minigraph Cross-Playground Routing
+A JSON response in the Minigraph console can be sent directly to the JSON-Path Playground payload editor with one click (➡️ button), navigating automatically and pre-filling the editor.
+
+**Key code locations:**
+- `src/components/Console/ConsoleMessage.tsx` [L41](../src/components/Console/ConsoleMessage.tsx#L41) — `canSendToJsonPath = !!onSendToJsonPath && jsonCheck.isJSON` — button only shown on JSON messages when the callback is wired
+- `src/components/Console/ConsoleMessage.tsx` [L63–L67](../src/components/Console/ConsoleMessage.tsx#L63) — `handleSendToJsonPath`: pretty-prints the JSON and calls `onSendToJsonPath(pretty)`
+- `src/components/Playground.tsx` [L200–L211](../src/components/Playground.tsx#L200) — `handleSendToJsonPath`: calls `ctx.setPendingPayload(wsPath, json)` then `navigate(jsonPathConfig.path)`
+- `src/contexts/WebSocketContext.tsx` [L59–L64](../src/contexts/WebSocketContext.tsx#L59) — `setPendingPayload` / `takePendingPayload` interface; backed by `useState` (not `useRef`) so that depositing triggers a re-render in the consuming playground
+- `src/components/Playground.tsx` [L43–L56](../src/components/Playground.tsx#L43) — receiving side: `payloadOverride` state initialised from `ctx.takePendingPayload(wsPath)` at mount; `useEffect` (L50–L57) also fires reactively when a new payload is deposited into an already-mounted playground
+
+---
+
+### 3.9 Two-Step Payload Upload (REST Handshake)
+The JSON-Path Playground supports uploading large JSON payloads over REST:
+1. The user clicks **Upload** → the hook sends `"upload"` over the WebSocket
+2. The server responds with `"Please upload XML/JSON text to /api/json/content/{id}"`
+3. The hook detects that URL in the message stream and fires `POST /api/json/content/{id}` with the payload
+
+**Key code locations:**
+- `src/utils/messageParser.ts` [L118–L123](../src/utils/messageParser.ts#L118) — `extractUploadPath()`: regex extracts `/api/json/content/{id}` from the server's reply
+- `src/hooks/useWebSocket.ts` [L123](../src/hooks/useWebSocket.ts#L123) — `pendingUploadRef = useRef(false)` — arms the two-step handshake
+- `src/hooks/useWebSocket.ts` [L232–L241](../src/hooks/useWebSocket.ts#L232) — `uploadPayload()`: sets `pendingUploadRef.current = true`, sends `"upload"` over the socket
+- `src/hooks/useWebSocket.ts` [L191–L230](../src/hooks/useWebSocket.ts#L191) — `useEffect` watching `messages`: when `pendingUploadRef` is true and `extractUploadPath` matches, fires `fetch(uploadPath, { method: 'POST', body })` (L200–L225)
+
+---
+
+### 3.10 Saved Graph Bookmarks
+The Minigraph playground lets users save a named graph snapshot. The name is stored in localStorage and sent to the server via `export graph as {name}`. Loading re-issues `import graph from {name}`, and the auto-refresh hook re-renders the graph.
+
+**Key code locations:**
+- `src/hooks/useSavedGraphs.ts` [L19–L28](../src/hooks/useSavedGraphs.ts#L19) — `UseSavedGraphsReturn` interface: `savedGraphs`, `saveGraph`, `deleteGraph`, `hasGraph`
+- `src/hooks/useSavedGraphs.ts` [L55–L82](../src/hooks/useSavedGraphs.ts#L55) — implementation: `useLocalStorage<SavedGraphsMap>` backing store; `useMemo` sort newest-first (L78)
+- `src/components/Playground.tsx` [L165–L173](../src/components/Playground.tsx#L165) — `handleSaveGraph()`: calls `savedGraphs.saveGraph(name)` then `ws.sendRawText('export graph as ${name}')`
+- `src/components/Playground.tsx` [L176–L182](../src/components/Playground.tsx#L176) — `handleLoadGraph()`: calls `ws.sendRawText('import graph from ${name}')` — auto-refresh hook takes it from there
+- `src/components/GraphSaveButton/GraphSaveButton.tsx` [L1–L116](../src/components/GraphSaveButton/GraphSaveButton.tsx#L1) — self-contained inline save form (open/close, pre-filled name, overwrite warning, Enter/Escape keyboard handling)
+- `src/components/SavedGraphsMenu/SavedGraphsMenu.tsx` [L1–L85](../src/components/SavedGraphsMenu/SavedGraphsMenu.tsx#L1) — dropdown list reusing `NavMenu`; Load/Delete actions per entry
+
+---
+
+### 3.11 Keep-Alive Pings
+Every 20 seconds the client sends `{"type":"ping","message":"keep alive"}` over each open socket. Pong responses and outgoing pings are silently filtered — they never appear in the console.
+
+**Key code locations:**
+- `src/config/playgrounds.ts` [L30](../src/config/playgrounds.ts#L30) — `PING_INTERVAL = 20_000` — the only place to change the frequency
+- `src/contexts/WebSocketContext.tsx` [L227–L231](../src/contexts/WebSocketContext.tsx#L227) — `setInterval` started in `ws.onopen`; fires `ws.send(eventWithTimestamp('ping', 'keep alive'))`
+- `src/contexts/WebSocketContext.tsx` [L187–L196](../src/contexts/WebSocketContext.tsx#L187) — `isKeepAliveMessage()`: checks `parsed.type === 'ping' || 'pong'`; messages passing this check are dropped before `dispatch(MESSAGE_RECEIVED)` (L234–L239)
+
+---
+
+### 3.12 Mock-Data Upload Modal
+When the server responds to a command (e.g. `upload mock data`) with the message `"You may upload JSON payload -> POST /api/mock/{id}"`, the app automatically opens a modal dialog. The user can paste JSON directly, drag-and-drop a `.json` file onto a drop zone, or click "Browse file…" to open the system file-picker. Submitting POSTs the payload to the provided URL.
+
+The console row for the invitation displays a ⬆️ icon and an "⬆️ Upload JSON…" re-open button so the modal can be recalled after it has been dismissed. A ✅ badge appears on the row after a successful upload (session-only).
+
+**Two triggers, one modal:** The modal is opened either (a) automatically by `useAutoMockUpload` when the server message arrives, or (b) manually via the re-open button on the console row. Both paths call the same `handleOpenUploadModal` callback in `Playground.tsx`.
+
+**Key code locations:**
+- `src/utils/messageParser.ts` [L182–L193](../src/utils/messageParser.ts#L182) — `extractMockUploadPath()` / `isMockUploadMessage()`: regex extracts `/api/mock/{id}` from the server's invitation message
+- `src/hooks/useAutoMockUpload.ts` — watches the message stream for `isMockUploadMessage`, follows the watermark pattern, calls `onOpenModal(uploadPath)` on first match per batch
+- `src/hooks/useMockUpload.ts` — owns the `fetch` lifecycle: `AbortController` per attempt, `isUploading` state, `upload()` / `cancel()` functions
+- `src/components/MockUploadModal/MockUploadModal.tsx` — native `<dialog>` with `.showModal()`; textarea + drop zone + "Browse file…" button; `Ctrl+Enter` / `⌘+Enter` submit shortcut; inline JSON validation via `tryParseJSON`
+- `src/components/MockUploadModal/MockUploadModal.module.css` — amber accent theming; drop zone active state; spinner; `--warning-color` token for file/validation errors
+- `src/components/Playground.tsx` [L121–L127](../src/components/Playground.tsx#L121) — `modalUploadPath` / `modalTriggerRef` / `successfulUploadPaths` state
+- `src/components/Playground.tsx` [L168–L200](../src/components/Playground.tsx#L168) — `handleOpenUploadModal`, `handleCloseUploadModal`, `handleUploadSuccess`, `handleUploadError` callbacks + `useAutoMockUpload` invocation
+- `src/components/Console/ConsoleMessage.tsx` [L41–L50](../src/components/Console/ConsoleMessage.tsx#L41) — `isMockUpload`, `mockUploadPath`, `canUploadMock`, `uploadSucceeded` derived flags; `isPinnable` guard (`&& !isMockUpload`) prevents a nested-interactive-element accessibility violation
+- `src/hooks/useAutoMarkdownPin.ts` — `isPinnableResponse()` excludes `isMockUploadMessage` rows so the invitation is never accidentally pinned to the Developer Guides tab
+
+---
+
+### 3.13 Save-Name Management
+When the user opens the **💾 Save Graph** inline form, the input is pre-filled according to a strict priority chain:
+
+| Priority | Source | Condition |
+|---|---|---|
+| 1 | `lastSavedName` | The working graph was previously saved this session |
+| 2 | `importedName` | The graph was loaded via `import graph from {name}` |
+| 3 | `untitled-{n}` | Fallback — monotonically incrementing per-playground counter |
+
+A new import always supersedes a previous save: when a new `import graph from {name}` echo is detected in the message stream, `lastSavedName` is cleared to `null` immediately, ensuring the imported name wins on the next form open.
+
+**Untitled counter semantics.** The counter only advances when the current `untitled-{n}` slot has actually been *used as a save name*. Clearing the console without ever saving reuses the same slot — so `untitled-2` will never appear in storage unless `untitled-1` was saved first. The counter is persisted in localStorage (keyed per playground) so it survives page refreshes.
+
+**Key code locations:**
+- `src/hooks/useGraphSaveName.ts` [L9–L38](../src/hooks/useGraphSaveName.ts#L9) — `UseGraphSaveNameReturn` interface with documented priority order and counter invariant
+- `src/hooks/useGraphSaveName.ts` [L68](../src/hooks/useGraphSaveName.ts#L68) — `useLocalStorage<number>(storageKey, 1)` — counter persisted, starts at 1
+- `src/hooks/useGraphSaveName.ts` [L80–L83](../src/hooks/useGraphSaveName.ts#L80) — `untitledSlotConsumedRef = useRef(false)` — tracks whether the current slot has been used; stored as a ref (not state) because it never drives a re-render
+- `src/hooks/useGraphSaveName.ts` [L104–L118](../src/hooks/useGraphSaveName.ts#L104) — import-echo scanner: clears `lastSavedName` to `null` whenever a new `import graph from {name}` echo arrives, so the imported name takes over immediately
+- `src/hooks/useGraphSaveName.ts` [L122–L131](../src/hooks/useGraphSaveName.ts#L122) — `setLastSavedName(name)`: sets the saved name and marks `untitledSlotConsumedRef = true` only when the name equals the current `untitled-{n}` fallback
+- `src/hooks/useGraphSaveName.ts` [L133–L142](../src/hooks/useGraphSaveName.ts#L133) — `resetName()`: clears both names; advances counter only when `untitledSlotConsumedRef.current` is `true`, then resets the flag
+- `src/hooks/useGraphSaveName.ts` [L145–L148](../src/hooks/useGraphSaveName.ts#L145) — derived `defaultName`: `lastSavedName ?? importedName ?? \`untitled-${untitledCounter}\``
+- `src/components/Playground.tsx` [L216–L219](../src/components/Playground.tsx#L216) — hook instantiated with key `\`${storageKeySavedGraphs}-untitled-counter\`` to keep the counter isolated per playground
+- `src/utils/messageParser.ts` [L266–L276](../src/utils/messageParser.ts#L266) — `extractImportGraphName()`: parses `> import graph from {name}` echoes; returns the trimmed name or `null`
+
+---
+
+## 4. Repository Layout
+
+```
+webapp/
+├── src/
+│   ├── main.tsx                  # React root mount
+│   ├── App.tsx                   # Router + WebSocketProvider bootstrap
+│   ├── index.css                 # Global resets / CSS variables
+│   ├── config/
+│   │   └── playgrounds.ts        # ★ SINGLE source of truth for all playgrounds
+│   ├── contexts/
+│   │   └── WebSocketContext.tsx  # Shared multi-socket state (above Routes)
+│   ├── hooks/
+│   │   ├── useWebSocket.ts       # Per-playground WS + command input logic
+│   │   ├── useGraphData.ts       # REST fetch + graph state management
+│   │   ├── useAutoGraphRefresh.ts# Mutation detection → auto re-fetch
+│   │   ├── useAutoMarkdownPin.ts # help/describe echo → auto-pin preview
+│   │   ├── useLargePayloadDownload.ts # Large payload REST fetch → console
+│   │   ├── useAutoMockUpload.ts  # Mock-upload invitation → auto-open modal
+│   │   ├── useMockUpload.ts      # POST fetch lifecycle for mock-upload modal
+│   │   ├── useSavedGraphs.ts     # localStorage graph bookmark CRUD
+│   │   ├── useGraphSaveName.ts   # Save-form pre-fill name (priority: saved > imported > untitled-n)
+│   │   ├── useLocalStorage.ts    # Generic localStorage hook
+│   │   ├── useToast.ts           # Toast notification queue
+│   │   ├── useCopyToClipboard.ts # Clipboard write with copied state
+│   │   ├── useMediaQuery.ts      # Responsive breakpoint detection
+│   │   └── useAutocomplete.ts    # Command autocomplete suggestions
+│   ├── components/
+│   │   ├── Playground.tsx        # ★ Top-level orchestrator per route
+│   │   ├── Navigation.tsx        # Header nav bar (Tools + Quick Links menus)
+│   │   ├── Toast.tsx             # Toast container + item
+│   │   ├── LeftPanel/            # Console + CommandInput wrapper
+│   │   ├── RightPanel/           # Tab switcher (payload/preview/graph/graph-data)
+│   │   ├── Console/              # Message list + ConsoleMessage renderer
+│   │   ├── CommandInput/         # Text input + send button
+│   │   ├── GraphView/            # ReactFlow canvas + NodeTypes + ErrorBoundary
+│   │   ├── GraphDataView/        # Raw JSON viewer for graph model
+│   │   ├── GraphToolbar/         # Copy/download toolbar for graph panel
+│   │   ├── GraphSaveButton/      # Inline save-form button in header
+│   │   ├── SavedGraphsMenu/      # Dropdown list of saved graph bookmarks
+│   │   ├── MockUploadModal/      # Modal dialog for mock-data JSON upload
+│   │   ├── PayloadEditor/        # Textarea + validation + SampleButtons
+│   │   ├── MarkdownPreview/      # react-markdown renderer
+│   │   └── NavMenu/              # Generic accessible dropdown menu
+│   └── utils/
+│       ├── messageParser.ts      # ★ Message classification & pattern matching
+│       ├── graphTransformer.ts   # Backend JSON → ReactFlow nodes + edges
+│       ├── graphTypes.ts         # TypeScript interfaces + type guard
+│       ├── validators.ts         # JSON/XML payload validation + formatting
+│       ├── urls.ts               # WebSocket & HTTP URL construction
+│       └── commandSuggestions.ts # Autocomplete command list
+├── docs/
+│   ├── SPEC-auto-graph-refresh.md
+│   ├── SPEC-large-payload-inline.md
+│   └── SPEC-mock-data-upload-modal.md
+├── scripts/
+│   └── upload-json.mjs           # CLI helper: POST a JSON file to the backend
+├── vite.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+---
+
+## 5. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                      App.tsx                        │
+│  ┌──────────────────────────────────────────────┐  │
+│  │           WebSocketProvider                  │  │
+│  │   (lives above Routes — sockets persist)     │  │
+│  │  ┌────────────────────────────────────────┐  │  │
+│  │  │           BrowserRouter                │  │  │
+│  │  │   Route /        → Playground (cfg A)  │  │  │
+│  │  │   Route /json-path → Playground (cfg B)|  │  │
+│  │  └────────────────────────────────────────┘  │  │
+│  └──────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+
+Each Playground instance:
+
+  Playground.tsx (orchestrator)
+  ├── useWebSocket          ← command input + history + WS actions
+  ├── useGraphData          ← REST fetch + graph state
+  ├── useAutoGraphRefresh   ← mutation detection → silent describe graph
+  ├── useAutoMarkdownPin    ← help/describe echo → auto-pin preview
+  ├── useLargePayloadDownload ← oversized payload → REST fetch → console
+  ├── useAutoMockUpload     ← upload invitation → auto-open modal
+  ├── useSavedGraphs        ← localStorage bookmark CRUD
+  ├── useGraphSaveName      ← save-form pre-fill name (saved › imported › untitled-n)
+  │
+  ├── LeftPanel
+  │   ├── Console           ← message list (ConsoleMessage per row)
+  │   └── CommandInput      ← textarea + send button + history nav
+  │
+  ├── RightPanel (tabbed)
+  │   ├── PayloadEditor     ← textarea + validation (JSON-Path only)
+  │   ├── MarkdownPreview   ← react-markdown (Minigraph only)
+  │   ├── GraphView         ← ReactFlow canvas
+  │   └── GraphDataView     ← raw JSON tree of graph model
+  │
+  └── MockUploadModal       ← native <dialog>; JSON paste / drop / browse; POST
+```
+
+**Key design principle:** State flows top-down through props; side-effects are encapsulated in hooks; components are dumb renderers. `Playground.tsx` is the only component that coordinates between hooks.
+
+---
+
+## 6. Layer-by-Layer Walkthrough
+
+### 6.1 Entry Point & Routing
+
+**`src/main.tsx`** — Standard React 19 root mount. Wraps `<App>` in `<StrictMode>`.
+
+**`src/App.tsx`** — Two responsibilities:
+1. Wraps the entire tree in `<WebSocketProvider>` *outside* `<BrowserRouter>` so connections survive route changes.
+2. Generates one `<Route>` per entry in `PLAYGROUND_CONFIGS` — adding a playground requires only a config entry, never a code change here.
+
+A catch-all `<Route path="*">` redirects unknown paths to the first playground.
+
+---
+
+### 6.2 Playground Configuration
+
+**`src/config/playgrounds.ts`** — The single source of truth for everything that varies per playground:
+
+```typescript
+interface PlaygroundConfig {
+  path:                  string;   // URL route, e.g. "/json-path"
+  label:                 string;   // Nav bar label
+  title:                 string;   // Page heading
+  wsPath:                string;   // WebSocket endpoint, e.g. "/ws/json/path"
+  storageKeyPayload:     string;   // localStorage key for payload
+  storageKeyHistory:     string;   // localStorage key for command history
+  storageKeyTab:         string;   // localStorage key for right-panel tab
+  storageKeySavedGraphs?: string;  // present → enables saved-graph bookmarks
+  supportsUpload?:       boolean;  // present → enables REST upload handshake
+  tabs:                  RightTab[]; // ordered list of right-panel tabs to show
+}
+```
+
+The file also exports shared runtime constants used across the app:
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `MAX_ITEMS` | 200 | Console message ring buffer size |
+| `MAX_HISTORY` | 50 | Command history entries in localStorage |
+| `MAX_BUFFER` | 63,488 | WebSocket send character limit (safely under 64 KB) |
+| `PING_INTERVAL` | 20,000 ms | Keep-alive ping frequency |
+
+> **Maintainer tip:** To add a new playground, add one object to `PLAYGROUND_CONFIGS`. The route, nav link, connection dot, localStorage namespace, and right-panel tabs are all derived automatically.
+
+---
+
+### 6.3 WebSocket State — Context + Hook
+
+The WebSocket layer is split across two files with distinct responsibilities:
+
+#### `src/contexts/WebSocketContext.tsx` — shared, navigation-persistent state
+
+Holds a `useReducer`-managed map of `SlotState` objects, one per `wsPath`. A "slot" contains:
+- `phase: 'idle' | 'connecting' | 'connected'`
+- `messages: { id: number; raw: string }[]` (ring-buffered at `MAX_ITEMS`)
+
+WebSocket instances, ping interval handles, and message ID counters live in `useRef` objects (outside the reducer) so they never cause re-renders.
+
+**`connect(wsPath, onToast)`:**
+1. Dispatches `CONNECTING`
+2. Opens `new WebSocket(makeWsUrl(wsPath))`
+3. On `open`: dispatches `CONNECTED`, sends `{"type":"welcome"}`, starts the ping interval
+4. On `message`: filters out keep-alive ping/pong frames, dispatches `MESSAGE_RECEIVED`
+5. On `close`/`error`: clears ping interval, dispatches `DISCONNECTED`
+
+**`send(wsPath, data)`:** Writes directly to `wsRef.current` — no React re-render.
+
+**`pendingPayloads`** is a `useState` (not `useRef`) map so that depositing a payload via `setPendingPayload` triggers a re-render in consuming components (specifically the JSON-Path Playground's `useEffect` polling for cross-playground payload transfer).
+
+#### `src/hooks/useWebSocket.ts` — per-playground UI state
+
+A thin delegation layer that reads its slot from the context and adds purely local concerns:
+
+- **Command input + history** via a local `useReducer` (not shared — intentionally resets on remount)
+- **Auto-scroll** via a `consoleRef` and a `useEffect` watching `messages`
+- **History navigation** with ↑/↓ arrow key handling; saves and restores the in-progress draft when entering/exiting history mode
+- **`sendCommand()`**: sends the command, pushes to history, and — for the special `load` command — also sends the payload as a second WebSocket message
+- **Two-step upload handshake**: a `pendingUploadRef` is armed by `uploadPayload()`; a `useEffect` watches messages for the `extractUploadPath` pattern and fires the `fetch` POST
+- **`sendRawText(text)`**: sends without echoing to history, used by automation hooks for silent commands like `describe graph`
+
+---
+
+### 6.4 Playground.tsx — The Orchestrator
+
+`Playground.tsx` is the most important file to understand. It does **no rendering logic** — it wires together all hooks and passes their outputs as props to dumb layout components.
+
+Key responsibilities:
+
+| Concern | How handled |
+|---|---|
+| Payload persistence | `useLocalStorage(storageKeyPayload)` — survives navigation and refresh |
+| Large payload override | Separate `useState(null)` — never written to localStorage to avoid quota exhaustion; wins over stored value when set |
+| Payload validation | `useMemo(() => validatePayload(payload))` — synchronous, no extra render |
+| Toast notifications | `useToast()` — queue-based, auto-removes after timeout |
+| Graph path pinning | `useState<string \| null>(null)` — the REST path extracted from a graph-link message |
+| Preview message pinning | `useState<number \| null>(null)` — stores message **id**, not raw string |
+| Panel split persistence | `useDefaultLayout` from `react-resizable-panels` — keyed per route |
+| Responsive layout | `useMediaQuery('(max-width: 768px)')` → vertical panel stacking on mobile |
+| Clear messages | Also clears `pinnedMessageId`, `pinnedGraphPath`, `modalUploadPath`, `successfulUploadPaths`, and `graphData` so no stale state lingers |
+| Cross-playground routing | `ctx.setPendingPayload` + `navigate()` — deposits JSON then navigates; consuming playground reads it via `ctx.takePendingPayload` |
+| Mock-upload modal path | `useState<string \| null>(null)` — `null` = closed; non-null = open for that specific POST endpoint |
+| Modal trigger element | `useRef<HTMLElement \| null>(null)` — captures `document.activeElement` before open; `.focus()` restored on close via `setTimeout` |
+| Successful upload paths | `useState<Set<string>>(new Set())` — keyed by POST path; drives ✅ badge on invitation rows; session-only (cleared with `clearMessages`) |
+| Graph save-form name | `useGraphSaveName(storageKey, ws.messages)` — provides `defaultName`, `setLastSavedName`, `resetName`; see §3.13 |
+
+**Pinning logic** (`handlePinMessage`):
+- If the message is a graph-link → set `pinnedGraphPath` (triggers `useGraphData`) and also highlight the row
+- Otherwise → set `pinnedMessageId` and clear `pinnedGraphPath`
+
+---
+
+### 6.5 Left Panel — Console & Command Input
+
+**`LeftPanel.tsx`** — a thin layout shell that positions `Console` above `CommandInput`.
+
+**`Console.tsx`** — renders a scrollable `role="log"` div. Each message is wrapped in a `ConsoleErrorBoundary` so a rendering crash in one row does not take down the whole list. It also has copy-all and clear-all toolbar buttons.
+
+**`ConsoleMessage.tsx`** — the most visually complex component. For each message it:
+1. Calls `parseMessage()` to extract `{type, message, time}`
+2. Calls `tryParseJSON()` — JSON messages render as a collapsible `<JsonView>` tree
+3. Classifies the message as a graph-link, large-payload link, mock-upload invitation, or plain text for appropriate styling and icons
+4. Conditionally renders:
+   - A **pin button** (📌 for plain-text, 🕸️ for graph-links) — clickable rows with full keyboard support (`role="button"`, `tabIndex`, `Enter`/`Space` handlers). Mock-upload rows are **explicitly excluded** from `isPinnable` via `&& !isMockUpload` to prevent a nested-interactive-element accessibility violation
+   - A **copy button** (📄 → ✅) with scoped `copied` state
+   - A **send-to-JSON-Path button** (➡️) on JSON messages when the callback is wired
+   - A **"⬆️ Upload JSON…" re-open button** on mock-upload invitation rows when `onUploadMockData` is wired; shows a ✅ badge when `successfulUploadPaths` contains the row's POST path
+
+**`CommandInput.tsx`** — textarea (single or multiline mode) with a Send button and multiline toggle. Delegates all logic to `useWebSocket` via callbacks.
+
+---
+
+### 6.6 Right Panel — Tabs
+
+**`RightPanel.tsx`** — renders only the tabs listed in the playground's `tabs` config. Uses `useId()` for accessible `aria-controls` / `role="tab"` associations. Active tab is driven by `rightTab` state from `useGraphData` (persisted in localStorage).
+
+The four possible tabs:
+
+| Tab key | Component | When shown |
+|---|---|---|
+| `'payload'` | `PayloadEditor` | JSON-Path playground |
+| `'preview'` | `MarkdownPreview` | Minigraph playground |
+| `'graph'` | `GraphView` | Both playgrounds |
+| `'graph-data'` | `GraphDataView` | Both playgrounds |
+
+---
+
+### 6.7 Graph Pipeline
+
+The journey from a WebSocket message to a rendered graph has four stages:
+
+```
+1. Server emits graph-link message in WebSocket stream
+   e.g. "Graph described in /api/graph/model/ws-123-1"
+
+2. messageParser.extractGraphApiPath() → "/api/graph/model/ws-123-1"
+   (either by user clicking the 🕸️ row, or automatically via useAutoGraphRefresh)
+
+3. Playground.tsx sets pinnedGraphPath → useGraphData fires REST fetch
+   GET /api/graph/model/ws-123-1
+   Response: { nodes: [...], connections: [...] }
+
+4. graphTransformer.transformGraphData(data)
+   → ReactFlow nodes[]  (with computed layout positions + per-type styles)
+   → ReactFlow edges[]  (with relation labels)
+
+5. GraphView renders <ReactFlow> with the computed nodes/edges
+```
+
+#### `src/utils/graphTypes.ts` — Type definitions & type guard
+
+Defines `MinigraphGraphData`, `MinigraphNode`, `MinigraphConnection`, and `MinigraphRelation`. The exported `isMinigraphGraphData(value)` type guard is called on every REST response before setting state — it guards against malformed JSON without throwing.
+
+#### `src/utils/graphTransformer.ts` — Layout algorithm
+
+Uses a **BFS topological layout**:
+1. Build adjacency lists and in-degree counts from `connections`
+2. Identify seed nodes: in-degree 0 or typed as `entry_point`
+3. BFS assigns a column (level) to each node — a node's level is always ≥ its predecessor's level + 1
+4. Within each level, nodes are stacked vertically with equal spacing
+5. Disconnected nodes are placed in a trailing column
+
+Node styles are applied via `node.style` (not CSS classes) using the CSS custom property `--node-accent` for per-type accent colours. This is the pattern required by ReactFlow's `NodeResizer` — having no inner wrapper div means the RF wrapper element *is* the visual shell.
+
+#### `src/components/GraphView/NodeTypes.tsx` — Custom node
+
+`MinigraphNode` renders as a **React Fragment** (no wrapper div). `NodeResizer`, handles, and content are top-level siblings. This avoids all the sizing workarounds that a nested div structure requires. The `nodeTypes` map exported here is passed directly to `<ReactFlow nodeTypes={nodeTypes}>`.
+
+#### `src/components/GraphView/GraphViewErrorBoundary.tsx`
+
+A class-based error boundary that resets when its `key` prop changes. `GraphView` passes a `boundaryKey` derived from `graphData.nodes.map(n => n.alias)` — a corrected graph after a previous render failure renders cleanly without a page reload.
+
+---
+
+### 6.8 Automation Hooks
+
+These hooks share the same pattern: **message-ID watermark + flag ref + effects**.
+
+#### Pattern common to all automation hooks
+
+```
+useEffect (runs once at mount, empty dep []):
+  watermarkRef.current = last message ID in existing log
+
+useEffect (runs on connect change):
+  if (!connected) clear pending flags + cancel timers/fetches
+
+useEffect (runs on messages change — the main loop):
+  newMessages = messages.filter(m => m.id > watermarkRef.current)
+  watermarkRef.current = messages[last].id
+  for each new message: inspect + act
+```
+
+The watermark prevents replaying historical messages as new mutations/echoes/large-payloads when the component mounts into an already-populated message log.
+
+#### `useAutoGraphRefresh`
+
+Watches for `detectMutation(raw)` returning `'node-mutation'` or `'import-graph'`.
+
+- **`'node-mutation'`**: arms a 300 ms debounce timer. On fire, sends `describe graph` silently and sets `waitingForDescribeRef = true`. The next graph-link message is consumed to call `setPinnedGraphPath`.
+- **`'import-graph'`**: immediately cancels any pending debounce and sends `describe graph`.
+- When `waitingForDescribeRef` is true, a prior "Pass 1" in the main effect scans new messages for a graph-link and calls `setPinnedGraphPath` on the first one found, then returns early.
+
+**Stale-closure fix**: `pinnedGraphPath` is read via `pinnedGraphPathRef` inside the debounce timer callback — if it were read directly from closure it would be stale after subsequent renders.
+
+#### `useAutoMarkdownPin`
+
+Watches for `isHelpOrDescribeCommand(raw)` (echoed `> help ...` or `> describe <non-graph>` commands). Sets `waitingForResponseRef = true`. The next message that passes `isPinnableResponse` (plain text, not an echo, not a graph-link, **not a mock-upload invitation**) is pinned via `setPinnedMessageId` and `onAutoPin()` is called to switch the tab.
+
+**Critical guard**: echoed commands start with `> ` and pass `isMarkdownCandidate`. Without the echo guard in `isPinnableResponse`, the echo itself would be pinned instead of the actual response.
+
+**Mock-upload guard**: `isPinnableResponse` also excludes `isMockUploadMessage` rows. Because the upload invitation is plain text, `isMarkdownCandidate` returns `true` for it. Without this exclusion, if `waitingForResponseRef` were armed (e.g. the user sent `help` and then quickly ran `upload mock data`), the invitation would be stolen and pinned to the Developer Guides tab instead of opening the modal.
+
+#### `useLargePayloadDownload`
+
+Watches for `extractLargePayloadLink(raw)` matching `"Large payload (N) -> GET /api/inspect/..."`. Fetches the endpoint, pretty-prints the JSON, and calls `appendMessage(content)` to inject the result into the console. An `isFetchingRef` re-entrancy guard prevents the appended result from being re-processed as a new notification. Only the first large-payload link in each message batch is processed (a `break` after the first match prevents concurrent fetches).
+
+#### `useAutoMockUpload`
+
+Watches for `isMockUploadMessage(raw)` — the server's upload invitation pattern `"You may upload JSON payload -> POST /api/mock/{id}"`. When detected, calls `onOpenModal(uploadPath)` immediately (no debounce, no two-step handshake — the invitation message itself contains the complete target URL).
+
+Key design decisions compared with the other automation hooks:
+
+| Decision | Rationale |
+|---|---|
+| No `waitingForRef` flag | No two-step server handshake; the invitation is self-contained |
+| Watermark NOT reset on disconnect | No pending-wait flag to clear; resetting would replay old invitations on reconnect and auto-open the modal for stale endpoints |
+| `connected` accepted but aliased `_connected` | Symmetry with peer hooks; body does not depend on it |
+| Break on first match per batch | Consistent with `useLargePayloadDownload`; prevents two modal opens in one message batch |
+
+---
+
+### 6.9 Utilities
+
+#### `src/utils/messageParser.ts`
+
+The classification engine for all WebSocket messages. Key exports:
+
+| Function | Purpose |
+|---|---|
+| `parseMessage(raw)` | Parse JSON or return raw as `{type:'raw'}` |
+| `tryParseJSON(str)` | Returns `{isJSON, data}` — only true for objects/arrays, not primitives |
+| `isMarkdownCandidate(raw)` | True for non-JSON strings; false for JSON lifecycle events |
+| `isGraphLinkMessage(raw)` | True when the message contains `/api/graph/model/...` |
+| `isLargePayloadMessage(raw)` | True for `"Large payload (N) -> GET ..."` |
+| `isMockUploadMessage(raw)` | True for `"You may upload … -> POST /api/mock/..."` upload invitations |
+| `isHelpOrDescribeCommand(raw)` | True for `"> help ..."` and `"> describe <non-graph>"` echoes |
+| `detectMutation(raw)` | Returns `'node-mutation'`, `'import-graph'`, or `null` |
+| `extractGraphApiPath(raw)` | Regex extracts `/api/graph/model/{id}` |
+| `extractUploadPath(raw)` | Regex extracts `/api/json/content/{id}` (JSON-Path upload handshake) |
+| `extractMockUploadPath(raw)` | Regex extracts `/api/mock/{id}` from the mock-upload invitation |
+| `extractLargePayloadLink(raw)` | Parses the size and path from the large-payload notification |
+
+**`detectMutation` matching rules** (important to understand for maintenance):
+
+```
+'import-graph'   if lower includes 'graph model imported as draft'
+'node-mutation'  if lower includes ' -> ' AND 'removed'         (connection delete)
+'node-mutation'  if lower.startsWith('node ') AND:
+                    includes ' created'
+                    includes ' updated'
+                    includes ' deleted'
+                    includes ' connected to '
+                    includes ' imported from '
+                    includes ' overwritten by node from '
+```
+
+The `startsWith('node ')` prefix guard is critical — it prevents false positives from `"Graph instance created"` (`instantiate graph`) and `"Root node created because it does not exist"` (`export graph`).
+
+#### `src/utils/graphTransformer.ts`
+
+Converts `MinigraphGraphData` to ReactFlow `nodes[]` and `edges[]`. See §6.7 for the layout algorithm detail.
+
+#### `src/utils/urls.ts`
+
+Single source of truth for URL construction:
+
+```typescript
+makeWsUrl(wsPath)
+  // dev  → ws://localhost:3000{wsPath}   (Vite proxy on port 3000)
+  // prod → ws://{window.location.host}{wsPath}  (same origin)
+```
+
+HTTP API paths are always **relative** — the Vite proxy forwards them in dev; the same-origin server handles them in production.
+
+#### `src/utils/validators.ts`
+
+`validatePayload(text)` tries `JSON.parse`, then `DOMParser` XML parse. Returns `{valid, error, type}`. `formatJSON` pretty-prints JSON. Used in `PayloadEditor` for live validation feedback.
+
+---
+
+### 6.10 Navigation Bar
+
+**`Navigation.tsx`** reads all playground configs and renders two dropdown menus built on `NavMenu`:
+
+**Tools menu** — per-playground entry with:
+- A `<NavLink>` (navigates) with a status dot
+- A separate **Start/Stop** button (connects/disconnects without navigating)
+
+The aggregate dot status across all playgrounds uses `aggregateDotStatus()`:
+- All connected → green
+- All idle → grey
+- Any connecting → pulsing yellow
+- Mixed → partial (some connected)
+
+**Quick Links menu** — static links to backend `/info`, `/health`, `/env`, etc.
+
+**`NavMenu.tsx`** — a reusable accessible dropdown:
+- `Escape` closes it
+- Click outside closes it (`useEffect` + `mousedown` listener)
+- `aria-expanded` / `aria-haspopup` for screen readers
+
+---
+
+### 6.11 Saved Graphs
+
+**`useSavedGraphs(storageKey)`** manages a `Record<string, SavedGraphEntry>` in localStorage. The data model stores only the graph **name** (a string), not the graph data itself — the server holds the actual file.
+
+**Save flow:**
+```
+User clicks Save → GraphSaveButton inline form →
+  handleSaveGraph(name):
+    savedGraphs.saveGraph(name)          // write to localStorage
+    ws.sendRawText(`export graph as ${name}`)  // server writes {name}.json
+```
+
+**Load flow:**
+```
+User clicks Load in SavedGraphsMenu →
+  handleLoadGraph(name):
+    ws.sendRawText(`import graph from ${name}`)  // server reads {name}.json
+    → server responds with a mutation success message
+    → useAutoGraphRefresh detects import-graph
+    → fires describe graph automatically
+    → graph renders
+```
+
+**Save-form pre-fill (`useGraphSaveName`):**
+
+The name pre-filled in the save form is managed entirely by `useGraphSaveName` — `GraphSaveButton` receives only the already-computed `defaultName` string and a `setLastSavedName` callback; it knows nothing about the priority logic.
+
+```
+Priority (highest → lowest):
+
+1. lastSavedName   set by setLastSavedName(name) after a successful save
+2. importedName    extracted from "> import graph from {name}" echo in WS stream
+3. untitled-{n}    persisted localStorage counter, starts at 1, never skips
+```
+
+The counter increment rule: `untitled-{n}` only advances to `untitled-{n+1}` when `untitled-{n}` was actually saved (i.e. `setLastSavedName` was called with a name matching the current untitled fallback). Clearing the console without ever saving reuses the same slot. This guarantees `untitled-2` never appears unless `untitled-1` was saved first.
+
+`importedName` always supersedes `lastSavedName` for a new import: the import-echo scanner calls `setLastSavedNameState(null)` immediately when a fresh `> import graph from {name}` arrives — `lastSavedName` is cleared in the same effect pass that sets `importedName`, so the priority chain reflects the new state in the very next render.
+
+See §3.13 for the full feature description and all code locations.
+
+---
+
+## 7. Key Engineering Decisions
+
+### 7.1 WebSocket Context Above the Router
+
+**Decision:** `WebSocketProvider` wraps `<BrowserRouter>`, not the other way around.
+
+**Why:** If the provider were inside a route, it would unmount and re-mount on navigation — closing the socket. By living above routes, all playground sockets share a single provider instance that never unmounts during normal navigation.
+
+**Trade-off:** The context holds state for all playgrounds simultaneously, which is a small memory overhead. Given the bounded `MAX_ITEMS = 200` ring buffer per slot, this is negligible.
+
+---
+
+### 7.2 Refs Outside the Reducer for Socket Instances
+
+**Decision:** `WebSocket` instances, ping interval handles, and message ID counters live in `useRef` (not `useState` or inside the reducer).
+
+**Why:** These are imperative handles that must be accessible synchronously in event callbacks. Putting them in state would cause render cycles on every incoming message. The reducer owns only the serialisable view of state (phase + messages array) that React needs to diff and render.
+
+---
+
+### 7.3 Monotonic Message IDs Instead of Array Indices
+
+**Decision:** Each message has a stable `id: number` that increments globally per slot, never recycled.
+
+**Why:** Array indices shift when the ring buffer drops old messages. A pinned message identified by index would shift to a different message after the buffer rotates. The stable ID means `pinnedMessageId` always refers to the correct row.
+
+---
+
+### 7.4 Message Watermark Pattern
+
+**Decision:** All three automation hooks (`useAutoGraphRefresh`, `useAutoMarkdownPin`, `useLargePayloadDownload`) initialise a watermark ref at mount to the highest ID in the existing log.
+
+**Why:** Without this, a `useEffect` that runs on the initial `messages` dependency would scan every historical message as if it were new — triggering spurious mutations, auto-pins, or payload downloads for messages that arrived before the component mounted (e.g. from a previous session's localStorage-restored messages or from messages received while the user was on a different playground tab).
+
+---
+
+### 7.5 `sendRawText` vs `sendCommand`
+
+**Decision:** Two separate send functions.
+
+- `sendCommand()` — writes to history, echoes the command, handles the `load` special case
+- `sendRawText(text)` — sends silently, used exclusively by automation hooks
+
+**Why:** Automation hooks must not pollute the command history or produce `> describe graph` echo entries in the console (those would trigger `useAutoMarkdownPin` falsely, since `describe` is a triggering word). `sendRawText` bypasses all that.
+
+---
+
+### 7.6 Node Styles via `node.style` + CSS Custom Properties
+
+**Decision:** ReactFlow node visual styling is applied via `node.style` on the node data object, not via a wrapper `<div className>` inside the component.
+
+**Why:** When `MinigraphNode` renders as a `<Fragment>` (no inner wrapper), the ReactFlow-managed wrapper element *is* the visible shell. `node.style` is the only way to style it. The per-type accent colour is passed as `--node-accent` CSS custom property so the CSS module can reference it for header background, badge colour, and border — without any JS–CSS coupling in the component itself.
+
+---
+
+### 7.7 Two-Path `useGraphData` Design
+
+The hook has two distinct code paths:
+
+- **Initial-load path** (triggered by `pinnedGraphPath` changing): clears `graphData` to `null` (clean loading state for new graphs), auto-switches the tab to `'graph'` on success. Uses a `useEffect`-managed `AbortController`.
+- **Auto-refresh path** (triggered by `refetchGraph()` call): does *not* clear `graphData` (stale graph stays visible under a spinner overlay), does *not* switch the tab (user is not interrupted). Uses a `useCallback`-stable imperative function with its own abort ref.
+
+**Why separate paths?** A first-time load of a new graph needs visual loading feedback and should switch context to the Graph tab. A background refresh should be invisible to the user — just a spinner on the existing graph.
+
+---
+
+### 7.8 `useLargePayloadDownload` Re-entrancy Guard
+
+**Decision:** `isFetchingRef` is checked at the top of the main effect.
+
+**Why:** After `appendMessage(content)` injects the fetched payload into the console, `messages` changes, triggering the effect again. Without the guard, the newly appended message would be scanned — `extractLargePayloadLink` would return null for it, but the watermark advance logic uses `+ 1` as a belt-and-suspenders measure to ensure the appended message is treated as seen even before React re-renders.
+
+---
+
+### 7.9 `localStorage` for Persistence, Not Global State
+
+**Decision:** All persistence (payload, command history, right-panel tab, saved graphs) uses `useLocalStorage` — a hook that wraps `useState` with read/write effects and a `storage` event listener.
+
+**Why not Redux or Zustand?** The app's cross-component state needs are modest: the WebSocket context covers the only truly global mutable state. Everything else is either local to a component or derivable from props. Adding a global state library would be over-engineering. The `storage` event listener handles multi-tab synchronisation as a bonus.
+
+---
+
+### 7.10 Payload Override Pattern
+
+**Decision:** `payloadOverride: string | null` is a separate `useState` that wins over `storedPayload` when non-null.
+
+**Why:** Large payloads fetched via REST should not be written to localStorage (they can be megabytes). Instead the override is held in memory. Any manual edit in the textarea calls `setPayload` which calls `setPayloadOverride(null)` first — the user always gets back in control.
+
+---
+
+## 8. Data & Message Flows
+
+### 8.1 User Sends a Command
+
+```
+User types in CommandInput → ws.command state
+User presses Enter or Send button → ws.sendCommand()
+  → ctx.send(wsPath, text)           — fires WebSocket.send()
+  → pushes to history in localStorage
+  → if text === 'load': also sends payload as second WS message
+  → dispatch CLEAR_COMMAND
+Server echoes: "> <command>"          — arrives via ws.onmessage
+  → dispatch MESSAGE_RECEIVED
+  → ConsoleMessage renders it as plain text
+Server sends response (JSON or plain text)
+  → dispatch MESSAGE_RECEIVED
+  → ConsoleMessage renders:
+      JSON object/array  → <JsonView>
+      graph-link text    → 🕸️ pinnable row
+      plain text         → plain text row
+```
+
+### 8.2 User Pins a Graph
+
+```
+User clicks 🕸️ row in Console → handlePinMessage(msg)
+  → extractGraphApiPath(msg.raw) → "/api/graph/model/ws-123-1"
+  → setPinnedGraphPath("/api/graph/model/ws-123-1")
+  → setPinnedMessageId(msg.id)   — highlights the row
+  → useGraphData effect fires:
+      fetch("/api/graph/model/ws-123-1")
+      → transformGraphData(json)  — BFS layout + ReactFlow nodes/edges
+      → setGraphData(result)
+      → setRightTab('graph')      — tab switches automatically
+```
+
+### 8.3 Auto-Refresh After Mutation
+
+```
+User sends "create node foo" → ws.sendCommand()
+Server echoes "> create node foo"   — ignored by useAutoGraphRefresh
+Server responds "Node foo created"  — detectMutation → 'node-mutation'
+  → 300 ms debounce arms
+  → (300 ms passes, no further mutations)
+  → sendRawText('describe graph')   — silent, no history entry
+  → waitingForDescribeRef = true
+
+Server echoes graph-link "Graph described in /api/graph/model/ws-123-2"
+  → useAutoGraphRefresh Pass 1: waitingForDescribeRef === true
+  → extractGraphApiPath → "/api/graph/model/ws-123-2"
+  → setPinnedGraphPath("/api/graph/model/ws-123-2")
+  → waitingForDescribeRef = false
+
+  → useGraphData initial-load path:
+      fetch("/api/graph/model/ws-123-2")
+      → setGraphData(result)
+      → setRightTab('graph')
+```
+
+### 8.4 Large Payload Flow
+
+```
+User sends a command that returns a large payload
+Server responds: "Large payload (254922) -> GET /api/inspect/ws-563-1/input.body"
+  → useLargePayloadDownload detects via extractLargePayloadLink
+  → isFetchingRef = true
+  → fetch("/api/inspect/ws-563-1/input.body")
+  → appendMessage(JSON.stringify(parsedJson, null, 2))
+  → ConsoleMessage renders it as a <JsonView>
+  → ➡️ button available: user can send to JSON-Path Playground
+```
+
+### 8.5 REST Upload Handshake
+
+```
+User pastes JSON in PayloadEditor, clicks Upload
+  → ws.uploadPayload():
+      pendingUploadRef = true
+      ctx.send(wsPath, 'upload')
+
+Server responds: "Please upload XML/JSON text to /api/json/content/ws-123-1"
+  → useWebSocket effect detects extractUploadPath
+  → pendingUploadRef = false
+  → fetch POST /api/json/content/ws-123-1  body: payload JSON
+  → addToast('Payload uploaded successfully')
+```
+
+### 8.6 Mock-Data Upload Flow
+
+```
+User sends "upload mock data" → ws.sendCommand()
+Server responds: "You may upload JSON payload -> POST /api/mock/ws-417669-24"
+  → useAutoMockUpload detects isMockUploadMessage (watermark-guarded)
+  → extractMockUploadPath → "/api/mock/ws-417669-24"
+  → handleOpenUploadModal("/api/mock/ws-417669-24")
+      modalTriggerRef.current = document.activeElement   (command input)
+      setModalUploadPath("/api/mock/ws-417669-24")        → modal mounts + showModal()
+
+ConsoleMessage renders the invitation row with ⬆️ icon + "⬆️ Upload JSON…" button
+
+User provides JSON (paste, drag-and-drop, or Browse file…):
+  a. Paste / type → inline validation on every keystroke (tryParseJSON)
+  b. Drop .json file onto drop zone → validateFileType → readFileAsText →
+       tryParseJSON → formatJSON → textarea (focus restored)
+  c. Click "Browse file…" → hidden <input type="file"> → same path as (b)
+
+User clicks "Upload ▶" (or presses Ctrl+Enter / ⌘+Enter):
+  → useMockUpload.upload()
+      isUploading = true
+      fetch POST /api/mock/ws-417669-24  Content-Type: application/json
+      → 2xx:  isUploading = false → onSuccess(body)
+                → setSuccessfulUploadPaths (adds path → ✅ badge on console row)
+                → setModalUploadPath(null)  → modal unmounts
+                → setTimeout: modalTriggerRef.current?.focus()
+                → addToast('Mock data uploaded successfully ✓', 'success')
+      → non-2xx: isUploading = false → onError('HTTP 400 — <body>')
+                → setUploadError (inline banner) + addToast (error toast)
+                → modal stays open for retry
+
+User dismisses modal (Escape / Cancel / backdrop click):
+  → handleClose → cancel() (AbortController.abort()) → onClose()
+  → setModalUploadPath(null) → modal unmounts
+  → setTimeout: focus restored to modalTriggerRef
+
+User clicks "⬆️ Upload JSON…" re-open button on the console row:
+  → handleOpenUploadModal(mockUploadPath) → modal re-opens for same endpoint
+```
+
+---
+
+### 8.7 Save-Name Lifecycle
+
+```
+── Fresh session ─────────────────────────────────────────────────────
+localStorage has no counter yet
+  → useLocalStorage initialises untitledCounter = 1
+  → defaultName = "untitled-1"
+
+── User saves as "untitled-1" ────────────────────────────────────────
+handleSaveGraph("untitled-1"):
+  savedGraphs.saveGraph("untitled-1")          // localStorage bookmark
+  setLastSavedName("untitled-1")               // in useGraphSaveName
+    → setLastSavedNameState("untitled-1")
+    → "untitled-1" === `untitled-${1}` → untitledSlotConsumedRef = true
+  ws.sendRawText("export graph as untitled-1") // server writes file
+  → defaultName = "untitled-1"                 // lastSavedName wins
+
+── User clears console (slot was consumed) ───────────────────────────
+handleClearMessages() → resetSaveName() → resetName():
+  setImportedName(null)
+  setLastSavedNameState(null)
+  untitledSlotConsumedRef.current === true
+    → setUntitledCounter(1 + 1 = 2)            // advances: slot was used
+  untitledSlotConsumedRef.current = false
+  → defaultName = "untitled-2"
+
+── User clears console WITHOUT saving ────────────────────────────────
+resetName():
+  setImportedName(null)
+  setLastSavedNameState(null)
+  untitledSlotConsumedRef.current === false
+    → counter stays at 2                        // slot NOT advanced: never used
+  → defaultName = "untitled-2"                 // same slot reused
+
+── User saves as "my-graph" (renaming away from untitled) ────────────
+setLastSavedName("my-graph"):
+  setLastSavedNameState("my-graph")
+  "my-graph" !== `untitled-${2}` → flag stays false
+  → defaultName = "my-graph"                   // lastSavedName wins
+  → counter is still 2; "untitled-2" was never used
+
+── User imports "other-graph" (supersedes lastSavedName) ─────────────
+WS echo: "> import graph from other-graph"
+  → extractImportGraphName → "other-graph"
+  → setImportedName("other-graph")
+  → setLastSavedNameState(null)               // lastSavedName cleared
+  → defaultName = "other-graph"              // importedName wins
+```
+
+---
+
+## 9. State Ownership Map
+
+| State | Owner | Persistence | Notes |
+|---|---|---|---|
+| WS phase per slot | `WebSocketContext` reducer | Memory only | Resets on page reload |
+| Messages per slot | `WebSocketContext` reducer | Memory only | Ring-buffered at 200 |
+| WS refs (socket, ping, msgId) | `useRef` in Context | Memory only | Not in reducer (no renders) |
+| Pending payload (cross-playground) | `useState` in Context | Memory only | `useState` (not `useRef`) for re-render trigger |
+| Command input | `localReducer` in `useWebSocket` | Memory only | Resets on unmount — intentional |
+| Command history | `useLocalStorage` in `useWebSocket` | `localStorage` | Keyed per playground |
+| Payload text | `useLocalStorage` in `Playground` | `localStorage` | Keyed per playground |
+| Payload override (large) | `useState` in `Playground` | Memory only | Never written to localStorage |
+| Pinned message id | `useState` in `Playground` | Memory only | |
+| Pinned graph path | `useState` in `Playground` | Memory only | |
+| Modal upload path | `useState` in `Playground` | Memory only | `null` = closed; non-null = modal open |
+| Modal trigger element | `useRef` in `Playground` | Memory only | Captures active element before open for focus restore |
+| Successful upload paths | `useState` in `Playground` | Memory only | `Set<string>`; cleared on `clearMessages` |
+| Graph data | `useState` in `useGraphData` | Memory only | |
+| Right panel tab | `useLocalStorage` in `useGraphData` | `localStorage` | Keyed per playground |
+| Is refreshing | `useState` in `useGraphData` | Memory only | |
+| Saved graph names | `useLocalStorage` in `useSavedGraphs` | `localStorage` | Keyed per playground |
+| Untitled counter | `useLocalStorage` in `useGraphSaveName` | `localStorage` | Keyed per playground; only increments when slot was consumed by a save |
+| Last-saved name | `useState` in `useGraphSaveName` | Memory only | Cleared on import or reset |
+| Imported graph name | `useState` in `useGraphSaveName` | Memory only | Set from WS echo; cleared on reset |
+| Untitled slot consumed | `useRef` in `useGraphSaveName` | Memory only | Write-only flag; never drives a re-render |
+| Multiline mode | `useState` in `Playground` | Memory only | |
+| Toasts | `useReducer` in `useToast` | Memory only | Auto-expires |
+| Panel split ratio | `react-resizable-panels` | `localStorage` | Keyed per route path |
+| Automation watermarks | `useRef` in automation hooks | Memory only | Per hook instance |
+
+---
+
+## 10. Build, Dev & Deploy
+
+### Development
+
+```bash
+# Start the Java backend (in examples/minigraph-playground)
+java -jar target/minigraph-playground-4.3.77.jar   # port 8085
+
+# Start the Vite dev server (in webapp/)
+npm run dev   # port 3000, proxies /ws and /api to 8085
+```
+
+Open `http://localhost:3000`. Hot module replacement is active.
+
+### Production Build + Deploy
+
+```bash
+npm run build:deploy
+# Equivalent to:
+npm run build    # → dist/
+npm run deploy   # → cp dist/* ../src/main/resources/public/
+```
+
+The Java jar is then rebuilt and serves the SPA from the same origin as the WebSocket and REST endpoints — no CORS, no proxy needed.
+
+### Bundle splitting (`vite.config.ts`)
+
+Manual chunks keep each heavy vendor isolated:
+
+| Chunk | Content |
+|---|---|
+| `vendor-xyflow` | `@xyflow/react` (largest dependency) |
+| `vendor-router` | `react-router-dom` |
+| `vendor-markdown` | `react-markdown` + `remark-gfm` |
+| `vendor-json-view` | `react-json-view-lite` |
+| `vendor-panels` | `react-resizable-panels` |
+
+Source maps are enabled for production (`sourcemap: true`).
+
+### Upload JSON CLI
+
+`scripts/upload-json.mjs` is a Node.js script for testing the REST upload endpoint directly without the UI:
+
+```bash
+node scripts/upload-json.mjs \
+  --url http://localhost:8085/api/mock/ws-563496-16 \
+  --file ./64.json
+```
+
+---
+
+## 11. Extending the App
+
+### Add a new playground
+
+1. Add an entry to `PLAYGROUND_CONFIGS` in `src/config/playgrounds.ts`
+2. That's it. The route, nav link, localStorage namespace, right-panel tabs, and connection management are all derived automatically.
+
+### Add a new right-panel tab type
+
+1. Add the new key to the `RightTab` union in `RightPanel.tsx`
+2. Add the tab button and panel in `RightPanel.tsx`
+3. Reference it in `tabs:` arrays in `PLAYGROUND_CONFIGS`
+
+### Add a new node type to the graph
+
+1. Add the type string to `NODE_ACCENT` in `graphTransformer.ts` (gives it an accent colour)
+2. Add the type to `TYPE_META` in `NodeTypes.tsx` (gives it an icon and label)
+3. Add the type to the `nodeTypes` export in `NodeTypes.tsx` (maps it to `MinigraphNode`)
+4. (Optionally) add it to the MiniMap `colorMap` in `GraphView.tsx`
+
+### Add a new mutation command to auto-refresh
+
+Edit `detectMutation()` in `messageParser.ts`. Follow the existing patterns — always guard with `!isMarkdownCandidate` (skip JSON), `!raw.startsWith('> ')` (skip echoes), and `!isGraphLinkMessage` (skip graph links). Add the new success message pattern as a return case.
+
+---
+
+## 12. Pitfalls & Gotchas
+
+### P1 — Do not move `WebSocketProvider` inside `<BrowserRouter>`
+It must stay *above* the router. Inside the router it would unmount on every navigation, closing all sockets. See §7.1.
+
+### P2 — Do not put WS instances in React state
+`WebSocket` instances are imperative handles that must be available synchronously. In state they would cause render cycles on every incoming message. They belong in `useRef`. See §7.2.
+
+### P3 — Message IDs are not array indices
+The ring buffer drops old messages. Always identify pinned/processed messages by their stable `id`, never by their position in the array. See §7.3.
+
+### P4 — `detectMutation` requires the `startsWith('node ')` prefix
+Without this guard, `"Graph instance created"` and `"Root node created because..."` trigger false-positive auto-refreshes. Do not remove the prefix check. See §6.9 and §7.4.
+
+### P5 — `sendRawText` must be used for silent commands, not `sendCommand`
+`sendCommand` pushes to history and echos the command — the echo would trigger `useAutoMarkdownPin`'s `describe` guard and steal the graph-link response. See §7.5.
+
+### P6 — Watermarks must be set in a separate `useEffect` with an empty dep array
+The watermark init must run *before* the main scanning effect at mount, not inside it. React guarantees effects in a component run in declaration order on the first render, so declaring it first works. Merging it into the main effect would process historical messages as new ones. See §7.4.
+
+### P7 — `payloadOverride` must be cleared on manual edits
+The `setPayload` callback does `setPayloadOverride(null)` before calling `setStoredPayload`. If you add a new code path that modifies the payload, ensure it also clears the override so the user's edit is not silently discarded. See §7.10.
+
+### P8 — `refetchGraph` has an intentionally empty dependency array
+It reads `pinnedGraphPath` via `pinnedGraphPathRef` to avoid stale closures. Adding `pinnedGraphPath` to its dep array would break the "stable reference" contract that lets automation hooks include it in their own dep arrays safely. See §7.7.
+
+### P9 — Large payloads must never be written to localStorage
+The payload override pattern exists precisely for this reason. Never call `setStoredPayload` (the localStorage-backed setter) with a large blob. See §7.10.
+
+### P10 — ReactFlow node type must be in `nodeTypes` map
+If the backend sends a node whose `types[0]` value is not a key in the `nodeTypes` map in `NodeTypes.tsx`, ReactFlow will render a default node without the custom styling. Add new types to all four places listed in §11.
+
+### P11 — `isPinnable` must exclude mock-upload invitation rows
+The upload invitation is plain text, so `isMarkdownCandidate` returns `true` for it. Without the `&& !isMockUpload` guard in the `isPinnable` derivation in `ConsoleMessage.tsx`, the row would receive `role="button"` and `onClick` *alongside* the "⬆️ Upload JSON…" re-open button — creating nested interactive elements that violate WCAG. Always keep the `!isMockUpload` exclusion. See §3.12 and §6.5.
+
+### P12 — `useAutoMarkdownPin.isPinnableResponse` must exclude mock-upload invitations
+Same plain-text nature: if `waitingForResponseRef` is armed (user sent `help`, then quickly ran `upload mock data`), the invitation message passes `isMarkdownCandidate` and would be stolen as the "response" and pinned to the Developer Guides tab. The `isMockUploadMessage` exclusion in `isPinnableResponse` prevents this. Do not remove it. See §6.8.
+
+### P13 — Do not reset `useAutoMockUpload`'s watermark on disconnect
+Unlike the other automation hooks, this hook has no pending-wait flag to clear on disconnect. Resetting the watermark to `−1` on disconnect would cause invitation messages still in the store to be replayed as "new" on reconnect, auto-opening the modal for a stale endpoint from a previous session. Leave the watermark at its current value. See §6.8.
+
+---

--- a/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
@@ -72,14 +72,14 @@
 
 /* ── Individual message row ─────────────────────────────────────── */
 /*
- * Column layout:  [icon]  [message body]  [copy button]  [timestamp]
- * The copy button column is sized to its content and stays hidden
- * until the row is hovered or focused-within, so it does not consume
- * horizontal space in the normal reading state.
+ * Column layout:  [icon]  [message body]  [copy button]  [send-to-json-path]  [upload-mock]  [timestamp]
+ * Action buttons are sized to their content and stay hidden until the row
+ * is hovered or focused-within, so they do not consume horizontal space
+ * in the normal reading state.
  */
 .consoleMessage {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto 1fr auto auto auto auto;
   gap: 0.75rem;
   align-items: start;
   padding: 0.5rem;
@@ -125,6 +125,57 @@
 .consoleMessageGraphLink.consoleMessagePinned {
   background-color: rgba(20, 184, 166, 0.18);
   outline: 1px solid rgba(20, 184, 166, 0.55);
+}
+
+/* Large-payload download link — amber accent */
+.consoleMessageLargePayload {
+  background-color: rgba(245, 158, 11, 0.06);
+  outline: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 4px;
+}
+
+/* Mock-upload invitation row — amber accent (pairs with ⬇️ large-payload style) */
+.consoleMessageMockUpload {
+  background-color: rgba(245, 158, 11, 0.06);
+  outline: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 4px;
+}
+
+/* ── Upload-mock re-open button ───────────────────────────────────── */
+/* Same hide/reveal pattern as copyButton; uses an amber accent to
+ * match the invitation row highlight. Only rendered on mock-upload rows. */
+.uploadMockButton {
+  appearance: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1;
+  align-self: start;
+  font-weight: 600;
+  background-color: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  color: rgba(245, 158, 11, 0.85);
+  opacity: 0;
+  transition: opacity 0.15s, background-color 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.consoleMessage:hover .uploadMockButton,
+.consoleMessage:focus-within .uploadMockButton {
+  opacity: 1;
+}
+
+.uploadMockButton:hover {
+  background-color: rgba(245, 158, 11, 0.2);
+  border-color: rgba(245, 158, 11, 0.6);
+  color: #fcd34d;
+}
+
+.uploadMockButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid rgba(245, 158, 11, 0.8);
+  outline-offset: 2px;
 }
 
 /* ── Copy-to-clipboard button ───────────────────────────────────── */
@@ -191,6 +242,43 @@
   opacity: 1;
   color: #86efac;
   border-color: rgba(134, 239, 172, 0.5);
+}
+
+/* ── Send-to-JSON-Path button ────────────────────────────────────── */
+/* Same hide/reveal pattern as copyButton; uses a green accent to
+ * distinguish it from copy. Only rendered on JSON message rows. */
+.sendToJsonPathButton {
+  appearance: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  align-self: start;
+  font-weight: bold;
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  color: rgba(255, 255, 255, 0.75);
+  opacity: 0;
+  transition: opacity 0.15s, background-color 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.consoleMessage:hover .sendToJsonPathButton,
+.consoleMessage:focus-within .sendToJsonPathButton {
+  opacity: 1;
+}
+
+.sendToJsonPathButton:hover {
+  background-color: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.6);
+  color: #86efac;
+}
+
+.sendToJsonPathButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
 }
 
 .messageIcon {

--- a/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.tsx
@@ -12,6 +12,12 @@ interface ConsoleProps {
   pinnedMessageId?:   number | null;
   /** Called after any per-message copy succeeds — use this to show a toast. */
   onCopyMessage?:     () => void;
+  /** When provided, a "Send to JSON-Path" button appears on JSON messages. */
+  onSendToJsonPath?:  (json: string) => void;
+  /** When provided, a "⬆️ Upload JSON…" re-open button appears on mock-upload invitation rows. */
+  onUploadMockData?:  (uploadPath: string) => void;
+  /** Set of POST paths for which a mock upload has succeeded this session. */
+  successfulUploadPaths?: Set<string>;
 }
 
 export default function Console({
@@ -22,6 +28,9 @@ export default function Console({
   onPinMessage,
   pinnedMessageId,
   onCopyMessage,
+  onSendToJsonPath,
+  onUploadMockData,
+  successfulUploadPaths,
 }: ConsoleProps) {
   return (
     <div className={styles.consoleRoot}>
@@ -55,6 +64,9 @@ export default function Console({
               onPin={onPinMessage ? () => onPinMessage(msg) : undefined}
               pinned={pinnedMessageId === msg.id}
               onCopyMessage={onCopyMessage}
+              onSendToJsonPath={onSendToJsonPath}
+              onUploadMockData={onUploadMockData}
+              successfulUploadPaths={successfulUploadPaths}
             />
           </ConsoleErrorBoundary>
         ))}

--- a/extensions/minigraph-playground-engine/webapp/src/components/Console/ConsoleMessage.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Console/ConsoleMessage.tsx
@@ -1,33 +1,63 @@
-import { parseMessage, getMessageIcon, tryParseJSON, isMarkdownCandidate, isGraphLinkMessage } from '../../utils/messageParser';
+import { parseMessage, getMessageIcon, tryParseJSON, isMarkdownCandidate, isGraphLinkMessage, isLargePayloadMessage, isMockUploadMessage, extractMockUploadPath } from '../../utils/messageParser';
 import { JsonView, darkStyles } from 'react-json-view-lite';
 import 'react-json-view-lite/dist/index.css';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import styles from './Console.module.css';
 
 interface ConsoleMessageProps {
-  message:         string;
+  message:              string;
   /** Called when the user clicks/activates this row to pin it. The parent
    *  is responsible for capturing the message identity — this component
    *  just signals the intent. */
-  onPin?:          () => void;
-  pinned?:         boolean;
+  onPin?:               () => void;
+  pinned?:              boolean;
   /** Called after a successful clipboard write — use this to show a toast. */
-  onCopyMessage?:  () => void;
+  onCopyMessage?:       () => void;
+  /**
+   * When provided, a "Send to JSON-Path" action button is shown on hover for
+   * JSON messages.  Called with the pretty-printed JSON string.
+   * Only rendered when the message body is a valid JSON object/array.
+   */
+  onSendToJsonPath?:    (json: string) => void;
+  /**
+   * When provided, a "⬆️ Upload JSON…" re-open button appears on hover for
+   * mock-upload invitation rows. Called with the extracted POST path.
+   */
+  onUploadMockData?:    (uploadPath: string) => void;
+  /**
+   * Set of POST paths for which a mock upload has succeeded this session.
+   * When the current row's path is in this set, a ✅ badge is appended.
+   */
+  successfulUploadPaths?: Set<string>;
 }
 
-export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage }: ConsoleMessageProps) {
+export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage, onSendToJsonPath, onUploadMockData, successfulUploadPaths }: ConsoleMessageProps) {
   const parsed    = parseMessage(message);
   const icon      = getMessageIcon(parsed.type);
   const jsonCheck = tryParseJSON(parsed.message);
 
-  const isGraphLink  = isGraphLinkMessage(message);
-  const isPinnable   = !!onPin && (!isGraphLink ? isMarkdownCandidate(message) : true);
-  const pinTitle     = isGraphLink
+  const isGraphLink      = isGraphLinkMessage(message);
+  const isLargePayload   = isLargePayloadMessage(message);
+  const isMockUpload     = isMockUploadMessage(message);
+  const mockUploadPath   = isMockUpload ? extractMockUploadPath(message) : null;
+  const canUploadMock    = !!onUploadMockData && isMockUpload && mockUploadPath !== null;
+  const uploadSucceeded  = canUploadMock && !!successfulUploadPaths?.has(mockUploadPath!);
+
+  // ⚠️ Critical: isMockUpload must be excluded to prevent the invitation row
+  // from getting role="button" + onClick alongside the canUploadMock button,
+  // which would create a nested interactive element violating WCAG.
+  // Consistent with isLargePayload rows which are also non-pinnable.
+  const isPinnable       = !!onPin && !isMockUpload && (!isGraphLink ? isMarkdownCandidate(message) : true);
+  const pinTitle         = isGraphLink
     ? 'Click to load graph in Graph View'
     : 'Click to pin to Developer Guides';
-  const pinLabel     = isGraphLink
+  const pinLabel         = isGraphLink
     ? 'Load graph in Graph View'
     : 'Pin to Developer Guides';
+
+  // Only show the "send to JSON-Path" button when the message is a JSON object/array
+  // and the parent has wired up the callback.
+  const canSendToJsonPath = !!onSendToJsonPath && jsonCheck.isJSON;
 
   // Each message row owns its own copy state so the "✓" button confirmation
   // is scoped to exactly the row the user clicked — not the whole console.
@@ -48,14 +78,29 @@ export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage }
     }
   };
 
+  const handleSendToJsonPath = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    if (!onSendToJsonPath || !jsonCheck.isJSON) return;
+    const pretty = JSON.stringify(jsonCheck.data, null, 2);
+    onSendToJsonPath(pretty);
+  };
+
+  const handleUploadMockData = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    if (!onUploadMockData || !mockUploadPath) return;
+    onUploadMockData(mockUploadPath);
+  };
+
   return (
     <div
       className={[
         styles.consoleMessage,
         styles[`messageType-${parsed.type}`],
-        isPinnable ? styles.consoleMessagePinnable  : '',
-        pinned     ? styles.consoleMessagePinned    : '',
-        isGraphLink ? styles.consoleMessageGraphLink : '',
+        isPinnable     ? styles.consoleMessagePinnable    : '',
+        pinned         ? styles.consoleMessagePinned      : '',
+        isGraphLink    ? styles.consoleMessageGraphLink   : '',
+        isLargePayload ? styles.consoleMessageLargePayload : '',
+        isMockUpload   ? styles.consoleMessageMockUpload  : '',
       ].filter(Boolean).join(' ')}
       onClick={isPinnable ? () => onPin!() : undefined}
       title={isPinnable ? pinTitle : undefined}
@@ -67,14 +112,16 @@ export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage }
       aria-label={isPinnable ? pinLabel : undefined}
       aria-pressed={isPinnable ? pinned : undefined}
     >
-      <span className={styles.messageIcon}>{isGraphLink ? '🕸️' : icon}</span>
+      <span className={styles.messageIcon}>
+        {isMockUpload ? '⬆️' : isLargePayload ? '⬇️' : isGraphLink ? '🕸️' : icon}
+      </span>
 
       <div className={styles.messageContent}>
         {jsonCheck.isJSON ? (
           <div className={styles.jsonViewWrapper}>
             <JsonView
               data={jsonCheck.data!}
-              shouldExpandNode={(level) => level < 2}
+              shouldExpandNode={(level) => level < 1}
               style={{
                 ...darkStyles,
                 container: `${darkStyles.container} ${styles.jsonContainer}`,
@@ -87,7 +134,10 @@ export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage }
             />
           </div>
         ) : (
-          <span className={styles.messageText}>{parsed.message}</span>
+          <span className={styles.messageText}>
+            {parsed.message}
+            {uploadSucceeded && <span title="Upload succeeded"> ✅</span>}
+          </span>
         )}
       </div>
 
@@ -98,12 +148,38 @@ export default function ConsoleMessage({ message, onPin, pinned, onCopyMessage }
         onKeyDown={handleCopyKeyDown}
         title={copied ? 'Copied!' : 'Copy message'}
         aria-label={copied ? 'Copied to clipboard' : 'Copy message to clipboard'}
-        // Prevent the button from participating in the pin row's tab stop —
-        // it has its own independent tab stop below.
         tabIndex={0}
       >
         {copied ? '✅' : '📄'}
       </button>
+
+      {/* ── Send-to-JSON-Path button — only on JSON messages ─── */}
+      {canSendToJsonPath && (
+        <button
+          className={styles.sendToJsonPathButton}
+          onClick={handleSendToJsonPath}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleSendToJsonPath(e); }}
+          title="Open in JSON-Path Playground"
+          aria-label="Open this JSON in the JSON-Path Playground"
+          tabIndex={0}
+        >
+          ➡️
+        </button>
+      )}
+
+      {/* ── Upload mock data re-open button — only on upload invitation rows ─── */}
+      {canUploadMock && (
+        <button
+          className={styles.uploadMockButton}
+          onClick={handleUploadMockData}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleUploadMockData(e); }}
+          title="Re-open upload dialog"
+          aria-label="Re-open mock data upload dialog"
+          tabIndex={0}
+        >
+          ⬆️ Upload JSON…
+        </button>
+      )}
 
       {parsed.time && (
         <span className={styles.messageTime}>{parsed.time}</span>

--- a/extensions/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.tsx
@@ -28,25 +28,6 @@ const EXPAND_FN: Record<ExpandMode, (level: number) => boolean> = {
   none:    collapseAll,
 };
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Derive a sensible default save name from the graph data.
- * Uses the root node's `name` property if present, otherwise falls back to
- * the entry-point node's alias, or a timestamped default.
- */
-export function deriveDefaultName(graphData: MinigraphGraphData): string {
-  const root = graphData.nodes.find(n => n.types.includes('entry_point'));
-  const nameFromRoot = root?.properties?.name as string | undefined;
-  if (nameFromRoot && typeof nameFromRoot === 'string') return nameFromRoot;
-  if (root) return root.alias;
-  const first = graphData.nodes[0];
-  if (first) return first.alias;
-  return `graph-${new Date().toISOString().slice(0, 10)}`;
-}
-
 interface GraphDataViewProps {
   graphData:       MinigraphGraphData | null;
   /** Called after the raw graph JSON is successfully copied to the clipboard. */

--- a/extensions/minigraph-playground-engine/webapp/src/components/LeftPanel/LeftPanel.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/LeftPanel/LeftPanel.tsx
@@ -14,6 +14,12 @@ interface LeftPanelProps {
   pinnedMessageId?:   number | null;
   /** Called after any per-message copy succeeds — use this to show a toast. */
   onCopyMessage?:     () => void;
+  /** When provided, a "Send to JSON-Path" button appears on JSON messages. */
+  onSendToJsonPath?:  (json: string) => void;
+  /** When provided, a "⬆️ Upload JSON…" re-open button appears on mock-upload invitation rows. */
+  onUploadMockData?:  (uploadPath: string) => void;
+  /** Set of POST paths for which a mock upload has succeeded this session. */
+  successfulUploadPaths?: Set<string>;
   // CommandInput props
   command:            string;
   onCommandChange:    (value: string) => void;
@@ -27,7 +33,8 @@ interface LeftPanelProps {
 
 export default function LeftPanel({
   messages, onCopy, onClear, consoleRef,
-  onPinMessage, pinnedMessageId, onCopyMessage,
+  onPinMessage, pinnedMessageId, onCopyMessage, onSendToJsonPath,
+  onUploadMockData, successfulUploadPaths,
   command, onCommandChange, onCommandKeyDown, onSend,
   sendDisabled, inputDisabled, multiline, onToggleMultiline,
 }: LeftPanelProps) {
@@ -41,6 +48,9 @@ export default function LeftPanel({
         onPinMessage={onPinMessage}
         pinnedMessageId={pinnedMessageId}
         onCopyMessage={onCopyMessage}
+        onSendToJsonPath={onSendToJsonPath}
+        onUploadMockData={onUploadMockData}
+        successfulUploadPaths={successfulUploadPaths}
       />
       <CommandInput
         command={command}

--- a/extensions/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
@@ -1,0 +1,345 @@
+/* ── Native <dialog> element ────────────────────────────────────────────── */
+/* The browser supplies focus-trap and backdrop rendering via showModal(). */
+
+.dialog {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 0;
+  width: min(560px, 94vw);
+  max-height: 90vh;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+
+  /* Override browser's default dialog positioning */
+  margin: auto;
+}
+
+.dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+/* Inner wrapper — stops click propagation from content to backdrop */
+.modalInner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+.modalHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  flex: 0 0 auto;
+}
+
+.modalTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.modalTitle {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.modalPath {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.closeButton {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.4rem;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.closeButton:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.closeButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Body ────────────────────────────────────────────────────────────────── */
+.modalBody {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* ── Drop zone ───────────────────────────────────────────────────────────── */
+.dropZone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  text-align: center;
+  transition: border-color 0.15s, background-color 0.15s;
+  /* Prevent text selection while dragging */
+  user-select: none;
+}
+
+.dropZone:focus-within {
+  border-color: var(--primary-color);
+}
+
+/* Active drag-over state — amber to match the modal's accent colour */
+.dropZoneActive {
+  border-color: rgba(245, 158, 11, 0.8);
+  background: rgba(245, 158, 11, 0.06);
+  color: var(--text-primary);
+}
+
+.dropZoneIcon {
+  font-size: 1.5rem;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.dropZoneText {
+  font-size: 0.875rem;
+  pointer-events: none;
+}
+
+.dropZoneText code {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.825rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  padding: 0 3px;
+}
+
+.dropZoneOr {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+/* ── Browse file button ──────────────────────────────────────────────────── */
+.browseButton {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.65rem;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.browseButton:hover:not(:disabled) {
+  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(245, 158, 11, 0.6);
+  color: var(--text-primary);
+}
+
+.browseButton:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.browseButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Hidden native file input — triggered programmatically */
+.fileInputHidden {
+  display: none;
+}
+
+/* File-type / read error — warning colour, not danger */
+.fileError {
+  color: var(--warning-color);
+  font-size: 0.8rem;
+}
+
+.textareaLabel {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-dark);
+  color: var(--console-text);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.75rem;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.875rem;
+  resize: vertical;
+  min-height: 180px;
+  line-height: 1.5;
+  transition: border-color 0.15s;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: var(--focus-ring);
+}
+
+.validationError {
+  color: var(--warning-color);
+  font-size: 0.8rem;
+}
+
+.keyboardHint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.errorBanner {
+  color: var(--danger-color);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  word-break: break-word;
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+.modalFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  gap: 0.75rem;
+  flex: 0 0 auto;
+}
+
+.footerActions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* ── Shared button base ──────────────────────────────────────────────────── */
+.formatButton,
+.cancelButton,
+.uploadButton {
+  appearance: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s, opacity 0.15s;
+  line-height: 1.4;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.formatButton:focus-visible,
+.cancelButton:focus-visible,
+.uploadButton:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.formatButton:disabled,
+.cancelButton:disabled,
+.uploadButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Format button — secondary ───────────────────────────────────────────── */
+.formatButton {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.formatButton:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  border-color: var(--primary-color);
+  color: var(--text-primary);
+}
+
+/* ── Cancel button — ghost ───────────────────────────────────────────────── */
+.cancelButton {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+/* ── Upload button — primary amber accent ────────────────────────────────── */
+.uploadButton {
+  background: rgba(245, 158, 11, 0.85);
+  border: 1px solid rgba(245, 158, 11, 0.9);
+  color: #1c1917;
+  font-weight: 600;
+}
+
+.uploadButton:hover:not(:disabled) {
+  background: rgba(245, 158, 11, 1);
+  border-color: #d97706;
+}
+
+/* ── Spinner ──────────────────────────────────────────────────────────────── */
+.spinner {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  border: 2px solid rgba(28, 25, 23, 0.3);
+  border-top-color: #1c1917;
+  border-radius: 50%;
+  animation: spin 0.65s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.tsx
@@ -1,0 +1,345 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import styles from './MockUploadModal.module.css';
+import { tryParseJSON } from '../../utils/messageParser';
+import { formatJSON } from '../../utils/validators';
+import { useMockUpload } from '../../hooks/useMockUpload';
+
+interface MockUploadModalProps {
+  /** The POST path extracted from the server message, e.g. "/api/mock/ws-417669-24" */
+  uploadPath: string;
+  /** Called (with the drained response body) on a 2xx response. */
+  onSuccess: (responseBody: string) => void;
+  /** Called to close the modal. Playground restores focus. */
+  onClose: () => void;
+  /** Called with a human-readable error string on failure. */
+  onError: (errorMessage: string) => void;
+}
+
+// Derive macOS status once — no hook needed; navigator APIs are synchronous.
+// navigator.userAgentData?.platform is preferred (Chromium-based browsers);
+// navigator.platform is the deprecated-but-universal fallback (Firefox, Safari).
+const isMac =
+  ((navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform
+    ?? navigator.platform)
+    .toLowerCase()
+    .includes('mac');
+
+/** Read a File as text, resolving with the string or rejecting with an Error. */
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload  = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error(`Could not read file "${file.name}"`));
+    reader.readAsText(file, 'utf-8');
+  });
+}
+
+/**
+ * Validate that a dropped / selected file is acceptable:
+ *  - Must have a `.json` extension OR a `application/json` MIME type.
+ * Returns null on success, or a human-readable error string on failure.
+ */
+function validateFileType(file: File): string | null {
+  const hasJsonExt  = file.name.toLowerCase().endsWith('.json');
+  const hasJsonMime = file.type === 'application/json' || file.type === 'text/plain';
+  if (!hasJsonExt && !hasJsonMime) {
+    return `"${file.name}" does not appear to be a JSON file. Only .json files are accepted.`;
+  }
+  return null;
+}
+
+export function MockUploadModal({ uploadPath, onSuccess, onClose, onError }: MockUploadModalProps) {
+  const [json,        setJson]        = useState('');
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [fileError,   setFileError]   = useState<string | null>(null);
+  const [isDragOver,  setIsDragOver]  = useState(false);
+
+  const dialogRef   = useRef<HTMLDialogElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ── Validation ──────────────────────────────────────────────────────────
+  // Uses tryParseJSON directly — not validatePayload — because the mock endpoint
+  // is JSON-only. tryParseJSON returns isJSON: false for JSON primitives, which
+  // is intentional: the endpoint expects an object or array.
+  const jsonResult  = tryParseJSON(json);
+  const isValidJson = jsonResult.isJSON;
+  const canSubmit   = isValidJson && json.trim() !== '';
+
+  // ── useMockUpload ────────────────────────────────────────────────────────
+  const { isUploading, upload, cancel } = useMockUpload({
+    uploadPath,
+    json,
+    onSuccess,
+    onError: (msg) => {
+      setUploadError(msg);   // inline error banner
+      onError(msg);          // Playground fires a toast
+    },
+  });
+
+  // ── Open the native dialog on mount ─────────────────────────────────────
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (!dialog.open) {
+      dialog.showModal();
+    }
+    // Focus the textarea after the dialog is shown
+    textareaRef.current?.focus();
+
+    return () => {
+      // Gracefully close the dialog on unmount to avoid "dialog already closed" warnings.
+      if (dialog.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
+  // ── Close handling ───────────────────────────────────────────────────────
+  const handleClose = useCallback(() => {
+    cancel();
+    onClose(); // Playground unmounts the component and restores focus.
+  }, [cancel, onClose]);
+
+  // Distinguish backdrop click (target === dialog element) from inner content.
+  const handleBackdropClick = useCallback((e: React.MouseEvent<HTMLDialogElement>) => {
+    if (e.target === dialogRef.current) {
+      handleClose();
+    }
+  }, [handleClose]);
+
+  // Browser fires `cancel` event on Escape — delegate to our close handler.
+  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault(); // prevent automatic dialog.close() — we control unmounting
+    handleClose();
+  }, [handleClose]);
+
+  // ── Upload handling ──────────────────────────────────────────────────────
+  const handleUpload = useCallback(() => {
+    setUploadError(null); // clear stale error from previous attempt
+    upload();
+  }, [upload]);
+
+  const handleTextareaKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      if (canSubmit && !isUploading) {
+        handleUpload();
+      }
+    }
+  }, [canSubmit, isUploading, handleUpload]);
+
+  const handleFormat = useCallback(() => {
+    if (!isValidJson) return;
+    setJson(formatJSON(json));
+  }, [isValidJson, json]);
+
+  // ── File loading (shared by drop and file-picker) ────────────────────────
+  const loadFile = useCallback(async (file: File) => {
+    setFileError(null);
+    setUploadError(null);
+
+    const typeError = validateFileType(file);
+    if (typeError) {
+      setFileError(typeError);
+      return;
+    }
+
+    try {
+      const text = await readFileAsText(file);
+      // Validate it parses as a JSON object/array before loading into textarea.
+      const result = tryParseJSON(text);
+      if (!result.isJSON) {
+        setFileError(`"${file.name}" contains invalid JSON.`);
+        return;
+      }
+      setJson(formatJSON(text));   // pretty-print on load
+      textareaRef.current?.focus();
+    } catch (err) {
+      setFileError((err as Error).message);
+    }
+  }, []);
+
+  // ── Drag-and-drop handlers ────────────────────────────────────────────────
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isDragOver) setIsDragOver(true);
+  }, [isDragOver]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Only clear if leaving the drop zone itself, not a child element.
+    if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+    loadFile(file);
+  }, [loadFile]);
+
+  // ── File-picker handler ───────────────────────────────────────────────────
+  const handleFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    loadFile(file);
+    // Reset the input so the same file can be re-selected after a fix.
+    e.target.value = '';
+  }, [loadFile]);
+
+  const showValidationError = !isValidJson && json.trim() !== '';
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      aria-modal="true"
+      aria-labelledby="mock-upload-modal-title"
+      onClick={handleBackdropClick}
+      onCancel={handleCancel}
+    >
+      <div className={styles.modalInner} onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header ─────────────────────────────────────────────────── */}
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitleGroup}>
+            <span id="mock-upload-modal-title" className={styles.modalTitle}>
+              ⬆️ Upload Mock Data
+            </span>
+            <span className={styles.modalPath}>{uploadPath}</span>
+          </div>
+          <button
+            className={styles.closeButton}
+            onClick={handleClose}
+            aria-label="Close upload modal"
+            title="Close"
+            disabled={isUploading}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* ── Body ───────────────────────────────────────────────────── */}
+        <div className={styles.modalBody}>
+
+          {/* ── Drop zone ──────────────────────────────────────────── */}
+          <div
+            className={`${styles.dropZone} ${isDragOver ? styles.dropZoneActive : ''}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            aria-label="Drop a JSON file here"
+          >
+            <span className={styles.dropZoneIcon}>📂</span>
+            <span className={styles.dropZoneText}>
+              Drop a <code>.json</code> file here
+            </span>
+            <span className={styles.dropZoneOr}>— or —</span>
+            {/* Hidden file input, triggered by the visible button below */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className={styles.fileInputHidden}
+              aria-hidden="true"
+              tabIndex={-1}
+              onChange={handleFileInputChange}
+            />
+            <button
+              type="button"
+              className={styles.browseButton}
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              aria-label="Browse for a JSON file"
+            >
+              Browse file…
+            </button>
+          </div>
+
+          {fileError && (
+            <span className={styles.fileError} role="alert">
+              ⚠️ {fileError}
+            </span>
+          )}
+
+          <label htmlFor="mock-upload-textarea" className={styles.textareaLabel}>
+            JSON Payload
+          </label>
+          <textarea
+            id="mock-upload-textarea"
+            ref={textareaRef}
+            className={styles.textarea}
+            value={json}
+            onChange={(e) => { setJson(e.target.value); setFileError(null); }}
+            onKeyDown={handleTextareaKeyDown}
+            placeholder='Paste JSON here, or drop / browse a .json file above'
+            rows={10}
+            spellCheck={false}
+            aria-describedby={showValidationError ? 'mock-upload-validation' : undefined}
+          />
+          {showValidationError && (
+            <span
+              id="mock-upload-validation"
+              className={styles.validationError}
+              role="status"
+            >
+              ⚠️ Invalid JSON — check syntax
+            </span>
+          )}
+          <span className={styles.keyboardHint}>
+            {isMac ? '⌘+Enter to upload' : 'Ctrl+Enter to upload'}
+          </span>
+          {uploadError && (
+            <div className={styles.errorBanner} role="alert">
+              ❌ Upload failed: {uploadError}
+            </div>
+          )}
+        </div>
+
+        {/* ── Footer ─────────────────────────────────────────────────── */}
+        <div className={styles.modalFooter}>
+          <button
+            className={styles.formatButton}
+            onClick={handleFormat}
+            disabled={!isValidJson || isUploading}
+            title="Format JSON"
+            aria-label="Format JSON"
+          >
+            Format
+          </button>
+          <div className={styles.footerActions}>
+            <button
+              className={styles.cancelButton}
+              onClick={handleClose}
+              disabled={isUploading}
+            >
+              Cancel
+            </button>
+            <button
+              className={styles.uploadButton}
+              onClick={handleUpload}
+              disabled={!canSubmit || isUploading}
+              aria-busy={isUploading}
+            >
+              {isUploading ? (
+                <><span className={styles.spinner} aria-hidden="true" /> Uploading…</>
+              ) : (
+                'Upload ▶'
+              )}
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </dialog>
+  );
+}
+

--- a/extensions/minigraph-playground-engine/webapp/src/components/Navigation.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Navigation.module.css
@@ -98,6 +98,48 @@
 .toolDotConnecting { background: var(--warning-color); animation: pulse 1.5s infinite; }
 .toolDotConnected  { background: var(--success-color); animation: pulse 2s infinite; }
 
+/* ── Connect All / Disconnect All row ── */
+
+.connectAllRow {
+  display: flex;
+  padding: 0.45rem 0.75rem 0.45rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.connectAllBtn {
+  flex: 1 1 auto;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid var(--primary-color);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--primary-color);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.connectAllBtn:hover:not(:disabled) {
+  background: var(--primary-color);
+  color: white;
+}
+
+.connectAllBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.connectAllBtnStop {
+  border-color: var(--danger-color);
+  color: var(--danger-color);
+}
+
+.connectAllBtnStop:hover:not(:disabled) {
+  background: var(--danger-color);
+  color: white;
+}
+
 /* ── Connect / stop button ── */
 
 .toolConnectBtn {

--- a/extensions/minigraph-playground-engine/webapp/src/components/Navigation.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Navigation.tsx
@@ -62,11 +62,43 @@ export default function Navigation({ addToast }: NavigationProps) {
   const phases = PLAYGROUND_CONFIGS.map(cfg => ctx.getSlot(cfg.wsPath).phase);
   const toolsDotStatus = aggregateDotStatus(phases);
 
+  const allConnected  = phases.every(p => p === 'connected');
+  const anyConnecting = phases.some(p => p === 'connecting');
+
+  function handleConnectAll() {
+    PLAYGROUND_CONFIGS.forEach(cfg => {
+      if (ctx.getSlot(cfg.wsPath).phase === 'idle') {
+        ctx.connect(cfg.wsPath, addToast);
+      }
+    });
+  }
+
+  function handleDisconnectAll() {
+    PLAYGROUND_CONFIGS.forEach(cfg => {
+      const { phase } = ctx.getSlot(cfg.wsPath);
+      if (phase === 'connected' || phase === 'connecting') {
+        ctx.disconnect(cfg.wsPath);
+      }
+    });
+  }
+
   return (
     <nav className={styles.nav} aria-label="Main navigation">
 
       {/* ── Tools (nav + connection status combined) ── */}
       <NavMenu label="Tools" dotStatus={toolsDotStatus}>
+        {/* ── Connect / Disconnect All ── */}
+        <div className={styles.connectAllRow}>
+          <button
+            className={`${styles.connectAllBtn} ${allConnected ? styles.connectAllBtnStop : ''}`}
+            onClick={allConnected ? handleDisconnectAll : handleConnectAll}
+            disabled={anyConnecting}
+            aria-label={anyConnecting ? 'Connecting…' : allConnected ? 'Disconnect all WebSockets' : 'Connect all WebSockets'}
+          >
+            {anyConnecting ? 'Connecting…' : allConnected ? 'Disconnect All' : 'Connect All'}
+          </button>
+        </div>
+
         <ul className={styles.menuList} role="none">
           {PLAYGROUND_CONFIGS.map((cfg) => {
             const { phase } = ctx.getSlot(cfg.wsPath);

--- a/extensions/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Group, Panel, Separator, useDefaultLayout } from 'react-resizable-panels';
 import styles from './Playground.module.css';
 import { validatePayload, formatJSON } from '../utils/validators';
@@ -9,26 +10,62 @@ import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useGraphData } from '../hooks/useGraphData';
 import { useAutoGraphRefresh } from '../hooks/useAutoGraphRefresh';
 import { useAutoMarkdownPin } from '../hooks/useAutoMarkdownPin';
+import { useLargePayloadDownload } from '../hooks/useLargePayloadDownload';
+import { useAutoMockUpload } from '../hooks/useAutoMockUpload';
 import { useSavedGraphs } from '../hooks/useSavedGraphs';
+import { useGraphSaveName } from '../hooks/useGraphSaveName';
 import { ToastContainer } from './Toast';
 import Navigation from './Navigation';
 import GraphSaveButton from './GraphSaveButton/GraphSaveButton';
 import SavedGraphsMenu from './SavedGraphsMenu/SavedGraphsMenu';
-import { deriveDefaultName } from './GraphDataView/GraphDataView';
 import { isMarkdownCandidate, isGraphLinkMessage, extractGraphApiPath } from '../utils/messageParser';
 import RightPanel from './RightPanel/RightPanel';
 import LeftPanel from './LeftPanel/LeftPanel';
-import { type PlaygroundConfig } from '../config/playgrounds';
+import { MockUploadModal } from './MockUploadModal/MockUploadModal';
+import { type PlaygroundConfig, PLAYGROUND_CONFIGS } from '../config/playgrounds';
+import { useWebSocketContext } from '../contexts/WebSocketContext';
 
 interface PlaygroundProps {
   config: PlaygroundConfig;
 }
 
 export default function Playground({ config }: PlaygroundProps) {
-  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeySavedGraphs, supportsUpload, tabs } = config;
+  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeyTab, storageKeySavedGraphs, supportsUpload, tabs } = config;
 
-  // Persisted payload
-  const [payload, setPayload] = useLocalStorage<string>(storageKeyPayload, '');
+  const navigate = useNavigate();
+
+  // Persisted payload (survives navigation / refresh via localStorage).
+  const [storedPayload, setStoredPayload] = useLocalStorage<string>(storageKeyPayload, '');
+
+  // Large-payload override — set by useLargePayloadDownload via WebSocketContext
+  // when the server returns a payload too big to echo inline.  Using a separate
+  // useState means we never write large blobs to localStorage, avoiding quota
+  // exhaustion.  null = no override; the stored value is used instead.
+  const ctx = useWebSocketContext();
+  const [payloadOverride, setPayloadOverride] = useState<string | null>(() =>
+    ctx.takePendingPayload(wsPath)
+  );
+
+  // Reactively consume a pending payload deposited by useLargePayloadDownload.
+  // takePendingPayload has a new identity whenever a payload is deposited
+  // (backed by useState in the context), so this effect fires precisely when
+  // a new payload arrives — covering both the first-mount and already-mounted cases.
+  const { takePendingPayload } = ctx;
+  useEffect(() => {
+    const pending = takePendingPayload(wsPath);
+    if (pending !== null) {
+      setPayloadOverride(pending);
+    }
+  }, [takePendingPayload, wsPath]);
+
+  // The active payload: override wins over the persisted value.
+  const payload    = payloadOverride ?? storedPayload;
+  // Writers: the textarea and format/clear actions always write to localStorage.
+  // Clearing the override on any manual edit lets the user take back control.
+  const setPayload = useCallback((value: string | ((prev: string) => string)) => {
+    setPayloadOverride(null);
+    setStoredPayload(value as string);
+  }, [setStoredPayload]);
 
   // Live payload validation — derived synchronously from payload, no extra render cycle needed
   const payloadValidation = useMemo(
@@ -76,7 +113,18 @@ export default function Playground({ config }: PlaygroundProps) {
   const [pinnedGraphPath, setPinnedGraphPath] = useState<string | null>(null);
 
   // Fetch + parse graph data, auto-switch to Graph tab — logic lives in the hook.
-  const { graphData, setGraphData, rightTab, setRightTab, isRefreshing, refetchGraph } = useGraphData(pinnedGraphPath, addToast, tabs[0]);
+  const { graphData, setGraphData, rightTab, setRightTab, isRefreshing, refetchGraph } = useGraphData(pinnedGraphPath, addToast, tabs[0], storageKeyTab);
+
+  // ── Mock-upload modal state ───────────────────────────────────────────────
+  // Path extracted from the server's upload invitation.
+  // null = modal closed; non-null = modal open for that specific endpoint.
+  const [modalUploadPath, setModalUploadPath] = useState<string | null>(null);
+
+  // Capture the element that triggered the modal so focus can be restored on close.
+  const modalTriggerRef = useRef<HTMLElement | null>(null);
+
+  // POST paths of invitations that have been successfully fulfilled — drives ✅ badge.
+  const [successfulUploadPaths, setSuccessfulUploadPaths] = useState<Set<string>>(new Set());
 
   // ── Auto-refresh on mutation commands ────────────────────────────────────
   useAutoGraphRefresh({
@@ -104,10 +152,71 @@ export default function Playground({ config }: PlaygroundProps) {
                           : undefined,
   });
 
+  // ── Auto-download large payloads ──────────────────────────────────────────
+  // When the server responds with a "Large payload (N) -> GET /api/inspect/…"
+  // message (i.e. a namespace value that exceeds the 64 KB inline limit),
+  // this hook fetches the data from the provided endpoint and immediately
+  // triggers a browser file download — no extra user interaction required.
+  useLargePayloadDownload({
+    messages:      ws.messages,
+    connected:     ws.connected,
+    appendMessage: ws.appendMessage,
+    addToast,
+  });
+
+  // ── Mock-upload modal callbacks ───────────────────────────────────────────
+  const handleOpenUploadModal = useCallback((path: string) => {
+    // Capture the focused element before opening so we can restore focus on close.
+    modalTriggerRef.current = document.activeElement as HTMLElement;
+    setModalUploadPath(path);
+  }, []);
+
+  const handleCloseUploadModal = useCallback(() => {
+    setModalUploadPath(null);
+    // Restore focus to the element that triggered the modal open.
+    // setTimeout ensures the dialog is fully unmounted before focus() runs.
+    setTimeout(() => modalTriggerRef.current?.focus(), 0);
+  }, []);
+
+  const handleUploadSuccess = useCallback((_responseBody: string) => {
+    // _responseBody is available but intentionally not surfaced per spec §2.
+    setSuccessfulUploadPaths(prev => new Set([...prev, modalUploadPath!]));
+    setModalUploadPath(null);
+    setTimeout(() => modalTriggerRef.current?.focus(), 0);
+    addToast('Mock data uploaded successfully ✓', 'success');
+  }, [modalUploadPath, addToast]);
+
+  const handleUploadError = useCallback((errorMessage: string) => {
+    // Modal stays open — error is displayed inline inside the modal.
+    addToast(`Upload failed: ${errorMessage}`, 'error');
+  }, [addToast]);
+
+  // ── Auto-open modal when server sends upload invitation ───────────────────
+  useAutoMockUpload({
+    messages:    ws.messages,
+    connected:   ws.connected,
+    onOpenModal: handleOpenUploadModal,
+  });
+
   // ── Saved graphs (localStorage snapshots) ────────────────────────────────
   // Only instantiated when the playground config provides a storage key so
   // playgrounds that don't use this feature have zero overhead.
   const savedGraphs = useSavedGraphs(storageKeySavedGraphs ?? '');
+
+  // ── Save-form default name ────────────────────────────────────────────────
+  // Tracks the pre-fill name for the GraphSaveButton input with priority:
+  //   1. last-saved name (if this working graph was previously saved)
+  //   2. imported name   (if the graph was loaded via `import graph from …`)
+  //   3. untitled-{n}    (monotonically incrementing per-playground fallback)
+  //
+  // The untitled counter key is derived from the saved-graphs key so it stays
+  // isolated per playground (e.g. "minigraph-saved-graphs" →
+  // "minigraph-untitled-counter").  When there is no saved-graphs key the hook
+  // is still instantiated but is effectively unused (the save button is hidden).
+  const { defaultName: graphSaveName, setLastSavedName, resetName: resetSaveName } = useGraphSaveName(
+    storageKeySavedGraphs ? `${storageKeySavedGraphs}-untitled-counter` : 'untitled-counter',
+    ws.messages,
+  );
 
   // Save the current graph name as a bookmark in localStorage.
   // Also sends `export graph as {name}` over the WebSocket so the server
@@ -117,11 +226,12 @@ export default function Playground({ config }: PlaygroundProps) {
   // so the user can reconnect and load it later.
   const handleSaveGraph = useCallback((name: string) => {
     savedGraphs.saveGraph(name);
+    setLastSavedName(name);
     if (ws.connected) {
       ws.sendRawText(`export graph as ${name}`);
     }
     addToast(`Graph saved as "${name}"`, 'success');
-  }, [savedGraphs.saveGraph, ws.connected, ws.sendRawText, addToast]);
+  }, [savedGraphs.saveGraph, setLastSavedName, ws.connected, ws.sendRawText, addToast]);
 
   // Load a saved graph by sending `import graph from {name}` over the WebSocket.
   // The backend reads {name}.json from its temp directory — the file that was
@@ -146,6 +256,56 @@ export default function Playground({ config }: PlaygroundProps) {
     }
   }, []);
 
+  // Send an inline JSON response to the JSON-Path playground payload editor.
+  // Mirrors the large-payload flow: navigate first, then deposit via context.
+  // If JSON-Path is not yet connected, auto-connect and defer the
+  // navigation + payload deposit until the socket reaches 'connected' phase.
+  const jsonPathConfig = PLAYGROUND_CONFIGS.find(c => c.tabs.includes('payload') && c.supportsUpload);
+
+  // Holds a pending deferred send triggered while JSON-Path was still connecting.
+  // Stored as a ref so the watching useEffect below can consume it without
+  // needing to be in the dependency array of handleSendToJsonPath.
+  const deferredSendRef = useRef<{ wsPath: string; json: string } | null>(null);
+
+  // Watch the JSON-Path slot phase; when it reaches 'connected' and there is a
+  // deferred send pending, execute it and clear the ref.
+  const jsonPathWsPath = jsonPathConfig?.wsPath;
+  useEffect(() => {
+    if (!jsonPathWsPath || !deferredSendRef.current) return;
+    const slot = ctx.getSlot(jsonPathWsPath);
+    if (slot.phase === 'connected') {
+      const { wsPath: targetPath, json } = deferredSendRef.current;
+      deferredSendRef.current = null;
+      ctx.setPendingPayload(targetPath, json);
+      navigate(jsonPathConfig!.path);
+      addToast('JSON loaded into JSON-Path editor ✓', 'success');
+    }
+  }, [jsonPathWsPath, ctx, navigate, addToast, jsonPathConfig,
+      // getSlot returns a new object reference when the slot changes, so
+      // reading it inside the effect (keyed on ctx) is sufficient — but we
+      // also need to re-run when the slot's phase changes.  ctx.getSlot is
+      // wrapped in useCallback(_, [slots]) so it changes whenever slots does,
+      // which is exactly what we want.
+     ]);
+
+  const handleSendToJsonPath = useCallback((json: string) => {
+    if (!jsonPathConfig) return;
+    const slot = ctx.getSlot(jsonPathConfig.wsPath);
+    if (slot.phase === 'connected') {
+      // Already connected — deposit immediately.
+      ctx.setPendingPayload(jsonPathConfig.wsPath, json);
+      navigate(jsonPathConfig.path);
+      addToast('JSON loaded into JSON-Path editor ✓', 'success');
+    } else {
+      // Not yet connected — arm a deferred send and auto-connect.
+      deferredSendRef.current = { wsPath: jsonPathConfig.wsPath, json };
+      if (slot.phase === 'idle') {
+        ctx.connect(jsonPathConfig.wsPath, addToast);
+      }
+      addToast('Connecting to JSON-Path Playground…', 'info');
+    }
+  }, [ctx, navigate, addToast, jsonPathConfig]);
+
   // Responsive layout: stack panels vertically on narrow viewports
   const isMobile = useMediaQuery('(max-width: 768px)');
 
@@ -168,11 +328,26 @@ export default function Playground({ config }: PlaygroundProps) {
     setPinnedMessageId(null);
     setPinnedGraphPath(null);
     setGraphData(null);
-  }, [ws.clearMessages, setGraphData]);
+    // Reset mock-upload session state so ✅ badges clear with the console.
+    // Modal upload path is NOT reset here — if the modal is open while the
+    // user clears the console, it remains open for the current upload attempt.
+    setSuccessfulUploadPaths(new Set());
+    // Advance the untitled counter so the next saved graph gets a fresh name.
+    resetSaveName();
+  }, [ws.clearMessages, setGraphData, resetSaveName]);
 
   return (
     <div className={styles.wrapper}>
       <ToastContainer toasts={toasts} onRemove={removeToast} />
+
+      {modalUploadPath && (
+        <MockUploadModal
+          uploadPath={modalUploadPath}
+          onSuccess={handleUploadSuccess}
+          onClose={handleCloseUploadModal}
+          onError={handleUploadError}
+        />
+      )}
 
       <header className={styles.header}>
         <h1 className={styles.title}>{title}</h1>
@@ -180,7 +355,7 @@ export default function Playground({ config }: PlaygroundProps) {
           {storageKeySavedGraphs && (
             <GraphSaveButton
               disabled={!graphData}
-              defaultName={graphData ? deriveDefaultName(graphData) : ''}
+              defaultName={graphSaveName}
               onSave={handleSaveGraph}
               nameExists={savedGraphs.hasGraph}
               connected={ws.connected}
@@ -221,6 +396,9 @@ export default function Playground({ config }: PlaygroundProps) {
             onPinMessage={handlePinMessage}
             pinnedMessageId={pinnedMessageId}
             onCopyMessage={() => addToast('Copied to clipboard', 'success')}
+            onSendToJsonPath={jsonPathConfig && wsPath !== jsonPathConfig.wsPath ? handleSendToJsonPath : undefined}
+            onUploadMockData={handleOpenUploadModal}
+            successfulUploadPaths={successfulUploadPaths}
           />
         </Panel>
         <Separator className={styles.resizeHandle} aria-label="Resize panels" />

--- a/extensions/minigraph-playground-engine/webapp/src/components/Toast.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Toast.module.css
@@ -1,6 +1,6 @@
 .toastContainer {
   position: fixed;
-  top: 1rem;
+  bottom: 1rem;
   right: 1rem;
   z-index: 1000;
   display: flex;

--- a/extensions/minigraph-playground-engine/webapp/src/config/playgrounds.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/config/playgrounds.ts
@@ -37,6 +37,7 @@ export interface PlaygroundConfig {
   wsPath:                string;     // WebSocket endpoint path served by the backend
   storageKeyPayload:     string;     // localStorage key for the last payload
   storageKeyHistory:     string;     // localStorage key for command history
+  storageKeyTab:         string;     // localStorage key for the last selected right-panel tab
   storageKeySavedGraphs?: string;   // localStorage key for graphs saved from the Graph Data tab (omit to hide the feature)
   supportsUpload?:       boolean;    // true when the backend supports POST /api/json/content/{id} upload
   /**
@@ -61,6 +62,7 @@ export const PLAYGROUND_CONFIGS: PlaygroundConfig[] = [
     wsPath: '/ws/json/path',
     storageKeyPayload: 'jsonpath-last-payload',
     storageKeyHistory: 'jsonpath-command-history',
+    storageKeyTab: 'jsonpath-right-tab',
     supportsUpload: true,
     // JSON-Path needs a payload input and graph views; Developer Guides is not useful here.
     tabs: ['payload', 'graph', 'graph-data'],
@@ -72,6 +74,7 @@ export const PLAYGROUND_CONFIGS: PlaygroundConfig[] = [
     wsPath: '/ws/graph/playground',
     storageKeyPayload: 'minigraph-last-payload',
     storageKeyHistory: 'minigraph-command-history',
+    storageKeyTab: 'minigraph-right-tab',
     storageKeySavedGraphs: 'minigraph-saved-graphs',
     // Minigraph works with graph commands and text responses; it has no payload input.
     tabs: ['preview', 'graph', 'graph-data'],

--- a/extensions/minigraph-playground-engine/webapp/src/contexts/WebSocketContext.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/contexts/WebSocketContext.tsx
@@ -16,9 +16,10 @@ import {
   useEffect,
   useReducer,
   useRef,
+  useState,
   type ReactNode,
 } from 'react';
-import { MAX_ITEMS, PING_INTERVAL } from '../config/playgrounds';
+import { MAX_ITEMS, PING_INTERVAL, PLAYGROUND_CONFIGS } from '../config/playgrounds';
 import { type ToastType } from '../hooks/useToast';
 import { makeWsUrl } from '../utils/urls';
 
@@ -40,8 +41,13 @@ export interface WsSlot {
 export interface WebSocketContextValue {
   /** Get the reactive state (phase + messages) for a given wsPath. */
   getSlot: (wsPath: string) => { phase: WsPhase; messages: { id: number; raw: string }[] };
-  /** Open a WebSocket connection for the given path. */
-  connect: (wsPath: string, onToast: (msg: string, type?: ToastType) => void) => void;
+  /**
+   * Open a WebSocket connection for the given path.
+   * When `onToast` is omitted the connection is established silently — no
+   * toast is shown for "Connected", "Already connected", or "Disconnected".
+   * Useful for background auto-connect at startup or deferred-send flows.
+   */
+  connect: (wsPath: string, onToast?: (msg: string, type?: ToastType) => void) => void;
   /** Close the connection for the given path. */
   disconnect: (wsPath: string) => void;
   /** Send a raw string on the given path's socket. */
@@ -50,6 +56,17 @@ export interface WebSocketContextValue {
   appendMessage: (wsPath: string, raw: string) => void;
   /** Clear all messages for a given path. */
   clearMessages: (wsPath: string) => void;
+  /**
+   * Store a payload string for the given wsPath so its Playground can pick
+   * it up on the next render without writing to localStorage.
+   * Pass `null` to clear a previously-stored pending payload.
+   */
+  setPendingPayload: (wsPath: string, payload: string | null) => void;
+  /**
+   * Retrieve and immediately clear the pending payload for the given wsPath.
+   * Returns `null` when nothing is pending.
+   */
+  takePendingPayload: (wsPath: string) => string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -186,14 +203,14 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   };
 
   // ── connect ──────────────────────────────────────────────────────────────
-  const connect = useCallback((wsPath: string, onToast: (msg: string, type?: ToastType) => void) => {
+  const connect = useCallback((wsPath: string, onToast?: (msg: string, type?: ToastType) => void) => {
     if (!window.WebSocket) {
-      onToast('WebSocket not supported by your browser', 'error');
+      onToast?.('WebSocket not supported by your browser', 'error');
       return;
     }
     const existing = wsRefs.current[wsPath];
     if (existing && (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)) {
-      onToast('Already connected', 'error');
+      onToast?.('Already connected', 'error');
       return;
     }
 
@@ -209,7 +226,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         id:   nextId(wsPath),
         msg:  eventWithTimestamp('info', 'connected'),
       });
-      onToast('Connected to WebSocket', 'success');
+      onToast?.('Connected to WebSocket', 'success');
       ws.send(JSON.stringify({ type: 'welcome' }));
 
       pingRefs.current[wsPath] = setInterval(() => {
@@ -243,8 +260,13 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         id:   nextId(wsPath),
         msg:  eventWithTimestamp('info', `disconnected - (${evt.code}) ${evt.reason}`),
       });
-      onToast('Disconnected from WebSocket', 'info');
-      wsRefs.current[wsPath] = null;
+      onToast?.('Disconnected from WebSocket', 'info');
+      // Only clear the ref if it still points to THIS socket.  If a new
+      // connect() call already stored a different socket (e.g. StrictMode
+      // remount), leaving the ref alone keeps the new socket reachable.
+      if (wsRefs.current[wsPath] === ws) {
+        wsRefs.current[wsPath] = null;
+      }
     };
   }, []);
 
@@ -261,6 +283,30 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         msg:  eventWithTimestamp('error', 'already disconnected'),
       });
     }
+  }, []);
+
+  // ── Auto-connect on startup ───────────────────────────────────────────────
+  // Silently opens a WebSocket for every configured playground when the
+  // provider first mounts.  Placed here — after connect/disconnect are defined
+  // — so the closure captures the final, stable function references.
+  //
+  // The cleanup closes whatever sockets this effect opened.  This makes the
+  // React StrictMode double-invoke cycle safe: the cleanup undoes the first
+  // mount's connections so the second mount starts from a clean slate, and the
+  // status dots (driven entirely by the reducer) accurately reflect each
+  // transition (idle → connecting → connected, and back on cleanup).
+  useEffect(() => {
+    PLAYGROUND_CONFIGS.forEach(cfg => {
+      connect(cfg.wsPath); // silent — no onToast
+    });
+    return () => {
+      PLAYGROUND_CONFIGS.forEach(cfg => {
+        const ws = wsRefs.current[cfg.wsPath];
+        if (ws) ws.close();
+      });
+    };
+  // connect is useCallback([]) — stable for the lifetime of the provider.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ── send ─────────────────────────────────────────────────────────────────
@@ -288,13 +334,42 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     dispatch({ type: 'CLEAR_MESSAGES', path: wsPath });
   }, []);
 
+  // ── pendingPayload ────────────────────────────────────────────────────────
+  // useState (not useRef) so that calling setPendingPayload triggers a
+  // re-render in any consuming component — specifically the already-mounted
+  // JSON-Path Playground whose useEffect polls for this value.
+  const [pendingPayloads, setPendingPayloads] = useState<Record<string, string>>({});
+
+  const setPendingPayload = useCallback((wsPath: string, payload: string | null) => {
+    setPendingPayloads(prev => {
+      if (payload === null) {
+        const next = { ...prev };
+        delete next[wsPath];
+        return next;
+      }
+      return { ...prev, [wsPath]: payload };
+    });
+  }, []);
+
+  const takePendingPayload = useCallback((wsPath: string): string | null => {
+    const value = pendingPayloads[wsPath] ?? null;
+    if (value !== null) {
+      setPendingPayloads(prev => {
+        const next = { ...prev };
+        delete next[wsPath];
+        return next;
+      });
+    }
+    return value;
+  }, [pendingPayloads]);
+
   // ── getSlot ──────────────────────────────────────────────────────────────
   const getSlot = useCallback((wsPath: string) => {
     return slots[wsPath] ?? { phase: 'idle' as WsPhase, messages: [] };
   }, [slots]);
 
   return (
-    <WebSocketContext.Provider value={{ getSlot, connect, disconnect, send, appendMessage, clearMessages }}>
+    <WebSocketContext.Provider value={{ getSlot, connect, disconnect, send, appendMessage, clearMessages, setPendingPayload, takePendingPayload }}>
       {children}
     </WebSocketContext.Provider>
   );

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useAutoMarkdownPin.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useAutoMarkdownPin.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { isHelpOrDescribeCommand, isMarkdownCandidate, isGraphLinkMessage } from '../utils/messageParser';
+import { isHelpOrDescribeCommand, isMarkdownCandidate, isGraphLinkMessage, isMockUploadMessage } from '../utils/messageParser';
 
 export interface UseAutoMarkdownPinOptions {
   /**
@@ -31,9 +31,30 @@ export interface UseAutoMarkdownPinOptions {
 }
 
 /**
+ * Returns true when a raw message is a server response that is a valid
+ * auto-pin target: a markdown candidate that is neither a graph-link nor
+ * an echoed user command (echoes start with `> `), nor a mock-upload invitation.
+ *
+ * The echo guard is critical: `> help` passes `isMarkdownCandidate` because
+ * it is plain text. Without this check a stranded `waitingForResponseRef`
+ * would pin the echo instead of the actual help content.
+ *
+ * The mock-upload guard prevents the upload invitation (plain-text) from
+ * being accidentally pinned to the Developer Guides tab when waitingForResponseRef
+ * is armed — e.g. if the user sends `help` and then quickly runs `upload mock data`
+ * before the help response arrives.
+ */
+function isPinnableResponse(raw: string): boolean {
+  if (raw.startsWith('> ')) return false;       // echoed command — never pin
+  if (isGraphLinkMessage(raw)) return false;    // graph-link → Graph tab, not preview
+  if (isMockUploadMessage(raw)) return false;   // upload invitation → modal, not preview
+  return isMarkdownCandidate(raw);              // plain-text response → pin candidate
+}
+
+/**
  * Watches the WebSocket message stream for `help` or text-producing
  * `describe` command echoes, then auto-pins the first plain-text
- * (markdown-candidate, non-graph-link) response that follows.
+ * (markdown-candidate, non-graph-link, non-echo) response that follows.
  *
  * Behaviour:
  *
@@ -41,24 +62,25 @@ export interface UseAutoMarkdownPinOptions {
  *     sending the response.  When the hook sees an echo that matches
  *     `isHelpOrDescribeCommand`, it sets `waitingForResponseRef = true`.
  *
- *  2. On the next batch of new messages, if `waitingForResponseRef` is
- *     true and a markdown-candidate (non-graph-link) message is found,
- *     it is auto-pinned via `setPinnedMessageId` and `onAutoPin` is called.
+ *  2. On the next batch of new messages, if `waitingForResponseRef` is true
+ *     and a pinnable response is found (plain text, not an echo, not a
+ *     graph-link), it is auto-pinned and `onAutoPin` is called.
  *
- *  3. The flag is cleared after consuming the response so subsequent
- *     unrelated messages do not trigger spurious pins.
+ *  3. If the expected response turns out to be JSON (e.g. `describe node`
+ *     returns a JSON map), the flag is cleared without pinning so it cannot
+ *     accumulate across commands and cause a later spurious pin.
+ *
+ *  4. The flag is always cleared on disconnect to prevent cross-session
+ *     contamination.
  *
  * Relationship to useAutoGraphRefresh:
  *  - That hook sends a silent `describe graph` command (no echo) which
- *    produces a graph-link message.  Graph-link messages are excluded by
- *    `isMarkdownCandidate`, so the two hooks' response-consumption paths
- *    are completely disjoint and cannot interfere.
+ *    produces a graph-link message.  `isPinnableResponse` excludes graph-link
+ *    messages, so the two hooks' response-consumption paths are disjoint.
  *  - After `import graph`, useAutoGraphRefresh silently sends `describe
- *    graph`.  The only echo present in the stream is `> import graph from
- *    {name}` (which does NOT match `isHelpOrDescribeCommand`), so this
- *    hook will NOT set `waitingForResponseRef = true` for that flow.
- *    The subsequent graph-link response is therefore never stolen by this
- *    hook.
+ *    graph`.  The only echo in the stream is `> import graph from {name}`
+ *    which does NOT match `isHelpOrDescribeCommand`, so this hook never arms
+ *    its flag for that flow and the graph-link response is never stolen.
  *
  * This hook has no return value — its only job is to dispatch side effects.
  */
@@ -109,16 +131,33 @@ export function useAutoMarkdownPin({
 
     for (const msg of newMessages) {
       if (waitingForResponseRef.current) {
-        // Consume the first markdown-candidate (non-graph-link) response.
-        // Graph-link messages belong to the Graph tab and must be skipped.
-        // JSON messages (e.g. `describe node` replies) are not markdown
-        // candidates, so they are also skipped — the flag stays true and
-        // the hook will consume the first text message that follows.
-        if (!isGraphLinkMessage(msg.raw) && isMarkdownCandidate(msg.raw)) {
+        // Skip echoed commands — they are plain text and would pass
+        // isPinnableResponse if not for the explicit echo guard inside it.
+        // This is the primary defence against pinning an echo instead of
+        // its response (e.g. if the flag was stranded from a prior command).
+        if (msg.raw.startsWith('> ')) continue;
+
+        // A new help/describe echo re-arms the flag for the new command
+        // instead of waiting for a response to the old one.  This keeps
+        // things correct if the user sends two help commands back-to-back
+        // quickly enough to land in the same batch.
+        if (isHelpOrDescribeCommand(msg.raw)) {
+          // flag stays true — re-armed for the new command
+          continue;
+        }
+
+        if (isPinnableResponse(msg.raw)) {
+          // Plain-text response — pin it.
           waitingForResponseRef.current = false;
           setPinnedMessageId(msg.id);
           onAutoPin?.();
           return; // done for this batch
+        } else {
+          // A non-pinnable server response arrived (e.g. a JSON map from
+          // `describe node`, or a graph-link from an unrelated command).
+          // Clear the flag so it cannot accumulate across unrelated commands
+          // and cause a future spurious pin.
+          waitingForResponseRef.current = false;
         }
       } else if (isHelpOrDescribeCommand(msg.raw)) {
         // A help/describe echo arrived — arm the flag so we catch the response.

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useAutoMockUpload.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useAutoMockUpload.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+import { extractMockUploadPath, isMockUploadMessage } from '../utils/messageParser';
+
+export interface UseAutoMockUploadOptions {
+  /**
+   * Full incoming message log from useWebSocket.
+   * The hook inspects only messages with IDs greater than the watermark
+   * recorded at mount time — older history is never reprocessed.
+   */
+  messages: { id: number; raw: string }[];
+
+  /**
+   * Whether the WebSocket is currently connected.
+   * Accepted for symmetry with the other automation hooks and future
+   * extensibility (e.g. disabling the re-open button when disconnected).
+   * The effect body does not read or depend on it — no flag is reset on
+   * disconnect because there is no pending-wait state to clear.
+   *
+   * Resetting the watermark to -1 on disconnect would cause old invitation
+   * messages still in the message store to be replayed as "new" on reconnect,
+   * auto-opening the modal for a stale endpoint. The watermark stays at its
+   * current value; the server sends a fresh invitation for each new session.
+   */
+  connected: boolean;
+
+  /**
+   * Called with the extracted upload path when a mock-upload invitation is
+   * detected in the message stream. This is the only side-effect the hook
+   * produces — Playground owns all modal state.
+   */
+  onOpenModal: (uploadPath: string) => void;
+}
+
+/**
+ * Watches the WebSocket message stream for mock-data upload invitations
+ * ("You may upload JSON payload -> POST /api/mock/{id}") and automatically
+ * calls `onOpenModal` with the extracted POST path when one is detected.
+ *
+ * Design decisions:
+ *  - No `waitingForRef` flag: unlike useAutoGraphRefresh, there is no two-step
+ *    server handshake. The invitation message itself contains the complete
+ *    target URL — we open the modal immediately.
+ *  - Watermark NOT reset on disconnect: see `connected` JSDoc above.
+ *  - Break on first match per batch: prevents two modals from stacking if the
+ *    server sends two invitations in one message batch (consistent with
+ *    useLargePayloadDownload).
+ *  - `connected` is aliased to `_connected` to signal intentional non-use
+ *    while keeping the interface symmetrical with peer hooks.
+ *
+ * This hook has no return value — its only job is to dispatch side effects.
+ */
+export function useAutoMockUpload({
+  messages,
+  connected: _connected,
+  onOpenModal,
+}: UseAutoMockUploadOptions): void {
+
+  // ── Message-ID watermark ──────────────────────────────────────────────────
+  // Initialised to the highest message ID present at mount time.
+  // Prevents replaying historical upload invitations on mount.
+  const watermarkRef = useRef<number>(-1);
+
+  // ── Set watermark at mount ────────────────────────────────────────────────
+  // Runs once. Captures the highest message ID currently in the log so
+  // only genuinely new messages are processed.
+  useEffect(() => {
+    if (messages.length > 0) {
+      watermarkRef.current = messages[messages.length - 1].id;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Main effect ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    const newMessages = messages.filter(m => m.id > watermarkRef.current);
+    if (newMessages.length === 0) return;
+
+    // Advance watermark to the latest processed ID.
+    watermarkRef.current = messages[messages.length - 1].id;
+
+    for (const msg of newMessages) {
+      if (isMockUploadMessage(msg.raw)) {
+        const uploadPath = extractMockUploadPath(msg.raw);
+        if (uploadPath) {
+          onOpenModal(uploadPath);
+          // Break on first match — prevents two modals from stacking if
+          // the server sends two invitations in one message batch.
+          break;
+        }
+      }
+    }
+  }, [messages, onOpenModal]);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useGraphData.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useGraphData.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { isMinigraphGraphData, type MinigraphGraphData } from '../utils/graphTypes';
 import { type ToastType } from './useToast';
 import { type RightTab } from '../components/RightPanel/RightPanel';
+import { useLocalStorage } from './useLocalStorage';
 
 export interface UseGraphDataReturn {
   graphData:    MinigraphGraphData | null;
@@ -37,25 +38,24 @@ export interface UseGraphDataReturn {
  * @param pinnedGraphPath  Relative API path e.g. `/api/graph/model/my-graph/123-1`,
  *                         or null when no graph is pinned.
  * @param addToast         Toast callback from the parent's useToast hook.
- * @param initialTab       The tab to show before any graph is loaded.
+ * @param initialTab       The tab to show when no persisted selection exists.
  *                         Should be the first entry in the playground's `tabs` config.
+ * @param storageKeyTab    localStorage key for persisting the selected tab across
+ *                         navigation. Each playground supplies its own key so
+ *                         selections are independent and survive page refreshes.
  */
 export function useGraphData(
   pinnedGraphPath: string | null,
   addToast: (message: string, type?: ToastType) => void,
   initialTab: RightTab,
+  storageKeyTab: string,
 ): UseGraphDataReturn {
   const [graphData, setGraphData] = useState<MinigraphGraphData | null>(null);
-  const [rightTab, setRightTab]   = useState<RightTab>(initialTab);
+  // useLocalStorage re-reads from storage whenever `storageKeyTab` changes
+  // (playground switch), so the correct persisted tab is restored immediately
+  // without any additional synchronisation effect.
+  const [rightTab, setRightTab]   = useLocalStorage<RightTab>(storageKeyTab, initialTab);
   const [isRefreshing, setIsRefreshing] = useState(false);
-
-  // useState only uses its initialiser on the very first mount — it ignores
-  // subsequent changes to `initialTab`.  When the user switches playgrounds,
-  // Playground remounts with a different config.tabs[0], so we must
-  // explicitly sync rightTab back to the new playground's first tab.
-  useEffect(() => {
-    setRightTab(initialTab);
-  }, [initialTab]);
 
   // Keep a ref in sync with the prop so that refetchGraph() (which has an
   // empty dep array) always reads the latest path rather than a stale closure.

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useGraphSaveName.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useGraphSaveName.ts
@@ -1,0 +1,162 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+import { extractImportGraphName } from '../utils/messageParser';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseGraphSaveNameReturn {
+  /**
+   * The name that should pre-fill the save-form input when the user opens it.
+   *
+   * Priority order:
+   *  1. lastSavedName  — the name the working graph was most recently saved as.
+   *  2. importedName   — the name that was supplied in the last
+   *                      `import graph from {name}` command sent this session.
+   *  3. `untitled-{n}` — a monotonically incrementing fallback, persisted to
+   *                      localStorage so it never resets across page refreshes
+   *                      within the same playground.
+   */
+  defaultName:      string;
+  /**
+   * Call this after a successful save so the input remembers the chosen name
+   * for subsequent opens of the save form.
+   *
+   * When the name matches the current `untitled-{n}` slot, the slot is marked
+   * as consumed so `resetName` knows to advance the counter on the next clear.
+   */
+  setLastSavedName: (name: string) => void;
+  /**
+   * Call this when the user clears the console / working graph (e.g. via the
+   * Clear button). Clears the imported- and last-saved names. The untitled
+   * counter only advances when the current `untitled-{n}` slot was actually
+   * consumed by a save — so clearing without ever saving reuses the same slot,
+   * guaranteeing `untitled-{n}` only exists when `untitled-{n-1}` does (min 1).
+   */
+  resetName:        () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages the pre-fill name for the GraphSaveButton input.
+ *
+ * Design notes:
+ *  - `untitledCounter` is stored in localStorage (keyed per playground) so
+ *    the counter survives page refreshes.  It only increments when the current
+ *    `untitled-{n}` slot has been consumed by an actual save — clearing without
+ *    ever saving reuses the same slot number, so numbers are never skipped.
+ *  - `untitledSlotConsumed` tracks whether the current slot has been used.
+ *    It is set to true only when setLastSavedName is called with a name that
+ *    matches the active untitled fallback, and is reset to false on resetName().
+ *  - `importedName` is derived reactively from the WebSocket message stream
+ *    using a message-ID watermark (same pattern as useAutoMockUpload /
+ *    useAutoGraphRefresh) so stale history is never replayed on mount.
+ *  - `lastSavedName` is plain component state — it is intentionally NOT
+ *    persisted to localStorage; it is reset on `resetName()` so a cleared
+ *    graph starts fresh.
+ *
+ * @param storageKey  localStorage key for the untitled counter
+ *                    (should be unique per playground, e.g.
+ *                    `"minigraph-untitled-counter"`).
+ * @param messages    Incoming WebSocket message log from useWebSocket.
+ */
+export function useGraphSaveName(
+  storageKey: string,
+  messages:   { id: number; raw: string }[],
+): UseGraphSaveNameReturn {
+
+  // ── Untitled counter ──────────────────────────────────────────────────────
+  // Persisted per playground so numbers never reuse within a playground's
+  // lifetime.  Starts at 1 for a fresh localStorage (i.e. first ever save).
+  const [untitledCounter, setUntitledCounter] = useLocalStorage<number>(storageKey, 1);
+
+  // ── Untitled slot consumed flag ───────────────────────────────────────────
+  // True only after setLastSavedName is called with a name that matches the
+  // current `untitled-{n}` fallback.  Tells resetName() whether to advance
+  // the counter.  Stored in a ref (not state) because it is write-only from
+  // the hook's perspective — it never drives a re-render on its own.
+  const untitledSlotConsumedRef = useRef(false);
+
+  // ── Imported name ─────────────────────────────────────────────────────────
+  // Updated whenever the user sends `import graph from {name}`.
+  // Cleared by resetName().
+  const [importedName, setImportedName] = useState<string | null>(null);
+
+  // ── Last-saved name ───────────────────────────────────────────────────────
+  // Updated by the caller via setLastSavedName after a successful save.
+  // Cleared by resetName().
+  const [lastSavedName, setLastSavedNameState] = useState<string | null>(null);
+
+  // ── Message-ID watermark ──────────────────────────────────────────────────
+  // Mirrors the pattern used by useAutoMockUpload / useAutoGraphRefresh.
+  // Initialised to -1; set to the highest ID present at mount time so that
+  // import commands that are already in the console history at page load
+  // are NOT replayed as a fresh import.
+  const watermarkRef = useRef<number>(-1);
+
+  // ── Set watermark at mount ────────────────────────────────────────────────
+  useEffect(() => {
+    if (messages.length > 0) {
+      watermarkRef.current = messages[messages.length - 1].id;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Scan new messages for import-graph echoes ─────────────────────────────
+  useEffect(() => {
+    if (messages.length === 0) return;
+
+    const newMessages = messages.filter(m => m.id > watermarkRef.current);
+    if (newMessages.length === 0) return;
+
+    watermarkRef.current = messages[messages.length - 1].id;
+
+    // Walk in reverse so that if multiple imports arrived in one batch, the
+    // most-recent one wins (consistent with "last command wins" semantics).
+    for (let i = newMessages.length - 1; i >= 0; i--) {
+      const name = extractImportGraphName(newMessages[i].raw);
+      if (name) {
+        // A new import supersedes any previous saved name — the user is working
+        // with an externally-supplied graph now.
+        setImportedName(name);
+        setLastSavedNameState(null);
+        break;
+      }
+    }
+  }, [messages]);
+
+  // ── Public setters ────────────────────────────────────────────────────────
+
+  const setLastSavedName = useCallback((name: string) => {
+    setLastSavedNameState(name);
+    // Mark the current untitled slot as consumed when the user saves with the
+    // untitled fallback name — but NOT when they rename it to something else.
+    // This is read by resetName() to decide whether to advance the counter.
+    if (name === `untitled-${untitledCounter}`) {
+      untitledSlotConsumedRef.current = true;
+    }
+  }, [untitledCounter]);
+
+  const resetName = useCallback(() => {
+    setImportedName(null);
+    setLastSavedNameState(null);
+    // Only advance the counter when the current untitled slot was actually used
+    // as a save name.  Clearing without ever saving reuses the same slot so
+    // that `untitled-{n}` only exists in storage when `untitled-{n-1}` does.
+    if (untitledSlotConsumedRef.current) {
+      setUntitledCounter(prev => prev + 1);
+    }
+    untitledSlotConsumedRef.current = false;
+  }, [setUntitledCounter]);
+
+  // ── Derived default name ──────────────────────────────────────────────────
+  const defaultName =
+    lastSavedName  ??
+    importedName   ??
+    `untitled-${untitledCounter}`;
+
+  return { defaultName, setLastSavedName, resetName };
+}

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useLargePayloadDownload.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useLargePayloadDownload.ts
@@ -1,0 +1,168 @@
+import { useEffect, useRef } from 'react';
+import { extractLargePayloadLink } from '../utils/messageParser';
+import { type ToastType } from './useToast';
+
+export interface UseLargePayloadDownloadOptions {
+  /**
+   * Full incoming message log from the WebSocket slot.
+   * Only messages with IDs greater than the watermark set at mount time are
+   * processed — historical messages are never replayed.
+   */
+  messages: { id: number; raw: string }[];
+
+  /**
+   * Whether the WebSocket is currently connected (for this playground's slot).
+   * The pending state is cleared on disconnect to prevent cross-session
+   * contamination.
+   */
+  connected: boolean;
+
+  /**
+   * Callback to append a local-only message to this playground's console.
+   */
+  appendMessage: (raw: string) => void;
+
+  addToast: (msg: string, type?: ToastType) => void;
+}
+
+/**
+ * Watches the WebSocket message stream for large-payload inspect links.
+ *
+ * When the server sends a message matching:
+ *   "Large payload (<bytes>) -> GET /api/inspect/<id>/<namespace>"
+ *
+ * this hook fetches the payload from the backend inspect endpoint and
+ * appends it directly to this playground's console as a collapsible
+ * JSON row — no navigation, no pre-connection requirement.
+ *
+ * The user can then use the per-row ➡️ button (onSendToJsonPath) to
+ * move the payload into the JSON-Path Playground editor in one click,
+ * identical to the flow for inline small payloads.
+ *
+ * Follows the same patterns as useAutoGraphRefresh / useAutoMarkdownPin:
+ *  - Message-ID watermark set at mount prevents replaying history.
+ *  - isFetchingRef guard prevents re-entrancy when the appended result
+ *    message triggers the effect again.
+ *  - AbortController cancels in-flight fetches on disconnect or unmount.
+ */
+export function useLargePayloadDownload({
+  messages,
+  connected,
+  appendMessage,
+  addToast,
+}: UseLargePayloadDownloadOptions): void {
+
+  // ── Message-ID watermark ──────────────────────────────────────────────────
+  const watermarkRef = useRef<number>(-1);
+
+  // ── In-flight fetch AbortController ──────────────────────────────────────
+  const abortRef = useRef<AbortController | null>(null);
+
+  // ── Re-entrancy guard ─────────────────────────────────────────────────────
+  // Prevents the appended result message from being re-processed as a new
+  // large-payload notification by this hook's own main effect.
+  const isFetchingRef = useRef<boolean>(false);
+
+  // ── Initialise watermark at mount ─────────────────────────────────────────
+  // Declared before the main effect so React fires it first on initial render,
+  // matching the ordering guarantee used by useAutoGraphRefresh.
+  useEffect(() => {
+    if (messages.length > 0) {
+      watermarkRef.current = messages[messages.length - 1].id;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Cancel in-flight fetch on disconnect ──────────────────────────────────
+  useEffect(() => {
+    if (!connected) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      // Clear guard so the next reconnect + large-payload message is not
+      // silently skipped due to a stale isFetchingRef from the aborted request.
+      isFetchingRef.current = false;
+    }
+  }, [connected]);
+
+  // ── Cancel in-flight fetch on unmount ─────────────────────────────────────
+  useEffect(() => {
+    return () => { abortRef.current?.abort(); };
+  }, []);
+
+  // ── Main effect ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    // Re-entrancy guard: skip the entire effect while a fetch is in flight.
+    // Placed before the messages.length === 0 check so the filter() call is
+    // also avoided. Non-large-payload messages that arrive during a fetch
+    // remain above the watermark and are re-scanned on the next tick once
+    // isFetchingRef is cleared — safe because extractLargePayloadLink returns
+    // null for non-notification strings (one redundant scan, negligible cost).
+    if (isFetchingRef.current) return;
+    if (messages.length === 0) return;
+
+    const newMessages = messages.filter(m => m.id > watermarkRef.current);
+    if (newMessages.length === 0) return;
+
+    // Unconditional advance: all messages up to this tick are now "seen".
+    watermarkRef.current = messages[messages.length - 1].id;
+
+    for (const msg of newMessages) {
+      const link = extractLargePayloadLink(msg.raw);
+      if (!link) continue;
+
+      const { apiPath, byteSize } = link;
+
+      // Cancel any previous in-flight fetch.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const sizeMB = (byteSize / (1024 * 1024)).toFixed(2);
+      addToast(`Fetching large payload (${sizeMB} MB)…`, 'info');
+
+      // Arm the re-entrancy guard before the async boundary.
+      isFetchingRef.current = true;
+
+      // Fetch the payload from the backend inspect endpoint.
+      fetch(apiPath, { signal: controller.signal })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.text();
+        })
+        .then(text => {
+          // Guard against empty response body (e.g. 200 with no content).
+          if (!text.trim()) throw new Error('empty response body');
+
+          // Pretty-print if it parses as JSON, otherwise pass through as-is.
+          let content = text;
+          try { content = JSON.stringify(JSON.parse(text), null, 2); } catch { /* not JSON — pass raw */ }
+
+          // Append the fetched payload to this playground's console.
+          // ConsoleMessage already handles JSON via JsonView and will show
+          // the ➡️ send-to-JSON-Path button identical to small-payload flow.
+          appendMessage(content);
+
+          // Belt-and-suspenders watermark advance: use +1 as a safe upper bound
+          // so the appended message (id = lastNotificationId + 1 or higher) is
+          // treated as "already seen" on the next tick, even before React
+          // re-renders and the messages closure is refreshed.
+          watermarkRef.current = newMessages[newMessages.length - 1].id + 1;
+          isFetchingRef.current = false;
+          abortRef.current = null;
+        })
+        .catch((err: Error) => {
+          if (err.name === 'AbortError') return;
+          // Clear guard before appending: the error string cannot match
+          // extractLargePayloadLink so re-entrancy risk is zero.
+          isFetchingRef.current = false;
+          abortRef.current = null;
+          appendMessage(`ERROR: payload fetch failed — ${err.message}`);
+          addToast(`Payload fetch failed: ${err.message}`, 'error');
+        });
+
+      // Only process the first large-payload link per batch.
+      // Without the break, two concurrent fetches could race and both attempt
+      // to write abortRef.current, leaving the second one unabortable.
+      break;
+    }
+  }, [messages, connected, appendMessage, addToast]);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useMockUpload.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useMockUpload.ts
@@ -1,0 +1,94 @@
+import { useState, useRef, useCallback } from 'react';
+
+export interface UseMockUploadOptions {
+  /** The POST path extracted from the server message, e.g. "/api/mock/ws-417669-24" */
+  uploadPath: string;
+  /** The current textarea value — the JSON string to POST. */
+  json: string;
+  /** Called with the response body text on a successful (2xx) upload. */
+  onSuccess: (responseBody: string) => void;
+  /** Called with a human-readable error message on failure. */
+  onError:   (message: string) => void;
+}
+
+export interface UseMockUploadReturn {
+  /** True while a fetch is in-flight. */
+  isUploading: boolean;
+  /** Initiate the POST request with the current `json` value. */
+  upload: () => void;
+  /** Abort any in-flight request. */
+  cancel: () => void;
+}
+
+/**
+ * Owns the fetch lifecycle for a mock-data upload POST request.
+ *
+ * Keeping this logic out of the modal component means MockUploadModal is a
+ * pure renderer and this hook is independently testable.
+ *
+ * Design decisions:
+ *  - AbortController per upload attempt — a new controller is created each
+ *    time `upload()` is called, cancelling the previous one if still running.
+ *  - On success (2xx): calls `onSuccess` with the drained response body.
+ *    The body is available to the caller but the spec mandates it is not
+ *    surfaced in the console or toast — that decision belongs to Playground.tsx.
+ *  - On failure (non-2xx or network error): calls `onError` with a message
+ *    of the form "HTTP 400 — <server response body>" or the caught error message.
+ *  - `isUploading` is set false before calling callbacks so the modal can
+ *    re-enable its button immediately on error (for retry) or unmount on success.
+ */
+export function useMockUpload({
+  uploadPath,
+  json,
+  onSuccess,
+  onError,
+}: UseMockUploadOptions): UseMockUploadReturn {
+
+  const [isUploading, setIsUploading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsUploading(false);
+  }, []);
+
+  const upload = useCallback(async () => {
+    // Abort any previous in-flight request before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsUploading(true);
+
+    try {
+      const response = await fetch(uploadPath, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    json,
+        signal:  controller.signal,
+      });
+
+      const body = await response.text();
+
+      if (!response.ok) {
+        setIsUploading(false);
+        onError(`HTTP ${response.status} — ${body}`);
+        return;
+      }
+
+      setIsUploading(false);
+      onSuccess(body);
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        // Cancelled by the caller — do not call onError.
+        setIsUploading(false);
+        return;
+      }
+      setIsUploading(false);
+      onError((err as Error).message ?? 'Network error');
+    }
+  }, [uploadPath, json, onSuccess, onError]);
+
+  return { isUploading, upload, cancel };
+}

--- a/extensions/minigraph-playground-engine/webapp/src/hooks/useWebSocket.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/hooks/useWebSocket.ts
@@ -54,6 +54,8 @@ export interface UseWebSocketReturn {
   clearMessages:    () => void;
   uploadPayload:    () => void;
   sendRawText:      (text: string) => void;
+  /** Append a local-only message to this slot's console (no WebSocket round-trip). */
+  appendMessage:    (raw: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -257,6 +259,10 @@ export function useWebSocket({ wsPath, storageKeyHistory, payload, addToast }: U
     addToast('Console cleared', 'info');
   }, [ctx, wsPath, addToast]);
 
+  const appendMessage = useCallback((raw: string) => {
+    ctx.appendMessage(wsPath, raw);
+  }, [ctx, wsPath]);
+
   const setCommand = useCallback(
     (value: string) => dispatch({ type: 'SET_COMMAND', value }),
     []
@@ -277,5 +283,6 @@ export function useWebSocket({ wsPath, storageKeyHistory, payload, addToast }: U
     clearMessages,
     uploadPayload,
     sendRawText,
+    appendMessage,
   };
 }

--- a/extensions/minigraph-playground-engine/webapp/src/index.css
+++ b/extensions/minigraph-playground-engine/webapp/src/index.css
@@ -2,7 +2,7 @@
   --primary-color: #2563eb;
   --primary-hover: #1d4ed8;
   --success-color: #10b981;
-  --warning-color: #f5780b;
+  --warning-color: #f59e0b;
   --danger-color: #ef4444;
   --bg-primary: #ffffff;
   --bg-secondary: #f8fafc;

--- a/extensions/minigraph-playground-engine/webapp/src/utils/messageParser.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/utils/messageParser.ts
@@ -40,7 +40,7 @@ export const getMessageIcon = (type: MessageType): string => {
     error:   '❌',
     ping:    '🔄',
     welcome: '👋',
-    raw:     '📝',
+    raw:     '',
   };
   return icons[type] ?? '•';
 };
@@ -121,6 +121,78 @@ export function extractUploadPath(raw: string): string | null {
 }
 
 /**
+ * Represents a detected large-payload link with metadata extracted from the
+ * server's "Large payload (N) -> GET /api/inspect/..." message.
+ */
+export interface LargePayloadLink {
+  /** The relative API path to GET the payload, e.g. "/api/inspect/ws-734563-3/input.body" */
+  apiPath:   string;
+  /** The size in bytes reported by the server, e.g. 254922 */
+  byteSize:  number;
+  /**
+   * A suggested filename for the download, derived from the last path segment,
+   * e.g. "input.body.json"
+   */
+  filename:  string;
+}
+
+/**
+ * Matches the server's large-payload message pattern:
+ *   "Large payload (254922) -> GET /api/inspect/ws-734563-3/input.body"
+ *
+ * Returns a {@link LargePayloadLink} when the pattern is found, or null otherwise.
+ *
+ * The message is always a plain-text (non-JSON) line so there is no need to
+ * guard with isMarkdownCandidate — the caller should already know the context.
+ */
+export function extractLargePayloadLink(raw: string): LargePayloadLink | null {
+  // Pattern: Large payload (<bytes>) -> GET <path>
+  const match = raw.match(/Large payload \((\d+)\)\s*->\s*GET\s+(\/api\/inspect\/[^\s]+)/i);
+  if (!match) return null;
+
+  const byteSize = parseInt(match[1], 10);
+  const apiPath  = match[2];
+
+  // Derive a safe filename from the last path segment plus ".json"
+  const lastSegment = apiPath.split('/').filter(Boolean).pop() ?? 'payload';
+  const filename    = `${lastSegment}.json`;
+
+  return { apiPath, byteSize, filename };
+}
+
+/**
+ * Returns true when a raw WebSocket message is a large-payload link.
+ * Used by ConsoleMessage.tsx to apply a distinct visual treatment.
+ */
+export function isLargePayloadMessage(raw: string): boolean {
+  return extractLargePayloadLink(raw) !== null;
+}
+
+/**
+ * Extracts the POST path from a mock-data upload invitation:
+ *   "You may upload JSON payload -> POST /api/mock/{id}"
+ *
+ * Returns the path string (e.g. "/api/mock/ws-417669-24") or null if
+ * the message does not match the pattern.
+ *
+ * The regex is anchored to `/api/mock/` (not a generic POST capture) to
+ * avoid false positives from future unrelated messages. The case-insensitive
+ * flag handles any minor casing variation the server might introduce.
+ */
+export function extractMockUploadPath(raw: string): string | null {
+  const match = raw.match(/You may upload .*?->\s*POST\s+(\/api\/mock\/[\w-]+)/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Returns true when a raw WebSocket message is a mock-data upload invitation.
+ * Used by ConsoleMessage.tsx and useAutoMockUpload to detect the upload trigger.
+ */
+export function isMockUploadMessage(raw: string): boolean {
+  return extractMockUploadPath(raw) !== null;
+}
+
+/**
  * Returns true when a raw WebSocket message is an echoed command that should
  * trigger an auto-pin of the next plain-text response to the Markdown Preview.
  *
@@ -156,6 +228,24 @@ export function isHelpOrDescribeCommand(raw: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Extracts the graph name from an echoed `import graph from {name}` command.
+ *
+ * The backend echoes every user command with a `> ` prefix, so the message
+ * that arrives in the WebSocket stream looks like:
+ *   "> import graph from my-graph-name"
+ *
+ * Returns the trimmed name string (e.g. `"my-graph-name"`) or `null` if the
+ * message is not an import-graph echo.
+ */
+export function extractImportGraphName(raw: string): string | null {
+  if (!raw.startsWith('> ')) return null;
+  const lower = raw.slice(2).trimStart().toLowerCase();
+  if (!lower.startsWith('import graph from ')) return null;
+  const name = raw.slice(2).trimStart().slice('import graph from '.length).trim();
+  return name.length > 0 ? name : null;
 }
 
 /**


### PR DESCRIPTION
- **MockUploadModal**: New `<dialog>`-based modal for uploading mock JSON data to a server endpoint; supports drag-and-drop, file browse, inline validation, and `Cmd/Ctrl+Enter` to submit
- **`useMockUpload`**: New hook encapsulating the fetch lifecycle (POST, abort, error handling) for the mock upload modal
- **`useAutoMockUpload`**: New hook that watches the WebSocket message stream for upload invitation messages and auto-opens the modal; uses a message-ID watermark to skip history replay on mount
- **`useLargePayloadDownload`**: New hook that detects `Large payload (N) → GET /api/inspect/…` server messages, fetches the payload inline, and appends it to the console — replacing the former download-to-file flow
- **`useGraphSaveName`**: New hook managing the save-form pre-fill name with priority: last saved → imported → `untitled-{n}` (persisted per playground); integrates `import graph from {name}` echo detection
- **WebSocketContext**: Added `setPendingPayload` / `takePendingPayload` for cross-playground payload handoff (e.g. "Send to JSON-Path"); made `onToast` optional in `connect()` for silent background auto-connect; added startup auto-connect for all playgrounds
- **`useGraphData`**: Persists the selected right-panel tab to `localStorage` per playground via a new `storageKeyTab` config field
- **`useAutoMarkdownPin`**: Hardened pin logic to skip echoed commands, mock-upload invitations, and non-pinnable server responses; added `isPinnableResponse` guard
- **`messageParser`**: Added `extractLargePayloadLink`, `isLargePayloadMessage`, `extractMockUploadPath`, `isMockUploadMessage`, `extractImportGraphName`; changed raw message icon from 📝 to empty
- **Navigation**: Added "Connect All / Disconnect All" button to the Tools dropdown
- **Toast**: Moved toast container from top-right to bottom-right
- **`playgrounds.ts`**: Added `storageKeyTab` field to `PlaygroundConfig` and all playground entries
- **`index.css`**: Fixed `--warning-color` hex value (`#f5780b` → `#f59e0b`)