### PR TITLE
Feature/UI graphview enhancements

### DIFF
--- a/system/minigraph-playground-engine/webapp/docs/Technical Documentation.md
+++ b/system/minigraph-playground-engine/webapp/docs/Technical Documentation.md
@@ -2,7 +2,7 @@
 
 **Audience:** Engineers inheriting or maintaining this webapp  
 **Branch:** `feature/playground`  
-**Last updated:** April 10, 2026
+**Last updated:** April 16, 2026
 
 > **Note on line-number citations:** All `[Lxx]` anchors in this document are approximate and reflect the state of the codebase at the last documentation update. The codebase continues to grow; use the cited symbols and function names to locate code rather than relying on line numbers literally.
 
@@ -161,19 +161,25 @@ Switching between the Minigraph and JSON-Path playgrounds does **not** close eit
 - Nodes are **resizable** (NodeResizer) and can be re-arranged interactively
 - A **minimap** provides navigation for large graphs
 - A **refreshing overlay** (spinner) is displayed during background re-fetches without clearing the existing graph
+- The **graph toolbar** displays a resolved graph name (root node name → save-name fallback → "Untitled"), with node/connection counts revealed on hover
+- **Orphan node segregation** — nodes not participating in any connection are classified by type and placed in horizontal rows below the main flow: Dictionary → Provider → Module → Entity → unknown catch-all
+- **Cycle detection & back-edge routing** — cycles in the graph are detected via iterative DFS; back-edges (edges pointing from a deeper level to a shallower one) are excluded from BFS level assignment so the layout doesn't loop infinitely. Back-edges are still rendered: they exit from the **left** side of the source node and enter the **right** side of the target node (the reverse of forward edges), producing a natural backward-arcing bezier curve. Handles on each side are sorted by peer y-position and interleaved (forward + back-edge) to prevent crossing
 
 **Key code locations:**
 - `src/utils/graphTypes.ts` [L1–L47](../src/utils/graphTypes.ts#L1) — `MinigraphGraphData`, `MinigraphNode`, `MinigraphConnection` types + `isMinigraphGraphData()` type guard
 - `src/hooks/useGraphData.ts` [L7–L20](../src/hooks/useGraphData.ts#L7) — `normalizeRightTab()`: validates the persisted tab value against the current playground's `tabs` list and migrates stale entries (for example legacy `"preview"`) to a safe fallback before render
 - `src/hooks/useGraphData.ts` [L66–L144](../src/hooks/useGraphData.ts#L66) — normalized right-tab state + initial-load path: reads `storedRightTab` from localStorage, derives a safe `rightTab`, writes the normalized value back when migration is needed, then `fetch(pinnedGraphPath)` → `setGraphData(json)` → `setRightTab('graph')`; clears `graphData` to `null` on path change
 - `src/hooks/useGraphData.ts` [L149–L189](../src/hooks/useGraphData.ts#L149) — `refetchGraph()`: overlay-mode re-fetch; does NOT clear `graphData` (stale graph stays visible), sets `isRefreshing = true`
-- `src/utils/graphTransformer.ts` [L61–L76](../src/utils/graphTransformer.ts#L61) — `NODE_ACCENT` colour map + `nodeStyle()` applying `--node-accent` CSS custom property
-- `src/utils/graphTransformer.ts` [L83–L157](../src/utils/graphTransformer.ts#L83) — `computeLayout()`: BFS topological layout (levels = columns, stacked vertically within each level)
-- `src/utils/graphTransformer.ts` [L163–L205](../src/utils/graphTransformer.ts#L163) — `transformGraphData()`: converts `MinigraphGraphData` → ReactFlow `nodes[]` + `edges[]`
-- `src/components/GraphView/NodeTypes.tsx` [L9–L16](../src/components/GraphView/NodeTypes.tsx#L9) — `TYPE_META` icon/label map per node type
-- `src/components/GraphView/NodeTypes.tsx` [L55–L88](../src/components/GraphView/NodeTypes.tsx#L55) — `MinigraphNode`: renders as `<Fragment>` (no wrapper div), `NodeResizer` + `Handle` + content as siblings (L60–L86)
-- `src/components/GraphView/NodeTypes.tsx` [L96–L103](../src/components/GraphView/NodeTypes.tsx#L96) — `nodeTypes` export map used by `<ReactFlow nodeTypes={nodeTypes}>`
-- `src/components/GraphView/GraphView.tsx` [L115–L157](../src/components/GraphView/GraphView.tsx#L115) — `<ReactFlow>` with `fitView`, `<Controls>`, `<MiniMap>` (L130), and `isRefreshing` overlay (L144–L152)
+- `src/utils/graphTransformer.ts` — `NODE_ACCENT` colour map + `nodeStyle()` applying `--node-accent` CSS custom property
+- `src/utils/graphTransformer.ts` — `classifyNode()`: classifies each node into a `LayoutCategory` — connected nodes always go to `'flow'`; orphaned nodes are segregated into `'Dictionary'`, `'Provider'`, `'Module'`, `'Entity'`, or `'__unknown__'`
+- `src/utils/graphTransformer.ts` — `computeLayout()`: BFS topological layout with DFS cycle detection and segregated rows for orphan nodes; returns `{ positions, levelOf }`
+- `src/utils/graphTransformer.ts` — `transformGraphData()`: converts `MinigraphGraphData` → ReactFlow `nodes[]` + `edges[]`; classifies edges as forward or backward using `levelOf`, builds per-side handle arrays sorted by peer y-position with forward and back-edge handles interleaved
+- `src/components/GraphView/NodeTypes.tsx` [L9–L22](../src/components/GraphView/NodeTypes.tsx#L9) — `TYPE_META` icon/label map per node type
+- `src/components/GraphView/NodeTypes.tsx` — `MinigraphNode`: renders as `<Fragment>` (no wrapper div); `NodeResizer` + forward target handles (left) + back-edge source handles (left) + content + forward source handles (right) + back-edge target handles (right) as siblings
+- `src/components/GraphView/NodeTypes.tsx` — `nodeTypes` export map used by `<ReactFlow nodeTypes={nodeTypes}>`
+- `src/components/GraphView/GraphView.tsx` — `<ReactFlow>` with `fitView`, `<Controls>`, `<MiniMap>`, and `isRefreshing` overlay; accepts `graphName` prop and threads it to `GraphToolbar`
+- `src/components/GraphToolbar/GraphToolbar.tsx` — displays `graphName` prominently with hover-reveal node/connection stats; accepts `graphName?` prop
+- `src/components/Playground.tsx` — `graphDisplayName` memo: resolves root node's `name` property → `graphSaveName` fallback; threaded via `RightPanel` → `GraphView` / `GraphDataView` → `GraphToolbar`
 
 ---
 
@@ -457,7 +463,7 @@ webapp/
 │   │   ├── CommandInput/         # Text input + send button
 │   │   ├── GraphView/            # ReactFlow canvas + NodeTypes + ErrorBoundary
 │   │   ├── GraphDataView/        # Raw JSON viewer for graph model
-│   │   ├── GraphToolbar/         # Copy/download toolbar for graph panel
+│   │   ├── GraphToolbar/         # Graph name display + copy toolbar for graph panel
 │   │   ├── GraphSaveButton/      # Inline save-form button in header
 │   │   ├── SavedGraphsMenu/      # Dropdown list of saved graph bookmarks
 │   │   │   ├── MockUploadModal/      # Modal dialog for mock-data JSON upload
@@ -468,7 +474,7 @@ webapp/
 │   └── utils/
 │       ├── messageParser.ts      # ★ Message classification & pattern matching (extractGraphExportSuccess, detectGraphExportFailure)
 │       ├── localHelpCommand.ts   # resolveBundledHelpTopic — pure local-help resolver
-│       ├── graphTransformer.ts   # Backend JSON → ReactFlow nodes + edges
+│       ├── graphTransformer.ts   # Backend JSON → ReactFlow nodes + edges (BFS layout, cycle detection, orphan segregation, back-edge routing)
 │       ├── graphTypes.ts         # TypeScript interfaces + type guard
 │       ├── validators.ts         # JSON/XML payload validation + formatting
 │       ├── urls.ts               # WebSocket & HTTP URL construction
@@ -527,10 +533,10 @@ Each Playground instance:
   │   │                       classificationMap threaded down for render-time lookups
   │   └── CommandInput      ← textarea + send button + history nav
   │
-  ├── RightPanel (tabbed: payload / graph / graph-data)
+  ├── RightPanel (tabbed: payload / graph / graph-data; receives graphName)
   │   ├── PayloadEditor     ← textarea + validation (JSON-Path only)
-  │   ├── GraphView         ← ReactFlow canvas (onClipNode wired when supportsClipboard)
-  │   ├── GraphDataView     ← raw JSON tree of graph model
+  │   ├── GraphView         ← ReactFlow canvas (receives graphName; onClipNode wired when supportsClipboard)
+  │   ├── GraphDataView     ← raw JSON tree of graph model (receives graphName)
   │   └── HelpBrowser       ← bundled help panel (resizable overlay — not a tab)
   │
   ├── MockUploadModal       ← native <dialog>; JSON paste / drop / browse; POST
@@ -667,6 +673,7 @@ Key responsibilities:
 | Mock-upload modal path | `useState<string \| null>(null)` — `null` = closed; non-null = open for that specific POST endpoint |
 | Modal trigger element | `useRef<HTMLElement \| null>(null)` — captures `document.activeElement` before open; `.focus()` restored on close via `setTimeout` |
 | Successful upload paths | `useState<Set<string>>(new Set())` — keyed by POST path; drives ✅ badge on invitation rows; session-only (cleared with `clearMessages`) |
+| Graph display name | `graphDisplayName = useMemo(...)` — resolves root node's `name` property → `graphSaveName` fallback; threaded as `graphName` prop to `RightPanel` → `GraphView` / `GraphDataView` → `GraphToolbar` |
 | Graph save-form name | `useGraphSaveName(storageKey, bus)` — provides `defaultName`, `setLastSavedName`, `resetName`; see §3.13 |
 | Deferred graph export | `pendingSaveRef = useRef<PendingSave | null>(null)` where `PendingSave = { graphName, timeoutId }` — armed when connected save is sent; confirmed by `graph.exported` (name-matched), rejected by `graph.export.failed`, timeout (10 s), or disconnect |
 | Deferred JSON-Path send | `pendingJsonTransferRef = useRef<{ wsPath, json } | null>(null)` — last-write-wins mailbox; overwritten on each send while JSON-Path is `'connecting'`; consumed by a `useEffect` watching the slot once `phase === 'connected'` |
@@ -717,8 +724,8 @@ The four possible tabs:
 | Tab key | Component | When shown |
 |---|---|---|
 | `'payload'` | `PayloadEditor` | JSON-Path playground |
-| `'graph'` | `GraphView` | Both playgrounds |
-| `'graph-data'` | `GraphDataView` | Both playgrounds |
+| `'graph'` | `GraphView` | Both playgrounds (receives `graphName` prop) |
+| `'graph-data'` | `GraphDataView` | Both playgrounds (receives `graphName` prop) |
 
 The help panel is **not** a tab. It is a resizable overlay rendered inside `RightPanel` when `supportsHelp` is true and `helpOpen` is set. Its split position and maximised state are persisted in `localStorage`.
 
@@ -750,20 +757,35 @@ The journey from a WebSocket message to a rendered graph has four stages:
 
 Defines `MinigraphGraphData`, `MinigraphNode`, `MinigraphConnection`, and `MinigraphRelation`. The exported `isMinigraphGraphData(value)` type guard is called on every REST response before setting state — it guards against malformed JSON without throwing.
 
-#### `src/utils/graphTransformer.ts` — Layout algorithm
+#### `src/utils/graphTransformer.ts` — Layout algorithm & edge routing
 
-Uses a **BFS topological layout**:
-1. Build adjacency lists and in-degree counts from `connections`
-2. Identify seed nodes: in-degree 0 or typed as `Root`
-3. BFS assigns a column (level) to each node — a node's level is always ≥ its predecessor's level + 1
-4. Within each level, nodes are stacked vertically with equal spacing
-5. Disconnected nodes are placed in a trailing column
+The transformer performs two major jobs: **layout** (assigning pixel positions) and **edge routing** (assigning per-connection handle IDs with correct side placement).
+
+**Layout — `computeLayout()`** returns `{ positions, levelOf }`:
+
+1. **Classify & partition:** Every node is classified via `classifyNode()` into a `LayoutCategory`. Connected nodes (participating in at least one edge) always go to `'flow'`. Orphaned nodes are segregated by type: `'Dictionary'`, `'Provider'`, `'Module'` (has `graph.math` / `graph.js` skill), `'Entity'` (no skill), or `'__unknown__'` catch-all.
+2. **Cycle detection (iterative DFS):** Before BFS, a DFS from all seed/flow nodes identifies back-edges (edges to an ancestor in the DFS tree). These are recorded in a `backEdges` set and excluded from the BFS queue to prevent infinite looping on cycles.
+3. **BFS level assignment:** Seeds (in-degree 0 or `entry_point` typed) start at level 0. BFS assigns each flow node a column, skipping back-edges. A node's level is always > its predecessor's level.
+4. **Vertical stacking:** Within each level, flow nodes are stacked vertically centred at y = 0 with per-node heights preventing overlap.
+5. **Segregated rows:** After computing the main flow bounding box, each non-flow category gets its own horizontal row below the flow in order: Dictionary → Provider → Module → Entity → __unknown__. Nodes within each row are sorted alphabetically for visual stability.
+
+**Edge routing — inside `transformGraphData()`:**
+
+After layout, each connection is classified as forward or backward by comparing source/target levels from `levelOf`. Forward edges exit the **right** side of the source and enter the **left** side of the target (normal left-to-right flow). Back-edges reverse this: they exit the **left** side of the source and enter the **right** side of the target, producing a natural backward-arcing bezier curve.
+
+Handles on each node side (left and right) are collected, sorted by the y-position of the connected peer node, and assigned interleaved handle IDs (forward + back-edge mixed together). This y-sorting prevents edge crossing: connections to higher peers get higher handle slots.
+
+The `GraphNodeData` interface carries four handle arrays: `sourceHandles` (right, forward out), `targetHandles` (left, forward in), `backSourceHandles` (left, back-edge out), and `backTargetHandles` (right, back-edge in).
 
 Node styles are applied via `node.style` (not CSS classes) using the CSS custom property `--node-accent` for per-type accent colours. The full set of recognised type names is `Root`, `End`, `Fetcher`, `mapper`, `Math`, `JavaScript`, `Provider`, `Dictionary`, `Join`, `Extension`, `Island`, `Decision` — unknown types fall back to a neutral grey accent. This is the pattern required by ReactFlow's `NodeResizer` — having no inner wrapper div means the RF wrapper element *is* the visual shell.
 
 #### `src/components/GraphView/NodeTypes.tsx` — Custom node
 
-`MinigraphNode` renders as a **React Fragment** (no wrapper div). `NodeResizer`, handles, and content are top-level siblings. This avoids all the sizing workarounds that a nested div structure requires. The `nodeTypes` map exported here is passed directly to `<ReactFlow nodeTypes={nodeTypes}>`.
+`MinigraphNode` renders as a **React Fragment** (no wrapper div). Top-level siblings in order: `NodeResizer`, forward target handles (left), back-edge source handles (left), content div, forward source handles (right), back-edge target handles (right). This avoids all the sizing workarounds that a nested div structure requires. The `nodeTypes` map exported here is passed directly to `<ReactFlow nodeTypes={nodeTypes}>`.
+
+#### `src/components/GraphToolbar/GraphToolbar.tsx` — Graph name & stats
+
+Displays a resolved `graphName` prop prominently (falls back to "Untitled"). Node and connection counts are shown as hover-reveal stats (CSS transition: opacity + max-width on `.nameGroup:hover`). The `graphName` prop is threaded from `Playground.tsx` → `RightPanel` → `GraphView` / `GraphDataView` → `GraphToolbar`.
 
 #### `src/components/GraphView/GraphView.tsx` — Clipboard context menu
 
@@ -897,7 +919,7 @@ The `startsWith('node ')` prefix guard is critical — it prevents false positiv
 
 #### `src/utils/graphTransformer.ts`
 
-Converts `MinigraphGraphData` to ReactFlow `nodes[]` and `edges[]`. See §6.7 for the layout algorithm detail.
+Converts `MinigraphGraphData` to ReactFlow `nodes[]` and `edges[]`. Includes node classification (`classifyNode`), BFS layout with DFS cycle detection, orphan-node segregated rows, and back-edge handle routing. See §6.7 for the full layout algorithm and edge routing detail.
 
 #### `src/utils/urls.ts`
 
@@ -1331,6 +1353,7 @@ WS echo: "> import graph from other-graph"
 | Clipboard items | `ClipboardContext` reducer | IndexedDB | Hydrated at mount; cross-tab sync via BroadcastChannel |
 | `clipboardOpen` | `useLocalStorage` in `Playground` | `localStorage` | Key `'clipboard-sidebar-open'`; persists sidebar open/closed state |
 | Duplicate dialog state | `useState` in `Playground` | Memory only | `null` = closed; non-null = `{ pendingItem, existingItem }` |
+| Graph display name | `useMemo` in `Playground` | Memory only | Derived: root node `name` property → `graphSaveName` fallback; threaded as `graphName` prop |
 | Graph data | `useState` in `useGraphData` | Memory only | |
 | Right panel tab | `useLocalStorage` in `useGraphData` | `localStorage` | Keyed per playground; normalized against the current `tabs` array before render so removed legacy values are migrated to a valid tab |
 | Is refreshing | `useState` in `useGraphData` | Memory only | |
@@ -1421,6 +1444,7 @@ Source maps are enabled for production (`sourcemap: true`).
 2. Add the type to `TYPE_META` in `NodeTypes.tsx` (gives it an icon and label)
 3. Add the type to the `nodeTypes` export in `NodeTypes.tsx` (maps it to `MinigraphNode`)
 4. (Optionally) add it to the MiniMap `colorMap` in `GraphView.tsx`
+5. If the new type should be **segregated when orphaned** (not connected to any edge), add it to `SEGREGATED_ROW_ORDER` in `graphTransformer.ts` and handle it in `classifyNode()`. Connected nodes of any type always participate in the main BFS flow regardless of classification
 
 ### Add a new mutation command to auto-refresh
 

--- a/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphDataView/GraphDataView.tsx
@@ -30,13 +30,15 @@ const EXPAND_FN: Record<ExpandMode, (level: number) => boolean> = {
 
 interface GraphDataViewProps {
   graphData:       MinigraphGraphData | null;
+  /** Resolved display name for the graph (shown in the toolbar). */
+  graphName?:      string;
   /** Called after the raw graph JSON is successfully copied to the clipboard. */
   onCopySuccess?:  () => void;
   /** Called when the clipboard write fails. */
   onCopyError?:    () => void;
 }
 
-export default function GraphDataView({ graphData, onCopySuccess, onCopyError }: GraphDataViewProps) {
+export default function GraphDataView({ graphData, graphName, onCopySuccess, onCopyError }: GraphDataViewProps) {
   const [expandMode, setExpandMode] = useState<ExpandMode>('all');
 
   if (!graphData) {
@@ -57,6 +59,7 @@ export default function GraphDataView({ graphData, onCopySuccess, onCopyError }:
     <div className={styles.root}>
       <GraphToolbar
         graphData={graphData}
+        graphName={graphName}
         onCopySuccess={onCopySuccess}
         onCopyError={onCopyError}
         extraActions={

--- a/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.module.css
@@ -9,10 +9,41 @@
   background: var(--bg-secondary);
 }
 
-.label {
+/* ── Name + stats group ── */
+.nameGroup {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  overflow: hidden;
+}
+
+.graphName {
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono-terminal);
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.stats {
   font-size: 0.75rem;
   color: var(--text-secondary);
   font-family: var(--font-mono-terminal);
+  white-space: nowrap;
+  opacity: 0;
+  max-width: 0;
+  overflow: hidden;
+  transition: opacity 0.2s ease, max-width 0.3s ease;
+}
+
+.stats::before {
+  content: ' · ';
+}
+
+.nameGroup:hover .stats {
+  opacity: 1;
+  max-width: 20rem;
 }
 
 .toolbarActions {

--- a/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphToolbar/GraphToolbar.tsx
@@ -4,6 +4,8 @@ import styles from './GraphToolbar.module.css';
 
 interface GraphToolbarProps {
   graphData:      MinigraphGraphData | null;
+  /** Resolved display name for the graph (root node name or fallback). */
+  graphName?:     string;
   onCopySuccess?: () => void;
   onCopyError?:   () => void;
   /** Optional extra action buttons rendered before the copy button. */
@@ -12,6 +14,7 @@ interface GraphToolbarProps {
 
 export default function GraphToolbar({
   graphData,
+  graphName,
   onCopySuccess,
   onCopyError,
   extraActions,
@@ -29,11 +32,14 @@ export default function GraphToolbar({
 
   return (
     <div className={styles.toolbar}>
-      <span className={styles.label}>
-        {nodeCount} node{nodeCount !== 1 ? 's' : ''}
-        {' · '}
-        {connectionCount} connection{connectionCount !== 1 ? 's' : ''}
-      </span>
+      <div className={styles.nameGroup}>
+        <span className={styles.graphName}>{graphName ?? 'Untitled'}</span>
+        <span className={styles.stats}>
+          {nodeCount} node{nodeCount !== 1 ? 's' : ''}
+          {' · '}
+          {connectionCount} connection{connectionCount !== 1 ? 's' : ''}
+        </span>
+      </div>
 
       <div className={styles.toolbarActions}>
         {extraActions}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -22,6 +22,8 @@ import styles from './GraphView.module.css';
 
 interface GraphViewProps {
   graphData:       MinigraphGraphData | null;
+  /** Resolved display name for the graph (shown in the toolbar). */
+  graphName?:      string;
   /** Called after the raw graph JSON is successfully copied to the clipboard. */
   onCopySuccess?:  () => void;
   /** Called when the clipboard write fails. */
@@ -36,7 +38,7 @@ interface GraphViewProps {
 const EMPTY_NODES: Node<GraphNodeData>[]  = [];
 const EMPTY_EDGES: Edge<GraphEdgeData>[]  = [];
 
-export default function GraphView({ graphData, onCopySuccess, onCopyError, onRenderError, isRefreshing = false, onClipNode }: GraphViewProps) {
+export default function GraphView({ graphData, graphName, onCopySuccess, onCopyError, onRenderError, isRefreshing = false, onClipNode }: GraphViewProps) {
 
   // ── Context menu state ──────────────────────────────────────────────────
   const [contextMenu, setContextMenu] = useState<{
@@ -142,6 +144,7 @@ export default function GraphView({ graphData, onCopySuccess, onCopyError, onRen
       <div className={styles.graphWrapper} aria-busy={isRefreshing}>
         <GraphToolbar
           graphData={graphData}
+          graphName={graphName}
           onCopySuccess={onCopySuccess}
           onCopyError={onCopyError}
         />

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
@@ -92,6 +92,19 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
         />
       ))}
 
+      {/* Back-edge source handles (left) — outgoing back-edges exit from the left side. */}
+      {data.backSourceHandles.map(({ id, offset }) => (
+        <Handle
+          key={id}
+          id={id}
+          type="source"
+          position={Position.Left}
+          isConnectable={isConnectable}
+          className={styles.edgeHandle}
+          style={{ top: `calc(50% + ${offset}px)` }}
+        />
+      ))}
+
       {/*
         * Content container — fills the React Flow wrapper (which carries the
         * border/background via node.style) and clips its own overflow.
@@ -115,6 +128,19 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
           key={id}
           id={id}
           type="source"
+          position={Position.Right}
+          isConnectable={isConnectable}
+          className={styles.edgeHandle}
+          style={{ top: `calc(50% + ${offset}px)` }}
+        />
+      ))}
+
+      {/* Back-edge target handles (right) — incoming back-edges enter from the right side. */}
+      {data.backTargetHandles.map(({ id, offset }) => (
+        <Handle
+          key={id}
+          id={id}
+          type="target"
           position={Position.Right}
           isConnectable={isConnectable}
           className={styles.edgeHandle}

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -296,6 +296,15 @@ export default function Playground({ config }: PlaygroundProps) {
     bus,
   );
 
+  // ── Resolved graph display name ────────────────────────────────────────────
+  // Priority: root node's "name" property (from graph data) → defaultName from
+  // the save-name hook (lastSavedName → importedName → untitled-{n}).
+  const graphDisplayName = useMemo(() => {
+    const rootNode = graphData?.nodes.find(n => n.types.includes('Root'));
+    const rootName = typeof rootNode?.properties?.name === 'string' ? rootNode.properties.name : undefined;
+    return rootName ?? graphSaveName;
+  }, [graphData, graphSaveName]);
+
   // ── Saved graph workflow ──────────────────────────────────────────────────
   // Note: must be called AFTER useAutoGraphRefresh — both listen on graph.link
   // and ProtocolBus fires listeners in insertion order.
@@ -473,6 +482,7 @@ export default function Playground({ config }: PlaygroundProps) {
             onFormat={handleFormatPayload}
             onUpload={supportsUpload ? ws.uploadPayload : undefined}
             graphData={graphData}
+            graphName={graphDisplayName}
             activeTab={rightTab}
             onTabChange={setRightTab}
             onGraphRenderError={(msg) => addToast(msg, 'error')}

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
@@ -18,6 +18,8 @@ interface RightPanelProps {
   onFormat:       () => void;
   onUpload?:      () => void;
   graphData:      MinigraphGraphData | null;
+  /** Resolved display name for the graph (shown in toolbar). */
+  graphName?:     string;
   activeTab:      RightTab;
   onTabChange:    (tab: RightTab) => void;
   onGraphRenderError?: (message: string) => void;
@@ -53,6 +55,7 @@ export default function RightPanel({
   onFormat,
   onUpload,
   graphData,
+  graphName,
   activeTab,
   onTabChange,
   onGraphRenderError,
@@ -137,6 +140,7 @@ export default function RightPanel({
         >
           <GraphView
             graphData={graphData}
+            graphName={graphName}
             onRenderError={onGraphRenderError}
             isRefreshing={isGraphRefreshing}
             onCopySuccess={onGraphDataCopySuccess}
@@ -156,6 +160,7 @@ export default function RightPanel({
         >
           <GraphDataView
             graphData={graphData}
+            graphName={graphName}
             onCopySuccess={onGraphDataCopySuccess}
             onCopyError={onGraphDataCopyError}
           />

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -31,8 +31,10 @@ export interface GraphEdgeData extends Record<string, unknown> {
 // updates accordingly, keeping NodeResizer in sync.
 const NODE_WIDTH  = 240;
 const NODE_HEIGHT = 100; // rough estimate; ResizeObserver will correct it post-mount
-const ROW_GAP     = 60;   // vertical gap between nodes stacked in the same column
-const COL_GAP     = 120;  // horizontal gap between columns (levels)
+const ROW_GAP            = 60;   // vertical gap between nodes stacked in the same column
+const COL_GAP            = 120;  // horizontal gap between columns (levels)
+const SECTION_GAP        = 120;  // vertical gap between main flow and first segregated row
+const SEGREGATED_ROW_GAP = 80;   // vertical gap between successive segregated rows
 
 // ─── Per-type visual style ───────────────────────────────────────────────────
 // Because MinigraphNode renders as a React Fragment (no wrapper <div>),
@@ -178,38 +180,139 @@ function nodeStyle(nodeType: string): CSSProperties {
   };
 }
 
+// ─── Layout node classification ─────────────────────────────────────────────
+// Nodes are classified into one of several layout categories that determine
+// where they appear in the rendered graph.  The classification uses BOTH the
+// node's primary type AND its runtime properties (skill, connections).
+//
+// FLOW_TYPE_SET — primary types that *may* participate in the main left-to-right
+// BFS columns.  A node whose type is in this set will be placed in the flow
+// UNLESS it is an unconnected module (see classifyNode).
+//
+// MODULE_SKILLS — skill values that identify "module" nodes.  A node with one
+// of these skills that participates in zero graph connections is a reusable
+// computation block invoked via the EXECUTE keyword rather than graph traversal.
+//
+// SEGREGATED_ROW_ORDER — the ordered list of non-flow layout categories.  Each
+// category gets its own horizontal row below the main flow.  Any node that does
+// not match a named category falls into a trailing '__unknown__' catch-all row.
+const FLOW_TYPE_SET = new Set([
+  'Root', 'End', 'Fetcher', 'mapper', 'Math', 'JavaScript',
+  'Join', 'Extension', 'Island', 'Decision',
+]);
+
+const MODULE_SKILLS = new Set(['graph.math', 'graph.js']);
+
+const SEGREGATED_ROW_ORDER: readonly string[] = [
+  'Dictionary',   // data extraction contracts from API responses
+  'Provider',     // reusable API endpoint configurations
+    'Module',       // reusable computation blocks (EXECUTE keyword)
+  'Entity',       // skill-less data-holder nodes (business domain objects)
+];
+
+// ─── Node classification ────────────────────────────────────────────────────
+// Layout categories returned by classifyNode.  'flow' nodes participate in the
+// main BFS layout; all other categories are placed in segregated rows below.
+type LayoutCategory = 'flow' | 'Dictionary' | 'Provider' | 'Entity' | 'Module' | '__unknown__';
+
 /**
- * Very lightweight left-to-right topological layout.
+ * Classify a node into its layout category.
+ *
+ * Priority order (first match wins):
+ *  1. Dictionary / Provider — always segregated regardless of connections.
+ *  2. Module — has a compute skill (graph.math / graph.js) and participates
+ *     in zero graph connections.  These are reusable computation blocks
+ *     invoked by the EXECUTE keyword, not by graph traversal.
+ *  3. Flow (by type) — primary type is in FLOW_TYPE_SET.
+ *  4. Flow (by behaviour) — connected and has a skill.  Covers user-defined
+ *     types like "Compute" or "Module" that are wired into the graph.
+ *  5. Entity — no skill property; a passive data-holder representing a
+ *     business domain object (e.g. person, account).
+ *  6. __unknown__ — catch-all safety net for anything else.
+ */
+function classifyNode(
+  node: MinigraphGraphData['nodes'][number],
+  connectedAliases: Set<string>,
+): LayoutCategory {
+  const pt = node.types[0] ?? '';
+
+  if (pt === 'Dictionary') return 'Dictionary';
+  if (pt === 'Provider')   return 'Provider';
+
+  const skill = typeof node.properties.skill === 'string' ? node.properties.skill : undefined;
+  const isConnected = connectedAliases.has(node.alias);
+
+  if (skill && MODULE_SKILLS.has(skill) && !isConnected) return 'Module';
+  if (FLOW_TYPE_SET.has(pt)) return 'flow';
+  if (isConnected && skill) return 'flow';
+  if (!skill) return 'Entity';
+
+  return '__unknown__';
+}
+
+/**
+ * Left-to-right topological layout with row segregation for non-flow nodes.
  *
  * Strategy:
- *  1. Build an adjacency list from the connections.
- *  2. Assign each node a "level" (column) via BFS from root nodes.
- *  3. Within each level, stack nodes vertically.
+ *  1. Classify every node via classifyNode (uses type, skill, and connection
+ *     participation — see its JSDoc for the full priority chain).
+ *     Partition into "flow" vs segregated categories.
+ *  2. Assign flow nodes a "level" (column) via BFS from root seeds.
+ *  3. Within each level, stack flow nodes vertically, centred at y = 0.
+ *  4. Compute the bounding box of the main flow, then place each segregated
+ *     category in its own horizontal row below it, left-aligned with the flow.
  *
- * If no root is found (no entry_point and no node lacking incoming edges) all
- * nodes are placed on level 0 so the graph is still renderable.
+ * Segregated row order: Dictionary → Provider → Module → Entity → __unknown__.
+ *
+ * If no root is found (no entry_point and no flow node lacking incoming edges)
+ * all flow nodes are placed on level 0 so the graph is still renderable.
  */
 function computeLayout(
   nodes: MinigraphGraphData['nodes'],
   connections: MinigraphGraphData['connections'],
   nodeHeights: Map<string, number>,
 ): Map<string, { x: number; y: number }> {
-  // Build in-degree and adjacency maps
-  const outEdges = new Map<string, string[]>();
-  const inDegree  = new Map<string, number>();
+  // ── Step 1: Classify & partition ──────────────────────────────────────────
+  // Build the set of aliases that participate in at least one connection so
+  // classifyNode can distinguish modules (disconnected) from flow nodes.
+  const connectedAliases = new Set<string>();
+  for (const conn of connections ?? []) {
+    connectedAliases.add(conn.source);
+    connectedAliases.add(conn.target);
+  }
+
+  const flowNodes:       MinigraphGraphData['nodes'] = [];
+  const segregatedNodes: MinigraphGraphData['nodes'] = [];
+  // Cache each node's category so we don't classify twice.
+  const categoryOf = new Map<string, LayoutCategory>();
 
   for (const n of nodes) {
+    const cat = classifyNode(n, connectedAliases);
+    categoryOf.set(n.alias, cat);
+    if (cat === 'flow') flowNodes.push(n);
+    else segregatedNodes.push(n);
+  }
+
+  // ── Step 2: BFS layout for flow nodes ─────────────────────────────────────
+  const flowAliases = new Set(flowNodes.map(n => n.alias));
+  const outEdges    = new Map<string, string[]>();
+  const inDegree    = new Map<string, number>();
+
+  for (const n of flowNodes) {
     outEdges.set(n.alias, []);
     inDegree.set(n.alias, 0);
   }
 
   for (const conn of connections ?? []) {
+    // Only count edges entirely within the flow set so that connections to/from
+    // segregated nodes do not influence BFS level assignment.
+    if (!flowAliases.has(conn.source) || !flowAliases.has(conn.target)) continue;
     outEdges.get(conn.source)?.push(conn.target);
     inDegree.set(conn.target, (inDegree.get(conn.target) ?? 0) + 1);
   }
 
-  // Seeds: nodes with in-degree 0, or explicitly typed as entry_point
-  const seeds = nodes
+  // Seeds: flow nodes with in-degree 0, or explicitly typed as entry_point
+  const seeds = flowNodes
     .filter(n => inDegree.get(n.alias) === 0 || n.types.includes('entry_point'))
     .map(n => n.alias);
 
@@ -230,21 +333,21 @@ function computeLayout(
     }
   }
 
-  // Nodes that BFS never visited (disconnected) go to the last level + 1
+  // Flow nodes that BFS never visited (disconnected) go to the last level + 1
   const maxLevel = levelOf.size > 0 ? Math.max(...levelOf.values()) : 0;
-  for (const n of nodes) {
+  for (const n of flowNodes) {
     if (!levelOf.has(n.alias)) levelOf.set(n.alias, maxLevel + 1);
   }
 
-  // Group nodes by level
+  // Group flow nodes by level
   const byLevel = new Map<number, string[]>();
   for (const [alias, level] of levelOf) {
     if (!byLevel.has(level)) byLevel.set(level, []);
     byLevel.get(level)!.push(alias);
   }
 
-  // Assign pixel positions — use per-node heights to avoid overlap when nodes
-  // are taller than NODE_HEIGHT due to many edge handles.
+  // Assign pixel positions for the main flow — centred at y = 0 per column.
+  // Per-node heights prevent overlap when nodes are taller than NODE_HEIGHT.
   const positions = new Map<string, { x: number; y: number }>();
   for (const [level, aliases] of byLevel) {
     const totalHeight = aliases.reduce(
@@ -261,6 +364,46 @@ function computeLayout(
       });
       cursorY += nodeHeight + ROW_GAP;
     });
+  }
+
+  // ── Step 3: Bounding box of the main flow ──────────────────────────────────
+  // Used to anchor the vertical start of the segregated rows.
+  let mainMaxY = 0;
+  for (const [alias, pos] of positions) {
+    mainMaxY = Math.max(mainMaxY, pos.y + (nodeHeights.get(alias) ?? NODE_HEIGHT));
+  }
+  // If there are no flow nodes at all, start at y = 0 with no section gap.
+  let nextRowY = mainMaxY + (positions.size > 0 ? SECTION_GAP : 0);
+
+  // ── Step 4: Segregated rows ────────────────────────────────────────────────
+  // Group segregated nodes by their layout category (already computed in Step 1).
+  const groupMap = new Map<string, string[]>();
+  for (const key of SEGREGATED_ROW_ORDER) groupMap.set(key, []);
+  groupMap.set('__unknown__', []);
+
+  for (const n of segregatedNodes) {
+    const cat = categoryOf.get(n.alias) as Exclude<LayoutCategory, 'flow'>;
+    groupMap.get(cat)!.push(n.alias);
+  }
+
+  for (const key of [...SEGREGATED_ROW_ORDER, '__unknown__']) {
+    const aliases = (groupMap.get(key) ?? []).slice().sort(); // alphabetical for visual stability
+    if (aliases.length === 0) continue;
+
+    const startX = 0; // left-align segregated rows with the main flow
+    const rowHeight = aliases.reduce(
+      (max, alias) => Math.max(max, nodeHeights.get(alias) ?? NODE_HEIGHT),
+      0,
+    );
+
+    aliases.forEach((alias, i) => {
+      positions.set(alias, {
+        x: startX + i * (NODE_WIDTH + COL_GAP),
+        y: nextRowY,
+      });
+    });
+
+    nextRowY += rowHeight + SEGREGATED_ROW_GAP;
   }
 
   return positions;

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -10,6 +10,10 @@ export interface GraphNodeData extends Record<string, unknown> {
   properties: Record<string, unknown>;
   sourceHandles: GraphHandleData[];
   targetHandles: GraphHandleData[];
+  /** Back-edge source handles — rendered on the LEFT side (outgoing back-edges from this node). */
+  backSourceHandles: GraphHandleData[];
+  /** Back-edge target handles — rendered on the RIGHT side (incoming back-edges to this node). */
+  backTargetHandles: GraphHandleData[];
   minHeight: number;
 }
 
@@ -151,18 +155,20 @@ function edgeTargetHandleId(index: number): string {
   return `target-${index}`;
 }
 
+function backEdgeSourceHandleId(index: number): string {
+  return `back-source-${index}`;
+}
+
+function backEdgeTargetHandleId(index: number): string {
+  return `back-target-${index}`;
+}
+
 function edgeHandleOffset(index: number, total: number): number {
   if (total <= 1) return 0;
   if (total === 2) return index === 0 ? -EDGE_HANDLE_GAP : EDGE_HANDLE_GAP;
   return (index - (total - 1) / 2) * EDGE_HANDLE_GAP;
 }
 
-function buildEdgeHandles(total: number, idForIndex: (index: number) => string): GraphHandleData[] {
-  return Array.from({ length: total }, (_, index) => ({
-    id: idForIndex(index),
-    offset: edgeHandleOffset(index, total),
-  }));
-}
 
 function nodeHeightForHandleCount(handleCount: number): number {
   if (handleCount <= 1) return NODE_HEIGHT;
@@ -260,7 +266,7 @@ function computeLayout(
   nodes: MinigraphGraphData['nodes'],
   connections: MinigraphGraphData['connections'],
   nodeHeights: Map<string, number>,
-): Map<string, { x: number; y: number }> {
+): { positions: Map<string, { x: number; y: number }>; levelOf: Map<string, number> } {
   // ── Step 1: Classify & partition ──────────────────────────────────────────
   // Build the set of aliases that participate in at least one connection so
   // classifyNode can distinguish modules (disconnected) from flow nodes.
@@ -305,6 +311,50 @@ function computeLayout(
     .filter(n => inDegree.get(n.alias) === 0 || n.types.includes('entry_point'))
     .map(n => n.alias);
 
+  // ── Cycle detection: find back-edges via iterative DFS ────────────────
+  // Back-edges (edges pointing to an ancestor in the DFS tree) cause the
+  // BFS level-assignment loop below to run forever — each node in a cycle
+  // endlessly re-enqueues the other with ever-increasing levels.  We detect
+  // them here and exclude them from BFS so cycles are broken for layout
+  // purposes.  The edges are still rendered in the final ReactFlow output.
+  const backEdges = new Set<string>();
+  {
+    const WHITE = 0, GRAY = 1, BLACK = 2;
+    const color = new Map<string, number>();
+    for (const n of flowNodes) color.set(n.alias, WHITE);
+
+    function dfsFrom(root: string) {
+      if (color.get(root) !== WHITE) return;
+      color.set(root, GRAY);
+      const stack: { node: string; childIdx: number }[] = [{ node: root, childIdx: 0 }];
+
+      while (stack.length > 0) {
+        const frame = stack[stack.length - 1];
+        const neighbors = outEdges.get(frame.node) ?? [];
+
+        if (frame.childIdx >= neighbors.length) {
+          color.set(frame.node, BLACK);
+          stack.pop();
+          continue;
+        }
+
+        const neighbor = neighbors[frame.childIdx++];
+        const nc = color.get(neighbor);
+        if (nc === GRAY) {
+          backEdges.add(`${frame.node}\t${neighbor}`);
+        } else if (nc === WHITE) {
+          color.set(neighbor, GRAY);
+          stack.push({ node: neighbor, childIdx: 0 });
+        }
+        // BLACK → cross or forward edge, safe to ignore
+      }
+    }
+
+    // Prefer starting from seeds so the DFS tree mirrors the BFS flow
+    for (const s of seeds) dfsFrom(s);
+    for (const n of flowNodes) dfsFrom(n.alias);
+  }
+
   const levelOf = new Map<string, number>();
   const queue: string[] = [...seeds];
   seeds.forEach(s => levelOf.set(s, 0));
@@ -314,6 +364,9 @@ function computeLayout(
     const current = queue.shift()!;
     const currentLevel = levelOf.get(current) ?? 0;
     for (const neighbor of outEdges.get(current) ?? []) {
+      // Skip back-edges — they create cycles and are excluded from layout
+      // assignment but are still rendered as visual edges in the output.
+      if (backEdges.has(`${current}\t${neighbor}`)) continue;
       // Only advance the level; never move a node to a shallower level
       if (!levelOf.has(neighbor) || levelOf.get(neighbor)! <= currentLevel) {
         levelOf.set(neighbor, currentLevel + 1);
@@ -395,7 +448,7 @@ function computeLayout(
     nextRowY += rowHeight + SEGREGATED_ROW_GAP;
   }
 
-  return positions;
+  return { positions, levelOf };
 }
 
 /**
@@ -407,74 +460,160 @@ export function transformGraphData(
 ): { nodes: Node<GraphNodeData>[]; edges: Edge<GraphEdgeData>[] } {
   const connections = data.connections ?? [];
 
-  // Count outgoing/incoming connections per node to size handles.
-  const outgoingEdgeCounts = new Map<string, number>();
-  const incomingEdgeCounts = new Map<string, number>();
+  // ── Approximate node heights for layout ────────────────────────────────────
+  // Count total outgoing/incoming to get rough handle counts.  The layout only
+  // needs heights for vertical stacking; accurate per-side counts come later
+  // once we know which edges are back-edges.
+  const totalOutgoing = new Map<string, number>();
+  const totalIncoming = new Map<string, number>();
   for (const conn of connections) {
-    outgoingEdgeCounts.set(conn.source, (outgoingEdgeCounts.get(conn.source) ?? 0) + 1);
-    incomingEdgeCounts.set(conn.target, (incomingEdgeCounts.get(conn.target) ?? 0) + 1);
+    totalOutgoing.set(conn.source, (totalOutgoing.get(conn.source) ?? 0) + 1);
+    totalIncoming.set(conn.target, (totalIncoming.get(conn.target) ?? 0) + 1);
   }
 
-  // Compute per-node heights so nodes with many connections don't overlap.
-  const nodeHeights = new Map(
+  const approxNodeHeights = new Map(
     data.nodes.map(n => [
       n.alias,
       nodeHeightForHandleCount(Math.max(
-        outgoingEdgeCounts.get(n.alias) ?? 0,
-        incomingEdgeCounts.get(n.alias) ?? 0,
+        totalOutgoing.get(n.alias) ?? 0,
+        totalIncoming.get(n.alias) ?? 0,
       )),
     ]),
   );
-  const positions = computeLayout(data.nodes, connections, nodeHeights);
+  const { positions, levelOf } = computeLayout(data.nodes, connections, approxNodeHeights);
+
+  // ── Classify connections as forward or backward ───────────────────────────
+  // A back-edge goes from a deeper (or equal) level to a shallower level.
+  // These edges exit from the LEFT side of the source and enter the RIGHT
+  // side of the target — the reverse of forward edges — so the bezier curve
+  // arcs naturally backward.
+  const backEdgeIndices = new Set<number>();
+  for (const [i, conn] of connections.entries()) {
+    const srcLevel = levelOf.get(conn.source);
+    const tgtLevel = levelOf.get(conn.target);
+    if (srcLevel !== undefined && tgtLevel !== undefined && srcLevel >= tgtLevel) {
+      backEdgeIndices.add(i);
+    }
+  }
+
+  // ── Collect per-node, per-side connections sorted by peer y-position ─────
+  // Sorting handles by the y-position of the connected peer node prevents
+  // crossing: connections to a higher peer get a higher handle slot, and
+  // connections to a lower peer get a lower slot.  Forward and back-edge
+  // handles are interleaved within the sorted order rather than grouped
+  // separately, so a node that has both a forward edge and a retry to the
+  // same peer gets adjacent handles for both.
+  //
+  // Each side entry records the connection index, the peer alias, and
+  // whether the connection is a back-edge.  After sorting we walk the
+  // entries to build handle arrays and a connectionIndex → handleId map
+  // used when constructing ReactFlow edges.
+
+  interface SideEntry { connIndex: number; peerAlias: string; isBack: boolean }
+
+  const rightSide = new Map<string, SideEntry[]>(); // source (fwd out) + back-target (back in)
+  const leftSide  = new Map<string, SideEntry[]>(); // target (fwd in)  + back-source (back out)
+
+  for (const n of data.nodes) {
+    rightSide.set(n.alias, []);
+    leftSide.set(n.alias, []);
+  }
+
+  for (const [i, conn] of connections.entries()) {
+    if (backEdgeIndices.has(i)) {
+      // Back-edge: source exits LEFT, target enters RIGHT
+      leftSide.get(conn.source)!.push({ connIndex: i, peerAlias: conn.target, isBack: true });
+      rightSide.get(conn.target)!.push({ connIndex: i, peerAlias: conn.source, isBack: true });
+    } else {
+      // Forward: source exits RIGHT, target enters LEFT
+      rightSide.get(conn.source)!.push({ connIndex: i, peerAlias: conn.target, isBack: false });
+      leftSide.get(conn.target)!.push({ connIndex: i, peerAlias: conn.source, isBack: false });
+    }
+  }
+
+  // Sort each side by peer y-position so handle order matches spatial layout.
+  const peerY = (alias: string) => positions.get(alias)?.y ?? 0;
+  for (const entries of rightSide.values()) entries.sort((a, b) => peerY(a.peerAlias) - peerY(b.peerAlias));
+  for (const entries of leftSide.values())  entries.sort((a, b) => peerY(a.peerAlias) - peerY(b.peerAlias));
+
+  // Maps from connection index → handle ID, populated during node building.
+  const connSourceHandle = new Map<number, string>();
+  const connTargetHandle = new Map<number, string>();
 
   const rfNodes: Node<GraphNodeData>[] = data.nodes.map(n => {
-    const sourceHandleCount = outgoingEdgeCounts.get(n.alias) ?? 0;
-    const targetHandleCount = incomingEdgeCounts.get(n.alias) ?? 0;
-    const nodeHeight = nodeHeights.get(n.alias) ?? NODE_HEIGHT;
+    const right = rightSide.get(n.alias) ?? [];
+    const left  = leftSide.get(n.alias) ?? [];
+    const nodeHeight = nodeHeightForHandleCount(Math.max(right.length, left.length));
+
+    // ── Right side: interleaved source + back-target handles ──
+    const sourceHandles:     GraphHandleData[] = [];
+    const backTargetHandles: GraphHandleData[] = [];
+    let srcIdx = 0, btIdx = 0;
+    for (let i = 0; i < right.length; i++) {
+      const entry = right[i];
+      const offset = edgeHandleOffset(i, right.length);
+      if (entry.isBack) {
+        const id = backEdgeTargetHandleId(btIdx++);
+        backTargetHandles.push({ id, offset });
+        connTargetHandle.set(entry.connIndex, id);
+      } else {
+        const id = edgeSourceHandleId(srcIdx++);
+        sourceHandles.push({ id, offset });
+        connSourceHandle.set(entry.connIndex, id);
+      }
+    }
+
+    // ── Left side: interleaved target + back-source handles ──
+    const targetHandles:     GraphHandleData[] = [];
+    const backSourceHandles: GraphHandleData[] = [];
+    let tgtIdx = 0, bsIdx = 0;
+    for (let i = 0; i < left.length; i++) {
+      const entry = left[i];
+      const offset = edgeHandleOffset(i, left.length);
+      if (entry.isBack) {
+        const id = backEdgeSourceHandleId(bsIdx++);
+        backSourceHandles.push({ id, offset });
+        connSourceHandle.set(entry.connIndex, id);
+      } else {
+        const id = edgeTargetHandleId(tgtIdx++);
+        targetHandles.push({ id, offset });
+        connTargetHandle.set(entry.connIndex, id);
+      }
+    }
 
     return {
       id:       n.alias,
-      type:     n.types[0] ?? 'default',     // matches the nodeTypes key in GraphView
+      type:     n.types[0] ?? 'default',
       position: positions.get(n.alias) ?? { x: 0, y: 0 },
-      // width / height give the React Flow wrapper its initial size.
-      // NodeResizer will update these as the user drags a handle.
       width:  NODE_WIDTH,
       height: nodeHeight,
-      // style is applied directly to the React Flow wrapper element — since
-      // MinigraphNode renders as a Fragment there is no inner shell div, so
-      // this IS the visible node appearance.
       style: nodeStyle(n.types[0] ?? 'unknown'),
       data: {
         alias:         n.alias,
         nodeType:      n.types[0] ?? 'unknown',
         properties:    n.properties,
-        sourceHandles: buildEdgeHandles(sourceHandleCount, edgeSourceHandleId),
-        targetHandles: buildEdgeHandles(targetHandleCount, edgeTargetHandleId),
+        sourceHandles,
+        targetHandles,
+        backSourceHandles,
+        backTargetHandles,
         minHeight:     nodeHeight,
       },
     };
   });
 
-  const outgoingEdgeIndex = new Map<string, number>();
-  const incomingEdgeIndex = new Map<string, number>();
-
-  // Flatten connections → edges (one edge per connection with per-handle routing).
+  // ── Build edges using the pre-computed handle mappings ─────────────────────
   const rfEdges: Edge<GraphEdgeData>[] = [];
   for (const [index, conn] of connections.entries()) {
     const relationTypes = conn.relations.map(r => r.type);
     const edgeId = `${conn.source}__${conn.target}__${index}`;
     const labelColor = edgeColor(relationTypes);
-    const sourceEdgeIndex = outgoingEdgeIndex.get(conn.source) ?? 0;
-    const targetEdgeIndex = incomingEdgeIndex.get(conn.target) ?? 0;
-    outgoingEdgeIndex.set(conn.source, sourceEdgeIndex + 1);
-    incomingEdgeIndex.set(conn.target, targetEdgeIndex + 1);
 
     rfEdges.push({
       id:           edgeId,
       source:       conn.source,
       target:       conn.target,
-      sourceHandle: edgeSourceHandleId(sourceEdgeIndex),
-      targetHandle: edgeTargetHandleId(targetEdgeIndex),
+      sourceHandle: connSourceHandle.get(index)!,
+      targetHandle: connTargetHandle.get(index)!,
       label:        relationTypes.join(', '),
       type:         'bezier',
       markerEnd: {
@@ -495,7 +634,6 @@ export function transformGraphData(
       labelBgStyle: {
         fill:        EDGE_LABEL_BG,
         fillOpacity: 0.94,
-        // --text-primary (rgb 15 23 42) at 16% opacity — subtle label border
         stroke:      'rgba(15, 23, 42, 0.16)',
         strokeWidth: 1,
       },

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -185,10 +185,6 @@ function nodeStyle(nodeType: string): CSSProperties {
 // where they appear in the rendered graph.  The classification uses BOTH the
 // node's primary type AND its runtime properties (skill, connections).
 //
-// FLOW_TYPE_SET — primary types that *may* participate in the main left-to-right
-// BFS columns.  A node whose type is in this set will be placed in the flow
-// UNLESS it is an unconnected module (see classifyNode).
-//
 // MODULE_SKILLS — skill values that identify "module" nodes.  A node with one
 // of these skills that participates in zero graph connections is a reusable
 // computation block invoked via the EXECUTE keyword rather than graph traversal.
@@ -196,11 +192,6 @@ function nodeStyle(nodeType: string): CSSProperties {
 // SEGREGATED_ROW_ORDER — the ordered list of non-flow layout categories.  Each
 // category gets its own horizontal row below the main flow.  Any node that does
 // not match a named category falls into a trailing '__unknown__' catch-all row.
-const FLOW_TYPE_SET = new Set([
-  'Root', 'End', 'Fetcher', 'mapper', 'Math', 'JavaScript',
-  'Join', 'Extension', 'Island', 'Decision',
-]);
-
 const MODULE_SKILLS = new Set(['graph.math', 'graph.js']);
 
 const SEGREGATED_ROW_ORDER: readonly string[] = [
@@ -218,33 +209,31 @@ type LayoutCategory = 'flow' | 'Dictionary' | 'Provider' | 'Entity' | 'Module' |
 /**
  * Classify a node into its layout category.
  *
+ * Connected nodes always participate in the main left-to-right BFS flow,
+ * matching the original layout behaviour.  Only orphaned (unconnected)
+ * nodes are segregated into categorised rows below the flow.
+ *
  * Priority order (first match wins):
- *  1. Dictionary / Provider — always segregated regardless of connections.
- *  2. Module — has a compute skill (graph.math / graph.js) and participates
- *     in zero graph connections.  These are reusable computation blocks
- *     invoked by the EXECUTE keyword, not by graph traversal.
- *  3. Flow (by type) — primary type is in FLOW_TYPE_SET.
- *  4. Flow (by behaviour) — connected and has a skill.  Covers user-defined
- *     types like "Compute" or "Module" that are wired into the graph.
- *  5. Entity — no skill property; a passive data-holder representing a
- *     business domain object (e.g. person, account).
- *  6. __unknown__ — catch-all safety net for anything else.
+ *  1. Connected — participates in at least one edge → flow.
+ *  2. Dictionary / Provider — orphaned type-based segregation.
+ *  3. Module — has a compute skill (graph.math / graph.js) with no
+ *     connections.  Reusable computation blocks invoked via EXECUTE.
+ *  4. Entity — no skill property; a passive data-holder node.
+ *  5. __unknown__ — catch-all safety net for anything else.
  */
 function classifyNode(
   node: MinigraphGraphData['nodes'][number],
   connectedAliases: Set<string>,
 ): LayoutCategory {
-  const pt = node.types[0] ?? '';
+  const isConnected = connectedAliases.has(node.alias);
+  if (isConnected) return 'flow';
+
+  const pt    = node.types[0] ?? '';
+  const skill = typeof node.properties.skill === 'string' ? node.properties.skill : undefined;
 
   if (pt === 'Dictionary') return 'Dictionary';
   if (pt === 'Provider')   return 'Provider';
-
-  const skill = typeof node.properties.skill === 'string' ? node.properties.skill : undefined;
-  const isConnected = connectedAliases.has(node.alias);
-
-  if (skill && MODULE_SKILLS.has(skill) && !isConnected) return 'Module';
-  if (FLOW_TYPE_SET.has(pt)) return 'flow';
-  if (isConnected && skill) return 'flow';
+  if (skill && MODULE_SKILLS.has(skill)) return 'Module';
   if (!skill) return 'Entity';
 
   return '__unknown__';


### PR DESCRIPTION
## Summary

- **Orphan node segregation**: Nodes not participating in any connection are
  classified by type (Dictionary, Provider, Module, Entity, unknown) and placed
  in labelled horizontal rows below the main left-to-right BFS flow, keeping
  the main graph clean and scannable.
- **Connected-node-first classification fix**: Reversed the classification
  priority so connected nodes always participate in the main BFS flow regardless
  of their type — fixes Dictionary/Provider nodes being incorrectly pulled out
  of the flow when they have edges.
- **Graph name display**: The graph toolbar now shows a resolved graph name
  (root node "name" property → save-name fallback → "Untitled") with
  node/connection counts revealed on hover. Threaded via Playground → RightPanel
  → GraphView / GraphDataView → GraphToolbar.
- **Cycle detection & back-edge routing**: Cycles are detected via iterative DFS;
  back-edges are excluded from BFS level assignment (preventing infinite loops)
  but still rendered — they exit from the left side of the source and enter the
  right side of the target, producing backward-arcing bezier curves. Handles are
  sorted by peer y-position to prevent crossing.