### PR TITLE
fix: explicit Locale.US for parsing float from String

### DIFF
--- a/system/event-script-engine/src/main/java/com/accenture/models/TaskMetrics.java
+++ b/system/event-script-engine/src/main/java/com/accenture/models/TaskMetrics.java
@@ -32,7 +32,7 @@ public class TaskMetrics {
     public void complete() {
         float delta = (float) (System.nanoTime() - begin) / EventEmitter.ONE_MILLISECOND;
         // adjust precision to 3 decimal points
-        elapsed = Float.parseFloat(String.format("%.3f", Math.max(0.0f, delta)));
+        elapsed = Float.parseFloat(String.format(java.util.Locale.US, "%.3f", Math.max(0.0f, delta)));
     }
 
     public String getRoute() {

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
@@ -702,7 +702,7 @@ public class EventEnvelope {
      * @return event envelope
      */
     public EventEnvelope setExecutionTime(float milliseconds) {
-        this.executionTime = Math.max(0, Float.parseFloat(String.format("%.3f", milliseconds)));
+        this.executionTime = Math.max(0, Float.parseFloat(String.format(java.util.Locale.US, "%.3f", milliseconds)));
         return this;
     }
 
@@ -713,7 +713,7 @@ public class EventEnvelope {
      * @return event envelope
      */
     public EventEnvelope setRoundTrip(float milliseconds) {
-        this.roundTrip = Math.max(0, Float.parseFloat(String.format("%.3f", milliseconds)));
+        this.roundTrip = Math.max(0, Float.parseFloat(String.format(java.util.Locale.US, "%.3f", milliseconds)));
         return this;
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -553,7 +553,7 @@ public class WorkerHandler {
     private float getExecTime(long begin) {
         float delta = (float) (System.nanoTime() - begin) / EventEmitter.ONE_MILLISECOND;
         // adjust precision to 3 decimal points
-        return Float.parseFloat(String.format("%.3f", Math.max(0.0f, delta)));
+        return Float.parseFloat(String.format(java.util.Locale.US, "%.3f", Math.max(0.0f, delta)));
     }
 
     private String simplifyCastError(Throwable ex) {


### PR DESCRIPTION
### Why?

To ensure that project builds and runs outside of US Locale, e.g. in Europe, where numbers use `,` instead of `.`

### How? 

Setting explicit Locale.US for parsing float from String. 

Other options: 
- setting US locale at the app startup
- updating instructions to require env variable `JAVA_TOOL_OPTIONS="-Duser.language=en -Duser.country=US"`