### PR TITLE
feat(webapp): graph edge improvements, CSS token refactoring, chip strip label

### DIFF
--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
@@ -68,7 +68,7 @@
 }
 
 .removeBtn:hover {
-  background: rgba(239, 68, 68, 0.08);
+  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
   color: var(--danger-color);
   border-color: var(--danger-color);
 }
@@ -81,6 +81,6 @@
 .pasteBtn:focus-visible,
 .inspectBtn:focus-visible,
 .removeBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
@@ -68,7 +68,7 @@
 }
 
 .removeBtn:hover {
-  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
+  background: var(--danger-08);
   color: var(--danger-color);
   border-color: var(--danger-color);
 }

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
@@ -38,7 +38,7 @@
 }
 
 .clearBtn:hover {
-  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
+  background: var(--danger-08);
 }
 
 /* ── Item list (scrollable) ── */

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.module.css
@@ -38,7 +38,7 @@
 }
 
 .clearBtn:hover {
-  background: rgba(239, 68, 68, 0.08);
+  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
 }
 
 /* ── Item list (scrollable) ── */

--- a/system/minigraph-playground-engine/webapp/src/components/CommandInput/CommandInput.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/CommandInput/CommandInput.module.css
@@ -49,12 +49,18 @@
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
-.paletteToggle:hover,
+.paletteToggle:hover {
+  background: var(--bg-secondary);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
 .paletteToggle:focus-visible {
   background: var(--bg-secondary);
   border-color: var(--primary-color);
   color: var(--primary-color);
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .paletteToggleActive {
@@ -74,10 +80,10 @@
   width: 26rem;
   max-height: 22rem;
   overflow-y: scroll;
-  background: var(--bg-primary, #fff);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-popover);
   padding: 0 0.75rem 0.5rem;
   /* Hidden until hovered or pinned open via click */
   opacity: 0;
@@ -100,12 +106,12 @@
 
 .popover::-webkit-scrollbar-track {
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 .popover::-webkit-scrollbar-thumb {
   background: var(--text-secondary);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 .popover::-webkit-scrollbar-thumb:hover {
@@ -132,20 +138,24 @@
   gap: 0.75rem;
   padding: 0.25rem 0.35rem;
   margin: 0 -0.35rem;
-  border-radius: var(--radius-xs, 3px);
+  border-radius: var(--radius-xs);
   cursor: pointer;
   transition: background 0.1s;
 }
 
-.popoverRow:hover,
+.popoverRow:hover {
+  background: var(--autocomplete-highlight);
+}
+
 .popoverRow:focus-visible {
-  background: var(--hover-bg, rgba(37, 99, 235, 0.07));
-  outline: none;
+  background: var(--autocomplete-highlight);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .popoverKeyword {
   flex: 0 0 9.5rem;
-  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-family: var(--font-mono-code);
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--primary-color);
@@ -163,7 +173,7 @@
 
 .popoverAlias {
   font-weight: bold;
-  font-family: Monospace;
+  font-family: var(--font-mono-code);
   opacity: 1;
 }
 
@@ -201,9 +211,9 @@
 }
 
 .textarea:focus {
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
   border-color: var(--input-focus-border);
-  box-shadow: var(--focus-ring);
 }
 
 .textarea:disabled {
@@ -244,7 +254,7 @@
   left: 0;
   right: 0;
   z-index: 200;
-  background: var(--bg-primary, #fff);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.1);  /* shadow projects upward */
@@ -258,7 +268,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.25rem 0.75rem;
-  background: var(--bg-secondary, #f8fafc);
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   font-size: 0.65rem;
   font-weight: 600;
@@ -275,19 +285,19 @@
   gap: 0.25rem;
   padding: 0.45rem 0.75rem;
   cursor: pointer;
-  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-family: var(--font-mono-code);
   font-size: 0.85rem;
   color: var(--text-primary);
   transition: background 0.1s;
 }
 
 .dropupItem:hover {
-  background-color: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  background-color: var(--hover-bg);
 }
 
 /* Driven by aria-selected so visual and semantic states are always in sync */
 .dropupItem[aria-selected="true"] {
-  background-color: var(--autocomplete-highlight, rgba(37, 99, 235, 0.1));
+  background-color: var(--autocomplete-highlight);
   color: var(--text-primary);  /* ensures readable text in dark-mode themes */
 }
 

--- a/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
@@ -30,7 +30,7 @@
 .controlButton {
     background: transparent;
     border: 1px solid var(--border-color);
-    border-radius: 0.25rem;
+    border-radius: var(--radius-sm);
     padding: 0.125rem 0.25rem;
     cursor: pointer;
     font-size: 1.125rem;
@@ -58,7 +58,7 @@
   flex: 1 1 auto;
   min-height: 150px;
   overflow-y: auto;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.875rem;
   font-weight: bold;
   line-height: 1.5;
@@ -84,7 +84,7 @@
   align-items: start;
   padding: 0.5rem;
   margin-bottom: 0.25rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   transition: background-color 0.15s;
   /* Establish a stacking context so the copy button can be positioned
      relative to this row without escaping the scroll container. */
@@ -113,16 +113,16 @@
 
 /* Large-payload download link — amber accent */
 .consoleMessageLargePayload {
-  background-color: rgba(245, 158, 11, 0.06);
-  outline: 1px solid rgba(245, 158, 11, 0.25);
-  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--warning-color) 6%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--warning-color) 25%, transparent);
+  border-radius: var(--radius-sm);
 }
 
 /* Mock-upload invitation row — amber accent (pairs with ⬇️ large-payload style) */
 .consoleMessageMockUpload {
-  background-color: rgba(245, 158, 11, 0.06);
-  outline: 1px solid rgba(245, 158, 11, 0.25);
-  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--warning-color) 6%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--warning-color) 25%, transparent);
+  border-radius: var(--radius-sm);
 }
 
 /* ── Upload-mock re-open button ───────────────────────────────────── */
@@ -135,11 +135,11 @@
   line-height: 1;
   align-self: start;
   font-weight: 600;
-  background-color: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  border-radius: 0.25rem;
+  background-color: color-mix(in srgb, var(--warning-color) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning-color) 30%, transparent);
+  border-radius: var(--radius-sm);
   padding: 0.2rem 0.4rem;
-  color: rgba(245, 158, 11, 0.85);
+  color: color-mix(in srgb, var(--warning-color) 85%, transparent);
   opacity: 0;
   transition: opacity 0.15s, background-color 0.15s, border-color 0.15s, color 0.15s;
   white-space: nowrap;
@@ -151,14 +151,14 @@
 }
 
 .uploadMockButton:hover {
-  background-color: rgba(245, 158, 11, 0.2);
-  border-color: rgba(245, 158, 11, 0.6);
-  color: #fcd34d;
+  background-color: color-mix(in srgb, var(--warning-color) 20%, transparent);
+  border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
+  color: var(--warning-color);
 }
 
 .uploadMockButton:focus-visible {
   opacity: 1;
-  outline: 2px solid rgba(245, 158, 11, 0.8);
+  outline: 2px solid color-mix(in srgb, var(--warning-color) 80%, transparent);
   outline-offset: 2px;
 }
 
@@ -191,7 +191,7 @@
    */
   background-color: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   padding: 0.2rem 0.4rem;
   color: rgba(255, 255, 255, 0.75);
 
@@ -224,7 +224,7 @@
  * in-row reinforcement only. */
 .copyButtonCopied {
   opacity: 1;
-  color: #86efac;
+  color: var(--code-text);
   border-color: rgba(134, 239, 172, 0.5);
 }
 
@@ -240,7 +240,7 @@
   font-weight: bold;
   background-color: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   padding: 0.2rem 0.4rem;
   color: rgba(255, 255, 255, 0.75);
   opacity: 0;
@@ -256,12 +256,12 @@
 .sendToJsonPathButton:hover {
   background-color: rgba(34, 197, 94, 0.2);
   border-color: rgba(34, 197, 94, 0.6);
-  color: #86efac;
+  color: var(--code-text);
 }
 
 .sendToJsonPathButton:focus-visible {
   opacity: 1;
-  outline: 2px solid #22c55e;
+  outline: 2px solid var(--success-color);
   outline-offset: 2px;
 }
 
@@ -287,20 +287,20 @@
 }
 
 /* ── Message type colour overrides ─────────────────────────────── */
