### PR TITLE
Persistent Clipboard for Graph nodes

### DIFF
--- a/extensions/minigraph-playground-engine/webapp/docs/CHANGELOG-universal-graph-clipboard.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/CHANGELOG-universal-graph-clipboard.md
@@ -1,0 +1,144 @@
+# Universal Graph Clipboard — Spec Changelog
+
+**Spec:** `docs/SPEC-universal-graph-clipboard.md`  
+**Audit:** `docs/AUDIT-universal-graph-clipboard.md`
+
+---
+
+## Rev 4 (2026-03-31)
+
+Final revision addressing the 2 minor findings from the Rev 3 audit.
+
+| Audit # | Finding | Resolution | Section |
+|---------|---------|------------|---------|
+| **R3-1** | `ClipboardItemRecord` imported from `ClipboardContext` but defined in `clipboard/db.ts` — import would fail at build time | Changed S11.2 import to `import type { ClipboardItemRecord } from '../clipboard/db'` | S11.2 |
+| **R3-2** | `onReplace` handler in duplicate dialog lacks error boundary — `confirmReplace` rejection would be unhandled | Added `try/catch` wrapping the `confirmReplace` call, matching the pattern already used in `handleClipNode` | S11.2 |
+
+---
+
+## Rev 3 (2026-03-31)
+
+Revision addressing all 6 findings from the Rev 2 audit, plus a design change
+requested by the spec author.
+
+### Design Change: Remove Console Command (`clip node {alias}`)
+
+The `clip node {alias}` console command has been removed. The command input is
+reserved exclusively for WebSocket messages to the backend — no client-side
+command interception.
+
+**Rationale:** Mixing client-side-only commands with server commands blurs the
+boundary between local and remote operations and confuses users about which
+commands the server understands.
+
+| Section | Change |
+|---------|--------|
+| S3 Decision #5 | Changed from two triggers (context menu + console command) to context menu only |
+| S3.1 | Console command added as a third rejected alternative with rationale |
+| S4.1 | Removed "Console command interception" from Layer 3 description |
+| S7.4.4 | Removed `clip node {name}` reference from empty-state text |
+| S8.2 (old) | Entire section removed (was "Clip Trigger (b): Console Command"). Old S8.3 renumbered to S8.2. |
+| S11.2 | Removed `handleClipNodeByAlias` callback, removed `onClipNodeByAlias` wiring to `useWebSocket`, removed `ws.appendMessage` calls from `handleClipNode` (toasts only) |
+| S11.5 (old) | Entire section removed (was useWebSocket.ts changes) |
+| S12.2 | Removed `src/hooks/useWebSocket.ts` from modified files; moved to unchanged files list |
+| S13.1 | Removed `clip node X` with null graphData scenario (no longer possible) |
+| S13.3 | Removed `clip node {alias}` regex reference |
+| S14.2 | Removed "Clip via `clip node` command" integration test |
+| S14.3 | Removed two `clip node` QA checklist items |
+
+### Audit Fixes (Rev 2 Findings)
+
+| Audit # | Severity | Finding | Resolution | Sections Changed |
+|---------|----------|---------|------------|------------------|
+| **R2-1** | Medium | S13.9 claims an update-not-found fallback that S9.3 doesn't implement | Added **symmetrical fallback** to Step 2b: when `update node` returns "Node {alias} not found" (detected via `docs.response`), the hook falls back to `create node`. Mirrors Step 2a's "already exists" → update fallback. Added to S9.5 correlation table and S9.6 error handling table. Fixed S13.9 to cite the implemented mechanism. | S9.3 Step 2b, S9.5, S9.6, S13.9, S14.2 |
+| **R2-2** | Low-medium | `serializePropertyValue` wraps `'''`-containing single-line values in triple-quotes, causing a larger truncation than leaving them unquoted | Changed logic: only wrap on `\n`. Warn on `'''` regardless. Single-line values containing `'''` are left unquoted to preserve as much of the value as possible. Updated S14.1 test case. | S9.4, S14.1 |
+| **R2-3** | Low-medium | `handleClipNodeByAlias` lacked top-level error boundary — unhandled Promise rejections possible | With the console command removed, `handleClipNodeByAlias` no longer exists. The remaining `handleClipNode` (context menu path) now has a **top-level `try/catch`** that catches unexpected errors and shows a toast. Added explanatory note. | S11.2 |
+| **R2-4** | Minor | Console message appeared on context-menu clip too (orphaned result line without preceding command echo) | Resolved by removing all `ws.appendMessage` calls from `handleClipNode`. Clip operations now produce **toasts only** — no console messages. This is appropriate because the context menu is the only clip trigger and console echo is a server-command pattern. | S11.2 |
+| **R2-5** | Minor | Step 4 toast says "connections created" but connections are fire-and-forget (count is commands sent, not confirmed) | Reworded toast to `"connections sent"`. Added a note in S9.3 that the count is optimistic (commands sent after local counterpart verification; failures are rare). | S9.3 Step 4 |
+| **R2-6** | Minor | Context menu dismissal uses global `document.querySelector('[role="menu"]')` which is fragile if other menus exist | Replaced with a **`menuRef` ref** (`useRef<HTMLDivElement>`) attached to the menu element. The `useEffect` now uses `menuRef.current.contains()` instead of querying the DOM. | S11.3 |
+
+### Additional Consistency Edits (Non-Audit)
+
+| Change | Sections |
+|--------|----------|
+| Response correlation paragraph updated to describe both fallback paths (already-exists and not-found) symmetrically | S9.3 |
+| `Playground.tsx` imports updated: removed `findNodeByAlias`, `extractDirectConnections` (these are imported in `GraphView.tsx` only); added note explaining the indirection | S11.2 |
+| S13.7 remains unchanged — `isPasting` still disables the send button during paste operations. This is a guard (not a command interception) and is consistent with the principle that the command input is for backend messages only. | — |
+
+---
+
+## Rev 2 (2026-03-31)
+
+Revision addressing all 24 findings from the spec audit. Every finding was
+verified as valid against the codebase at commit `e75cb384`.
+
+### Critical Fixes
+
+| Audit # | Finding | Resolution | Sections Changed |
+|---------|---------|------------|------------------|
+| **1a** | Paste response correlation underspecified — shared `ProtocolBus` events could be misinterpreted by the paste hook | Replaced WebSocket `describe node` round-trips with **local `graphData` checks** for both node existence (Step 1) and connection counterpart existence (Step 3). This eliminates the N+1 bus-event disambiguation problem entirely. Remaining correlation (for `create`/`update` confirmation in Steps 2a/2b) is now a single `graph.mutation` listener with a 10-second step timeout. Added explicit correlation table in S9.5. | S1, S4.1, S4.3, S9.1 (new subsection on why local checks), S9.2 (`graphData` added to `UsePasteNodeOptions`), S9.3 (rewritten steps), S9.5 (rewritten), S13.7, S13.9 (new) |
+| **1b** | `create node` "already exists" unhandled — server returns `"Node {alias} already exists"` (confirmed `GraphCommandService.java:1010`) which doesn't match any `detectMutation()` pattern, stalling the paste state machine | Added **fallback path** in S9.3 Step 2a: when `create node` returns "already exists" (detected as a `docs.response` event containing the text), the hook retries as `update node`. Added to S9.5 correlation table and S9.6 error handling table. | S9.3 Step 2a, S9.5, S9.6, Appendix C |
+| **1c** | Self-connection (`source === target`) causes backend rejection — server returns `"source and target node names cannot be the same"` (confirmed `GraphLambdaFunction.java:106`) | `extractDirectConnections()` in `src/clipboard/helpers.ts` now **filters out self-connections** with `c.source !== c.target`. Added explanatory comment citing the backend constant `SAME_SOURCE_TARGET`. Updated the Terminology entry for "Direct connections" to note the exclusion. | S2 (Terminology), S5.3 (`connections` field doc), S6.4 (`connections` param doc), S8.1 (helpers code), S14.1 (helpers test cases), Appendix C |
+| **1d** | Console echo for successful clip was inconsistent — S8.2 showed a success line but S11.2's `handleClipNodeByAlias` only appended messages on error | `handleClipNode` now calls `ws.appendMessage()` on **both success and error**. S8.2 interception code now appends the command echo (`> clip node {alias}`) and adds to history. Clarified the duplicate case: the dialog opens without an immediate console message. | S8.2 (rewritten interception logic and console echo section), S11.2 (`handleClipNode` and `handleClipNodeByAlias`) |
+| **1e** | `handleClipNodeByAlias` didn't `await` the async `handleClipNode` — silent error swallowing and race on `duplicateDialogState` | `handleClipNodeByAlias` is now explicitly `async` and **`await`s `handleClipNode`**. | S11.2 |
+| **1f** | Multiple node types reduced to one on paste (data loss) — `buildNodeCommand` emits only `types[0]` but `MinigraphNode.types` is `string[]` | Documented as **Known Limitation 13.4.1**. `buildNodeCommand` now includes a JSDoc note about the constraint. During paste, a console warning is appended when `node.types.length > 1`. Added to manual QA checklist. | S9.4 (`buildNodeCommand` doc), S13.4.1 (new), S14.3 |
+| **1g** | Connection relation properties lost on paste — `MinigraphRelation.properties` exists but `connect` grammar has no syntax for them | Documented as **Known Limitation 13.4.2**. `buildConnectCommand` now includes a JSDoc note. During paste, a console warning is appended when any relation has non-empty properties. | S9.4 (`buildConnectCommand` doc), S13.4.2 (new), Appendix C (`MinigraphRelation` added) |
+
+### Design Concern Fixes
+
+| Audit # | Finding | Resolution | Sections Changed |
+|---------|---------|------------|------------------|
+| **2a** | `by-alias` index lacked unique constraint — concurrent clips from two tabs could create duplicate entries | Added `{ unique: true }` to the `by-alias` index definition. `clipNode()` now catches `ConstraintError` on `db.addItem()` and re-checks `findByAlias()` to surface the duplicate to the user. | S5.4 (index definition), S5.5 (`addItem` doc), S6.5 (`clipNode` implementation), S14.1 (test case added) |
+| **2b** | `confirmReplace` used two separate IndexedDB transactions — crash between delete and insert loses both records | Introduced `db.replaceItem(previousId, newItem)` that wraps delete + add in a **single IndexedDB transaction** (`db.transaction(STORE_NAME, 'readwrite')`). `confirmReplace` now calls `replaceItem` instead of separate `removeItem` + `addItem`. | S5.5 (new `replaceItem` function), S6.4 (`confirmReplace` doc updated), S6.5 (`confirmReplace` implementation), S12.1 (db.ts description updated), S14.1 (test case added) |
+| **2c** | Paste counterpart check was expensive — N WebSocket round-trips for connection counterparts | **Merged with 1a fix.** All existence checks now use local `graphData.nodes` lookups (O(1) per node, zero network). Added `graphData` to `UsePasteNodeOptions`. Documented staleness caveat and recovery behaviour in S9.1 and S13.9. | S9.1, S9.2, S9.3 Step 3 |
+| **2d** | `isPasting` not wired to disable command input | `isPasting` is now passed through to `sendDisabled` in `Playground.tsx` JSX: `sendDisabled={!ws.connected \|\| !ws.command.trim() \|\| isPasting}`. Added `isPasting` prop to `ClipboardSidebarProps` to disable all Paste buttons during an operation. | S7.4.1 (new `isPasting` prop), S7.4.2 (Paste button disabled-when column), S11.2, S13.7 |
+| **2e** | `serializePropertyValue` only checked `\n` for triple-quoting, missing edge cases with embedded `'''` | Now also checks `str.includes("'''")` and emits a `console.warn` when the value cannot be losslessly serialised. Documented as **Known Limitation 13.4.3**. | S9.4 (`serializePropertyValue` code), S13.4.3 (new) |
+| **2f** | Relative timestamps go stale in the sidebar | Documented as an accepted cosmetic trade-off in S7.4.2 with a note. Added **Future Enhancement 15.7** for auto-refreshing timestamps via `setInterval`. | S7.4.2, S15.7 (new) |
+
+### Gap Fixes
+
+| Audit # | Finding | Resolution | Sections Changed |
+|---------|---------|------------|------------------|
+| **3a** | Clip triggers (b) and (c) from original design review unexplained | Added **Section 3.1 "Rejected Clip Trigger Alternatives"** documenting the two rejected options (per-node button in GraphDataView; toolbar button on selected node) with reasons. Renumbered surviving triggers to (a) and (b) for consistency. | S3 Decision #5, S3.1 (new), S8.1 heading, S8.2 heading |
+| **3b** | `fake-indexeddb` not listed in dependency additions | Added `fake-indexeddb` to **Appendix A** as a dev dependency with install command. | Appendix A |
+| **3c** | No keyboard accessibility for context menu | Added accessibility subsection to S8.1: `Shift+F10` keyboard trigger, focus management (auto-focus first item on open, return focus to node on close), Escape key dismissal, ARIA attributes (`role="menu"`, `role="menuitem"`). Updated S11.3 code examples with `autoFocus` and ARIA roles. | S8.1, S11.3, S14.2 (new test cases) |
+| **3d** | Context menu dismissal was incomplete — only `onPaneClick` handled | Added `useEffect` in S11.3 with global `mousedown` and `keydown` listeners for outside-click and Escape dismissal. Updated S8.1 to list all dismissal triggers. | S8.1, S11.3 (new `useEffect`), S14.2 (new test cases), S14.3 (new QA items) |
+| **3e** | Multi-relation iteration not explicit in paste flow Step 3 | Rewrote Step 3 pseudocode with an explicit **nested loop**: outer loop over connections, inner loop over `connection.relations`. Updated `buildConnectCommand` doc to clarify "call once per relation." | S9.3 Step 3, S14.2 (new test case for multi-relation) |
+| **3f** | No documentation that re-paste after interruption is safe | Added explicit **"Re-paste after interruption"** row to the S9.6 error handling table stating that re-paste is safe due to idempotency and explaining the recovery path. | S9.6 |
+
+### Minor Fixes
+
+| Audit # | Finding | Resolution | Sections Changed |
+|---------|---------|------------|------------------|
+| **4a** | `ClipboardSidebar.open` prop was redundant (always `true` when component mounted) | Changed rendering strategy: sidebar is **always mounted** when `config.supportsClipboard` is true, and uses `open` prop for **CSS slide-in/slide-out transitions** rather than conditional mount/unmount. Updated `ClipboardSidebarProps` doc to explain the CSS transition role. | S7.4.1, S11.2 (JSX) |
+| **4b** | Appendix C commit reference was stale (`156ad7fa` vs actual `e75cb384`) | Updated commit hash to **`e75cb384`**. | Appendix C |
+| **4c** | `ClipboardProvider` position over-constrained — spec implied dependency on `WebSocketContext` | Added note to S4.2: "ClipboardProvider has no dependency on WebSocketContext. The nesting order is interchangeable. The only requirement is that both wrap BrowserRouter." | S4.2 |
+| **4d** | `MinigraphGraphData.connections` may be absent at runtime | Added explanatory comment in `extractDirectConnections` (S8.1) documenting why `?? []` is used and citing `isMinigraphGraphData` type guard at `src/utils/graphTypes.ts:42–46`. Added `isMinigraphGraphData` to Appendix C. | S8.1, Appendix C |
+| **4e** | `buildCreateNodeCommand` / `buildUpdateNodeCommand` duplication | Merged into single **`buildNodeCommand(verb, node)`** function parameterised on `'create' \| 'update'`. All references updated (`commandBuilder.ts`, Step 2a/2b pseudocode, test file descriptions, file inventory). | S9.4, S9.3, S12.1, S14.1 |
+
+### Additional Consistency Edits (Non-Audit)
+
+These changes were made during the full-document consistency pass following the
+audit fixes:
+
+| Change | Sections |
+|--------|----------|
+| Section 13 title changed from "Edge Cases" to "Edge Cases and Known Limitations" to reflect new S13.4 subsections | S13 heading, Table of Contents |
+| Renumbered clip triggers from "(a) and (d)" to "(a) and (b)" throughout — the original lettering skipped (b) and (c) which caused confusion (audit finding 3a). All references in S3, S8, S11 updated. | S3 Decision #5, S8.1 heading, S8.2 heading, S11.5 |
+| Replaced "describe → create/update → connect" in S4.1 Layer 2 description with "local check → create/update → connect" to match the new paste strategy | S4.1 |
+| Updated S4.1 Layer 1 description from "Indexes: by-alias, by-clippedAt" to "Indexes: by-alias (unique), by-clippedAt" | S4.1 |
+| Added `MinigraphRelation` interface to Appendix C (was missing; needed for S13.4.2 citation) | Appendix C |
+| Added `isMinigraphGraphData` type guard to Appendix C (needed for S8.1 citation) | Appendix C |
+| Added backend source citations to Appendix C: `GraphCommandService.java:1010` ("already exists") and `GraphLambdaFunction.java:106` (`SAME_SOURCE_TARGET`) | Appendix C |
+| S12.1 file descriptions updated to reflect new function names and capabilities (`replaceItem`, self-connection filter, step timeouts, `buildNodeCommand`) | S12.1 |
+| S12.2 `Playground.tsx` changes description updated to include `isPasting` wiring | S12.2 |
+| S12.2 `package.json` description updated to include `fake-indexeddb` | S12.2 |
+| S14.1 test case descriptions updated across all modules to reflect revised APIs | S14.1 |
+| S14.2 integration tests expanded with new scenarios: context menu accessibility, context menu dismissal, "already exists" fallback, multi-relation connections | S14.2 |
+| S14.3 manual QA checklist expanded with: multi-type warning, paste-during-paste disabled, context menu keyboard and dismissal tests | S14.3 |
+
+---
+
+## Rev 1 (2026-03-31)
+
+Initial draft.