-.messageType-error .messageContent   { color: #fca5a5; }
-.messageType-info .messageContent    { color: #93c5fd; }
-.messageType-welcome .messageContent { color: #86efac; }
+.messageType-error .messageContent   { color: var(--json-error); }
+.messageType-info .messageContent    { color: var(--json-key); }
+.messageType-welcome .messageContent { color: var(--code-text); }
 
 /* ── JSON tree viewer ───────────────────────────────────────────── */
 .jsonViewWrapper {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.875rem;
   margin: 0.25rem 0;
 }
 
 .jsonContainer { background: transparent !important; padding: 0 !important; }
-.jsonLabel     { color: #93c5fd !important; }
-.jsonString    { color: #86efac !important; }
-.jsonNumber    { color: #fbbf24 !important; }
-.jsonBoolean   { color: #c084fc !important; }
-.jsonNull      { color: #94a3b8 !important; }
+.jsonLabel     { color: var(--json-key)    !important; }
+.jsonString    { color: var(--json-string) !important; }
+.jsonNumber    { color: var(--json-number) !important; }
+.jsonBoolean   { color: var(--json-bool)   !important; }
+.jsonNull      { color: var(--json-null)   !important; }

--- a/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
@@ -113,15 +113,15 @@
 
 /* Large-payload download link — amber accent */
 .consoleMessageLargePayload {
-  background-color: color-mix(in srgb, var(--warning-color) 6%, transparent);
-  outline: 1px solid color-mix(in srgb, var(--warning-color) 25%, transparent);
+  background-color: var(--warning-06);
+  outline: 1px solid var(--warning-25);
   border-radius: var(--radius-sm);
 }
 
 /* Mock-upload invitation row — amber accent (pairs with ⬇️ large-payload style) */
 .consoleMessageMockUpload {
-  background-color: color-mix(in srgb, var(--warning-color) 6%, transparent);
-  outline: 1px solid color-mix(in srgb, var(--warning-color) 25%, transparent);
+  background-color: var(--warning-06);
+  outline: 1px solid var(--warning-25);
   border-radius: var(--radius-sm);
 }
 
@@ -135,11 +135,11 @@
   line-height: 1;
   align-self: start;
   font-weight: 600;
-  background-color: color-mix(in srgb, var(--warning-color) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning-color) 30%, transparent);
+  background-color: var(--warning-10);
+  border: 1px solid var(--warning-30);
   border-radius: var(--radius-sm);
   padding: 0.2rem 0.4rem;
-  color: color-mix(in srgb, var(--warning-color) 85%, transparent);
+  color: var(--warning-85);
   opacity: 0;
   transition: opacity 0.15s, background-color 0.15s, border-color 0.15s, color 0.15s;
   white-space: nowrap;
@@ -151,14 +151,14 @@
 }
 
 .uploadMockButton:hover {
-  background-color: color-mix(in srgb, var(--warning-color) 20%, transparent);
-  border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
+  background-color: var(--warning-20);
+  border-color: var(--warning-60);
   color: var(--warning-color);
 }
 
 .uploadMockButton:focus-visible {
   opacity: 1;
-  outline: 2px solid color-mix(in srgb, var(--warning-color) 80%, transparent);
+  outline: 2px solid var(--warning-80);
   outline-offset: 2px;
 }
 
@@ -287,7 +287,7 @@
 }
 
 /* ── Message type colour overrides ─────────────────────────────── */
-.messageType-error .messageContent   { color: var(--json-error); }
+.messageType-error .messageContent   { color: var(--error-text); }
 .messageType-info .messageContent    { color: var(--json-key); }
 .messageType-welcome .messageContent { color: var(--code-text); }
 

--- a/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Console/Console.module.css
@@ -299,8 +299,8 @@
 }
 
 .jsonContainer { background: transparent !important; padding: 0 !important; }
-.jsonLabel     { color: var(--json-key)    !important; }
-.jsonString    { color: var(--json-string) !important; }
-.jsonNumber    { color: var(--json-number) !important; }
-.jsonBoolean   { color: var(--json-bool)   !important; }
-.jsonNull      { color: var(--json-null)   !important; }
+.jsonLabel     { color: var(--json-key);    }
+.jsonString    { color: var(--json-string); }
+.jsonNumber    { color: var(--json-number); }
+.jsonBoolean   { color: var(--json-bool);   }
+.jsonNull      { color: var(--json-null);   }

--- a/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.module.css
@@ -25,32 +25,9 @@
   opacity: 0.4;
 }
 
-/* ── Toolbar button — shared style referenced by extraActions in GraphToolbar ── */
+/* ── Toolbar button — composes from the canonical definition in GraphToolbar ── */
 .toolbarButton {
-  background: transparent;
-  border: 1px solid var(--border-color);
-  border-radius: 0.25rem;
-  padding: 0.125rem 0.25rem;
-  cursor: pointer;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  transition: all 0.2s;
-  box-sizing: border-box;
-}
-
-.toolbarButton:hover {
-  background: var(--grey-10);
-  border-color: var(--primary-color);
-  color: var(--primary-color);
-}
-
-.toolbarButton:focus-visible {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
-}
-
-.toolbarButton:active {
-  box-shadow: inset 0 0 0 2px var(--grey-30);
+  composes: toolbarButton from '../GraphToolbar/GraphToolbar.module.css';
 }
 
 /* ── Scrollable JSON body ── */
@@ -59,15 +36,15 @@
   min-height: 0;
   overflow-y: auto;
   padding: 0.75rem 1rem;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.875rem;
   background: var(--console-bg);
 }
 
 /* ── JSON tree colour overrides — mirrors Console.module.css ── */
 .jsonContainer { background: transparent !important; padding: 0 !important; }
-.jsonLabel     { color: #93c5fd !important; }
-.jsonString    { color: #86efac !important; }
-.jsonNumber    { color: #fbbf24 !important; }
-.jsonBoolean   { color: #c084fc !important; }
-.jsonNull      { color: #94a3b8 !important; }
+.jsonLabel     { color: var(--json-key)    !important; }
+.jsonString    { color: var(--json-string) !important; }
+.jsonNumber    { color: var(--json-number) !important; }
+.jsonBoolean   { color: var(--json-bool)   !important; }
+.jsonNull      { color: var(--json-null)   !important; }

--- a/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.module.css
@@ -43,8 +43,8 @@
 
 /* ── JSON tree colour overrides — mirrors Console.module.css ── */
 .jsonContainer { background: transparent !important; padding: 0 !important; }
-.jsonLabel     { color: var(--json-key)    !important; }
-.jsonString    { color: var(--json-string) !important; }
-.jsonNumber    { color: var(--json-number) !important; }
-.jsonBoolean   { color: var(--json-bool)   !important; }
-.jsonNull      { color: var(--json-null)   !important; }
+.jsonLabel     { color: var(--json-key);    }
+.jsonString    { color: var(--json-string); }
+.jsonNumber    { color: var(--json-number); }
+.jsonBoolean   { color: var(--json-bool);   }
+.jsonNull      { color: var(--json-null);   }

--- a/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.module.css
@@ -12,7 +12,7 @@
 .label {
   font-size: 0.75rem;
   color: var(--text-secondary);
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
 }
 
 .toolbarActions {
@@ -24,7 +24,7 @@
 .toolbarButton {
   background: transparent;
   border: 1px solid var(--border-color);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   padding: 0.125rem 0.25rem;
   cursor: pointer;
   font-size: 0.75rem;

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
@@ -98,9 +98,9 @@
 /* ── Node context menu ──────────────────────────────────────────────────── */
 
 .contextMenu {
-  background: var(--bg-primary, #fff);
-  border: 1px solid var(--border-color, #e2e8f0);
-  border-radius: var(--radius-sm, 0.25rem);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
   box-shadow: var(--shadow-md);
   z-index: 50;
   min-width: 160px;
@@ -121,10 +121,10 @@
 }
 
 .contextMenuItem:hover {
-  background: var(--autocomplete-highlight, rgba(37, 99, 235, 0.1));
+  background: var(--autocomplete-highlight);
 }
 
 .contextMenuItem:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
 }

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.module.css
@@ -55,7 +55,7 @@
   font-size: 0.65rem;
   font-weight: 500;
   padding: 0.1rem 0.35rem;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   opacity: 0.85;
   background: color-mix(in srgb, var(--node-accent, #6c7086) 20%, transparent);

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.module.css
@@ -93,3 +93,18 @@
   flex: 1;
   min-width: 0;
 }
+
+/* ── Edge handle positioning ───────────────────────────────────────────────── */
+/*
+ * Hidden anchors rendered at computed vertical offsets so multiple edges
+ * from/to the same node land at different y-positions (spread).
+ * The `top` value is the only dynamic property and is set via `style` prop.
+ */
+.edgeHandle {
+  width: 8px;
+  height: 8px;
+  border: 0;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
@@ -77,10 +77,20 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
   return (
     <>
       {/* Resize handles — visible only when the node is selected */}
-      <NodeResizer minWidth={180} minHeight={60} isVisible={selected} />
+      <NodeResizer minWidth={180} minHeight={data.minHeight} isVisible={selected} />
 
-      {/* Target handle (left) */}
-      <Handle type="target" position={Position.Left} isConnectable={isConnectable} />
+      {/* Target handles (left) — multiple hidden anchors let edges land a few pixels apart. */}
+      {data.targetHandles.map(({ id, offset }) => (
+        <Handle
+          key={id}
+          id={id}
+          type="target"
+          position={Position.Left}
+          isConnectable={isConnectable}
+          className={styles.edgeHandle}
+          style={{ top: `calc(50% + ${offset}px)` }}
+        />
+      ))}
 
       {/*
         * Content container — fills the React Flow wrapper (which carries the
@@ -99,8 +109,18 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
         </div>
       </div>
 
-      {/* Source handle (right) */}
-      <Handle type="source" position={Position.Right} isConnectable={isConnectable} />
+      {/* Source handles (right) — paired with target handles for best-effort edge spreading. */}
+      {data.sourceHandles.map(({ id, offset }) => (
+        <Handle
+          key={id}
+          id={id}
+          type="source"
+          position={Position.Right}
+          isConnectable={isConnectable}
+          className={styles.edgeHandle}
+          style={{ top: `calc(50% + ${offset}px)` }}
+        />
+      ))}
     </>
   );
 }

--- a/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.module.css
@@ -138,7 +138,7 @@
 }
 
 .emptyFallback code {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-weight: bold;
   color: var(--primary-color);
 }
@@ -182,8 +182,8 @@
 
 .helpContent code {
   padding: 0.15em 0.35em;
-  border-radius: 0.25rem;
-  font-family: 'Courier New', Courier, monospace;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono-terminal);
   font-size: 1em;
   font-weight: bolder;
   color: var(--primary-color);

--- a/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.module.css
@@ -276,6 +276,7 @@
 .chipStrip {
   flex: 0 0 auto;
   display: flex;
+  align-items: center;
   gap: 0.375rem;
   padding: 0.375rem 0.75rem;
   overflow-x: auto;
@@ -285,6 +286,25 @@
 
 .chipStrip::-webkit-scrollbar {
   display: none;
+}
+
+/* ── Chip strip prefix label (e.g. 'Chapters') ───────────────────── */
+/* Non-interactive, visually muted; separated from the chips by a     */
+/* right border so the chips read as a discrete group.                */
+.chipStripLabel {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  padding-right: 0.5rem;
+  margin-right: 0.125rem;
+  border-right: 1px solid var(--border-color);
+  white-space: nowrap;
+  user-select: none;
 }
 
 .topicChip {

--- a/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/HelpBrowser/HelpBrowser.tsx
@@ -5,6 +5,7 @@ import {
   getHelpContent,
   resolveCategory,
   getCategoryPages,
+  getChipLabel,
   ORDERED_HELP_PAGES,
   HELP_CATEGORIES,
   type HelpCategory,
@@ -84,6 +85,12 @@ export default function HelpBrowser({ activeTopic, onNavigate, onClose, onToggle
   const activeCategory: HelpCategory = resolveCategory(activeTopic);
   const categoryPages = useMemo(() => getCategoryPages(activeCategory), [activeCategory]);
   const categoryTotal = categoryPages.length;
+
+  // Label rendered inside the chip strip before the topic chips (e.g. "Chapters").
+  const chipStripLabel = useMemo(
+    () => HELP_CATEGORIES.find(cat => cat.id === activeCategory)?.chipStripLabel ?? null,
+    [activeCategory]
+  );
 
   // Index within the GLOBAL page list (for cross-category scroll wrapping).
   const globalIndex = ORDERED_HELP_PAGES.indexOf(activeTopic);
@@ -173,9 +180,12 @@ export default function HelpBrowser({ activeTopic, onNavigate, onClose, onToggle
       {/* ── Scoped topic chips ──────────────────────────────────────── */}
       {categoryTotal > 1 && (
         <div className={styles.chipStrip} ref={chipStripRef}>
+          {chipStripLabel !== null && (
+            <span className={styles.chipStripLabel}>{chipStripLabel}</span>
+          )}
           {categoryPages.map(topic => {
             const isActive = topic === activeTopic;
-            const label    = topic === '' ? 'Overview' : topic;
+            const label    = getChipLabel(topic, activeCategory);
             return (
               <button
                 key={topic}

--- a/system/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
@@ -55,7 +55,7 @@
 }
 
 .modalPath {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.8rem;
   color: var(--text-secondary);
   word-break: break-all;
@@ -125,8 +125,8 @@
 
 /* Active drag-over state — amber to match the modal's accent colour */
 .dropZoneActive {
-  border-color: rgba(245, 158, 11, 0.8);
-  background: rgba(245, 158, 11, 0.06);
+  border-color: color-mix(in srgb, var(--warning-color) 80%, transparent);
+  background: color-mix(in srgb, var(--warning-color) 6%, transparent);
   color: var(--text-primary);
 }
 
@@ -142,10 +142,10 @@
 }
 
 .dropZoneText code {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.825rem;
   background: rgba(255, 255, 255, 0.08);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   padding: 0 3px;
 }
 
@@ -169,8 +169,8 @@
 }
 
 .browseButton:hover:not(:disabled) {
-  background: rgba(245, 158, 11, 0.08);
-  border-color: rgba(245, 158, 11, 0.6);
+  background: color-mix(in srgb, var(--warning-color) 8%, transparent);
+  border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
   color: var(--text-primary);
 }
 
@@ -209,7 +209,7 @@
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 0.6rem 0.75rem;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   font-size: 0.875rem;
   resize: vertical;
   min-height: 180px;
@@ -218,9 +218,9 @@
 }
 
 .textarea:focus {
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
   border-color: var(--primary-color);
-  box-shadow: var(--focus-ring);
 }
 
 .validationError {
@@ -235,8 +235,8 @@
 
 .errorBanner {
   color: var(--danger-color);
-  background: rgba(239, 68, 68, 0.08);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger-color) 30%, transparent);
   border-radius: var(--radius-sm);
   padding: 0.5rem 0.75rem;
   font-size: 0.85rem;
@@ -317,15 +317,15 @@
 
 /* ── Upload button — primary amber accent ────────────────────────────────── */
 .uploadButton {
-  background: rgba(245, 158, 11, 0.85);
-  border: 1px solid rgba(245, 158, 11, 0.9);
+  background: color-mix(in srgb, var(--warning-color) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning-color) 90%, transparent);
   color: #1c1917;
   font-weight: 600;
 }
 
 .uploadButton:hover:not(:disabled) {
-  background: rgba(245, 158, 11, 1);
-  border-color: #d97706;
+  background: var(--warning-color);
+  border-color: #d97706;  /* intentional darker border accent — one step below --warning-color */
 }
 
 /* ── Spinner ──────────────────────────────────────────────────────────────── */

--- a/system/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/MockUploadModal/MockUploadModal.module.css
@@ -125,8 +125,8 @@
 
 /* Active drag-over state — amber to match the modal's accent colour */
 .dropZoneActive {
-  border-color: color-mix(in srgb, var(--warning-color) 80%, transparent);
-  background: color-mix(in srgb, var(--warning-color) 6%, transparent);
+  border-color: var(--warning-80);
+  background: var(--warning-06);
   color: var(--text-primary);
 }
 
@@ -169,8 +169,8 @@
 }
 
 .browseButton:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--warning-color) 8%, transparent);
-  border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
+  background: var(--warning-08);
+  border-color: var(--warning-60);
   color: var(--text-primary);
 }
 
@@ -235,8 +235,8 @@
 
 .errorBanner {
   color: var(--danger-color);
-  background: color-mix(in srgb, var(--danger-color) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger-color) 30%, transparent);
+  background: var(--danger-08);
+  border: 1px solid var(--danger-30);
   border-radius: var(--radius-sm);
   padding: 0.5rem 0.75rem;
   font-size: 0.85rem;
@@ -317,8 +317,8 @@
 
 /* ── Upload button — primary amber accent ────────────────────────────────── */
 .uploadButton {
-  background: color-mix(in srgb, var(--warning-color) 85%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning-color) 90%, transparent);
+  background: var(--warning-85);
+  border: 1px solid var(--warning-90);
   color: #1c1917;
   font-weight: 600;
 }

--- a/system/minigraph-playground-engine/webapp/src/components/NavMenu/NavMenu.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/NavMenu/NavMenu.module.css
@@ -28,8 +28,8 @@
 }
 
 .trigger:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 /* ── Chevron ── */

--- a/system/minigraph-playground-engine/webapp/src/components/Navigation.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Navigation.module.css
@@ -30,11 +30,16 @@
   white-space: nowrap;
 }
 
-.menuItem:hover,
+.menuItem:hover {
+  background: var(--primary-color);
+  color: white;
+}
+
 .menuItem:focus-visible {
   background: var(--primary-color);
   color: white;
-  outline: none;
+  outline: 2px solid var(--bg-primary);
+  outline-offset: -2px;
 }
 
 /* ── Tool row (combined nav + connect) ── */
@@ -74,10 +79,14 @@
   min-width: 0;
 }
 
-.toolLink:hover,
+.toolLink:hover {
+  background: var(--bg-secondary);
+}
+
 .toolLink:focus-visible {
   background: var(--bg-secondary);
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .toolLinkActive {

--- a/system/minigraph-playground-engine/webapp/src/components/PayloadEditor/PayloadEditor.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/PayloadEditor/PayloadEditor.module.css
@@ -32,7 +32,7 @@
 .charCounter {
   font-size: 0.875rem;
   color: var(--text-secondary);
-  font-family: monospace;
+  font-family: var(--font-mono-terminal);
 }
 
 .typeIndicator {
@@ -94,9 +94,9 @@
 }
 
 .textarea:focus {
-  outline: none;
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
   border-color: var(--input-focus-border);
-  box-shadow: var(--focus-ring);
 }
 
 .textarea:disabled {

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
@@ -114,7 +114,7 @@
   top: calc(100% + 8px);
   right: 0;
   background: var(--bg-dark);
-  color: #e2e8f0;
+  color: var(--console-text);
   font-size: 0.8rem;
   font-weight: 500;
   padding: 0.4rem 0.65rem;
@@ -143,7 +143,7 @@
 
 .helpHintKbd {
   background: rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   padding: 0.1rem 0.3rem;
   font-family: inherit;
   font-size: 0.75rem;
@@ -159,10 +159,10 @@
 }
 
 .resizeHandle:hover {
-  background: rgba(37, 99, 235, 0.2);
+  background: color-mix(in srgb, var(--primary-color) 20%, transparent);
 }
 
 .resizeHandle[data-separator="active"] {
-  background: rgba(37, 99, 235, 0.4);
+  background: color-mix(in srgb, var(--primary-color) 40%, transparent);
 }
 

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
@@ -159,10 +159,10 @@
 }
 
 .resizeHandle:hover {
-  background: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  background: var(--primary-20);
 }
 
 .resizeHandle[data-separator="active"] {
-  background: color-mix(in srgb, var(--primary-color) 40%, transparent);
+  background: var(--primary-40);
 }
 

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
@@ -76,9 +76,9 @@
 }
 
 .verticalResizeHandle:hover {
-  background: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  background: var(--primary-20);
 }
 
 .verticalResizeHandle[data-separator="active"] {
-  background: color-mix(in srgb, var(--primary-color) 40%, transparent);
+  background: var(--primary-40);
 }

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
@@ -76,9 +76,9 @@
 }
 
 .verticalResizeHandle:hover {
-  background: rgba(37, 99, 235, 0.2);
+  background: color-mix(in srgb, var(--primary-color) 20%, transparent);
 }
 
 .verticalResizeHandle[data-separator="active"] {
-  background: rgba(37, 99, 235, 0.4);
+  background: color-mix(in srgb, var(--primary-color) 40%, transparent);
 }

--- a/system/minigraph-playground-engine/webapp/src/components/SavedGraphsMenu/SavedGraphsMenu.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/SavedGraphsMenu/SavedGraphsMenu.module.css
@@ -12,7 +12,7 @@
 .hint {
   padding: 0.35rem 1rem 0.5rem;
   font-size: 0.7rem;
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning-color);
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -67,7 +67,7 @@
 .rowMeta {
   font-size: 0.68rem;
   color: var(--text-secondary);
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -85,7 +85,7 @@
 .deleteBtn {
   background: transparent;
   border: 1px solid var(--border-color);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   padding: 0.2rem 0.45rem;
   cursor: pointer;
   font-size: 0.72rem;
@@ -105,8 +105,8 @@
 }
 
 .deleteBtn:hover {
-  border-color: var(--error-color, #f87171);
-  color: var(--error-color, #f87171);
+  border-color: var(--error-color);
+  color: var(--error-color);
 }
 
 .loadBtn:focus-visible,

--- a/system/minigraph-playground-engine/webapp/src/components/Toast.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Toast.module.css
@@ -14,9 +14,9 @@
   align-items: center;
   gap: 0.75rem;
   padding: 1rem;
-  background: white;
+  background: var(--bg-primary);
   border-radius: var(--radius);
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+  box-shadow: var(--shadow-lg);
   cursor: pointer;
   animation: slideIn 0.3s ease;
   border-left: 4px solid;

--- a/system/minigraph-playground-engine/webapp/src/data/helpContent.ts
+++ b/system/minigraph-playground-engine/webapp/src/data/helpContent.ts
@@ -67,10 +67,14 @@ export type HelpCategory = 'overview' | 'graph-model' | 'graph-skills' | 'instan
 
 /**
  * Display metadata for each category.
+ *
+ * `chipStripLabel` — if present, a non-interactive prefix label rendered
+ * inside the chip strip before the topic chips (e.g. "Chapters" for tutorials).
  */
 export interface HelpCategoryInfo {
-  id:    HelpCategory;
-  label: string;
+  id:             HelpCategory;
+  label:          string;
+  chipStripLabel?: string;
 }
 
 /**
@@ -83,7 +87,7 @@ export const HELP_CATEGORIES: ReadonlyArray<HelpCategoryInfo> = [
   { id: 'graph-model',    label: 'Graph Model' },
   { id: 'graph-skills',   label: 'Graph Skills' },
   { id: 'instance-model', label: 'Instance Model' },
-  { id: 'tutorials',      label: 'Tutorials' },
+  { id: 'tutorials',      label: 'Tutorials', chipStripLabel: 'Chapters' },
 ];
 
 /**
@@ -116,11 +120,30 @@ export function resolveCategory(key: string): HelpCategory {
 /**
  * Returns the ordered page sequence for a given category.
  * For 'overview', returns [''] (the single root page).
+ * For 'tutorials', returns topic keys in numeric order (1, 2 … 11).
  * For other categories, returns the alphabetically sorted topic keys.
  */
 export function getCategoryPages(categoryId: HelpCategory): ReadonlyArray<string> {
   if (categoryId === 'overview') return [''];
-  return HELP_TOPIC_KEYS.filter(key => resolveCategory(key) === categoryId);
+  const pages = HELP_TOPIC_KEYS.filter(key => resolveCategory(key) === categoryId);
+  if (categoryId === 'tutorials') {
+    return [...pages].sort((a, b) => {
+      const numA = parseInt(a.replace(/^tutorial\s+/, ''), 10);
+      const numB = parseInt(b.replace(/^tutorial\s+/, ''), 10);
+      return numA - numB;
+    });
+  }
+  return pages;
+}
+
+/**
+ * Returns the display label for a chip in the chip strip.
+ *
+ */
+export function getChipLabel(topic: string, category: HelpCategory): string {
+  if (topic === '') return 'Overview';
+  if (category === 'tutorials') return topic.replace(/^tutorial\s+/, '');
+  return topic;
 }
 
 /**

--- a/system/minigraph-playground-engine/webapp/src/index.css
+++ b/system/minigraph-playground-engine/webapp/src/index.css
@@ -1,33 +1,71 @@
 :root {
+  /* ── Semantic colours ── */
   --primary-color: #2563eb;
   --primary-hover: #1d4ed8;
   --success-color: #10b981;
   --warning-color: #f59e0b;
-  --danger-color: #ef4444;
-  --bg-primary: #ffffff;
+  --danger-color:  #ef4444;
+  --error-color:   #f87171;   /* red-400 — lighter than --danger-color; for reviewable delete actions */
+
+  /* ── Surfaces ── */
+  --bg-primary:   #ffffff;
   --bg-secondary: #f8fafc;
-  --bg-dark: #1e293b;
+  --bg-dark:      #1e293b;
+
+  /* ── Neutral overlays ── */
   --grey-50: rgba(0, 0, 0, 0.5);
   --grey-40: rgba(0, 0, 0, 0.4);
   --grey-30: rgba(0, 0, 0, 0.3);
   --grey-20: rgba(0, 0, 0, 0.2);
   --grey-10: rgba(0, 0, 0, 0.1);
-  --border-color: #e2e8f0;
-  --text-primary: #0f172a;
+
+  /* ── Text ── */
+  --text-primary:   #0f172a;
   --text-secondary: #64748b;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-  --radius: 0.5rem;
-  /* ── New tokens ── */
-  --focus-ring:         0 0 0 0.2rem rgba(37, 99, 235, 0.25);
-  --radius-sm:          0.25rem;
-  --text-muted:         #94a3b8;
-  --console-bg:         var(--bg-dark);
-  --console-text:       #e2e8f0;
-  --code-text:          #86efac;   /* green-300 — inline code highlight colour */
-  --disabled-bg:        #e9ecef;
+  --text-muted:     #94a3b8;
+
+  /* ── Borders ── */
+  --border-color: #e2e8f0;
+
+  /* ── Corner radii ── */
+  --radius:    0.5rem;    /* cards, dialogs */
+  --radius-sm: 0.25rem;  /* controls, inputs */
+  --radius-xs: 3px;      /* command palette rows, inline code badges, scrollbar thumb/track */
+
+  /* ── Shadows ── */
+  --shadow-sm:      0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md:      0 4px 6px -1px rgb(0 0 0 / 0.1);
+  --shadow-lg:      0 10px 15px -3px rgb(0 0 0 / 0.1);      /* elevated floating elements (Toast) */
+  --shadow-popover: 0 6px 18px rgba(0, 0, 0, 0.12);          /* command palette popover */
+
+  /* ── Hover backgrounds ── */
+  --hover-bg: rgba(0, 0, 0, 0.04);    /* neutral dropdown row hover */
+
+  /* ── Typography — stacks ── */
+  --font-mono-terminal: 'Courier New', Courier, monospace;
+  --font-mono-code:     ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+
+  /* ── Form / input ── */
   --input-focus-border: var(--primary-color);
+  --disabled-bg:        #e9ecef;
+
+  /* ── Focus ── */
+  /* --focus-ring was removed after Phase 3. Use outline: 2px solid var(--primary-color) */
+
+  /* ── Autocomplete / selection ── */
   --autocomplete-highlight: rgba(37, 99, 235, 0.1);  /* blue-600 at 10% — matches --primary-color */
+
+  /* ── Console / code surfaces ── */
+  --console-bg:   var(--bg-dark);
+  --console-text: #e2e8f0;
+  --code-text:    #86efac;   /* green-300 — success/confirmation text on dark surfaces */
+
+  /* ── JSON syntax (dark background) ── */
+  --json-key:    #93c5fd;   /* blue-300  — object keys */
+  --json-string: #86efac;   /* green-300 — string values */
+  --json-number: #fbbf24;   /* amber-300 — number values */
+  --json-bool:   #c084fc;   /* purple-400 — boolean values */
+  --json-null:   #94a3b8;   /* slate-400  — null values */
 }
 
 @media (prefers-color-scheme: dark) {
@@ -54,14 +92,14 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f8f9fa;
-  color: #212529;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
   line-height: 1.6;
 }
 
 code,
 pre {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono-terminal);
 }
 
 *:focus-visible {

--- a/system/minigraph-playground-engine/webapp/src/index.css
+++ b/system/minigraph-playground-engine/webapp/src/index.css
@@ -19,6 +19,26 @@
   --grey-20: rgba(0, 0, 0, 0.2);
   --grey-10: rgba(0, 0, 0, 0.1);
 
+  /* ── Warning overlays ── */
+  --warning-06: color-mix(in srgb, var(--warning-color)  6%, transparent);
+  --warning-08: color-mix(in srgb, var(--warning-color)  8%, transparent);
+  --warning-10: color-mix(in srgb, var(--warning-color) 10%, transparent);
+  --warning-20: color-mix(in srgb, var(--warning-color) 20%, transparent);
+  --warning-25: color-mix(in srgb, var(--warning-color) 25%, transparent);
+  --warning-30: color-mix(in srgb, var(--warning-color) 30%, transparent);
+  --warning-60: color-mix(in srgb, var(--warning-color) 60%, transparent);
+  --warning-80: color-mix(in srgb, var(--warning-color) 80%, transparent);
+  --warning-85: color-mix(in srgb, var(--warning-color) 85%, transparent);
+  --warning-90: color-mix(in srgb, var(--warning-color) 90%, transparent);
+
+  /* ── Danger overlays ── */
+  --danger-08: color-mix(in srgb, var(--danger-color)  8%, transparent);
+  --danger-30: color-mix(in srgb, var(--danger-color) 30%, transparent);
+
+  /* ── Primary overlays ── */
+  --primary-20: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  --primary-40: color-mix(in srgb, var(--primary-color) 40%, transparent);
+
   /* ── Text ── */
   --text-primary:   #0f172a;
   --text-secondary: #64748b;
@@ -59,6 +79,7 @@
   --console-bg:   var(--bg-dark);
   --console-text: #e2e8f0;
   --code-text:    #86efac;   /* green-300 — success/confirmation text on dark surfaces */
+  --error-text:   #fca5a5;   /* red-300  — error message text on dark surfaces */
 
   /* ── JSON syntax (dark background) ── */
   --json-key:    #93c5fd;   /* blue-300  — object keys */

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -1,4 +1,4 @@
-import type { Node, Edge } from '@xyflow/react';
+import { MarkerType, type Node, type Edge } from '@xyflow/react';
 import type { CSSProperties } from 'react';
 import type { MinigraphGraphData } from './graphTypes';
 
@@ -8,6 +8,14 @@ export interface GraphNodeData extends Record<string, unknown> {
   nodeType: string;   // primary type label, e.g. "Root"
   /** All properties from the MinigraphNode, passed through for rendering. */
   properties: Record<string, unknown>;
+  sourceHandles: GraphHandleData[];
+  targetHandles: GraphHandleData[];
+  minHeight: number;
+}
+
+export interface GraphHandleData {
+  id: string;
+  offset: number;
 }
 
 /** Data bag attached to every ReactFlow edge we create. */
@@ -72,6 +80,93 @@ const NODE_ACCENT: Record<string, string> = {
 };
 const UNKNOWN_ACCENT = '#6c7086';
 
+// ─── Edge styling constants ──────────────────────────────────────────────────
+// EDGE_STROKE: --text-muted (rgb 148 163 184) at 42% opacity — slate-400 tinted stroke
+// EDGE_LABEL_BG: references the --bg-secondary token directly so label badges
+//   automatically track any future token-level surface change.
+const EDGE_STROKE         = 'rgba(148, 163, 184, 0.42)';   // --text-muted at 42%
+const EDGE_LABEL_BG       = 'var(--bg-secondary)';          // token: --bg-secondary = #f8fafc
+const EDGE_HANDLE_GAP     = 24;   // px between adjacent handle anchors on the same side
+const EDGE_HANDLE_PADDING = 32;   // min px from node top/bottom to first/last handle
+
+// Semantic edge-type colors — intentional per-relation accent palette.
+// Matches the same amber/green/purple axis used by NODE_ACCENT above.
+const EDGE_FALLBACK_COLORS = [
+  '#0369a1',   // sky-700
+  '#15803d',   // green-700
+  '#b45309',   // amber-700
+  '#7e22ce',   // purple-700
+  '#b91c1c',   // red-700
+  '#0f766e',   // teal-700
+  '#c2410c',   // orange-700
+  '#a16207',   // yellow-700
+];
+
+// Named relation-type → accent color map.
+const EDGE_COLOR_BY_RELATION: Record<string, string> = {
+  fetch:        '#0369a1',   // sky-700
+  details:      '#0369a1',
+  'ext-call':   '#0369a1',
+  mapping:      '#b45309',   // amber-700
+  compute:      '#b45309',
+  calculate:    '#b45309',
+  evaluate:     '#b45309',
+  fork:         '#7e22ce',   // purple-700
+  join:         '#7e22ce',
+  one:          '#7e22ce',
+  two:          '#6d28d9',   // purple-800
+  three:        '#5b21b6',   // violet-800
+  more:         '#4c1d95',   // violet-900
+  done:         '#15803d',   // green-700
+  complete:     '#15803d',
+  finish:       '#15803d',
+  positive:     '#15803d',
+  negative:     '#b91c1c',   // red-700
+};
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function edgeColor(relationTypes: string[]): string {
+  if (relationTypes.length === 0) return EDGE_STROKE;
+  const primary = relationTypes[0].trim().toLowerCase();
+  const known = EDGE_COLOR_BY_RELATION[primary];
+  if (known) return known;
+  return EDGE_FALLBACK_COLORS[hashString(primary) % EDGE_FALLBACK_COLORS.length];
+}
+
+function edgeSourceHandleId(index: number): string {
+  return `source-${index}`;
+}
+
+function edgeTargetHandleId(index: number): string {
+  return `target-${index}`;
+}
+
+function edgeHandleOffset(index: number, total: number): number {
+  if (total <= 1) return 0;
+  if (total === 2) return index === 0 ? -EDGE_HANDLE_GAP : EDGE_HANDLE_GAP;
+  return (index - (total - 1) / 2) * EDGE_HANDLE_GAP;
+}
+
+function buildEdgeHandles(total: number, idForIndex: (index: number) => string): GraphHandleData[] {
+  return Array.from({ length: total }, (_, index) => ({
+    id: idForIndex(index),
+    offset: edgeHandleOffset(index, total),
+  }));
+}
+
+function nodeHeightForHandleCount(handleCount: number): number {
+  if (handleCount <= 1) return NODE_HEIGHT;
+  return Math.max(NODE_HEIGHT, ((handleCount - 1) * EDGE_HANDLE_GAP) + (EDGE_HANDLE_PADDING * 2));
+}
+
 function nodeStyle(nodeType: string): CSSProperties {
   const accent = NODE_ACCENT[nodeType] ?? UNKNOWN_ACCENT;
   return {
@@ -97,6 +192,7 @@ function nodeStyle(nodeType: string): CSSProperties {
 function computeLayout(
   nodes: MinigraphGraphData['nodes'],
   connections: MinigraphGraphData['connections'],
+  nodeHeights: Map<string, number>,
 ): Map<string, { x: number; y: number }> {
   // Build in-degree and adjacency maps
   const outEdges = new Map<string, string[]>();
@@ -147,15 +243,23 @@ function computeLayout(
     byLevel.get(level)!.push(alias);
   }
 
-  // Assign pixel positions
+  // Assign pixel positions — use per-node heights to avoid overlap when nodes
+  // are taller than NODE_HEIGHT due to many edge handles.
   const positions = new Map<string, { x: number; y: number }>();
   for (const [level, aliases] of byLevel) {
-    const totalHeight = aliases.length * NODE_HEIGHT + (aliases.length - 1) * ROW_GAP;
-    aliases.forEach((alias, idx) => {
+    const totalHeight = aliases.reduce(
+      (sum, alias) => sum + (nodeHeights.get(alias) ?? NODE_HEIGHT),
+      0,
+    ) + Math.max(0, aliases.length - 1) * ROW_GAP;
+
+    let cursorY = -totalHeight / 2;
+    aliases.forEach((alias) => {
+      const nodeHeight = nodeHeights.get(alias) ?? NODE_HEIGHT;
       positions.set(alias, {
         x: level * (NODE_WIDTH + COL_GAP),
-        y: idx * (NODE_HEIGHT + ROW_GAP) - totalHeight / 2,
+        y: cursorY,
       });
+      cursorY += nodeHeight + ROW_GAP;
     });
   }
 
@@ -169,39 +273,103 @@ function computeLayout(
 export function transformGraphData(
   data: MinigraphGraphData,
 ): { nodes: Node<GraphNodeData>[]; edges: Edge<GraphEdgeData>[] } {
-  const positions = computeLayout(data.nodes, data.connections ?? []);
+  const connections = data.connections ?? [];
 
-  const rfNodes: Node<GraphNodeData>[] = data.nodes.map(n => ({
-    id:       n.alias,
-    type:     n.types[0] ?? 'default',     // matches the nodeTypes key in GraphView
-    position: positions.get(n.alias) ?? { x: 0, y: 0 },
-    // width / height give the React Flow wrapper its initial size.
-    // NodeResizer will update these as the user drags a handle.
-    width:  NODE_WIDTH,
-    height: NODE_HEIGHT,
-    // style is applied directly to the React Flow wrapper element — since
-    // MinigraphNode renders as a Fragment there is no inner shell div, so
-    // this IS the visible node appearance.
-    style: nodeStyle(n.types[0] ?? 'unknown'),
-    data: {
-      alias:       n.alias,
-      nodeType:    n.types[0] ?? 'unknown',
-      properties:  n.properties,
-    },
-  }));
+  // Count outgoing/incoming connections per node to size handles.
+  const outgoingEdgeCounts = new Map<string, number>();
+  const incomingEdgeCounts = new Map<string, number>();
+  for (const conn of connections) {
+    outgoingEdgeCounts.set(conn.source, (outgoingEdgeCounts.get(conn.source) ?? 0) + 1);
+    incomingEdgeCounts.set(conn.target, (incomingEdgeCounts.get(conn.target) ?? 0) + 1);
+  }
 
-  // Flatten connections → edges (one edge per relation per connection)
+  // Compute per-node heights so nodes with many connections don't overlap.
+  const nodeHeights = new Map(
+    data.nodes.map(n => [
+      n.alias,
+      nodeHeightForHandleCount(Math.max(
+        outgoingEdgeCounts.get(n.alias) ?? 0,
+        incomingEdgeCounts.get(n.alias) ?? 0,
+      )),
+    ]),
+  );
+  const positions = computeLayout(data.nodes, connections, nodeHeights);
+
+  const rfNodes: Node<GraphNodeData>[] = data.nodes.map(n => {
+    const sourceHandleCount = outgoingEdgeCounts.get(n.alias) ?? 0;
+    const targetHandleCount = incomingEdgeCounts.get(n.alias) ?? 0;
+    const nodeHeight = nodeHeights.get(n.alias) ?? NODE_HEIGHT;
+
+    return {
+      id:       n.alias,
+      type:     n.types[0] ?? 'default',     // matches the nodeTypes key in GraphView
+      position: positions.get(n.alias) ?? { x: 0, y: 0 },
+      // width / height give the React Flow wrapper its initial size.
+      // NodeResizer will update these as the user drags a handle.
+      width:  NODE_WIDTH,
+      height: nodeHeight,
+      // style is applied directly to the React Flow wrapper element — since
+      // MinigraphNode renders as a Fragment there is no inner shell div, so
+      // this IS the visible node appearance.
+      style: nodeStyle(n.types[0] ?? 'unknown'),
+      data: {
+        alias:         n.alias,
+        nodeType:      n.types[0] ?? 'unknown',
+        properties:    n.properties,
+        sourceHandles: buildEdgeHandles(sourceHandleCount, edgeSourceHandleId),
+        targetHandles: buildEdgeHandles(targetHandleCount, edgeTargetHandleId),
+        minHeight:     nodeHeight,
+      },
+    };
+  });
+
+  const outgoingEdgeIndex = new Map<string, number>();
+  const incomingEdgeIndex = new Map<string, number>();
+
+  // Flatten connections → edges (one edge per connection with per-handle routing).
   const rfEdges: Edge<GraphEdgeData>[] = [];
-  for (const conn of data.connections ?? []) {
+  for (const [index, conn] of connections.entries()) {
     const relationTypes = conn.relations.map(r => r.type);
-    const edgeId = `${conn.source}__${conn.target}`;
+    const edgeId = `${conn.source}__${conn.target}__${index}`;
+    const labelColor = edgeColor(relationTypes);
+    const sourceEdgeIndex = outgoingEdgeIndex.get(conn.source) ?? 0;
+    const targetEdgeIndex = incomingEdgeIndex.get(conn.target) ?? 0;
+    outgoingEdgeIndex.set(conn.source, sourceEdgeIndex + 1);
+    incomingEdgeIndex.set(conn.target, targetEdgeIndex + 1);
+
     rfEdges.push({
-      id:     edgeId,
-      source: conn.source,
-      target: conn.target,
-      label:  relationTypes.join(', '),
-      type:   'smoothstep',
-      data:   { relationTypes },
+      id:           edgeId,
+      source:       conn.source,
+      target:       conn.target,
+      sourceHandle: edgeSourceHandleId(sourceEdgeIndex),
+      targetHandle: edgeTargetHandleId(targetEdgeIndex),
+      label:        relationTypes.join(', '),
+      type:         'bezier',
+      markerEnd: {
+        type:   MarkerType.ArrowClosed,
+        width:  16,
+        height: 16,
+        color:  EDGE_STROKE,
+      },
+      style: {
+        stroke:      EDGE_STROKE,
+        strokeWidth: 2,
+      },
+      labelStyle: {
+        fill:       labelColor,
+        fontSize:   10,
+        fontWeight: 700,
+      },
+      labelBgStyle: {
+        fill:        EDGE_LABEL_BG,
+        fillOpacity: 0.94,
+        // --text-primary (rgb 15 23 42) at 16% opacity — subtle label border
+        stroke:      'rgba(15, 23, 42, 0.16)',
+        strokeWidth: 1,
+      },
+      labelBgPadding:      [5, 2],
+      labelBgBorderRadius: 6,
+      data: { relationTypes },
     });
   }
 


### PR DESCRIPTION
### Graph edge improvements

- Multiple spread handles per node so parallel edges land at distinct vertical offsets instead of stacking
- Edges use bezier type with arrowheads and semantic per-relation-type label colors (with hash-based fallback)
- Layout accounts for variable node height driven by handle count

### CSS token refactoring

- Replaced hardcoded hex colors, font stacks, border-radius, and box-shadow-based focus rings with CSS custom - properties throughout all component stylesheets
- Added missing tokens: `--shadow-lg`, `--shadow-popover`, `--error-color`, `--radius-xs`, `--json-*` syntax colors
- `GraphDataView` now composes `.toolbarButton` from `GraphToolbar` instead of duplicating it

### Chip strip label for tutorials

Added optional `chipStripLabel` to `HelpCategoryInfo`; tutorials category shows a "Chapters" prefix label in the chip strip
Tutorial chips now sort numerically and strip the "tutorial " prefix from their labels

Note: Commit 5a6c77f8 references chipLabelStrip — the correct name is chipStripLabel.