--- a/extensions/minigraph-playground-engine/webapp/docs/SPEC-universal-graph-clipboard.md
+++ b/extensions/minigraph-playground-engine/webapp/docs/SPEC-universal-graph-clipboard.md
@@ -1,0 +1,2241 @@
+# Universal Graph Clipboard — Implementation Specification
+
+**Status:** Draft (Rev 4)  
+**Author:** Wes Yu  
+**Date:** 2026-03-31  
+**Scope:** `extensions/minigraph-playground-engine/webapp/`
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Terminology](#2-terminology)
+3. [Design Decisions](#3-design-decisions)
+4. [Architecture](#4-architecture)
+5. [Layer 1 — Storage (IndexedDB)](#5-layer-1--storage-indexeddb)
+6. [Layer 2 — Reactivity (BroadcastChannel + React Context)](#6-layer-2--reactivity-broadcastchannel--react-context)
+7. [Layer 3 — UI (ClipboardSidebar + Integration Points)](#7-layer-3--ui-clipboardsidebar--integration-points)
+8. [Clip Operations](#8-clip-operations)
+9. [Paste Execution Strategy](#9-paste-execution-strategy)
+10. [PlaygroundConfig Changes](#10-playgroundconfig-changes)
+11. [Component Tree Changes](#11-component-tree-changes)
+12. [File Inventory](#12-file-inventory)
+13. [Edge Cases and Known Limitations](#13-edge-cases-and-known-limitations)
+14. [Testing Strategy](#14-testing-strategy)
+15. [Future Enhancements](#15-future-enhancements)
+
+---
+
+## 1. Overview
+
+The Universal Graph Clipboard allows a user to **clip** (copy) a node from one
+instance of the Minigraph Playground and **paste** it into another instance (or
+the same instance) running in a different browser tab. The clipboard persists
+across page refreshes and browser restarts.
+
+**Core workflow:**
+
+```
+Tab A (Minigraph Playground)             Tab B (Minigraph Playground)
+─────────────────────────────            ─────────────────────────────
+1. Right-click node "fetcher"
+   → "Clip to Clipboard"
+2. Node + connections stored
+   in IndexedDB
+3. BroadcastChannel notifies  ────────►  4. Sidebar updates reactively
+   all other tabs                        5. User clicks "Paste" on
+                                            the "fetcher" item
+                                         6. Check local graphData for
+                                            node existence (by alias)
+                                         7a. Not found → send `create node …`
+                                         7b. Found     → send `update node …`
+                                         8. Check local graphData for
+                                            connection counterparts;
+                                            send `connect` for each
+                                            existing counterpart
+                                         9. Console shows the mutations;
+                                            graph auto-refreshes via
+                                            useAutoGraphRefresh
+```
+
+---
+
+## 2. Terminology
+
+The following terms are used consistently throughout this document.
+
+| Term | Definition |
+|------|------------|
+| **Clip** | The act of copying a node snapshot (plus its direct connections) into the clipboard store. Analogous to "copy" but avoids confusion with the browser's system clipboard used by `useCopyToClipboard`. |
+| **Paste** | The act of materialising a clipped item into the active playground's graph via WebSocket commands. |
+| **Clipboard item** | A single persisted record in IndexedDB representing one clipped node and its associated connections. |
+| **Clipboard sidebar** | The dedicated right-edge panel that displays all clipboard items. |
+| **Active playground** | The Minigraph Playground instance in the current browser tab where the user is interacting. |
+| **Source playground** | The playground instance from which a node was originally clipped. |
+| **Target playground** | The playground instance into which a clipboard item is being pasted. |
+| **Alias** | The `MinigraphNode.alias` field — the unique identifier of a node within a graph. Defined in `src/utils/graphTypes.ts:12`. Used as the identity key for create-vs-update decisions during paste. |
+| **Direct connections** | All entries in `MinigraphGraphData.connections` (defined in `src/utils/graphTypes.ts:32`) where the clipped node's alias appears as either `source` or `target`. Self-connections (where `source === target`) are excluded — see [Section 8.1](#81-clip-trigger-right-click-context-menu-on-reactflow-node). |
+
+---
+
+## 3. Design Decisions
+
+Decisions resolved during the design review, recorded here for future reference.
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | What is copied with a node? | Node snapshot + direct connections (excluding self-connections). On paste, only connections whose counterpart node exists in the target graph's local `graphData` are created; others are silently skipped with a notification. | Allows natural multi-clip workflow: clip several nodes, paste them all, connections wire up as nodes appear. |
+| 2 | What determines node identity for create-vs-update? | The `alias` field (`MinigraphNode.alias`, `src/utils/graphTypes.ts:12`). | `alias` is the primary identifier in the backend command grammar: `create node {alias}`, `describe node {alias}`, `update node {alias}`. |
+| 3 | Single-node or multi-node clip? | Single-node clip only (one clipboard item per clip action). | Start simple; validate the core workflow before investing in multi-select UI (selection mode, shift-click, lasso). The data model supports future bundling — see [Section 15](#15-future-enhancements). |
+| 4 | Cross-playground-type clipboard? | Scoped to Minigraph-type playgrounds only. | Minigraph nodes are not meaningful in the JSON-Path playground context. Gated by a new `supportsClipboard` flag on `PlaygroundConfig`. |
+| 5 | How does the user trigger a clip? | Right-click a node in the ReactFlow graph view → context menu → "Clip to Clipboard". | Discoverable and visual. The console command input is reserved exclusively for WebSocket messages to the backend; no client-side command interception. See [Section 3.1](#31-rejected-clip-trigger-alternatives) for rejected alternatives. |
+| 6 | How does the user trigger a paste? | "Paste" button on each clipboard item in the sidebar. Pastes into the currently active/connected playground. | Simplest mental model. Each tab's sidebar shows the same items via BroadcastChannel; "Paste" always targets *that tab's* graph. |
+| 7 | Duplicate clip handling? | Warn the user and let them choose: replace the existing clipboard entry or cancel. | Preserves user intent. Avoids silent data loss (overwrite) or unbounded growth (multiple versions). |
+| 8 | Clipboard item expiry? | No expiry. Items persist until manually removed. | User explicitly chose to clip; auto-deletion would be surprising. IndexedDB has ample capacity. |
+
+### 3.1 Rejected Clip Trigger Alternatives
+
+During the design review, four clip trigger mechanisms were evaluated.
+One was selected (see Decision #5); three were rejected:
+
+- **Console command (`clip node {alias}`)** — Rejected. Would require
+  client-side interception of user input in `useWebSocket.sendCommand()`
+  before it reaches the WebSocket. This violates the design principle that
+  the command input is reserved exclusively for messages sent to the backend
+  via WebSocket. Mixing client-side-only commands with server commands would
+  blur the boundary between local and remote operations and confuse users
+  about which commands the server understands.
+- **Per-node button in GraphDataView** — Rejected. The raw JSON view
+  (`src/components/GraphDataView/GraphDataView.tsx`) renders the entire graph
+  as a single JSON tree via `react-json-view-lite`. It has no per-node
+  interactive affordances. Adding clip buttons would require a custom renderer
+  or a second view mode, adding significant complexity for a secondary
+  interaction surface.
+- **Toolbar button on selected node** — Rejected. ReactFlow supports node
+  selection, but exposing it as a clip trigger requires a visible selection
+  mode indicator and changes to the toolbar. This is better suited as a future
+  enhancement alongside multi-node clip (Decision #3).
+
+---
+
+## 4. Architecture
+
+### 4.1 Three-Layer Stack
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│  Layer 3: UI                                                      │
+│  ClipboardSidebar component                                       │
+│  GraphView context menu integration                               │
+├───────────────────────────────────────────────────────────────────┤
+│  Layer 2: Reactivity                                              │
+│  ClipboardContext (React Context + useReducer)                     │
+│  BroadcastChannel (cross-tab synchronisation)                     │
+│  Paste orchestration (local check → create/update → connect)      │
+├───────────────────────────────────────────────────────────────────┤
+│  Layer 1: Storage                                                 │
+│  IndexedDB via `idb` library                                      │
+│  Schema: ClipboardItemRecord objects in a single object store     │
+│  Indexes: by-alias (unique), by-clippedAt                         │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Placement in Component Tree
+
+The `ClipboardProvider` must sit **above** `BrowserRouter` in `src/App.tsx` so
+that clipboard state survives playground tab navigation. This mirrors the
+existing pattern where `WebSocketProvider` wraps `BrowserRouter` to keep
+connections alive across routes (see `src/App.tsx:14–29`).
+
+> **Note:** `ClipboardProvider` has no dependency on `WebSocketContext`. The
+> nesting order of `WebSocketProvider` and `ClipboardProvider` is
+> interchangeable. The only requirement is that both wrap `BrowserRouter`.
+
+```tsx
+// src/App.tsx — proposed structure
+<WebSocketProvider>
+  <ClipboardProvider>
+    <BrowserRouter>
+      <Routes>
+        {PLAYGROUND_CONFIGS.map((cfg) => (
+          <Route key={cfg.path} path={cfg.path} element={<Playground config={cfg} />} />
+        ))}
+        <Route path="*" element={<Navigate to={defaultPath} replace />} />
+      </Routes>
+    </BrowserRouter>
+  </ClipboardProvider>
+</WebSocketProvider>
+```
+
+### 4.3 No New Backend Changes
+
+All clipboard operations are implemented client-side. Paste reuses the existing
+WebSocket command grammar (`create node`, `update node`, `connect`).
+Node existence is checked against local `graphData` (in-memory), not via
+WebSocket round-trips. No new Java endpoints or WebSocket message types are
+required.
+
+---
+
+## 5. Layer 1 — Storage (IndexedDB)
+
+### 5.1 Why IndexedDB
+
+| Storage API | Persistence | Size Limit | Structured Data | Async | Cross-Tab Reactivity |
+|-------------|------------|------------|----------------|-------|----------------------|
+| `localStorage` | Yes | ~5–10 MB | No (strings only) | No (blocking) | Via `storage` event (limited) |
+| **IndexedDB** | **Yes** | **Hundreds of MB+** | **Yes (structured clones)** | **Yes (Promise-based with `idb`)** | **No (needs BroadcastChannel)** |
+| `sessionStorage` | Tab-scoped | ~5 MB | No | No | No |
+
+Nodes can carry large property payloads (nested mappings, multi-line
+descriptions, array-valued `mapping` fields). IndexedDB's structured-clone
+storage handles these natively without JSON serialisation overhead.
+
+### 5.2 Library Choice: `idb`
+
+The [`idb`](https://github.com/jakearchibald/idb) library (~1.2 KB gzipped)
+wraps the callback-based IndexedDB API in Promises. Benefits:
+
+- Type-safe schema via TypeScript generics
+- Clean `async`/`await` that composes naturally with React hooks
+- Built-in schema migration support via the `upgrade` callback
+- Zero runtime dependencies
+
+The raw IndexedDB API is verbose (open request → onsuccess → transaction →
+objectStore → request → onsuccess) and error-prone. `idb` eliminates this
+boilerplate without adding meaningful bundle weight relative to the existing
+dependencies (e.g., `@xyflow/react`, `react-json-view-lite`).
+
+**Installation:**
+
+```bash
+npm install idb
+```
+
+### 5.3 Database Schema
+
+```typescript
+// src/clipboard/db.ts
+
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+
+/**
+ * A snapshot of a single node plus its direct connections at the time of
+ * clipping. This is the primary record stored in IndexedDB.
+ *
+ * Nodes are identified by alias (MinigraphNode.alias, src/utils/graphTypes.ts:12).
+ * Connections reference nodes by alias via source/target fields
+ * (MinigraphConnection.source/target, src/utils/graphTypes.ts:26–27).
+ */
+export interface ClipboardItemRecord {
+  /** Primary key. Generated via crypto.randomUUID() at clip time. */
+  id: string;
+
+  /** ISO 8601 timestamp of when the node was clipped. */
+  clippedAt: string;
+
+  /**
+   * The wsPath of the playground from which the node was clipped.
+   * Corresponds to PlaygroundConfig.wsPath (src/config/playgrounds.ts:40).
+   * Example: "/ws/graph/playground"
+   */
+  sourceWsPath: string;
+
+  /**
+   * Human-readable label of the source playground.
+   * Corresponds to PlaygroundConfig.label (src/config/playgrounds.ts:38).
+   * Example: "Minigraph"
+   */
+  sourceLabel: string;
+
+  /**
+   * Full snapshot of the MinigraphNode at clip time.
+   * Structure defined in src/utils/graphTypes.ts:10–16.
+   */
+  node: MinigraphNode;
+
+  /**
+   * All direct connections for this node, excluding self-connections.
+   * Structure defined in src/utils/graphTypes.ts:25–29.
+   *
+   * Stored for completeness; during paste, only connections whose counterpart
+   * node already exists in the target graph's local graphData are created
+   * (Decision #1).
+   */
+  connections: MinigraphConnection[];
+}
+```
+
+Where `MinigraphNode` and `MinigraphConnection` are the existing types from
+`src/utils/graphTypes.ts`:
+
+```typescript
+// src/utils/graphTypes.ts:10–16 (existing, unchanged)
+export interface MinigraphNode {
+  alias: string;
+  types: string[];
+  properties: MinigraphNodeProperties;
+}
+
+// src/utils/graphTypes.ts:25–29 (existing, unchanged)
+export interface MinigraphConnection {
+  source: string;
+  target: string;
+  relations: MinigraphRelation[];
+}
+```
+
+### 5.4 IndexedDB Database Definition
+
+```typescript
+// src/clipboard/db.ts (continued)
+
+import type { MinigraphNode, MinigraphConnection } from '../utils/graphTypes';
+
+const DB_NAME    = 'minigraph-clipboard';
+const DB_VERSION = 1;
+const STORE_NAME = 'items';
+
+interface ClipboardDB extends DBSchema {
+  [STORE_NAME]: {
+    key: string;                          // ClipboardItemRecord.id
+    value: ClipboardItemRecord;
+    indexes: {
+      'by-alias':     string;             // node.alias — unique, for duplicate detection
+      'by-clippedAt': string;             // clippedAt  — for sorted display
+    };
+  };
+}
+
+/** Singleton database promise. Reused by all callers. */
+let dbInstance: Promise<IDBPDatabase<ClipboardDB>> | null = null;
+
+export function getDB(): Promise<IDBPDatabase<ClipboardDB>> {
+  if (!dbInstance) {
+    dbInstance = openDB<ClipboardDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('by-alias', 'node.alias', { unique: true });
+        store.createIndex('by-clippedAt', 'clippedAt');
+      },
+    });
+  }
+  return dbInstance;
+}
+```
+
+**Design notes:**
+
+- `getDB()` is lazy-initialised and returns the same Promise on subsequent
+  calls, avoiding multiple `openDB` calls from concurrent React renders.
+- The `by-alias` index is **unique** (`{ unique: true }`). If two tabs race
+  to clip the same alias concurrently (before BroadcastChannel delivers the
+  notification), the second `db.add()` will throw a `ConstraintError`.
+  The `clipNode()` method catches this and returns `{ status: 'duplicate' }`
+  with the existing item — see [Section 6.5](#65-provider-implementation-outline).
+- The `by-clippedAt` index supports efficient reverse-chronological display
+  without loading all records and sorting in memory.
+- `DB_VERSION = 1` — the `upgrade` callback handles schema creation. Future
+  schema changes increment this version and add migration logic inside the same
+  `upgrade` function (an `idb` convention).
+
+### 5.5 Storage Access Functions
+
+```typescript
+// src/clipboard/db.ts (continued)
+
+/**
+ * Retrieve all clipboard items, sorted newest-first by clippedAt.
+ * Uses the by-clippedAt index for efficient ordering.
+ */
+export async function getAllItems(): Promise<ClipboardItemRecord[]> {
+  const db = await getDB();
+  const items = await db.getAllFromIndex(STORE_NAME, 'by-clippedAt');
+  return items.reverse(); // IDB index is ascending; reverse for newest-first
+}
+
+/**
+ * Find an existing clipboard item by node alias.
+ * Returns the first match or undefined. Used for duplicate detection
+ * (Decision #7) before inserting a new clip.
+ *
+ * Because the by-alias index is unique, at most one result is returned.
+ */
+export async function findByAlias(alias: string): Promise<ClipboardItemRecord | undefined> {
+  const db = await getDB();
+  return db.getFromIndex(STORE_NAME, 'by-alias', alias);
+}
+
+/**
+ * Insert a new clipboard item. Caller is responsible for duplicate
+ * checking via findByAlias() before calling this.
+ *
+ * Throws ConstraintError if a record with the same node.alias already
+ * exists (enforced by the unique by-alias index). The caller should
+ * catch this and treat it as a duplicate.
+ */
+export async function addItem(item: ClipboardItemRecord): Promise<void> {
+  const db = await getDB();
+  await db.add(STORE_NAME, item);
+}
+
+/**
+ * Replace an existing clipboard item (same id).
+ * Used when the user confirms overwrite on a duplicate alias (Decision #7).
+ */
+export async function putItem(item: ClipboardItemRecord): Promise<void> {
+  const db = await getDB();
+  await db.put(STORE_NAME, item);
+}
+
+/**
+ * Atomically remove the old clipboard item and insert a new one in a
+ * single IndexedDB transaction. Used by confirmReplace() to ensure
+ * that a crash between delete and insert cannot lose both records.
+ */
+export async function replaceItem(
+  previousId: string,
+  newItem: ClipboardItemRecord,
+): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  await tx.store.delete(previousId);
+  await tx.store.add(newItem);
+  await tx.done;
+}
+
+/**
+ * Remove a single clipboard item by id.
+ */
+export async function removeItem(id: string): Promise<void> {
+  const db = await getDB();
+  await db.delete(STORE_NAME, id);
+}
+
+/**
+ * Remove all clipboard items.
+ */
+export async function clearAll(): Promise<void> {
+  const db = await getDB();
+  await db.clear(STORE_NAME);
+}
+```
+
+---
+
+## 6. Layer 2 — Reactivity (BroadcastChannel + React Context)
+
+### 6.1 BroadcastChannel Protocol
+
+The `BroadcastChannel` API enables instant, same-origin communication between
+browser tabs/windows without polling. When a clipboard mutation occurs in any
+tab, the mutating tab writes to IndexedDB **and** posts a message to the
+channel. All other tabs receive the message and update their React state
+directly — no IndexedDB re-read required.
+
+```typescript
+// src/clipboard/channel.ts
+
+import type { ClipboardItemRecord } from './db';
+
+const CHANNEL_NAME = 'minigraph-clipboard-sync';
+
+/**
+ * Discriminated union of all messages sent over the clipboard
+ * BroadcastChannel. The `type` field is the discriminator.
+ */
+export type ClipboardChannelMessage =
+  | { type: 'item-added';   item: ClipboardItemRecord }
+  | { type: 'item-replaced'; item: ClipboardItemRecord; previousId: string }
+  | { type: 'item-removed'; id: string }
+  | { type: 'items-cleared' };
+
+/**
+ * Create a BroadcastChannel for clipboard synchronisation.
+ * Each tab creates its own instance; messages sent by a tab are NOT
+ * delivered back to that same tab (BroadcastChannel spec behaviour).
+ *
+ * Returns the channel instance. The caller must close it on unmount.
+ */
+export function createClipboardChannel(): BroadcastChannel {
+  return new BroadcastChannel(CHANNEL_NAME);
+}
+```
+
+**Why BroadcastChannel over alternatives:**
+
+| Approach | Latency | Complexity | Browser Support |
+|----------|---------|------------|-----------------|
+| **BroadcastChannel** | **Instant (microtask)** | **Low** | **All modern browsers** |
+| `storage` event on localStorage | Instant but string-only, 5 MB limit | Medium (serialise/deserialise) | Universal |
+| `SharedWorker` | Instant | High (requires separate worker file, message ports) | Good but not Safari iOS |
+| Polling IndexedDB via `setInterval` | 100 ms–1 s lag | Low | Universal |
+
+BroadcastChannel is the best fit: instant delivery, structured message passing
+(no serialisation overhead), and zero infrastructure beyond a channel name.
+
+### 6.2 Context State Shape
+
+```typescript
+// src/contexts/ClipboardContext.tsx
+
+import type { ClipboardItemRecord } from '../clipboard/db';
+
+/**
+ * Reducer state for the clipboard context.
+ */
+interface ClipboardState {
+  /** All clipboard items, sorted newest-first by clippedAt. */
+  items: ClipboardItemRecord[];
+
+  /**
+   * True during the initial IndexedDB hydration on mount.
+   * The sidebar shows a loading skeleton while this is true.
+   */
+  isLoading: boolean;
+}
+```
+
+### 6.3 Reducer Actions
+
+```typescript
+// src/contexts/ClipboardContext.tsx (continued)
+
+type ClipboardAction =
+  | { type: 'HYDRATE';        items: ClipboardItemRecord[] }
+  | { type: 'ITEM_ADDED';     item: ClipboardItemRecord }
+  | { type: 'ITEM_REPLACED';  item: ClipboardItemRecord; previousId: string }
+  | { type: 'ITEM_REMOVED';   id: string }
+  | { type: 'ITEMS_CLEARED' };
+
+function clipboardReducer(state: ClipboardState, action: ClipboardAction): ClipboardState {
+  switch (action.type) {
+    case 'HYDRATE':
+      return { items: action.items, isLoading: false };
+
+    case 'ITEM_ADDED':
+      // Prepend (newest-first)
+      return { ...state, items: [action.item, ...state.items] };
+
+    case 'ITEM_REPLACED': {
+      // Remove the previous entry, prepend the replacement
+      const filtered = state.items.filter(i => i.id !== action.previousId);
+      return { ...state, items: [action.item, ...filtered] };
+    }
+
+    case 'ITEM_REMOVED':
+      return { ...state, items: state.items.filter(i => i.id !== action.id) };
+
+    case 'ITEMS_CLEARED':
+      return { ...state, items: [] };
+
+    default:
+      return state;
+  }
+}
+```
+
+### 6.4 Context Value Interface
+
+```typescript
+// src/contexts/ClipboardContext.tsx (continued)
+
+import type { MinigraphNode, MinigraphConnection } from '../utils/graphTypes';
+
+/**
+ * Metadata provided by the caller when clipping a node.
+ * Avoids coupling the clipboard layer to PlaygroundConfig directly.
+ */
+export interface ClipMeta {
+  /** PlaygroundConfig.wsPath of the source playground. */
+  sourceWsPath: string;
+  /** PlaygroundConfig.label of the source playground. */
+  sourceLabel: string;
+}
+
+/**
+ * Result of a clipNode() call. The UI layer uses this to decide whether
+ * to show a confirmation dialog (when a duplicate exists).
+ */
+export type ClipResult =
+  | { status: 'added' }
+  | { status: 'duplicate'; existingItem: ClipboardItemRecord; pendingItem: ClipboardItemRecord }
+  | { status: 'error'; message: string };
+
+/**
+ * Public API of the ClipboardContext.
+ */
+export interface ClipboardContextValue {
+  /** All clipboard items, newest-first. */
+  items: ClipboardItemRecord[];
+
+  /** True during initial IndexedDB hydration. */
+  isLoading: boolean;
+
+  /**
+   * Clip a node (plus its direct connections) to the clipboard.
+   *
+   * If a clipboard item with the same alias already exists, returns
+   * { status: 'duplicate', existingItem, pendingItem } so the UI can
+   * prompt the user to confirm replacement (Decision #7).
+   *
+   * @param node        The MinigraphNode to clip (src/utils/graphTypes.ts:10–16).
+   * @param connections Direct connections for this node (src/utils/graphTypes.ts:25–29).
+   *                    Self-connections are excluded by the caller.
+   * @param meta        Source playground metadata.
+   */
+  clipNode(
+    node: MinigraphNode,
+    connections: MinigraphConnection[],
+    meta: ClipMeta,
+  ): Promise<ClipResult>;
+
+  /**
+   * Confirm replacement of a duplicate clipboard item.
+   * Called after the user accepts the duplicate-warning dialog.
+   *
+   * The IndexedDB delete + insert is performed in a single transaction
+   * to prevent data loss on crash.
+   *
+   * @param pendingItem  The ClipboardItemRecord built by clipNode() and returned
+   *                     in the 'duplicate' result.
+   * @param previousId   The id of the existing item being replaced.
+   */
+  confirmReplace(pendingItem: ClipboardItemRecord, previousId: string): Promise<void>;
+
+  /**
+   * Remove a single clipboard item by its id.
+   */
+  removeItem(id: string): Promise<void>;
+
+  /**
+   * Remove all clipboard items.
+   */
+  clearAll(): Promise<void>;
+}
+```
+
+### 6.5 Provider Implementation Outline
+
+```typescript
+// src/contexts/ClipboardContext.tsx (continued)
+
+import { createContext, useCallback, useContext, useEffect, useReducer, useRef, type ReactNode } from 'react';
+import * as db from '../clipboard/db';
+import { createClipboardChannel, type ClipboardChannelMessage } from '../clipboard/channel';
+
+const ClipboardContext = createContext<ClipboardContextValue | null>(null);
+
+export function ClipboardProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(clipboardReducer, { items: [], isLoading: true });
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  // ── Hydrate from IndexedDB on mount ─────────────────────────────────────
+  useEffect(() => {
+    db.getAllItems().then(items => dispatch({ type: 'HYDRATE', items }));
+  }, []);
+
+  // ── BroadcastChannel setup ──────────────────────────────────────────────
+  useEffect(() => {
+    let channel: BroadcastChannel;
+    try {
+      channel = createClipboardChannel();
+    } catch {
+      // BroadcastChannel unavailable (e.g. embedded WebView).
+      // Clipboard still works within a single tab; cross-tab sync is disabled.
+      return;
+    }
+    channelRef.current = channel;
+
+    channel.onmessage = (event: MessageEvent<ClipboardChannelMessage>) => {
+      const msg = event.data;
+      switch (msg.type) {
+        case 'item-added':
+          dispatch({ type: 'ITEM_ADDED', item: msg.item });
+          break;
+        case 'item-replaced':
+          dispatch({ type: 'ITEM_REPLACED', item: msg.item, previousId: msg.previousId });
+          break;
+        case 'item-removed':
+          dispatch({ type: 'ITEM_REMOVED', id: msg.id });
+          break;
+        case 'items-cleared':
+          dispatch({ type: 'ITEMS_CLEARED' });
+          break;
+      }
+    };
+
+    return () => { channel.close(); channelRef.current = null; };
+  }, []);
+
+  /** Post to BroadcastChannel (other tabs only — same tab uses dispatch). */
+  const broadcast = useCallback((msg: ClipboardChannelMessage) => {
+    channelRef.current?.postMessage(msg);
+  }, []);
+
+  // ── clipNode ────────────────────────────────────────────────────────────
+  const clipNode = useCallback(async (
+    node: MinigraphNode,
+    connections: MinigraphConnection[],
+    meta: ClipMeta,
+  ): Promise<ClipResult> => {
+    try {
+      const pendingItem: db.ClipboardItemRecord = {
+        id: crypto.randomUUID(),
+        clippedAt: new Date().toISOString(),
+        sourceWsPath: meta.sourceWsPath,
+        sourceLabel: meta.sourceLabel,
+        node,
+        connections,
+      };
+
+      // Duplicate detection (Decision #7)
+      const existing = await db.findByAlias(node.alias);
+      if (existing) {
+        return { status: 'duplicate', existingItem: existing, pendingItem };
+      }
+
+      try {
+        await db.addItem(pendingItem);
+      } catch (err) {
+        // Handle race condition: another tab clipped the same alias between
+        // our findByAlias check and this addItem call. The unique by-alias
+        // index enforces the constraint and throws ConstraintError.
+        if (err instanceof DOMException && err.name === 'ConstraintError') {
+          const raceExisting = await db.findByAlias(node.alias);
+          if (raceExisting) {
+            return { status: 'duplicate', existingItem: raceExisting, pendingItem };
+          }
+        }
+        throw err; // Re-throw unexpected errors
+      }
+
+      dispatch({ type: 'ITEM_ADDED', item: pendingItem });
+      broadcast({ type: 'item-added', item: pendingItem });
+      return { status: 'added' };
+    } catch (err) {
+      return { status: 'error', message: err instanceof Error ? err.message : String(err) };
+    }
+  }, [broadcast]);
+
+  // ── confirmReplace ──────────────────────────────────────────────────────
+  const confirmReplace = useCallback(async (
+    pendingItem: db.ClipboardItemRecord,
+    previousId: string,
+  ): Promise<void> => {
+    // Atomic: single IndexedDB transaction prevents data loss on crash.
+    await db.replaceItem(previousId, pendingItem);
+    dispatch({ type: 'ITEM_REPLACED', item: pendingItem, previousId });
+    broadcast({ type: 'item-replaced', item: pendingItem, previousId });
+  }, [broadcast]);
+
+  // ── removeItem ──────────────────────────────────────────────────────────
+  const removeItem = useCallback(async (id: string): Promise<void> => {
+    await db.removeItem(id);
+    dispatch({ type: 'ITEM_REMOVED', id });
+    broadcast({ type: 'item-removed', id });
+  }, [broadcast]);
+
+  // ── clearAll ────────────────────────────────────────────────────────────
+  const clearAll = useCallback(async (): Promise<void> => {
+    await db.clearAll();
+    dispatch({ type: 'ITEMS_CLEARED' });
+    broadcast({ type: 'items-cleared' });
+  }, [broadcast]);
+
+  return (
+    <ClipboardContext.Provider value={{
+      items: state.items,
+      isLoading: state.isLoading,
+      clipNode,
+      confirmReplace,
+      removeItem,
+      clearAll,
+    }}>
+      {children}
+    </ClipboardContext.Provider>
+  );
+}
+
+/**
+ * Consumer hook. Must be called inside <ClipboardProvider>.
+ */
+export function useClipboardContext(): ClipboardContextValue {
+  const ctx = useContext(ClipboardContext);
+  if (!ctx) throw new Error('useClipboardContext must be used inside <ClipboardProvider>');
+  return ctx;
+}
+```
+
+### 6.6 Why Context + useReducer (Not Zustand/Jotai)
+
+The existing codebase uses React Context + hooks throughout:
+`WebSocketContext` (`src/contexts/WebSocketContext.tsx`), `useLocalStorage`
+(`src/hooks/useLocalStorage.ts`), and per-hook state via `useReducer`
+(`src/hooks/useWebSocket.ts:75–95`). Adding an external state library for
+the clipboard alone would create an architectural inconsistency.
+
+The clipboard state is a flat list with four mutations (add, replace, remove,
+clear) — well within the complexity threshold where Context + useReducer
+performs efficiently. If the app later grows to require more complex
+cross-cutting state management, all Contexts could migrate to an external
+store at that point.
+
+---
+
+## 7. Layer 3 — UI (ClipboardSidebar + Integration Points)
+
+### 7.1 Sidebar Placement Decision
+
+Three layout options were evaluated:
+
+| Option | Description | Pros | Cons |
+|--------|-------------|------|------|
+| **A. Independent right sidebar** | Sits outside `RightPanel`, toggled independently | Coexists with graph/data tabs; can be wider | Adds layout complexity |
+| B. New tab in `RightPanel` | Added to `PlaygroundConfig.tabs` alongside `'graph'`, `'graph-data'`, etc. | Consistent with existing tab pattern | Can't view clipboard and graph simultaneously |
+| C. Slide-over overlay | Overlays from right edge | Doesn't displace content | Occludes graph view; transient feel |
+
+**Selected: Option A.** The user needs to see both the graph (to right-click
+nodes) and the clipboard (to manage/paste items) simultaneously. A tab inside
+`RightPanel` would force switching back and forth. An independent sidebar can
+be toggled open/closed and sized independently of the existing panel split.
+
+### 7.2 Layout Structure
+
+The `Playground` component (`src/components/Playground.tsx:34`) currently uses
+`react-resizable-panels` with a two-panel `<Group>`:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Header (title + actions + nav)                             │
+├──────────────────────────┬──────────────────────────────────┤
+│  LeftPanel (console)     │  RightPanel (tabs)               │
+│  Panel defaultSize="60%" │  Panel defaultSize="40%"         │
+│                          │                                  │
+└──────────────────────────┴──────────────────────────────────┘
+```
+
+The proposed layout adds the clipboard sidebar as a conditionally rendered
+element **to the right of the existing `<Group>`**, outside the resizable
+panel system:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Header (title + actions + nav + [clipboard toggle button])         │
+├──────────────────────────┬──────────────────────┬───────────────────┤
+│  LeftPanel (console)     │  RightPanel (tabs)   │ ClipboardSidebar  │
+│  Panel defaultSize="60%" │  Panel defaultSize=  │ width: 320px      │
+│                          │  "40%"               │ (collapsible)     │
+│                          │                      │                   │
+└──────────────────────────┴──────────────────────┴───────────────────┘
+```
+
+When the sidebar is collapsed, the `<Group>` fills the full width (current
+behaviour). When expanded, the sidebar takes a fixed width (320 px default)
+and the `<Group>` shrinks by the same amount via `calc(100% - 320px)`.
+
+**CSS approach:** The `.wrapper` class in `src/components/Playground.module.css`
+already uses `display: flex; flex-direction: column`. The panel area below
+the header currently contains only the `<Group>`. Wrap the `<Group>` and
+`ClipboardSidebar` in a horizontal flex container:
+
+```css
+/* src/components/Playground.module.css — new rules */
+
+.mainArea {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+}
+
+.mainArea .panelGroup {
+  flex: 1 1 0;
+  min-width: 0;
+}
+```
+
+### 7.3 Sidebar Toggle
+
+A toggle button is added to `header > .headerActions` in `Playground.tsx`,
+next to the existing `GraphSaveButton` and `SavedGraphsMenu`. The button
+is only rendered when `config.supportsClipboard` is `true` (see
+[Section 10](#10-playgroundconfig-changes)).
+
+```
+[Save] [Saved Graphs ▾] [Clipboard] [Nav dots]
+```
+
+The open/closed state is persisted in `localStorage` under the key
+`'clipboard-sidebar-open'` via the existing `useLocalStorage` hook
+(`src/hooks/useLocalStorage.ts`) so the sidebar remembers its state across
+refreshes.
+
+### 7.4 ClipboardSidebar Component
+
+```
+src/components/ClipboardSidebar/
+├── ClipboardSidebar.tsx
+├── ClipboardSidebar.module.css
+├── ClipboardItem.tsx
+├── ClipboardItem.module.css
+├── ClipboardEmptyState.tsx
+└── ClipboardDuplicateDialog.tsx
+```
+
+#### 7.4.1 ClipboardSidebar Props
+
+The sidebar is **always mounted** when `config.supportsClipboard` is true, and
+uses a CSS class to control visibility (slide-in/slide-out transition). This
+avoids remounting on toggle and allows a smooth animation.
+
+```typescript
+// src/components/ClipboardSidebar/ClipboardSidebar.tsx
+
+interface ClipboardSidebarProps {
+  /**
+   * Controls the CSS class for slide-in/slide-out transitions.
+   * When false, the sidebar is rendered but visually collapsed (width: 0,
+   * overflow: hidden). When true, it expands to its full 320px width.
+   */
+  open: boolean;
+
+  /**
+   * Whether the active playground has a live WebSocket connection.
+   * When false, "Paste" buttons are disabled.
+   * Mirrors `ws.connected` from useWebSocket (src/hooks/useWebSocket.ts:45).
+   */
+  connected: boolean;
+
+  /**
+   * True while a paste operation is in progress. Disables all "Paste"
+   * buttons to prevent concurrent paste operations.
+   */
+  isPasting: boolean;
+
+  /**
+   * Callback to execute the paste operation.
+   * Defined in Playground.tsx; delegates to the paste orchestration hook.
+   */
+  onPaste: (item: ClipboardItemRecord) => void;
+}
+```
+
+#### 7.4.2 Sidebar Visual Layout
+
+```
+┌──────────────────────────────────────────┐
+│ Clipboard                       [Clear]  │
+├──────────────────────────────────────────┤
+│ ┌──────────────────────────────────────┐ │
+│ │  fetcher_node                        │ │
+│ │  Type: api_fetcher                   │ │
+│ │  Skill: graph.api.fetcher            │ │
+│ │  Props: dictionary=..., provider=... │ │
+│ │  Connections: 2 (1 out, 1 in)        │ │
+│ │  Clipped 2 min ago from Minigraph    │ │
+│ │                                      │ │
+│ │  [Paste]  [Inspect]  [Remove]        │ │
+│ └──────────────────────────────────────┘ │
+│ ┌──────────────────────────────────────┐ │
+│ │  entry_point                         │ │
+│ │  Type: entry_point                   │ │
+│ │  Skill: —                            │ │
+│ │  Props: name=my-graph                │ │
+│ │  Connections: 1 (1 out, 0 in)        │ │
+│ │  Clipped 5 min ago from Minigraph    │ │
+│ │                                      │ │
+│ │  [Paste]  [Inspect]  [Remove]        │ │
+│ └──────────────────────────────────────┘ │
+│                                          │
+│      (scrollable list continues...)      │
+└──────────────────────────────────────────┘
+```
+
+**Display rules:**
+
+- **Alias** is the primary label (bold, top of card).
+- **Type** shows `node.types[0]` (the first type label, consistent with how
+  `graphTransformer.ts:170` selects the primary type).
+- **Skill** shows `node.properties.skill` or "—" if absent.
+- **Props** shows a truncated one-line summary of remaining properties. Keys
+  are listed comma-separated; values longer than 30 characters are replaced
+  with `...`. Uses CSS `text-overflow: ellipsis` for the line.
+- **Connections** shows a count summary: total, outgoing (where node is
+  `source`), incoming (where node is `target`).
+- **Clipped timestamp** uses relative time formatting ("2 min ago", "1 hour
+  ago", "yesterday"). A utility function `formatRelativeTime(isoString: string):
+  string` should be added to `src/utils/timeFormat.ts`.
+
+  > **Note:** Relative timestamps are computed at render time and do not
+  > auto-update. If the sidebar stays open for extended periods, timestamps
+  > may appear stale (e.g., "2 min ago" may actually be 30 min ago). This is
+  > accepted as a minor cosmetic issue. A future enhancement could add a
+  > `setInterval` refresh — see [Section 15](#15-future-enhancements).
+
+- **Source label** shows `sourceLabel` ("from Minigraph").
+
+**Action buttons per item:**
+
+| Button | Behaviour | Disabled when |
+|--------|-----------|---------------|
+| **Paste** | Calls `onPaste(item)` — see [Section 9](#9-paste-execution-strategy) | `connected` is `false` OR `isPasting` is `true` |
+| **Inspect** | Opens a modal (or expands inline) showing the full JSON of `item.node` and `item.connections` using `react-json-view-lite` (already a dependency, used in `GraphDataView`, `src/components/GraphDataView/GraphDataView.tsx:2`) | Never |
+| **Remove** | Calls `clipboardCtx.removeItem(item.id)` | Never |
+
+#### 7.4.3 ClipboardDuplicateDialog
+
+When `clipNode()` returns `{ status: 'duplicate' }`, a confirmation dialog is
+shown:
+
+```
+┌────────────────────────────────────────────────┐
+│  Duplicate Node                                │
+│                                                │
+│  A clipboard item with alias "fetcher_node"    │
+│  already exists (clipped 10 min ago).          │
+│                                                │
+│  Replace it with the new snapshot?             │
+│                                                │
+│              [Cancel]  [Replace]               │
+└────────────────────────────────────────────────┘
+```
+
+On **Replace**: calls `clipboardCtx.confirmReplace(pendingItem, existingItem.id)`.  
+On **Cancel**: no action; the pending item is discarded.
+
+This dialog follows the same pattern as `MockUploadModal`
+(`src/components/MockUploadModal/MockUploadModal.tsx`): rendered conditionally
+in `Playground.tsx`, with focus management via `modalTriggerRef` (see
+`src/components/Playground.tsx:138`).
+
+#### 7.4.4 ClipboardEmptyState
+
+When `items.length === 0` and `isLoading` is `false`:
+
+```
+┌──────────────────────────────────────────┐
+│ Clipboard                                │
+├──────────────────────────────────────────┤
+│                                          │
+│           (clipboard icon)               │
+│     No items clipped yet.                │
+│                                          │
+│  Right-click a node in the Graph view    │
+│  to get started.                         │
+│                                          │
+└──────────────────────────────────────────┘
+```
+
+Consistent with the empty-state pattern used in `GraphDataView`
+(`src/components/GraphDataView/GraphDataView.tsx:43–53`) and `GraphView`
+(`src/components/GraphView/GraphView.tsx:92–99`).
+
+---
+
+## 8. Clip Operations
+
+### 8.1 Clip Trigger: Right-Click Context Menu on ReactFlow Node
+
+`GraphView` (`src/components/GraphView/GraphView.tsx`) renders a `<ReactFlow>`
+component at line 115. ReactFlow supports a
+[`onNodeContextMenu`](https://reactflow.dev/api-reference/react-flow#on-node-context-menu)
+callback that fires when a node receives a right-click event.
+
+**Implementation outline:**
+
+1. Add an `onNodeContextMenu` handler to the `<ReactFlow>` component in
+   `GraphView.tsx`.
+2. The handler receives `(event: React.MouseEvent, node: Node<GraphNodeData>)`.
+   It calls `event.preventDefault()` to suppress the browser's default context
+   menu, then sets state to position a custom context menu at the cursor's
+   `clientX`/`clientY`.
+3. The context menu renders a single action: "Clip to Clipboard".
+4. On click, the handler resolves the full `MinigraphNode` from `graphData`
+   (passed as a prop) by matching `node.data.alias`, extracts its direct
+   connections (excluding self-connections), and calls the `onClipNode` callback.
+
+**Props change to GraphView:**
+
+```typescript
+// src/components/GraphView/GraphView.tsx — updated interface
+
+interface GraphViewProps {
+  graphData:       MinigraphGraphData | null;
+  onCopySuccess?:  () => void;
+  onCopyError?:    () => void;
+  onRenderError?:  (message: string) => void;
+  isRefreshing?:   boolean;
+  /**
+   * Called when the user right-clicks a node and selects "Clip to Clipboard".
+   * GraphView resolves the MinigraphNode and its direct connections from
+   * graphData, then invokes this callback. Playground.tsx wires this to
+   * the ClipboardContext.
+   */
+  onClipNode?: (node: MinigraphNode, connections: MinigraphConnection[]) => void;
+}
+```
+
+**Context menu accessibility and dismissal:**
+
+The context menu must be accessible and properly dismissable:
+
+- **Keyboard trigger:** When a ReactFlow node has focus, `Shift+F10` opens
+  the context menu positioned at the node's center.
+- **Focus management:** When the menu opens, focus moves to the first menu
+  item ("Clip to Clipboard"). When the menu closes (via action, Escape, or
+  outside click), focus returns to the triggering node.
+- **Escape key:** Dismisses the context menu without action.
+- **Outside click:** A `useEffect` with a global `mousedown` listener
+  dismisses the menu when the click target is outside the menu element.
+- **Canvas interaction:** `onPaneClick` (already available on `<ReactFlow>`)
+  dismisses the menu on canvas clicks.
+- **ARIA attributes:** The menu container uses `role="menu"` and each action
+  uses `role="menuitem"`.
+
+**Helper: extracting direct connections for a node:**
+
+```typescript
+// src/clipboard/helpers.ts
+
+import type { MinigraphNode, MinigraphConnection, MinigraphGraphData } from '../utils/graphTypes';
+
+/**
+ * Extract the full MinigraphNode from graphData by alias.
+ * Returns undefined if not found.
+ */
+export function findNodeByAlias(
+  graphData: MinigraphGraphData,
+  alias: string,
+): MinigraphNode | undefined {
+  return graphData.nodes.find(n => n.alias === alias);
+}
+
+/**
+ * Extract all connections where the given alias appears as source OR target,
+ * excluding self-connections (where source === target).
+ *
+ * Self-connections are excluded because the backend rejects
+ * `connect {alias} to {alias} with {relation}` with the error
+ * "source and target node names cannot be the same"
+ * (GraphLambdaFunction.java:106, constant SAME_SOURCE_TARGET).
+ *
+ * The server may omit `connections` on partially-built graphs
+ * (the TypeScript type declares it as required, but the
+ * isMinigraphGraphData type guard at src/utils/graphTypes.ts:42–46 only
+ * checks for `nodes`). The `?? []` fallback ensures a clean empty array.
+ *
+ * Uses MinigraphConnection.source and MinigraphConnection.target
+ * (src/utils/graphTypes.ts:26–27).
+ */
+export function extractDirectConnections(
+  graphData: MinigraphGraphData,
+  alias: string,
+): MinigraphConnection[] {
+  return (graphData.connections ?? []).filter(
+    c => c.source !== c.target && (c.source === alias || c.target === alias),
+  );
+}
+```
+
+### 8.2 Duplicate Handling Flow
+
+When `clipNode()` detects a duplicate (same alias already in clipboard):
+
+```
+clipNode() called
+  ↓
+db.findByAlias(alias) → existing item found
+  ↓
+Return { status: 'duplicate', existingItem, pendingItem }
+  ↓
+Playground.tsx receives the result
+  ↓
+Opens ClipboardDuplicateDialog
+  ├─ User clicks "Replace"
+  │   → clipboardCtx.confirmReplace(pendingItem, existingItem.id)
+  │   → IndexedDB updated atomically (single transaction), dispatch, broadcast
+  │   → Toast: 'Clipboard item "fetcher_node" replaced'
+  │
+  └─ User clicks "Cancel"
+      → No action; pendingItem is discarded
+      → Toast: 'Clip cancelled'
+```
+
+---
+
+## 9. Paste Execution Strategy
+
+### 9.1 Approach: Client-Constructed WebSocket Commands
+
+Paste is implemented entirely client-side by constructing and sending
+standard WebSocket commands through the existing `ctx.send()` path
+(`src/contexts/WebSocketContext.tsx:318–325`). Node existence and connection
+counterpart existence are checked against the **local `graphData`** (in-memory)
+rather than via WebSocket round-trips. No new backend endpoints or
+WebSocket message types are needed.
+
+**Why this approach:**
+
+- Zero backend changes required.
+- All mutations are visible in the console — the user sees exactly what
+  happened (discoverability, debuggability).
+- All mutations flow through the same code path as manual commands, so
+  `useAutoGraphRefresh` (`src/hooks/useAutoGraphRefresh.ts`) automatically
+  refreshes the graph view.
+- The server's response messages ("Node X created", "Node X updated")
+  are classified by `classifyMessage()` (`src/protocol/classifier.ts:27`)
+  as `graph.mutation` events, which trigger the existing auto-refresh
+  pipeline.
+
+**Why local `graphData` checks instead of WebSocket `describe node` commands:**
+
+Using `describe node {alias}` for existence checks would require N+1 WebSocket
+round-trips (1 for the target node + N for each connection counterpart) and
+complex response correlation on a shared `ProtocolBus` where other subscribers
+(`useAutoGraphRefresh`, `useAutoMarkdownPin`, `useLargePayloadDownload`) also
+listen. Local checks against `graphData.nodes` are instant, zero-latency, and
+require no bus coordination.
+
+> **Staleness caveat:** `graphData` reflects the most recent `describe graph`
+> fetch. If another tab created a node after the last fetch, the local check
+> may incorrectly conclude the node doesn't exist. In the worst case this
+> means `create node` is sent for a node that was just created by another tab,
+> which the server rejects with "Node {alias} already exists" — handled by
+> the fallback in [Section 9.6](#96-paste-error-handling). For connection
+> counterparts, staleness means some connections may be skipped; the user can
+> simply re-paste after the graph refreshes.
+
+### 9.2 Paste Orchestration Hook
+
+A new hook `usePasteNode` encapsulates the paste flow.
+
+```typescript
+// src/hooks/usePasteNode.ts
+
+import type { ClipboardItemRecord } from '../clipboard/db';
+import type { MinigraphGraphData } from '../utils/graphTypes';
+import type { ToastType } from './useToast';
+import type { ProtocolBus } from '../protocol/bus';
+
+export interface UsePasteNodeOptions {
+  /** The wsPath of the active playground's WebSocket. */
+  wsPath: string;
+  /** Whether the WebSocket is connected. */
+  connected: boolean;
+  /** Send a raw string over the WebSocket. */
+  sendRawText: (text: string) => void;
+  /** Append a local-only message to the console. */
+  appendMessage: (raw: string) => void;
+  /** Toast notification callback. */
+  addToast: (message: string, type?: ToastType) => void;
+  /**
+   * Reference to the ProtocolBus so the hook can subscribe to the
+   * graph.mutation event confirming node creation/update.
+   */
+  bus: ProtocolBus;
+  /**
+   * The current graph data from the target playground. Used for local
+   * existence checks (node and connection counterparts) without
+   * WebSocket round-trips.
+   */
+  graphData: MinigraphGraphData | null;
+}
+
+export interface UsePasteNodeReturn {
+  /**
+   * Initiate the paste flow for a clipboard item.
+   * Returns a Promise that resolves when the paste sequence completes.
+   */
+  pasteNode: (item: ClipboardItemRecord) => Promise<void>;
+
+  /** True while a paste operation is in flight. Disables additional paste clicks. */
+  isPasting: boolean;
+}
+```
+
+### 9.3 Paste Flow: Step by Step
+
+Given a `ClipboardItemRecord` with `node` and `connections`, and access to the
+target playground's local `graphData`:
+
+```
+Step 1: Check existence (local)
+  → Search graphData.nodes for an entry where alias === item.node.alias
+  → If not found → Step 2a (create)
+  → If found    → Step 2b (update)
+
+Step 2a: Create node
+  → Build multi-line command via buildNodeCommand('create', item.node)
+  → sendRawText(createCommand)
+  → Wait for graph.mutation event on the ProtocolBus (with step timeout)
+  → If server responds with "Node {alias} already exists" instead:
+      → Fall back to update: sendRawText(buildNodeCommand('update', item.node))
+      → Wait for graph.mutation event (with step timeout)
+  → Proceed to Step 3
+
+Step 2b: Update node
+  → Build multi-line command via buildNodeCommand('update', item.node)
+  → sendRawText(updateCommand)
+  → Wait for graph.mutation event on the ProtocolBus (with step timeout)
+  → If server responds with "Node {alias} not found" instead:
+      → Fall back to create: sendRawText(buildNodeCommand('create', item.node))
+      → Wait for graph.mutation event (with step timeout)
+  → Proceed to Step 3
+
+Step 3: Create connections (local counterpart check)
+  → For each connection in item.connections:
+      → Determine counterpart alias (the other end of the connection)
+      → Check if counterpart exists in graphData.nodes (local, instant)
+      → If counterpart exists:
+          → For each relation in connection.relations:
+              → sendRawText(buildConnectCommand(
+                    connection.source, connection.target, relation.type))
+      → If counterpart not found:
+          → Skip; count skipped connections and record counterpart alias
+  → Proceed to Step 4
+
+Step 4: Report
+  → Toast: "Pasted node '{alias}' — {N} of {M} connections sent"
+  → If any connections were skipped:
+      → appendMessage("Clipboard paste: skipped {K} connection(s)
+         (nodes not found in local graph: {list of aliases}).
+         Re-paste after graph refresh to retry.")
+  → useAutoGraphRefresh handles the graph view update automatically
+
+Note: The connection count in the toast is optimistic — it reflects the
+number of `connect` commands sent, not confirmed. Because counterpart
+existence is verified locally before sending, failures are rare (limited
+to transient server errors).
+```
+
+**Step timeout:** Each step that waits for a `ProtocolBus` event uses a
+configurable timeout (default: 10 seconds). If the timeout expires, the paste
+is aborted with a toast: "Paste timed out waiting for server response. Some
+changes may have been applied."
+
+**Response correlation for Steps 2a/2b:** The paste hook subscribes to
+`graph.mutation` events on the bus. Because `isPasting` is true, the hook
+knows the next `graph.mutation` with `mutationType: 'node-mutation'` is the
+response to its command. To handle the race-condition fallbacks, the hook also
+monitors `docs.response` events:
+- **Step 2a:** Text containing `"already exists"` triggers the update fallback.
+- **Step 2b:** Text starting with `"Node "` and containing `" not found"` triggers the create fallback.
+See [Section 9.6](#96-paste-error-handling) for the full error-handling table.
+
+> **Note about `useAutoGraphRefresh`:** The `graph.mutation` events from paste
+> commands also trigger `useAutoGraphRefresh`, which debounces and sends
+> `describe graph`. This is desirable — it refreshes `graphData` after paste,
+> improving the accuracy of subsequent paste operations. The paste hook does
+> not need to suppress auto-refresh; both can coexist.
+
+### 9.4 Command Construction
+
+The backend's command grammar is parsed in `GraphCommandService.java`. The
+key patterns (confirmed from source):
+
+**Create node:**
+```
+create node {alias}
+with type {type}
+with properties
+{key1}={value1}
+{key2}={value2}
+```
+
+**Update node:**
+```
+update node {alias}
+with type {type}
+with properties
+{key1}={value1}
+{key2}={value2}
+```
+
+**Connect:**
+```
+connect {source} to {target} with {relation}
+```
+
+**Command builder:**
+
+```typescript
+// src/clipboard/commandBuilder.ts
+
+import type { MinigraphNode } from '../utils/graphTypes';
+
+/**
+ * Serialise a property value for the "key=value" line in a create/update
+ * command. Multiline values are wrapped in triple-quotes (''').
+ *
+ * The backend parses these in GraphCommandService.getNodeProperties()
+ * using the TRIPLE_QUOTE = "'''" delimiter defined in
+ * GraphLambdaFunction.java.
+ *
+ * Known limitation: if a property value contains the literal string "'''"
+ * (triple single-quotes), the backend will interpret it as the closing
+ * delimiter. The backend grammar has no escape mechanism for this.
+ * See Section 13.4 (Known Limitations) for details.
+ */
+function serializePropertyValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+
+  // Warn if the value contains triple-quote — the backend has no escape
+  // mechanism, so the value will be truncated at the first embedded '''.
+  if (str.includes("'''")) {
+    console.warn(
+      `[commandBuilder] Property value contains "'''" which cannot be escaped ` +
+      `in the backend grammar. The value may be truncated on paste.`
+    );
+  }
+
+  // Only wrap in triple-quotes for multiline values.
+  // Single-line values containing ''' are left unquoted to preserve as much
+  // of the value as possible — wrapping would cause a larger truncation
+  // because the opening ''' introduces a newline before the embedded '''.
+  if (str.includes('\n')) {
+    return `'''\n${str}\n'''`;
+  }
+
+  return str;
+}
+
+/**
+ * Build a create or update node multi-line command string from a MinigraphNode.
+ *
+ * The verb parameter selects the command:
+ *   - 'create' → `create node {alias}` (GraphCommandService.handleCreateNode())
+ *   - 'update' → `update node {alias}` (GraphCommandService.handleUpdateNode())
+ *
+ * Both share the same grammar; only the leading verb differs.
+ *
+ * Known limitation: only node.types[0] is emitted. The backend's `with type`
+ * clause accepts a single type. Nodes with multiple types will have all types
+ * beyond the first silently dropped. See Section 13.4 (Known Limitations).
+ *
+ * @param verb 'create' or 'update'
+ * @param node The node whose data populates the command.
+ */
+export function buildNodeCommand(
+  verb: 'create' | 'update',
+  node: MinigraphNode,
+): string {
+  const lines: string[] = [`${verb} node ${node.alias}`];
+
+  if (node.types.length > 0) {
+    lines.push(`with type ${node.types[0]}`);
+  }
+
+  const propEntries = Object.entries(node.properties).filter(
+    ([, v]) => v !== undefined && v !== null,
+  );
+
+  if (propEntries.length > 0) {
+    lines.push('with properties');
+    for (const [key, value] of propEntries) {
+      lines.push(`${key}=${serializePropertyValue(value)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build a `connect` command for a single relation.
+ *
+ * Follows the grammar parsed by GraphCommandService.handleConnectCommand():
+ *   connect {source} to {target} with {relation}
+ *
+ * The backend accepts one relation per connect command. For connections with
+ * multiple relations, call this function once per relation.
+ *
+ * Known limitation: MinigraphRelation.properties (src/utils/graphTypes.ts:22)
+ * are not included. The backend's `connect` grammar has no syntax for
+ * relation properties. See Section 13.4 (Known Limitations).
+ */
+export function buildConnectCommand(
+  source: string,
+  target: string,
+  relationType: string,
+): string {
+  return `connect ${source} to ${target} with ${relationType}`;
+}
+```
+
+### 9.5 Response Correlation During Paste
+
+The paste hook needs to detect the server's confirmation of `create node` and
+`update node` commands to advance through its steps. The approach uses the
+`ProtocolBus` (`src/protocol/bus.ts`).
+
+**What the paste hook listens for:**
+
+| Paste step | Expected server response | Bus event kind | Detection |
+|------------|------------------------|----------------|-----------|
+| Create node | `"Node {alias} created"` | `graph.mutation` (`node-mutation`) | `detectMutation()` matches — `src/utils/messageParser.ts:296` |
+| Create node (race) | `"Node {alias} already exists"` | `docs.response` | Raw text contains `" already exists"` — triggers update fallback |
+| Update node | `"Node {alias} updated"` | `graph.mutation` (`node-mutation`) | `detectMutation()` matches — `src/utils/messageParser.ts:297` |
+| Update node (race) | `"Node {alias} not found"` | `docs.response` | Raw text starts with `"Node "` and contains `" not found"` — triggers create fallback |
+| Connect | `"Node {source} connected to {target}"` | `graph.mutation` (`node-mutation`) | `detectMutation()` matches — `src/utils/messageParser.ts:299` |
+
+**Correlation mechanism:** The paste hook enters a "waiting" state after
+sending each command. It subscribes to the relevant bus event kind and
+advances when the expected event arrives. A timeout (10 seconds per step)
+prevents indefinite stalls if the server doesn't respond.
+
+**Interaction with other bus subscribers:** `useAutoGraphRefresh` also listens
+for `graph.mutation`. Both subscribers receive every event (the bus dispatches
+to all listeners). This is harmless: `useAutoGraphRefresh` sends `describe
+graph` on mutation, which refreshes the graph — a desirable side effect.
+The paste hook's "waiting" flag ensures it consumes only the events it expects.
+
+### 9.6 Paste Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Node doesn't exist locally | `create node` command sent |
+| Node exists locally with different properties | `update node` command sent (replaces all properties — this matches backend behaviour) |
+| Node exists locally with identical properties | `update node` command still sent (server overwrites with same values; simpler than diffing) |
+| `create node` returns "already exists" (race) | Fallback: send `update node` command instead. This handles the race window where another tab or user creates the same node between the local check and the `create node` command. |
+| `update node` returns "not found" (race) | Fallback: send `create node` command instead. This handles the symmetric race where another tab deletes the node between the local check and the `update node` command. |
+| Connection already exists on server | `connect` command sent; server silently succeeds (adding a duplicate relation is idempotent in the backend) |
+| Counterpart node doesn't exist locally | Connection skipped; counted and reported in console message |
+| WebSocket disconnects mid-paste | Partial paste. Already-sent commands are processed server-side. Toast: "Paste interrupted — WebSocket disconnected. Some changes may have been applied." |
+| Step timeout (10 seconds) | Paste aborted. Toast: "Paste timed out waiting for server response. Some changes may have been applied." |
+| Multiple rapid paste clicks | `isPasting` flag disables all Paste buttons until the current sequence completes |
+| **Re-paste after interruption** | **Safe.** If the node was created in the first attempt, the local check now finds it → `update node` is sent (replaces with same data). Connections are idempotent. The user can simply click Paste again. |
+
+---
+
+## 10. PlaygroundConfig Changes
+
+A new optional boolean field `supportsClipboard` is added to
+`PlaygroundConfig` (`src/config/playgrounds.ts:36–58`):
+
+```typescript
+// src/config/playgrounds.ts — updated interface
+
+export interface PlaygroundConfig {
+  path:                   string;
+  label:                  string;
+  title:                  string;
+  wsPath:                 string;
+  storageKeyPayload:      string;
+  storageKeyHistory:      string;
+  storageKeyTab:          string;
+  storageKeySavedGraphs?: string;
+  supportsUpload?:        boolean;
+  /**
+   * When true, the clipboard sidebar toggle is shown in the header and
+   * the clip/paste features are enabled for this playground.
+   *
+   * Clipboard features are scoped to Minigraph-type playgrounds only
+   * (Decision #4). Playgrounds that do not set this flag — or set it
+   * to false — hide the toggle button and ignore clipboard operations.
+   */
+  supportsClipboard?:     boolean;
+  tabs:                   RightTab[];
+}
+```
+
+**Updated config entries:**
+
+```typescript
+// src/config/playgrounds.ts — PLAYGROUND_CONFIGS
+
+export const PLAYGROUND_CONFIGS: PlaygroundConfig[] = [
+  {
+    path: '/json-path',
+    label: 'JSON-Path',
+    // ... (unchanged)
+    supportsClipboard: false, // explicitly false — or simply omitted
+    tabs: ['payload', 'graph', 'graph-data'],
+  },
+  {
+    path: '/',
+    label: 'Minigraph',
+    // ... (unchanged)
+    supportsClipboard: true,
+    tabs: ['preview', 'graph', 'graph-data'],
+  },
+];
+```
+
+---
+
+## 11. Component Tree Changes
+
+### 11.1 App.tsx
+
+**Current** (`src/App.tsx:17–29`):
+```tsx
+<WebSocketProvider>
+  <BrowserRouter>
+    <Routes>...</Routes>
+  </BrowserRouter>
+</WebSocketProvider>
+```
+
+**Proposed:**
+```tsx
+<WebSocketProvider>
+  <ClipboardProvider>
+    <BrowserRouter>
+      <Routes>...</Routes>
+    </BrowserRouter>
+  </ClipboardProvider>
+</WebSocketProvider>
+```
+
+**Import added:**
+```typescript
+import { ClipboardProvider } from './contexts/ClipboardContext';
+```
+
+### 11.2 Playground.tsx
+
+**New imports:**
+```typescript
+import { useClipboardContext } from '../contexts/ClipboardContext';
+import type { ClipboardItemRecord } from '../clipboard/db';
+import { usePasteNode } from '../hooks/usePasteNode';
+import ClipboardSidebar from './ClipboardSidebar/ClipboardSidebar';
+import { ClipboardDuplicateDialog } from './ClipboardSidebar/ClipboardDuplicateDialog';
+```
+
+> **Note:** `findNodeByAlias` and `extractDirectConnections` are imported in
+> `GraphView.tsx` (see [Section 11.3](#113-graphviewtsx)), not in
+> `Playground.tsx`. The `onClipNode` callback passed to `GraphView` already
+> provides the resolved `MinigraphNode` and `MinigraphConnection[]`.
+
+**New state variables:**
+
+```typescript
+// Clipboard sidebar open/closed (persisted)
+const [clipboardOpen, setClipboardOpen] = useLocalStorage<boolean>('clipboard-sidebar-open', false);
+
+// Duplicate dialog state
+const [duplicateDialogState, setDuplicateDialogState] = useState<{
+  pendingItem: ClipboardItemRecord;
+  existingItem: ClipboardItemRecord;
+} | null>(null);
+```
+
+**New hooks:**
+```typescript
+const clipboardCtx = useClipboardContext();
+
+const { pasteNode, isPasting } = usePasteNode({
+  wsPath,
+  connected: ws.connected,
+  sendRawText: ws.sendRawText,
+  appendMessage: ws.appendMessage,
+  addToast,
+  bus,
+  graphData,
+});
+```
+
+**New callback for clip operations** (invoked by GraphView context menu):
+
+```typescript
+const handleClipNode = useCallback(async (
+  node: MinigraphNode,
+  connections: MinigraphConnection[],
+) => {
+  try {
+    const result = await clipboardCtx.clipNode(node, connections, {
+      sourceWsPath: wsPath,
+      sourceLabel: config.label,
+    });
+
+    switch (result.status) {
+      case 'added':
+        addToast(`Node "${node.alias}" clipped to clipboard`, 'success');
+        break;
+      case 'duplicate':
+        setDuplicateDialogState({
+          pendingItem: result.pendingItem,
+          existingItem: result.existingItem,
+        });
+        break;
+      case 'error':
+        addToast(`Clip failed: ${result.message}`, 'error');
+        break;
+    }
+  } catch (err) {
+    addToast(`Clip failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+  }
+}, [clipboardCtx, wsPath, config.label, addToast]);
+```
+
+> **Note:** The top-level `try/catch` ensures that unexpected errors (e.g.,
+> `graphData` in an unforeseen shape) do not produce unhandled Promise
+> rejections. The `clipNode()` method has its own internal error handling that
+> returns `{ status: 'error' }`, but errors outside that path (before or
+> after the call) are caught here.
+
+**Updated `sendDisabled` to include `isPasting`:**
+
+```typescript
+sendDisabled={!ws.connected || !ws.command.trim() || isPasting}
+```
+
+**JSX changes** (conceptual):
+
+```tsx
+{/* Duplicate confirmation dialog */}
+{duplicateDialogState && (
+  <ClipboardDuplicateDialog
+    existingItem={duplicateDialogState.existingItem}
+    pendingItem={duplicateDialogState.pendingItem}
+    onReplace={async () => {
+      try {
+        await clipboardCtx.confirmReplace(
+          duplicateDialogState.pendingItem,
+          duplicateDialogState.existingItem.id,
+        );
+        setDuplicateDialogState(null);
+        addToast(`Clipboard item "${duplicateDialogState.pendingItem.node.alias}" replaced`, 'success');
+      } catch (err) {
+        addToast(`Replace failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+      }
+    }}
+    onCancel={() => {
+      setDuplicateDialogState(null);
+      addToast('Clip cancelled', 'info');
+    }}
+  />
+)}
+
+{/* Main content area (replaces direct <Group> usage) */}
+<div className={styles.mainArea}>
+  <Group ...>
+    {/* LeftPanel and RightPanel unchanged */}
+  </Group>
+
+  {config.supportsClipboard && (
+    <ClipboardSidebar
+      open={clipboardOpen}
+      connected={ws.connected}
+      isPasting={isPasting}
+      onPaste={pasteNode}
+    />
+  )}
+</div>
+```
+
+### 11.3 GraphView.tsx
+
+**Updated props interface** — adds `onClipNode` (see [Section 8.1](#81-clip-trigger-right-click-context-menu-on-reactflow-node)):
+
+```typescript
+interface GraphViewProps {
+  graphData:       MinigraphGraphData | null;
+  onCopySuccess?:  () => void;
+  onCopyError?:    () => void;
+  onRenderError?:  (message: string) => void;
+  isRefreshing?:   boolean;
+  /** Callback for "Clip to Clipboard" from the node context menu. */
+  onClipNode?:     (node: MinigraphNode, connections: MinigraphConnection[]) => void;
+}
+```
+
+**New internal state and ref** for the context menu:
+
+```typescript
+const [contextMenu, setContextMenu] = useState<{
+  x: number;
+  y: number;
+  nodeAlias: string;
+} | null>(null);
+
+const menuRef = useRef<HTMLDivElement>(null);
+```
+
+**`<ReactFlow>` additions:**
+
+```tsx
+<ReactFlow
+  ...
+  onNodeContextMenu={(event, node) => {
+    event.preventDefault();
+    setContextMenu({ x: event.clientX, y: event.clientY, nodeAlias: node.data.alias });
+  }}
+  onPaneClick={() => setContextMenu(null)}
+>
+```
+
+**Context menu rendering** (inside the `<GraphViewErrorBoundary>`):
+
+```tsx
+{contextMenu && onClipNode && graphData && (
+  <div
+    ref={menuRef}
+    className={styles.contextMenu}
+    style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
+    role="menu"
+  >
+    <button
+      role="menuitem"
+      autoFocus
+      onClick={() => {
+        const node = findNodeByAlias(graphData, contextMenu.nodeAlias);
+        if (node) {
+          const connections = extractDirectConnections(graphData, contextMenu.nodeAlias);
+          onClipNode(node, connections);
+        }
+        setContextMenu(null);
+      }}
+    >
+      Clip to Clipboard
+    </button>
+  </div>
+)}
+```
+
+**Context menu dismissal `useEffect`:**
+
+```typescript
+useEffect(() => {
+  if (!contextMenu) return;
+
+  const handleDismiss = (e: MouseEvent) => {
+    // Close if click is outside the context menu element.
+    // Uses the menuRef to avoid ambiguity with other role="menu" elements.
+    if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+      setContextMenu(null);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') setContextMenu(null);
+  };
+
+  document.addEventListener('mousedown', handleDismiss);
+  document.addEventListener('keydown', handleKeyDown);
+  return () => {
+    document.removeEventListener('mousedown', handleDismiss);
+    document.removeEventListener('keydown', handleKeyDown);
+  };
+}, [contextMenu]);
+```
+
+### 11.4 RightPanel.tsx
+
+**No changes.** The clipboard sidebar is outside the `RightPanel` component.
+
+---
+
+## 12. File Inventory
+
+### 12.1 New Files
+
+| File | Purpose |
+|------|---------|
+| `src/clipboard/db.ts` | IndexedDB schema, `getDB()`, CRUD functions including atomic `replaceItem()`, for `ClipboardItemRecord` |
+| `src/clipboard/channel.ts` | `BroadcastChannel` message types and factory function |
+| `src/clipboard/helpers.ts` | `findNodeByAlias()`, `extractDirectConnections()` (with self-connection filter) |
+| `src/clipboard/commandBuilder.ts` | `buildNodeCommand()`, `buildConnectCommand()` |
+| `src/contexts/ClipboardContext.tsx` | `ClipboardProvider`, `useClipboardContext()`, reducer, types |
+| `src/hooks/usePasteNode.ts` | Paste orchestration hook with local existence checks and step timeouts |
+| `src/utils/timeFormat.ts` | `formatRelativeTime()` utility for sidebar timestamps |
+| `src/components/ClipboardSidebar/ClipboardSidebar.tsx` | Sidebar shell + item list |
+| `src/components/ClipboardSidebar/ClipboardSidebar.module.css` | Sidebar styles |
+| `src/components/ClipboardSidebar/ClipboardItem.tsx` | Individual item card |
+| `src/components/ClipboardSidebar/ClipboardItem.module.css` | Item card styles |
+| `src/components/ClipboardSidebar/ClipboardEmptyState.tsx` | Empty clipboard placeholder |
+| `src/components/ClipboardSidebar/ClipboardDuplicateDialog.tsx` | Duplicate-alias confirmation dialog |
+
+### 12.2 Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/App.tsx` | Wrap `<BrowserRouter>` with `<ClipboardProvider>` |
+| `src/config/playgrounds.ts` | Add `supportsClipboard?: boolean` to `PlaygroundConfig`; set `true` on Minigraph config |
+| `src/components/Playground.tsx` | Add clipboard state, handlers, sidebar rendering, duplicate dialog, wire `isPasting` to `sendDisabled` |
+| `src/components/Playground.module.css` | Add `.mainArea` horizontal flex wrapper |
+| `src/components/GraphView/GraphView.tsx` | Add `onClipNode` prop, `onNodeContextMenu` handler, context menu rendering with accessibility and dismissal |
+| `src/components/GraphView/GraphView.module.css` | Add `.contextMenu` styles |
+| `package.json` | Add `idb` dependency, add `fake-indexeddb` devDependency |
+
+### 12.3 Unchanged Files
+
+The following files are explicitly **not modified** by this feature:
+
+- All Java backend files — no server changes needed
+- `src/contexts/WebSocketContext.tsx` — no changes to WebSocket management
+- `src/protocol/classifier.ts` — existing classification handles all paste responses
+- `src/protocol/events.ts` — no new event types needed
+- `src/protocol/bus.ts` — no changes to the event bus
+- `src/hooks/useWebSocket.ts` — no changes; command input is reserved for backend WebSocket messages only
+- `src/hooks/useAutoGraphRefresh.ts` — already handles `graph.mutation` events from paste
+- `src/components/RightPanel/RightPanel.tsx` — sidebar is external to RightPanel
+- `src/utils/graphTypes.ts` — existing types are sufficient
+- `src/utils/graphTransformer.ts` — no layout changes
+
+---
+
+## 13. Edge Cases and Known Limitations
+
+### 13.1 Graph Data Not Loaded
+
+**Scenario:** User right-clicks a node, but `graphData` is `null` (graph not yet
+described).
+
+**This cannot happen.** The `<ReactFlow>` component only renders nodes when
+`graphData` is non-null and `graphData.nodes.length > 0`
+(`src/components/GraphView/GraphView.tsx:92`). If there are no nodes rendered,
+there is nothing to right-click. The context menu is the only clip trigger
+(Decision #5), so `graphData` is always available when a clip is initiated.
+
+### 13.2 Clipping a Node with Array/Object Property Values
+
+`MinigraphNodeProperties` allows `[key: string]: unknown`
+(`src/utils/graphTypes.ts:7`). When building the command, `serializePropertyValue`
+in `src/clipboard/commandBuilder.ts` handles this by calling
+`JSON.stringify(value)` for non-string values. The backend parses the resulting
+string as-is into the property map.
+
+**Potential issue:** If the backend expects a specific format for array-valued
+properties (e.g., `mapping` is `string[]` on the TypeScript side but may be
+stored differently server-side), the serialised JSON array
+`["input.body.field1","input.body.field2"]` may not round-trip correctly.
+
+**Recommendation:** Add integration tests that clip a node with array-valued
+`mapping` properties, paste it into a fresh graph, then `describe node` and
+compare the output. Adjust `serializePropertyValue` if the backend requires a
+different serialisation.
+
+### 13.3 Node Alias Contains Spaces or Special Characters
+
+The backend's command grammar parses `create node {alias}` by splitting on
+whitespace. An alias with spaces (e.g., "my node") would break the command.
+
+**In practice this does not occur.** The backend normalises aliases to
+single-word identifiers when creating nodes. The
+`MinigraphNode.alias` values returned by `describe graph` are always single
+tokens without spaces. No special handling needed.
+
+### 13.4 Known Limitations (Backend Grammar Constraints)
+
+These are constraints imposed by the backend's command grammar that cannot be
+resolved client-side. They are documented here so that implementers and users
+are aware.
+
+**13.4.1 Multiple node types reduced to one on paste.**
+`MinigraphNode.types` is `string[]` — a node can have multiple type labels.
+`buildNodeCommand()` only emits `node.types[0]` because the backend's
+`with type` clause accepts a single type string. All types beyond the first
+are silently dropped on paste. During paste, if `node.types.length > 1`,
+a console warning is appended:
+
+```
+Clipboard paste: node "{alias}" has {N} types but only "{types[0]}" was applied (backend limitation).
+```
+
+**13.4.2 Connection relation properties are lost on paste.**
+`MinigraphRelation` has a `properties: Record<string, unknown>` field
+(`src/utils/graphTypes.ts:22`). The backend's `connect` grammar
+(`connect {source} to {target} with {relation}`) has no syntax for relation
+properties. They are stored in the clipboard item for completeness (so a
+future backend enhancement could use them) but are not emitted during paste.
+During paste, if any relation has non-empty properties, a console warning
+is appended:
+
+```
+Clipboard paste: relation properties were not applied (backend limitation).
+```
+
+**13.4.3 Triple-quote in property values.**
+The backend uses `'''` (triple single-quotes) as the multiline property value
+delimiter (`GraphLambdaFunction.java`, constant `TRIPLE_QUOTE`). There is no
+escape mechanism. If a property value contains the literal string `'''`, the
+backend will interpret it as the closing delimiter, truncating the value.
+`serializePropertyValue()` logs a `console.warn` when this occurs.
+
+### 13.5 BroadcastChannel Not Available
+
+BroadcastChannel is supported by all modern browsers (Chrome 54+, Firefox 38+,
+Edge 79+, Safari 15.4+). In the unlikely event it is unavailable (e.g.,
+embedded WebViews), the clipboard still works correctly within a single tab
+(IndexedDB + React state). Cross-tab sync simply won't occur.
+
+**Handling:** The `createClipboardChannel()` call in `ClipboardProvider` is
+wrapped in a try/catch. If it throws, `channelRef.current` remains `null` and
+the `broadcast()` helper is a no-op. See [Section 6.5](#65-provider-implementation-outline).
+
+### 13.6 IndexedDB Quota Exceeded
+
+IndexedDB quotas are generous (typically 50% of available disk space).
+A single `ClipboardItemRecord` is unlikely to exceed a few KB even for
+complex nodes. With no expiry, a user would need to clip thousands of nodes
+to approach limits.
+
+**Handling:** All `db.*` functions are `async` and their rejections are caught
+by the `clipNode()` try/catch, which returns `{ status: 'error', message }`.
+The UI shows a toast.
+
+### 13.7 Concurrent Paste and Manual Commands
+
+If the user manually types a command in the console while a paste operation is
+in flight, the server processes commands sequentially (single-threaded WebSocket
+handler per session). The paste hook's response-correlation logic listens for
+specific `graph.mutation` events on the `ProtocolBus`. An unrelated manual
+command's response may arrive between paste steps.
+
+**Mitigation:** The `isPasting` flag is wired to `sendDisabled` on the command
+input (see [Section 11.2](#112-playgroundtsx)), preventing the user from
+sending manual commands during paste. If the user manages to send a command
+via other means (e.g., another automation), unrelated responses are ignored
+by the paste hook's step-based state machine — it only advances on
+`graph.mutation` events, and the step timeout prevents indefinite stalls.
+
+### 13.8 Pasting a Node Whose Type Doesn't Exist in the Target
+
+The backend creates nodes with whatever type string is provided — types are
+labels, not a pre-defined schema. No special handling needed.
+
+### 13.9 Stale `graphData` During Paste
+
+`graphData` reflects the most recent `describe graph` fetch. If another tab
+created or deleted nodes since the last fetch, the local existence check may
+be wrong.
+
+- **False negative (node exists but `graphData` doesn't have it):** `create
+  node` is sent. Server responds with "already exists." The paste hook falls
+  back to `update node` — see [Section 9.6](#96-paste-error-handling).
+- **False negative (counterpart exists but `graphData` doesn't have it):**
+  Connection is skipped. User can re-paste after the graph refreshes to
+  create the missing connection.
+- **False positive (node was deleted but `graphData` still has it):** `update
+  node` is sent. Server responds with `"Node {alias} not found"`. The paste
+  hook detects this via `docs.response` on the bus (text starting with `"Node "`
+  and containing `" not found"`) and falls back to `create node` — symmetric
+  with the Step 2a "already exists" fallback. See [Section 9.5](#95-response-correlation-during-paste).
+
+All scenarios recover gracefully. Re-paste after interruption is always safe
+(see [Section 9.6](#96-paste-error-handling)).
+
+---
+
+## 14. Testing Strategy
+
+### 14.1 Unit Tests
+
+| Module | Test File | Key Test Cases |
+|--------|-----------|----------------|
+| `clipboard/db.ts` | `clipboard/__tests__/db.test.ts` | `addItem` + `getAllItems` round-trip; `findByAlias` returns correct match; unique alias constraint throws `ConstraintError` on duplicate; `replaceItem` is atomic (delete + add in single tx); `removeItem` deletes; `clearAll` empties store; items sorted by `clippedAt` descending |
+| `clipboard/commandBuilder.ts` | `clipboard/__tests__/commandBuilder.test.ts` | `buildNodeCommand('create', ...)` with one type and string props; node with no type; node with array-valued `mapping` property (JSON-serialised); multiline property value gets triple-quoted; single-line value containing `'''` is NOT wrapped (left unquoted, triggers console.warn); `buildNodeCommand('update', ...)` produces identical output with `update` verb; `buildConnectCommand` format; properties with `null`/`undefined` values are filtered out |
+| `clipboard/helpers.ts` | `clipboard/__tests__/helpers.test.ts` | `findNodeByAlias` returns node or undefined; `extractDirectConnections` returns connections where alias is source, target, or both; self-connections (`source === target`) are excluded; empty connections array; missing `connections` field (uses `?? []` fallback) |
+| `clipboard/channel.ts` | `clipboard/__tests__/channel.test.ts` | Messages broadcast and received across two channel instances; channel.close() prevents further messages |
+| `contexts/ClipboardContext.tsx` | `contexts/__tests__/ClipboardContext.test.tsx` | Provider renders children; `clipNode` adds item; `clipNode` detects duplicate; `clipNode` catches `ConstraintError` race; `confirmReplace` replaces atomically; `removeItem` removes; `clearAll` clears; reducer state transitions |
+| `utils/timeFormat.ts` | `utils/__tests__/timeFormat.test.ts` | "just now", "X min ago", "X hours ago", "yesterday", date fallback |
+
+**IndexedDB in tests:** Use the `fake-indexeddb` package to run IndexedDB
+tests without a real browser.
+
+### 14.2 Integration Tests
+
+| Scenario | Test Plan |
+|----------|-----------|
+| Clip from GraphView context menu | Mount `GraphView` with mock `graphData`, simulate right-click on a node, verify `onClipNode` called with correct `MinigraphNode` and connections (excluding self-connections) |
+| Context menu accessibility | Verify menu opens on `Shift+F10`, closes on `Escape`, has `role="menu"` and `role="menuitem"`, focus moves to menu item on open |
+| Context menu dismissal | Verify menu closes on Escape, outside click, pane click |
+| Paste creates node | Provide `graphData` without the target alias, verify `create node` command sent via `sendRawText` |
+| Paste updates node | Provide `graphData` with the target alias, verify `update node` command sent |
+| Paste "already exists" fallback | Simulate `docs.response` with "already exists" text after `create node`, verify `update node` fallback is sent |
+| Paste "not found" fallback | Simulate `docs.response` with "not found" text after `update node`, verify `create node` fallback is sent |
+| Paste with partial connections | Provide `graphData` with some counterpart nodes missing, verify skipped connections counted and reported |
+| Paste with multi-relation connections | Provide connection with 3 relations, verify 3 separate `connect` commands sent |
+| Duplicate detection dialog | Clip same alias twice, verify dialog appears, verify Replace and Cancel paths |
+| Cross-tab sync | Use two `ClipboardProvider` instances sharing the same BroadcastChannel name, verify clip in one appears in the other's state |
+
+### 14.3 Manual QA Checklist
+
+- [ ] Clip a node from Graph view context menu → appears in sidebar
+- [ ] Clip same node again → duplicate dialog appears → Replace works
+- [ ] Clip same node again → duplicate dialog appears → Cancel discards
+- [ ] Open second tab → clipped item appears in sidebar
+- [ ] Paste into second tab (node doesn't exist) → node created
+- [ ] Paste into same tab (node exists) → node updated
+- [ ] Paste node with connections (counterparts exist) → connections created
+- [ ] Paste node with connections (some counterparts missing) → skip message shown
+- [ ] Paste node with multiple types → warning about type loss shown in console
+- [ ] Close all tabs, reopen → clipboard items persist
+- [ ] Clear all → IndexedDB emptied, other tabs update
+- [ ] Paste while disconnected → button disabled, no action
+- [ ] Paste while another paste in progress → button disabled
+- [ ] Context menu opens on right-click, closes on Escape
+- [ ] Context menu closes on click outside ReactFlow canvas
+
+---
+
+## 15. Future Enhancements
+
+These are out of scope for the initial implementation but the architecture
+is designed to support them.
+
+### 15.1 Multi-Node Clip (Bundle)
+
+> **Note:** Decision #3 specifies starting with single-node clips to validate
+> the core workflow before investing in multi-select UI.
+
+Add a new record type:
+
+```typescript
+interface ClipboardBundleRecord {
+  id: string;
+  clippedAt: string;
+  sourceWsPath: string;
+  sourceLabel: string;
+  nodes: MinigraphNode[];
+  connections: MinigraphConnection[];
+  label: string;
+}
+```
+
+Store in a separate IndexedDB object store (`bundles`) within the same
+database. Increment `DB_VERSION` to 2 and add the store in the `upgrade`
+callback. The `ClipboardContext` reducer, `BroadcastChannel` protocol, and
+sidebar rendering extend naturally to handle both item types.
+
+UI: ReactFlow supports `onSelectionChange` for multi-node selection. A toolbar
+button "Clip Selection" would collect the selected nodes and their
+inter-connections.
+
+### 15.2 Drag-and-Drop Paste
+
+Drag a clipboard item from the sidebar and drop it onto the ReactFlow canvas.
+ReactFlow's `onDrop` + `onDragOver` handlers can receive a custom drag payload
+containing the `ClipboardItemRecord.id`.
+
+### 15.3 Server-Side Clipboard Sync
+
+Add a REST endpoint (e.g., `POST /api/clipboard/sync`) that accepts the full
+clipboard state and stores it server-side. The `ClipboardProvider` becomes a
+sync orchestrator: writes to IndexedDB first (offline-first), then pushes to
+the server. On load, merges server state with local state by `clippedAt`
+timestamp. Enables clipboard sharing across browsers/devices.
+
+### 15.4 Clipboard Search and Filter
+
+Add a search input at the top of the sidebar. The IndexedDB `by-alias` index
+supports efficient prefix queries via `IDBKeyRange.bound()`. For full-text
+search across property values, consider a client-side index library like
+`FlexSearch`.
+
+### 15.5 Import from External JSON File
+
+Allow users to drag a `.json` file (exported graph) into the clipboard sidebar.
+Parse the file as `MinigraphGraphData`, display a node picker, and clip
+selected nodes without importing the entire graph into the active playground.
+
+### 15.6 Undo Paste
+
+Record a reverse operation when pasting:
+- If `create node` was sent → reverse is `delete node {alias}`
+- If `update node` was sent → reverse stores the pre-paste `describe node`
+  JSON and rebuilds the original `update node` command
+
+Store the reverse in the clipboard item's metadata. Surface an "Undo" button
+in the sidebar for recently pasted items (within a configurable time window).
+
+### 15.7 Auto-Refreshing Relative Timestamps
+
+Add a `setInterval` (e.g., every 60 seconds) inside `ClipboardSidebar` to
+force a re-render of the timestamp displays. This resolves the staleness
+issue noted in [Section 7.4.2](#742-sidebar-visual-layout).
+
+---
+
+## Appendix A: Dependency Additions
+
+**Runtime dependency:**
+
+```bash
+npm install idb
+```
+
+`idb` version `^8.0.0` (latest at time of writing). MIT licensed.
+~1.2 KB gzipped. Zero dependencies. TypeScript types included.
+
+**Dev dependency (test only):**
+
+```bash
+npm install --save-dev fake-indexeddb
+```
+
+`fake-indexeddb` provides a complete in-memory IndexedDB implementation for
+`vitest`/`jest` environments, enabling unit tests for `clipboard/db.ts`
+without a real browser.
+
+## Appendix B: CSS Custom Properties
+
+The sidebar uses the existing design tokens defined in `src/index.css:1–31`:
+
+| Token | Usage in Sidebar |
+|-------|-----------------|
+| `--bg-primary` (`#ffffff`) | Sidebar background |
+| `--bg-secondary` (`#f8fafc`) | Item card background |
+| `--border-color` (`#e2e8f0`) | Sidebar left border, card borders |
+| `--text-primary` (`#0f172a`) | Alias label, action button text |
+| `--text-secondary` (`#64748b`) | Type, skill, metadata labels |
+| `--text-muted` (`#94a3b8`) | Timestamp, connection count |
+| `--primary-color` (`#2563eb`) | Paste button, hover highlights |
+| `--danger-color` (`#ef4444`) | Remove button hover, Clear All |
+| `--radius-sm` (`0.25rem`) | Card border-radius |
+| `--shadow-sm` | Card box-shadow |
+| `--focus-ring` | Focus-visible outline on action buttons |
+
+No new CSS custom properties are needed.
+
+## Appendix C: Cross-Reference of Source Locations
+
+Key source files and line numbers referenced in this specification. Line
+numbers are accurate as of the `feature/command-input` branch at commit
+`e75cb384`.
+
+| Reference | File | Lines |
+|-----------|------|-------|
+| `MinigraphNode` interface | `src/utils/graphTypes.ts` | 10–16 |
+| `MinigraphNodeProperties` interface | `src/utils/graphTypes.ts` | 2–8 |
+| `MinigraphConnection` interface | `src/utils/graphTypes.ts` | 25–29 |
+| `MinigraphRelation` interface | `src/utils/graphTypes.ts` | 19–22 |
+| `MinigraphGraphData` interface | `src/utils/graphTypes.ts` | 32–35 |
+| `isMinigraphGraphData` type guard | `src/utils/graphTypes.ts` | 42–46 |
+| `PlaygroundConfig` interface | `src/config/playgrounds.ts` | 36–58 |
+| `PLAYGROUND_CONFIGS` array | `src/config/playgrounds.ts` | 60–85 |
+| `WebSocketProvider` component | `src/contexts/WebSocketContext.tsx` | 151–381 |
+| `WebSocketContextValue` interface | `src/contexts/WebSocketContext.tsx` | 46–75 |
+| `ctx.send()` function | `src/contexts/WebSocketContext.tsx` | 318–325 |
+| `App` component tree | `src/App.tsx` | 14–31 |
+| `Playground` component | `src/components/Playground.tsx` | 34–436 |
+| `useWebSocket` hook | `src/hooks/useWebSocket.ts` | 108–334 |
+| `UseWebSocketOptions` interface | `src/hooks/useWebSocket.ts` | 35–41 |
+| `UseWebSocketReturn` interface | `src/hooks/useWebSocket.ts` | 44–63 |
+| `sendCommand()` function | `src/hooks/useWebSocket.ts` | 150–170 |
+| `sendRawText()` function | `src/hooks/useWebSocket.ts` | 291–294 |
+| `ProtocolBus` class | `src/protocol/bus.ts` | 16–45 |
+| `classifyMessage()` function | `src/protocol/classifier.ts` | 27–181 |
+| `ProtocolEvent` union type | `src/protocol/events.ts` | 98–110 |
+| `ProtocolEventKind` type | `src/protocol/events.ts` | 113 |
+| `detectMutation()` function | `src/utils/messageParser.ts` | 279–305 |
+| `GraphView` component | `src/components/GraphView/GraphView.tsx` | 36–156 |
+| `GraphViewProps` interface | `src/components/GraphView/GraphView.tsx` | 22–31 |
+| `GraphDataView` component | `src/components/GraphDataView/GraphDataView.tsx` | 39–103 |
+| `GraphToolbar` component | `src/components/GraphToolbar/GraphToolbar.tsx` | 13–51 |
+| `RightPanel` component | `src/components/RightPanel/RightPanel.tsx` | 34–179 |
+| `RightTab` type | `src/components/RightPanel/RightPanel.tsx` | 10 |
+| `useCopyToClipboard` hook | `src/hooks/useCopyToClipboard.ts` | 47–90 |
+| `useAutoGraphRefresh` hook | `src/hooks/useAutoGraphRefresh.ts` | 21–107 |
+| `transformGraphData()` function | `src/utils/graphTransformer.ts` | 163–206 |
+| `GraphNodeData` interface | `src/utils/graphTransformer.ts` | 7–13 |
+| CSS design tokens | `src/index.css` | 1–31 |
+| Playground layout styles | `src/components/Playground.module.css` | 1–58 |
+| Backend: "already exists" response | `GraphCommandService.java` | 1010 |
+| Backend: self-connection rejection | `GraphLambdaFunction.java` | 106 |
+| Backend: `TRIPLE_QUOTE` constant | `GraphLambdaFunction.java` | — |

--- a/extensions/minigraph-playground-engine/webapp/package-lock.json
+++ b/extensions/minigraph-playground-engine/webapp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@xyflow/react": "^12.10.1",
+        "idb": "^8.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-json-view-lite": "^2.5.0",
@@ -22,6 +23,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
         "babel-plugin-react-compiler": "^1.0.0",
+        "fake-indexeddb": "^6.2.5",
         "typescript": "^5.9.3",
         "vite": "^6.0.5",
         "vite-plugin-svgr": "^4.5.0",
@@ -310,6 +312,74 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
@@ -322,6 +392,363 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -414,6 +841,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
@@ -426,6 +881,353 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -1608,6 +2410,16 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1700,6 +2512,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/extensions/minigraph-playground-engine/webapp/package.json
+++ b/extensions/minigraph-playground-engine/webapp/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@xyflow/react": "^12.10.1",
+    "idb": "^8.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-json-view-lite": "^2.5.0",
@@ -28,6 +29,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
     "babel-plugin-react-compiler": "^1.0.0",
+    "fake-indexeddb": "^6.2.5",
     "typescript": "^5.9.3",
     "vite": "^6.0.5",
     "vite-plugin-svgr": "^4.5.0",

--- a/extensions/minigraph-playground-engine/webapp/src/App.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Playground from './components/Playground';
 import { PLAYGROUND_CONFIGS } from './config/playgrounds';
 import { WebSocketProvider } from './contexts/WebSocketContext';
+import { ClipboardProvider } from './contexts/ClipboardContext';
 
 /**
  * To add a new playground tool, edit src/config/playgrounds.ts only —
@@ -15,17 +16,19 @@ export default function App() {
     // connections survive tab navigation — switching playgrounds no longer
     // closes the active socket.
     <WebSocketProvider>
-      <BrowserRouter>
-        <Routes>
-          {/* One route per configured playground */}
-          {PLAYGROUND_CONFIGS.map((cfg) => (
-            <Route key={cfg.path} path={cfg.path} element={<Playground config={cfg} />} />
-          ))}
+      <ClipboardProvider>
+        <BrowserRouter>
+          <Routes>
+            {/* One route per configured playground */}
+            {PLAYGROUND_CONFIGS.map((cfg) => (
+              <Route key={cfg.path} path={cfg.path} element={<Playground config={cfg} />} />
+            ))}
 
-          {/* Fallback: unknown routes go to the first playground */}
-          <Route path="*" element={<Navigate to={defaultPath} replace />} />
-        </Routes>
-      </BrowserRouter>
+            {/* Fallback: unknown routes go to the first playground */}
+            <Route path="*" element={<Navigate to={defaultPath} replace />} />
+          </Routes>
+        </BrowserRouter>
+      </ClipboardProvider>
     </WebSocketProvider>
   );
 }

--- a/extensions/minigraph-playground-engine/webapp/src/clipboard/channel.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/clipboard/channel.ts
@@ -1,0 +1,17 @@
+import type { ClipboardItemRecord } from './db';
+
+const CHANNEL_NAME = 'minigraph-clipboard-sync';
+
+/**
+ * Discriminated union of all messages sent over the clipboard BroadcastChannel.
+ */
+export type ClipboardChannelMessage =
+  | { type: 'item-added';    item: ClipboardItemRecord }
+  | { type: 'item-replaced'; item: ClipboardItemRecord; previousId: string }
+  | { type: 'item-removed';  id: string }
+  | { type: 'items-cleared' };
+
+/** Create a BroadcastChannel for clipboard synchronisation. */
+export function createClipboardChannel(): BroadcastChannel {
+  return new BroadcastChannel(CHANNEL_NAME);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/clipboard/commandBuilder.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/clipboard/commandBuilder.ts
@@ -1,0 +1,68 @@
+import type { MinigraphNode } from '../utils/graphTypes';
+
+/**
+ * Serialise a property value for the "key=value" line in a create/update command.
+ * Multiline values are wrapped in triple-quotes (''').
+ */
+function serializePropertyValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+
+  if (str.includes("'''")) {
+    console.warn(
+      `[commandBuilder] Property value contains "'''" which cannot be escaped ` +
+      `in the backend grammar. The value may be truncated on paste.`
+    );
+  }
+
+  if (str.includes('\n')) {
+    return `'''\n${str}\n'''`;
+  }
+
+  return str;
+}
+
+/**
+ * Build a create or update node multi-line command string from a MinigraphNode.
+ */
+export function buildNodeCommand(
+  verb: 'create' | 'update',
+  node: MinigraphNode,
+): string {
+  const lines: string[] = [`${verb} node ${node.alias}`];
+
+  if (node.types.length > 0) {
+    lines.push(`with type ${node.types[0]}`);
+  }
+
+  const propEntries = Object.entries(node.properties).filter(
+    ([, v]) => v !== undefined && v !== null,
+  );
+
+  if (propEntries.length > 0) {
+    lines.push('with properties');
+    for (const [key, value] of propEntries) {
+      if (Array.isArray(value)) {
+        for (const element of value) {
+          lines.push(`${key}[]=${serializePropertyValue(element)}`);
+        }
+      } else {
+        lines.push(`${key}[]=${serializePropertyValue(value)}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build a `connect` command for a single relation.
+ */
+export function buildConnectCommand(
+  source: string,
+  target: string,
+  relationType: string,
+): string {
+  return `connect ${source} to ${target} with ${relationType}`;
+}

--- a/extensions/minigraph-playground-engine/webapp/src/clipboard/db.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/clipboard/db.ts
@@ -1,0 +1,122 @@
+import { openDB, deleteDB, type DBSchema, type IDBPDatabase } from 'idb';
+import type { MinigraphNode, MinigraphConnection } from '../utils/graphTypes';
+
+/**
+ * A snapshot of a single node plus its direct connections at the time of
+ * clipping. This is the primary record stored in IndexedDB.
+ */
+export interface ClipboardItemRecord {
+  /** Primary key. Generated via crypto.randomUUID() at clip time. */
+  id: string;
+
+  /** ISO 8601 timestamp of when the node was clipped. */
+  clippedAt: string;
+
+  /** The wsPath of the playground from which the node was clipped. */
+  sourceWsPath: string;
+
+  /** Human-readable label of the source playground. */
+  sourceLabel: string;
+
+  /** Full snapshot of the MinigraphNode at clip time. */
+  node: MinigraphNode;
+
+  /** All direct connections for this node, excluding self-connections. */
+  connections: MinigraphConnection[];
+}
+
+const DB_NAME    = 'minigraph-clipboard';
+const DB_VERSION = 1;
+const STORE_NAME = 'items';
+
+interface ClipboardDB extends DBSchema {
+  [STORE_NAME]: {
+    key: string;
+    value: ClipboardItemRecord;
+    indexes: {
+      'by-alias':     string;
+      'by-clippedAt': string;
+    };
+  };
+}
+
+/** Singleton database promise. Reused by all callers. */
+let dbInstance: Promise<IDBPDatabase<ClipboardDB>> | null = null;
+
+function openClipboardDB(): Promise<IDBPDatabase<ClipboardDB>> {
+  return openDB<ClipboardDB>(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      // Delete any stale object store left over from a prior schema version
+      // so the fresh store + indexes are created cleanly.
+      if (db.objectStoreNames.contains(STORE_NAME)) {
+        db.deleteObjectStore(STORE_NAME);
+      }
+      const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      store.createIndex('by-alias', 'node.alias', { unique: true });
+      store.createIndex('by-clippedAt', 'clippedAt');
+    },
+  });
+}
+
+export function getDB(): Promise<IDBPDatabase<ClipboardDB>> {
+  if (!dbInstance) {
+    dbInstance = openClipboardDB().catch(async (err) => {
+      // Self-healing: if the database is corrupt or has a stale schema from
+      // a prior development cycle, delete it entirely and recreate.
+      console.warn('[clipboard/db] openDB failed, deleting and recreating:', err);
+      dbInstance = null;
+      await deleteDB(DB_NAME);
+      return openClipboardDB();
+    });
+  }
+  return dbInstance;
+}
+
+/** Retrieve all clipboard items, sorted newest-first by clippedAt. */
+export async function getAllItems(): Promise<ClipboardItemRecord[]> {
+  const db = await getDB();
+  const items = await db.getAllFromIndex(STORE_NAME, 'by-clippedAt');
+  return items.reverse();
+}
+
+/** Find an existing clipboard item by node alias. */
+export async function findByAlias(alias: string): Promise<ClipboardItemRecord | undefined> {
+  const db = await getDB();
+  return db.getFromIndex(STORE_NAME, 'by-alias', alias);
+}
+
+/** Insert a new clipboard item. */
+export async function addItem(item: ClipboardItemRecord): Promise<void> {
+  const db = await getDB();
+  await db.add(STORE_NAME, item);
+}
+
+/** Replace an existing clipboard item (same id). */
+export async function putItem(item: ClipboardItemRecord): Promise<void> {
+  const db = await getDB();
+  await db.put(STORE_NAME, item);
+}
+
+/** Atomically remove the old item and insert a new one in a single transaction. */
+export async function replaceItem(
+  previousId: string,
+  newItem: ClipboardItemRecord,
+): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  await tx.store.delete(previousId);
+  await tx.store.add(newItem);
+  await tx.done;
+}
+
+/** Remove a single clipboard item by id. */
+export async function removeItem(id: string): Promise<void> {
+  const db = await getDB();
+  await db.delete(STORE_NAME, id);
+}
+
+/** Remove all clipboard items. */
+export async function clearAll(): Promise<void> {
+  const db = await getDB();
+  await db.clear(STORE_NAME);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/clipboard/helpers.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/clipboard/helpers.ts
@@ -1,0 +1,22 @@
+import type { MinigraphNode, MinigraphConnection, MinigraphGraphData } from '../utils/graphTypes';
+
+/** Extract the full MinigraphNode from graphData by alias. */
+export function findNodeByAlias(
+  graphData: MinigraphGraphData,
+  alias: string,
+): MinigraphNode | undefined {
+  return graphData.nodes.find(n => n.alias === alias);
+}
+
+/**
+ * Extract all connections where the given alias appears as source OR target,
+ * excluding self-connections (where source === target).
+ */
+export function extractDirectConnections(
+  graphData: MinigraphGraphData,
+  alias: string,
+): MinigraphConnection[] {
+  return (graphData.connections ?? []).filter(
+    c => c.source !== c.target && (c.source === alias || c.target === alias),
+  );
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardDuplicateDialog.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardDuplicateDialog.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import type { ClipboardItemRecord } from '../../clipboard/db';
+import { formatRelativeTime } from '../../utils/timeFormat';
+import styles from './ClipboardSidebar.module.css';
+
+interface ClipboardDuplicateDialogProps {
+  existingItem: ClipboardItemRecord;
+  pendingItem: ClipboardItemRecord;
+  onReplace: () => void;
+  onCancel: () => void;
+}
+
+export function ClipboardDuplicateDialog({
+  existingItem,
+  pendingItem,
+  onReplace,
+  onCancel,
+}: ClipboardDuplicateDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.open) {
+      dialog.showModal();
+    }
+  }, []);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      onClose={onCancel}
+      aria-labelledby="duplicate-dialog-title"
+    >
+      <h2 id="duplicate-dialog-title" className={styles.dialogTitle}>Duplicate Node</h2>
+      <p className={styles.dialogBody}>
+        A clipboard item with alias <strong>"{pendingItem.node.alias}"</strong> already
+        exists (clipped {formatRelativeTime(existingItem.clippedAt)}).
+      </p>
+      <p className={styles.dialogBody}>
+        Replace it with the new snapshot?
+      </p>
+      <div className={styles.dialogActions}>
+        <button className={styles.cancelBtn} onClick={onCancel}>
+          Cancel
+        </button>
+        <button className={styles.replaceBtn} onClick={onReplace}>
+          Replace
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardEmptyState.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardEmptyState.tsx
@@ -1,0 +1,13 @@
+import styles from './ClipboardSidebar.module.css';
+
+export function ClipboardEmptyState() {
+  return (
+    <div className={styles.emptyState}>
+      <span className={styles.emptyIcon}>📋</span>
+      <span className={styles.emptyTitle}>No items clipped yet.</span>
+      <span className={styles.emptyHint}>
+        Right-click a node in the Graph view to get started.
+      </span>
+    </div>
+  );
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
@@ -1,0 +1,86 @@
+/* ── Item card ── */
+.card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 0.75rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.alias {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  margin-bottom: 0.25rem;
+  word-break: break-all;
+}
+
+.meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.propsLine {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.timestamp {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  margin-top: 0.375rem;
+}
+
+/* ── Action buttons ── */
+.actions {
+  display: flex;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+
+.pasteBtn,
+.inspectBtn,
+.removeBtn {
+  flex: 1;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.375rem;
+  font-size: 0.6875rem;
+  cursor: pointer;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.pasteBtn:hover:not(:disabled) {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.inspectBtn:hover {
+  background: var(--bg-secondary);
+  border-color: var(--text-muted);
+}
+
+.removeBtn:hover {
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--danger-color);
+  border-color: var(--danger-color);
+}
+
+.pasteBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pasteBtn:focus-visible,
+.inspectBtn:focus-visible,
+.removeBtn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
@@ -55,7 +55,7 @@ export function ClipboardItem({ item, connected, onPaste, onRemove, onInspect }:
           onClick={onInspect}
           aria-label={`Inspect node ${node.alias}`}
         >
-          Inspect
+          Describe
         </button>
         <button
           className={styles.removeBtn}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
@@ -1,0 +1,70 @@
+import type { ClipboardItemRecord } from '../../clipboard/db';
+import { formatRelativeTime } from '../../utils/timeFormat';
+import styles from './ClipboardItem.module.css';
+
+interface ClipboardItemProps {
+  item: ClipboardItemRecord;
+  connected: boolean;
+  onPaste: (item: ClipboardItemRecord) => void;
+  onRemove: () => void;
+  onInspect: () => void;
+}
+
+export function ClipboardItem({ item, connected, onPaste, onRemove, onInspect }: ClipboardItemProps) {
+  const { node, connections, clippedAt, sourceLabel } = item;
+  const primaryType = node.types[0] ?? '—';
+  const skill = node.properties.skill ?? '—';
+
+  // Truncated props summary
+  const propKeys = Object.entries(node.properties)
+    .filter(([k]) => k !== 'skill')
+    .map(([k, v]) => {
+      const val = typeof v === 'string' ? v : JSON.stringify(v);
+      return `${k}=${val && val.length > 30 ? val.slice(0, 30) + '…' : val}`;
+    });
+  const propsSummary = propKeys.length > 0 ? propKeys.join(', ') : '—';
+
+  // Connection counts
+  const outgoing = connections.filter(c => c.source === node.alias).length;
+  const incoming = connections.filter(c => c.target === node.alias).length;
+  const connSummary = `${connections.length} (${outgoing} out, ${incoming} in)`;
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.alias}>{node.alias}</div>
+      <div className={styles.meta}>Type: {primaryType}</div>
+      <div className={styles.meta}>Skill: {skill}</div>
+      <div className={styles.meta} title={propsSummary}>
+        <span className={styles.propsLine}>Props: {propsSummary}</span>
+      </div>
+      <div className={styles.meta}>Connections: {connSummary}</div>
+      <div className={styles.timestamp}>
+        Clipped {formatRelativeTime(clippedAt)} from {sourceLabel}
+      </div>
+      <div className={styles.actions}>
+        <button
+          className={styles.pasteBtn}
+          onClick={() => onPaste(item)}
+          disabled={!connected}
+          aria-label={`Paste node ${node.alias}`}
+        >
+          Paste
+        </button>
+        <button
+          className={styles.inspectBtn}
+          onClick={onInspect}
+          aria-label={`Inspect node ${node.alias}`}
+        >
+          Inspect
+        </button>
+        <button
+          className={styles.removeBtn}
+          onClick={onRemove}
+          aria-label={`Remove node ${node.alias} from clipboard`}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
@@ -1,0 +1,197 @@
+/* ── Sidebar container (fills its Panel) ── */
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-color);
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  min-height: 2.5rem;
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.clearBtn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--danger-color);
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.clearBtn:hover {
+  background: rgba(239, 68, 68, 0.08);
+}
+
+/* ── Item list (scrollable) ── */
+.itemList {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* ── Loading state ── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+/* ── Empty state ── */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.375rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.emptyIcon {
+  font-size: 2rem;
+  opacity: 0.4;
+}
+
+.emptyTitle {
+  font-weight: 500;
+}
+
+.emptyHint {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* ── Inspect panel ── */
+.inspectPanel {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-color);
+  max-height: 40%;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+}
+
+.inspectHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  background: var(--bg-secondary);
+}
+
+.inspectClose {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0.125rem;
+}
+
+.inspectClose:hover {
+  color: var(--text-primary);
+}
+
+.inspectBody {
+  padding: 0.5rem;
+  font-size: 0.75rem;
+}
+
+/* ── Duplicate dialog ── */
+.dialog {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  max-width: 420px;
+  box-shadow: var(--shadow-md);
+  background: var(--bg-primary);
+  align-self: center;
+  justify-self: center;
+}
+
+.dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.dialogTitle {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.dialogBody {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.dialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.cancelBtn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.cancelBtn:hover {
+  background: var(--bg-secondary);
+}
+
+.replaceBtn {
+  background: var(--primary-color);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  color: #fff;
+}
+
+.replaceBtn:hover {
+  background: var(--primary-hover);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useClipboardContext } from '../../contexts/ClipboardContext';
+import type { ClipboardItemRecord } from '../../clipboard/db';
+import { ClipboardItem } from './ClipboardItem';
+import { ClipboardEmptyState } from './ClipboardEmptyState';
+import styles from './ClipboardSidebar.module.css';
+import { JsonView, darkStyles } from 'react-json-view-lite';
+import 'react-json-view-lite/dist/index.css';
+
+interface ClipboardSidebarProps {
+  connected: boolean;
+  onPaste: (item: ClipboardItemRecord) => void;
+}
+
+export default function ClipboardSidebar({ connected, onPaste }: ClipboardSidebarProps) {
+  const clipboardCtx = useClipboardContext();
+  const [inspectItem, setInspectItem] = useState<ClipboardItemRecord | null>(null);
+
+  return (
+    <div className={styles.sidebar}>
+      <div className={styles.header}>
+        <span className={styles.headerTitle}>Clipboard</span>
+        {clipboardCtx.items.length > 0 && (
+          <button
+            className={styles.clearBtn}
+            onClick={() => clipboardCtx.clearAll()}
+            aria-label="Clear all clipboard items"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className={styles.itemList}>
+        {clipboardCtx.isLoading ? (
+          <div className={styles.loading}>Loading…</div>
+        ) : clipboardCtx.items.length === 0 ? (
+          <ClipboardEmptyState />
+        ) : (
+          clipboardCtx.items.map(item => (
+            <ClipboardItem
+              key={item.id}
+              item={item}
+              connected={connected}
+              onPaste={onPaste}
+              onRemove={() => clipboardCtx.removeItem(item.id)}
+              onInspect={() => setInspectItem(inspectItem?.id === item.id ? null : item)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Inspect panel (inline expand) */}
+      {inspectItem && (
+        <div className={styles.inspectPanel}>
+          <div className={styles.inspectHeader}>
+            <span>Inspect: {inspectItem.node.alias}</span>
+            <button
+              className={styles.inspectClose}
+              onClick={() => setInspectItem(null)}
+              aria-label="Close inspect panel"
+            >
+              ✕
+            </button>
+          </div>
+          <div className={styles.inspectBody}>
+            <JsonView
+              data={{ node: inspectItem.node, connections: inspectItem.connections }}
+              style={darkStyles}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
@@ -54,7 +54,7 @@ export default function ClipboardSidebar({ connected, onPaste }: ClipboardSideba
       {inspectItem && (
         <div className={styles.inspectPanel}>
           <div className={styles.inspectHeader}>
-            <span>Inspect: {inspectItem.node.alias}</span>
+            <span>Describe node {inspectItem.node.alias}</span>
             <button
               className={styles.inspectClose}
               onClick={() => setInspectItem(null)}

--- a/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
@@ -33,7 +33,7 @@
     border-radius: 0.25rem;
     padding: 0.125rem 0.25rem;
     cursor: pointer;
-    font-size: 0.75rem;
+    font-size: 1.125rem;
     color: var(--text-secondary);
     transition: all 0.2s;
     box-sizing: border-box;

--- a/extensions/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
@@ -94,3 +94,37 @@
 @keyframes graphRefreshSpin {
   to { transform: rotate(360deg); }
 }
+
+/* ── Node context menu ──────────────────────────────────────────────────── */
+
+.contextMenu {
+  background: var(--bg-primary, #fff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: var(--radius-sm, 0.25rem);
+  box-shadow: var(--shadow-md);
+  z-index: 50;
+  min-width: 160px;
+  padding: 0.25rem 0;
+}
+
+.contextMenuItem {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 0.8125rem;
+  color: var(--text-primary, #0f172a);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.contextMenuItem:hover {
+  background: var(--autocomplete-highlight, rgba(37, 99, 235, 0.1));
+}
+
+.contextMenuItem:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}

--- a/extensions/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -15,7 +15,8 @@ import '@xyflow/react/dist/style.css';
 import { nodeTypes } from './NodeTypes';
 import { GraphViewErrorBoundary } from './GraphViewErrorBoundary';
 import { transformGraphData, type GraphNodeData, type GraphEdgeData } from '../../utils/graphTransformer';
-import type { MinigraphGraphData } from '../../utils/graphTypes';
+import type { MinigraphGraphData, MinigraphNode, MinigraphConnection } from '../../utils/graphTypes';
+import { findNodeByAlias, extractDirectConnections } from '../../clipboard/helpers';
 import GraphToolbar from '../GraphToolbar/GraphToolbar';
 import styles from './GraphView.module.css';
 
@@ -28,12 +29,44 @@ interface GraphViewProps {
   onRenderError?:  (message: string) => void;
   /** When true, renders a semi-transparent overlay with a spinner to indicate a background re-fetch. */
   isRefreshing?:   boolean;
+  /** Callback for "Clip to Clipboard" from the node context menu. */
+  onClipNode?:     (node: MinigraphNode, connections: MinigraphConnection[]) => void;
 }
 
 const EMPTY_NODES: Node<GraphNodeData>[]  = [];
 const EMPTY_EDGES: Edge<GraphEdgeData>[]  = [];
 
-export default function GraphView({ graphData, onCopySuccess, onCopyError, onRenderError, isRefreshing = false }: GraphViewProps) {
+export default function GraphView({ graphData, onCopySuccess, onCopyError, onRenderError, isRefreshing = false, onClipNode }: GraphViewProps) {
+
+  // ── Context menu state ──────────────────────────────────────────────────
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    nodeAlias: string;
+  } | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss context menu on outside click or Escape
+  useEffect(() => {
+    if (!contextMenu) return;
+
+    const handleDismiss = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as globalThis.Node)) {
+        setContextMenu(null);
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setContextMenu(null);
+    };
+
+    document.addEventListener('mousedown', handleDismiss);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleDismiss);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [contextMenu]);
 
   // Keep a stable ref so the useEffect below can fire the error callback without
   // needing onRenderError in the useMemo dependency array.
@@ -124,16 +157,30 @@ export default function GraphView({ graphData, onCopySuccess, onCopyError, onRen
           maxZoom={2.5}
           // colorMode="dark" // enable for dark mode
           proOptions={{ hideAttribution: false }}
+          onNodeContextMenu={(event, node) => {
+            if (!onClipNode) return;
+            event.preventDefault();
+            setContextMenu({ x: event.clientX, y: event.clientY, nodeAlias: node.data.alias });
+          }}
+          onPaneClick={() => setContextMenu(null)}
         >
           <Background variant={BackgroundVariant.Dots} gap={18} size={1} color="rgba(255,255,255,0.07)" />
           <Controls showInteractive={false} />
           <MiniMap
             nodeColor={(node) => {
               const colorMap: Record<string, string> = {
-                entry_point: '#a6e3a1',
-                api_fetcher: '#89b4fa',
-                mapper:      '#fab387',
-                terminator:  '#f38ba8',
+                Root:        '#15803d',
+                End:         '#dc2626',
+                Fetcher:     '#2563eb',
+                mapper:      '#ea580c',
+                Math:        '#a16207',
+                JavaScript:  '#7e22ce',
+                Provider:    '#be185d',
+                Dictionary:  '#0e7490',
+                Join:        '#65a30d',
+                Extension:   '#4338ca',
+                Island:      '#475569',
+                Decision:    '#b45309',
               };
               return colorMap[node.type ?? ''] ?? '#6c7086';
             }}
@@ -148,6 +195,30 @@ export default function GraphView({ graphData, onCopySuccess, onCopyError, onRen
               role="status"
               aria-label="Graph refreshing"
             />
+          </div>
+        )}
+        {contextMenu && onClipNode && graphData && (
+          <div
+            ref={menuRef}
+            className={styles.contextMenu}
+            style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
+            role="menu"
+          >
+            <button
+              role="menuitem"
+              autoFocus
+              className={styles.contextMenuItem}
+              onClick={() => {
+                const node = findNodeByAlias(graphData, contextMenu.nodeAlias);
+                if (node) {
+                  const connections = extractDirectConnections(graphData, contextMenu.nodeAlias);
+                  onClipNode(node, connections);
+                }
+                setContextMenu(null);
+              }}
+            >
+              Clip to Clipboard
+            </button>
           </div>
         )}
       </div>

--- a/extensions/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
@@ -7,10 +7,18 @@ export type MinigraphRFNode = Node<GraphNodeData>;
 
 // ─── Per-type metadata ────────────────────────────────────────────────────────
 const TYPE_META: Record<string, { icon: string; label: string }> = {
-  entry_point: { icon: '🚀', label: 'Entry Point' },
-  api_fetcher: { icon: '🌐', label: 'API Fetcher'  },
+  Root:        { icon: '🚀', label: 'Root'         },
+  End:         { icon: '🏁', label: 'End'          },
+  Fetcher:     { icon: '🌐', label: 'Fetcher'      },
   mapper:      { icon: '🗺️', label: 'Mapper'       },
-  terminator:  { icon: '🏁', label: 'Terminator'   },
+  Math:        { icon: '🔢', label: 'Math'         },
+  JavaScript:  { icon: '📜', label: 'JavaScript'   },
+  Provider:    { icon: '🔌', label: 'Provider'     },
+  Dictionary:  { icon: '📖', label: 'Dictionary'   },
+  Join:        { icon: '🔀', label: 'Join'         },
+  Extension:   { icon: '🧩', label: 'Extension'    },
+  Island:      { icon: '🏝️', label: 'Island'       },
+  Decision:    { icon: '❓', label: 'Decision'     },
 };
 
 function getMeta(nodeType: string) {
@@ -18,8 +26,9 @@ function getMeta(nodeType: string) {
 }
 
 // ─── Shared detail rows ───────────────────────────────────────────────────────
-function Row({ label, value }: { label: string; value?: string }) {
-  if (!value) return null;
+
+/** Render a single key=value row. */
+function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className={styles.row}>
       <span className={styles.label}>{label}</span>
@@ -28,16 +37,27 @@ function Row({ label, value }: { label: string; value?: string }) {
   );
 }
 
-function MappingRows({ mapping }: { mapping?: string[] }) {
-  if (!mapping?.length) return null;
+/** Render all properties generically. Arrays get one row per element. */
+function PropertyRows({ properties }: { properties: Record<string, unknown> }) {
+  const entries = Object.entries(properties).filter(
+    ([, v]) => v !== undefined && v !== null,
+  );
+  if (entries.length === 0) return null;
+
   return (
     <>
-      {mapping.map((m, i) => (
-        <div key={m} className={styles.row}>
-          <span className={styles.label}>{i === 0 ? 'map' : ''}</span>
-          <span className={styles.value} title={m}>{m}</span>
-        </div>
-      ))}
+      {entries.map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return value.map((item, i) => {
+            const str = typeof item === 'string' ? item : JSON.stringify(item);
+            return (
+              <Row key={`${key}-${i}`} label={i === 0 ? key : ''} value={str} />
+            );
+          });
+        }
+        const str = typeof value === 'string' ? value : JSON.stringify(value);
+        return <Row key={key} label={key} value={str} />;
+      })}
     </>
   );
 }
@@ -75,10 +95,7 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
         </div>
 
         <div className={styles.body}>
-          <Row label="skill"    value={data.skill} />
-          <Row label="question" value={data.question} />
-          <Row label="desc"     value={data.description} />
-          <MappingRows mapping={data.mapping} />
+          <PropertyRows properties={data.properties} />
         </div>
       </div>
 
@@ -94,9 +111,17 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
 // Our transformer sets node.type = n.types[0], so we need an entry per known
 // type plus a "default" fallback for anything unrecognised.
 export const nodeTypes = {
-  entry_point: MinigraphNode,
-  api_fetcher: MinigraphNode,
+  Root:        MinigraphNode,
+  End:         MinigraphNode,
+  Fetcher:     MinigraphNode,
   mapper:      MinigraphNode,
-  terminator:  MinigraphNode,
+  Math:        MinigraphNode,
+  JavaScript:  MinigraphNode,
+  Provider:    MinigraphNode,
+  Dictionary:  MinigraphNode,
+  Join:        MinigraphNode,
+  Extension:   MinigraphNode,
+  Island:      MinigraphNode,
+  Decision:    MinigraphNode,
   default:     MinigraphNode,
 } as const;

--- a/extensions/minigraph-playground-engine/webapp/src/components/Playground.module.css
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Playground.module.css
@@ -38,6 +38,29 @@
   display: flex;
 }
 
+/* ── Clipboard toggle button ── */
+.clipboardToggle {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.clipboardToggle:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.clipboardToggle[aria-pressed="true"] {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
 /* ── Drag handle between panels ── */
 .resizeHandle {
   width: 1px;

--- a/extensions/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -14,6 +14,7 @@ import { useLargePayloadDownload } from '../hooks/useLargePayloadDownload';
 import { useAutoMockUpload } from '../hooks/useAutoMockUpload';
 import { useSavedGraphs } from '../hooks/useSavedGraphs';
 import { useGraphSaveName } from '../hooks/useGraphSaveName';
+import { buildNodeCommand } from '../clipboard/commandBuilder';
 import { ToastContainer } from './Toast';
 import Navigation from './Navigation';
 import GraphSaveButton from './GraphSaveButton/GraphSaveButton';
@@ -21,18 +22,23 @@ import SavedGraphsMenu from './SavedGraphsMenu/SavedGraphsMenu';
 import RightPanel from './RightPanel/RightPanel';
 import LeftPanel from './LeftPanel/LeftPanel';
 import { MockUploadModal } from './MockUploadModal/MockUploadModal';
+import ClipboardSidebar from './ClipboardSidebar/ClipboardSidebar';
+import { ClipboardDuplicateDialog } from './ClipboardSidebar/ClipboardDuplicateDialog';
 import { type PlaygroundConfig, PLAYGROUND_CONFIGS } from '../config/playgrounds';
 import { useWebSocketContext } from '../contexts/WebSocketContext';
+import { useClipboardContext } from '../contexts/ClipboardContext';
 import { ProtocolBus } from '../protocol/bus';
 import { useProtocolKernel } from '../protocol/useProtocolKernel';
 import type { GraphLinkEvent } from '../protocol/events';
+import type { ClipboardItemRecord } from '../clipboard/db';
+import type { MinigraphNode, MinigraphConnection } from '../utils/graphTypes';
 
 interface PlaygroundProps {
   config: PlaygroundConfig;
 }
 
 export default function Playground({ config }: PlaygroundProps) {
-  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeyTab, storageKeySavedGraphs, supportsUpload, tabs } = config;
+  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeyTab, storageKeySavedGraphs, supportsUpload, supportsClipboard, tabs } = config;
 
   const navigate = useNavigate();
 
@@ -213,6 +219,53 @@ export default function Playground({ config }: PlaygroundProps) {
     modalOpen:   modalUploadPath !== null,
   });
 
+  // ── Clipboard integration ────────────────────────────────────────────────
+  const clipboardCtx = useClipboardContext();
+
+  const [clipboardOpen, setClipboardOpen] = useLocalStorage<boolean>('clipboard-sidebar-open', false);
+
+  const [duplicateDialogState, setDuplicateDialogState] = useState<{
+    pendingItem: ClipboardItemRecord;
+    existingItem: ClipboardItemRecord;
+  } | null>(null);
+
+  const handlePasteToInput = useCallback((item: ClipboardItemRecord) => {
+    const existsLocally = graphData?.nodes.some(n => n.alias === item.node.alias) ?? false;
+    const verb = existsLocally ? 'update' : 'create';
+    const command = buildNodeCommand(verb, item.node);
+    ws.setCommand(command);
+    addToast(`${verb === 'create' ? 'Create' : 'Update'} command for "${item.node.alias}" pasted to input`, 'info');
+  }, [graphData, ws.setCommand, addToast]);
+
+  const handleClipNode = useCallback(async (
+    node: MinigraphNode,
+    connections: MinigraphConnection[],
+  ) => {
+    try {
+      const result = await clipboardCtx.clipNode(node, connections, {
+        sourceWsPath: wsPath,
+        sourceLabel: config.label,
+      });
+
+      switch (result.status) {
+        case 'added':
+          addToast(`Node "${node.alias}" clipped to clipboard`, 'success');
+          break;
+        case 'duplicate':
+          setDuplicateDialogState({
+            pendingItem: result.pendingItem,
+            existingItem: result.existingItem,
+          });
+          break;
+        case 'error':
+          addToast(`Clip failed: ${result.message}`, 'error');
+          break;
+      }
+    } catch (err) {
+      addToast(`Clip failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+    }
+  }, [clipboardCtx, wsPath, config.label, addToast]);
+
   // ── Saved graphs (localStorage snapshots) ────────────────────────────────
   // Only instantiated when the playground config provides a storage key so
   // playgrounds that don't use this feature have zero overhead.
@@ -233,20 +286,67 @@ export default function Playground({ config }: PlaygroundProps) {
     bus,
   );
 
-  // Save the current graph name as a bookmark in localStorage.
-  // Also sends `export graph as {name}` over the WebSocket so the server
-  // writes (or refreshes) the corresponding {name}.json file in its temp
-  // directory — that file is what `import graph from {name}` reads back.
-  // The WS send is a no-op when disconnected; the bookmark is still written
-  // so the user can reconnect and load it later.
+  // ── Pending graph export ──────────────────────────────────────────────────
+  // Tracks a save that is waiting for server confirmation.
+  // null = no pending save; string = the name being exported.
+  const pendingSaveRef = useRef<string | null>(null);
+
+  // Save the current graph under the given name.
+  // When connected, the localStorage write and success toast are deferred
+  // until the server confirms the export (graph.link → success, lifecycle
+  // error → failure).  When disconnected, the bookmark is written
+  // optimistically so the user can reconnect and load it later.
   const handleSaveGraph = useCallback((name: string) => {
-    savedGraphs.saveGraph(name);
     setLastSavedName(name);
     if (ws.connected) {
+      pendingSaveRef.current = name;
       ws.sendRawText(`export graph as ${name}`);
+    } else {
+      savedGraphs.saveGraph(name);
+      addToast(`Graph saved as "${name}"`, 'success');
     }
-    addToast(`Graph saved as "${name}"`, 'success');
   }, [savedGraphs.saveGraph, setLastSavedName, ws.connected, ws.sendRawText, addToast]);
+
+  // Confirm pending save: server responded with a graph-link after export.
+  useEffect(() => {
+    return bus.on('graph.link', () => {
+      if (pendingSaveRef.current === null) return;
+      const name = pendingSaveRef.current;
+      pendingSaveRef.current = null;
+      savedGraphs.saveGraph(name);
+      addToast(`Graph saved as "${name}"`, 'success');
+    });
+  }, [bus, savedGraphs.saveGraph, addToast]);
+
+  // Reject pending save: server responded with a plain-text error after export.
+  // The backend sends export errors as raw text (not JSON lifecycle events),
+  // which the classifier maps to docs.response.  Any docs.response while a
+  // save is pending means the export was rejected.
+  useEffect(() => {
+    return bus.on('docs.response', (event) => {
+      if (pendingSaveRef.current === null) return;
+      pendingSaveRef.current = null;
+      addToast(`Save failed: ${event.raw}`, 'error');
+    });
+  }, [bus, addToast]);
+
+  // Safety net: also handle JSON lifecycle errors in case future server
+  // versions send export errors as structured JSON.
+  useEffect(() => {
+    return bus.on('lifecycle', (event) => {
+      if (pendingSaveRef.current === null) return;
+      if (event.type !== 'error') return;
+      pendingSaveRef.current = null;
+      addToast(`Save failed: ${event.message}`, 'error');
+    });
+  }, [bus, addToast]);
+
+  // Clear pending save on disconnect so it doesn't linger.
+  useEffect(() => {
+    if (!ws.connected) {
+      pendingSaveRef.current = null;
+    }
+  }, [ws.connected]);
 
   // Load a saved graph by sending `import graph from {name}` over the WebSocket.
   // The backend reads {name}.json from its temp directory — the file that was
@@ -378,9 +478,42 @@ export default function Playground({ config }: PlaygroundProps) {
               connected={ws.connected}
             />
           )}
+          {supportsClipboard && (
+            <button
+              className={styles.clipboardToggle}
+              onClick={() => setClipboardOpen(prev => !prev)}
+              aria-label={clipboardOpen ? 'Close clipboard sidebar' : 'Open clipboard sidebar'}
+              aria-pressed={clipboardOpen}
+            >
+              Clipboard{clipboardCtx.items.length > 0 ? ` (${clipboardCtx.items.length})` : ''}
+            </button>
+          )}
           <Navigation addToast={addToast} />
         </div>
       </header>
+
+      {duplicateDialogState && (
+        <ClipboardDuplicateDialog
+          existingItem={duplicateDialogState.existingItem}
+          pendingItem={duplicateDialogState.pendingItem}
+          onReplace={async () => {
+            try {
+              await clipboardCtx.confirmReplace(
+                duplicateDialogState.pendingItem,
+                duplicateDialogState.existingItem.id,
+              );
+              setDuplicateDialogState(null);
+              addToast(`Clipboard item "${duplicateDialogState.pendingItem.node.alias}" replaced`, 'success');
+            } catch (err) {
+              addToast(`Replace failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+            }
+          }}
+          onCancel={() => {
+            setDuplicateDialogState(null);
+            addToast('Clip cancelled', 'info');
+          }}
+        />
+      )}
 
       <Group
         className={styles.panelGroup}
@@ -388,7 +521,7 @@ export default function Playground({ config }: PlaygroundProps) {
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
       >
-        <Panel defaultSize="60%" minSize="25%">
+        <Panel defaultSize={clipboardOpen ? "50%" : "60%"} minSize="25%">
           <LeftPanel
             messages={ws.messages}
             classificationMap={classificationMap}
@@ -411,7 +544,7 @@ export default function Playground({ config }: PlaygroundProps) {
           />
         </Panel>
         <Separator className={styles.resizeHandle} aria-label="Resize panels" />
-        <Panel defaultSize="40%" minSize="20%">
+        <Panel defaultSize={clipboardOpen ? "30%" : "40%"} minSize="20%">
           <RightPanel
             tabs={tabs}
             payload={payload}
@@ -428,8 +561,20 @@ export default function Playground({ config }: PlaygroundProps) {
             onGraphDataCopySuccess={() => addToast('Graph JSON copied to clipboard!', 'success')}
             onGraphDataCopyError={() => addToast('Copy failed', 'error')}
             isGraphRefreshing={isRefreshing}
+            onClipNode={supportsClipboard ? handleClipNode : undefined}
           />
         </Panel>
+        {supportsClipboard && clipboardOpen && (
+          <>
+            <Separator className={styles.resizeHandle} aria-label="Resize clipboard" />
+            <Panel defaultSize="20%" minSize="10%" maxSize="40%">
+              <ClipboardSidebar
+                connected={ws.connected}
+                onPaste={handlePasteToInput}
+              />
+            </Panel>
+          </>
+        )}
       </Group>
     </div>
   );

--- a/extensions/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
@@ -5,7 +5,7 @@ import GraphView from '../GraphView/GraphView';
 import GraphDataView from '../GraphDataView/GraphDataView';
 import styles from './RightPanel.module.css';
 import { type ValidationResult } from '../../utils/validators';
-import type { MinigraphGraphData } from '../../utils/graphTypes';
+import type { MinigraphGraphData, MinigraphNode, MinigraphConnection } from '../../utils/graphTypes';
 
 export type RightTab = 'payload' | 'preview' | 'graph' | 'graph-data';
 
@@ -29,6 +29,8 @@ interface RightPanelProps {
   onGraphDataCopyError?:   () => void;
   /** When true, forwards the loading-overlay state to GraphView. */
   isGraphRefreshing?:      boolean;
+  /** Callback for "Clip to Clipboard" from the node context menu in GraphView. */
+  onClipNode?:             (node: MinigraphNode, connections: MinigraphConnection[]) => void;
 }
 
 export default function RightPanel({
@@ -47,6 +49,7 @@ export default function RightPanel({
   onGraphDataCopySuccess,
   onGraphDataCopyError,
   isGraphRefreshing,
+  onClipNode,
 }: RightPanelProps) {
   const uid              = useId();
   const payloadPanelId   = `${uid}-tab-payload`;
@@ -154,6 +157,7 @@ export default function RightPanel({
             isRefreshing={isGraphRefreshing}
             onCopySuccess={onGraphDataCopySuccess}
             onCopyError={onGraphDataCopyError}
+            onClipNode={onClipNode}
           />
         </div>
       )}

--- a/extensions/minigraph-playground-engine/webapp/src/components/SavedGraphsMenu/SavedGraphsMenu.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/components/SavedGraphsMenu/SavedGraphsMenu.tsx
@@ -29,8 +29,8 @@ export default function SavedGraphsMenu({
   connected,
 }: SavedGraphsMenuProps) {
   const label = savedGraphs.length > 0
-    ? `Saved Graphs (${savedGraphs.length})`
-    : 'Saved Graphs';
+    ? `Load Graph (${savedGraphs.length})`
+    : 'Load Graph';
 
   return (
     <NavMenu label={label}>

--- a/extensions/minigraph-playground-engine/webapp/src/config/playgrounds.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/config/playgrounds.ts
@@ -43,6 +43,7 @@ export interface PlaygroundConfig {
   storageKeyTab:         string;     // localStorage key for the last selected right-panel tab
   storageKeySavedGraphs?: string;   // localStorage key for graphs saved from the Graph Data tab (omit to hide the feature)
   supportsUpload?:       boolean;    // true when the backend supports POST /api/json/content/{id} upload
+  supportsClipboard?:    boolean;    // true when clip/paste features are enabled (Minigraph only)
   /**
    * The ordered list of right-panel tabs to show for this playground.
    * The first entry is the default selected tab on first load.
@@ -79,6 +80,7 @@ export const PLAYGROUND_CONFIGS: PlaygroundConfig[] = [
     storageKeyHistory: 'minigraph-command-history',
     storageKeyTab: 'minigraph-right-tab',
     storageKeySavedGraphs: 'minigraph-saved-graphs',
+    supportsClipboard: true,
     // Minigraph works with graph commands and text responses; it has no payload input.
     tabs: ['preview', 'graph', 'graph-data'],
   },

--- a/extensions/minigraph-playground-engine/webapp/src/contexts/ClipboardContext.tsx
+++ b/extensions/minigraph-playground-engine/webapp/src/contexts/ClipboardContext.tsx
@@ -1,0 +1,197 @@
+import { createContext, useCallback, useContext, useEffect, useReducer, useRef, type ReactNode } from 'react';
+import * as db from '../clipboard/db';
+import type { ClipboardItemRecord } from '../clipboard/db';
+import { createClipboardChannel, type ClipboardChannelMessage } from '../clipboard/channel';
+import type { MinigraphNode, MinigraphConnection } from '../utils/graphTypes';
+
+// ── Context State ────────────────────────────────────────────────────────────
+
+interface ClipboardState {
+  items: ClipboardItemRecord[];
+  isLoading: boolean;
+}
+
+type ClipboardAction =
+  | { type: 'HYDRATE';        items: ClipboardItemRecord[] }
+  | { type: 'ITEM_ADDED';     item: ClipboardItemRecord }
+  | { type: 'ITEM_REPLACED';  item: ClipboardItemRecord; previousId: string }
+  | { type: 'ITEM_REMOVED';   id: string }
+  | { type: 'ITEMS_CLEARED' };
+
+function clipboardReducer(state: ClipboardState, action: ClipboardAction): ClipboardState {
+  switch (action.type) {
+    case 'HYDRATE':
+      return { items: action.items, isLoading: false };
+    case 'ITEM_ADDED':
+      return { ...state, items: [action.item, ...state.items] };
+    case 'ITEM_REPLACED': {
+      const filtered = state.items.filter(i => i.id !== action.previousId);
+      return { ...state, items: [action.item, ...filtered] };
+    }
+    case 'ITEM_REMOVED':
+      return { ...state, items: state.items.filter(i => i.id !== action.id) };
+    case 'ITEMS_CLEARED':
+      return { ...state, items: [] };
+    default:
+      return state;
+  }
+}
+
+// ── Public Types ─────────────────────────────────────────────────────────────
+
+export interface ClipMeta {
+  sourceWsPath: string;
+  sourceLabel: string;
+}
+
+export type ClipResult =
+  | { status: 'added' }
+  | { status: 'duplicate'; existingItem: ClipboardItemRecord; pendingItem: ClipboardItemRecord }
+  | { status: 'error'; message: string };
+
+export interface ClipboardContextValue {
+  items: ClipboardItemRecord[];
+  isLoading: boolean;
+  clipNode(
+    node: MinigraphNode,
+    connections: MinigraphConnection[],
+    meta: ClipMeta,
+  ): Promise<ClipResult>;
+  confirmReplace(pendingItem: ClipboardItemRecord, previousId: string): Promise<void>;
+  removeItem(id: string): Promise<void>;
+  clearAll(): Promise<void>;
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+const ClipboardContext = createContext<ClipboardContextValue | null>(null);
+
+export function ClipboardProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(clipboardReducer, { items: [], isLoading: true });
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  // Hydrate from IndexedDB on mount
+  useEffect(() => {
+    db.getAllItems().then(items => dispatch({ type: 'HYDRATE', items }));
+  }, []);
+
+  // BroadcastChannel setup
+  useEffect(() => {
+    let channel: BroadcastChannel;
+    try {
+      channel = createClipboardChannel();
+    } catch {
+      return;
+    }
+    channelRef.current = channel;
+
+    channel.onmessage = (event: MessageEvent<ClipboardChannelMessage>) => {
+      const msg = event.data;
+      switch (msg.type) {
+        case 'item-added':
+          dispatch({ type: 'ITEM_ADDED', item: msg.item });
+          break;
+        case 'item-replaced':
+          dispatch({ type: 'ITEM_REPLACED', item: msg.item, previousId: msg.previousId });
+          break;
+        case 'item-removed':
+          dispatch({ type: 'ITEM_REMOVED', id: msg.id });
+          break;
+        case 'items-cleared':
+          dispatch({ type: 'ITEMS_CLEARED' });
+          break;
+      }
+    };
+
+    return () => { channel.close(); channelRef.current = null; };
+  }, []);
+
+  const broadcast = useCallback((msg: ClipboardChannelMessage) => {
+    channelRef.current?.postMessage(msg);
+  }, []);
+
+  // ── clipNode ──────────────────────────────────────────────────────────────
+  const clipNode = useCallback(async (
+    node: MinigraphNode,
+    connections: MinigraphConnection[],
+    meta: ClipMeta,
+  ): Promise<ClipResult> => {
+    try {
+      const pendingItem: ClipboardItemRecord = {
+        id: crypto.randomUUID(),
+        clippedAt: new Date().toISOString(),
+        sourceWsPath: meta.sourceWsPath,
+        sourceLabel: meta.sourceLabel,
+        node,
+        connections,
+      };
+
+      const existing = await db.findByAlias(node.alias);
+      if (existing) {
+        return { status: 'duplicate', existingItem: existing, pendingItem };
+      }
+
+      try {
+        await db.addItem(pendingItem);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'ConstraintError') {
+          const raceExisting = await db.findByAlias(node.alias);
+          if (raceExisting) {
+            return { status: 'duplicate', existingItem: raceExisting, pendingItem };
+          }
+        }
+        throw err;
+      }
+
+      dispatch({ type: 'ITEM_ADDED', item: pendingItem });
+      broadcast({ type: 'item-added', item: pendingItem });
+      return { status: 'added' };
+    } catch (err) {
+      return { status: 'error', message: err instanceof Error ? err.message : String(err) };
+    }
+  }, [broadcast]);
+
+  // ── confirmReplace ────────────────────────────────────────────────────────
+  const confirmReplace = useCallback(async (
+    pendingItem: ClipboardItemRecord,
+    previousId: string,
+  ): Promise<void> => {
+    await db.replaceItem(previousId, pendingItem);
+    dispatch({ type: 'ITEM_REPLACED', item: pendingItem, previousId });
+    broadcast({ type: 'item-replaced', item: pendingItem, previousId });
+  }, [broadcast]);
+
+  // ── removeItem ────────────────────────────────────────────────────────────
+  const removeItem = useCallback(async (id: string): Promise<void> => {
+    await db.removeItem(id);
+    dispatch({ type: 'ITEM_REMOVED', id });
+    broadcast({ type: 'item-removed', id });
+  }, [broadcast]);
+
+  // ── clearAll ──────────────────────────────────────────────────────────────
+  const clearAll = useCallback(async (): Promise<void> => {
+    await db.clearAll();
+    dispatch({ type: 'ITEMS_CLEARED' });
+    broadcast({ type: 'items-cleared' });
+  }, [broadcast]);
+
+  return (
+    <ClipboardContext.Provider value={{
+      items: state.items,
+      isLoading: state.isLoading,
+      clipNode,
+      confirmReplace,
+      removeItem,
+      clearAll,
+    }}>
+      {children}
+    </ClipboardContext.Provider>
+  );
+}
+
+/** Consumer hook. Must be called inside <ClipboardProvider>. */
+export function useClipboardContext(): ClipboardContextValue {
+  const ctx = useContext(ClipboardContext);
+  if (!ctx) throw new Error('useClipboardContext must be used inside <ClipboardProvider>');
+  return ctx;
+}

--- a/extensions/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -5,11 +5,9 @@ import type { MinigraphGraphData } from './graphTypes';
 /** Data bag attached to every ReactFlow node we create. */
 export interface GraphNodeData extends Record<string, unknown> {
   alias: string;
-  nodeType: string;   // primary type label, e.g. "entry_point"
-  skill?: string;
-  description?: string;
-  question?: string;
-  mapping?: string[];
+  nodeType: string;   // primary type label, e.g. "Root"
+  /** All properties from the MinigraphNode, passed through for rendering. */
+  properties: Record<string, unknown>;
 }
 
 /** Data bag attached to every ReactFlow edge we create. */
@@ -59,10 +57,18 @@ const BASE_NODE_STYLE: CSSProperties = {
 // Accent colours per node type.  Only the accent value differs between types;
 // everything else is shared via BASE_NODE_STYLE.
 const NODE_ACCENT: Record<string, string> = {
-  entry_point: '#a6e3a1',
-  api_fetcher: '#89b4fa',
-  mapper:      '#fab387',
-  terminator:  '#f38ba8',
+  Root:        '#15803d',   // green-700
+  End:         '#dc2626',   // red-600
+  Fetcher:     '#2563eb',   // blue-600
+  mapper:      '#ea580c',   // orange-600
+  Math:        '#a16207',   // yellow-700
+  JavaScript:  '#7e22ce',   // purple-700
+  Provider:    '#be185d',   // pink-700
+  Dictionary:  '#0e7490',   // cyan-700
+  Join:        '#65a30d',   // lime-700
+  Extension:   '#4338ca',   // indigo-700
+  Island:      '#475569',   // slate-600
+  Decision:    '#b45309',   // amber-700
 };
 const UNKNOWN_ACCENT = '#6c7086';
 
@@ -180,10 +186,7 @@ export function transformGraphData(
     data: {
       alias:       n.alias,
       nodeType:    n.types[0] ?? 'unknown',
-      skill:       n.properties.skill,
-      description: n.properties.description,
-      question:    n.properties.question,
-      mapping:     n.properties.mapping,
+      properties:  n.properties,
     },
   }));
 

--- a/extensions/minigraph-playground-engine/webapp/src/utils/timeFormat.ts
+++ b/extensions/minigraph-playground-engine/webapp/src/utils/timeFormat.ts
@@ -1,0 +1,26 @@
+/**
+ * Format an ISO 8601 timestamp as a human-readable relative time string.
+ * Computed at render time — does not auto-update.
+ */
+export function formatRelativeTime(isoString: string): string {
+  const now = Date.now();
+  const then = new Date(isoString).getTime();
+  const diffMs = now - then;
+
+  if (diffMs < 0) return 'just now';
+
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days} days ago`;
+
+  return new Date(isoString).toLocaleDateString();
+}


### PR DESCRIPTION
Introduce a clipboard feature for saving, managing, and restoring graph snapshots across sessions
- Add ClipboardSidebar component with item cards, empty state, and duplicate-name dialog
- Add ClipboardContext for global clipboard state management
- Add src/clipboard/ utilities: IndexedDB persistence (db.ts), cross-tab sync via BroadcastChannel (channel.ts), command builder, and helpers
- Wire clipboard sidebar into Playground layout with toggle button and CSS adjustments
- Update GraphView and NodeTypes to support node-level copy/paste interactions
- Add timeFormat utility for relative timestamp display
- Install required dependencies