### PR TITLE
Add minigraph node authoring UI and workspace node drag/drop actions

### DIFF
--- a/system/minigraph-playground-engine/webapp/docs/Technical Documentation.md
+++ b/system/minigraph-playground-engine/webapp/docs/Technical Documentation.md
@@ -2,7 +2,7 @@
 
 **Audience:** Engineers inheriting or maintaining this webapp  
 **Branch:** `feature/playground`  
-**Last updated:** April 16, 2026
+**Last updated:** May 7, 2026
 
 > **Note on line-number citations:** All `[Lxx]` anchors in this document are approximate and reflect the state of the codebase at the last documentation update. The codebase continues to grow; use the cited symbols and function names to locate code rather than relying on line numbers literally.
 
@@ -28,6 +28,7 @@
    - 3.13 [Save-Name Management](#313-save-name-management)
    - 3.14 [Protocol Kernel (Centralized Message Classification)](#314-protocol-kernel-centralized-message-classification)
    - 3.15 [Clipboard Panel](#315-clipboard-panel)
+   - 3.16 [UI Node Authoring (Create Node)](#316-ui-node-authoring-create-node)
 4. [Repository Layout](#4-repository-layout)
 5. [Architecture Overview](#5-architecture-overview)
 6. [Layer-by-Layer Walkthrough](#6-layer-by-layer-walkthrough)
@@ -43,6 +44,7 @@
    - 6.10 [Utilities](#610-utilities)
    - 6.11 [Navigation Bar](#611-navigation-bar)
    - 6.12 [Saved Graphs](#612-saved-graphs)
+   - 6.13 [Graph Authoring Layer](#613-graph-authoring-layer)
 7. [Key Engineering Decisions](#7-key-engineering-decisions)
 8. [Data & Message Flows](#8-data--message-flows)
    - 8.1 [User Sends a Command](#81-user-sends-a-command)
@@ -52,6 +54,7 @@
    - 8.5 [REST Upload Handshake](#85-rest-upload-handshake)
    - 8.6 [Mock-Data Upload Flow](#86-mock-data-upload-flow)
    - 8.7 [Save-Name Lifecycle](#87-save-name-lifecycle)
+   - 8.8 [Create Node UI Flow](#88-create-node-ui-flow)
 9. [State Ownership Map](#9-state-ownership-map)
 10. [Build, Dev & Deploy](#10-build-dev--deploy)
 11. [Extending the App](#11-extending-the-app)
@@ -77,6 +80,7 @@ The UI offers:
 - **Large payload handling** — payloads exceeding 64 KB are automatically fetched via REST and displayed inline
 - **Mock-data upload modal** — when the server responds to a command with an upload invitation, a modal dialog opens automatically so the user can paste, drag-and-drop, or browse a JSON file and POST it to the provided endpoint
 - **Clipboard panel** — a resizable sidebar (Minigraph only) for clipping nodes from the graph and pasting their create/update command templates into the console input; persisted in IndexedDB and synchronised across open tabs via BroadcastChannel
+- **UI node authoring** — Minigraph-only create-node workflow with an empty-graph entry point and a graph-pane context menu entry point; the modal serialises form values into the same raw text command grammar used by the console
 
 The built output (`dist/`) is copied into the Java application's `src/main/resources/public/` directory and served as a static SPA by the same Spring Boot server that provides the WebSocket and REST endpoints.
 
@@ -147,8 +151,8 @@ Switching between the Minigraph and JSON-Path playgrounds does **not** close eit
 - `src/components/Console/ConsoleMessage.tsx` [L98–L170](../src/components/Console/ConsoleMessage.tsx#L98) — JSX: `<JsonView>` for JSON, plain `<span>` for text, copy button, ➡️ send-to-JSON-Path button
 - `src/components/Console/ConsoleMessage.tsx` [L42–L47](../src/components/Console/ConsoleMessage.tsx#L42) — `events` looked up from `classificationMap.get(msgId)`; `isGraphLink` / `isLargePayload` / `isMockUpload` derived via `events.some(e => e.kind === ...)` instead of direct parser calls
 - `src/hooks/useWebSocket.ts` [L145–L167](../src/hooks/useWebSocket.ts#L145) — `sendCommand()`: sends text, pushes to history, handles special `load` command
-- `src/hooks/useWebSocket.ts` [L168–L191](../src/hooks/useWebSocket.ts#L168) — `handleKeyDown()`: ↑/↓ history navigation with draft-save/restore (`ENTER_HISTORY` / `EXIT_HISTORY` / `SET_HISTORY_INDEX` reducer actions)
-- `src/hooks/useWebSocket.ts` [L14–L32](../src/hooks/useWebSocket.ts#L14) — `LocalState` + `LocalAction` types; `draftCommand` field saves in-progress input on first ↑ press
+- `src/hooks/useWebSocket.ts` [L168–L191](../src/hooks/useWebSocket.ts#L168) — `handleKeyDown()`: ↑/↓ history navigation with in-progress command save/restore (`ENTER_HISTORY` / `EXIT_HISTORY` / `SET_HISTORY_INDEX` reducer actions)
+- `src/hooks/useWebSocket.ts` [L14–L32](../src/hooks/useWebSocket.ts#L14) — `LocalState` + `LocalAction` types; local command state saves in-progress input on first ↑ press
 - `src/hooks/useHistoryAutocomplete.ts` — `useHistoryAutocomplete(history, command)`: pure filtering + dedup in a single `useMemo`; returns `suggestions`, `isOpen`, `activeIndex`, `navigate`, `accept`, `onTab`, `dismiss`, `onCommandChange`
 - `src/components/CommandInput/CommandInput.tsx` [L5](../src/components/CommandInput/CommandInput.tsx#L5) — imports `useHistoryAutocomplete`; [L43–L71](../src/components/CommandInput/CommandInput.tsx#L43) — command palette open/close + outside-click handler; [L62](../src/components/CommandInput/CommandInput.tsx#L62) — auto-grow `useEffect` (always rows=1, height derived from `scrollHeight`); [L82–L175](../src/components/CommandInput/CommandInput.tsx#L82) — `handleKeyDown`: Tab → accept suggestion; Enter → accept or send; Escape → dismiss dropup; ↑/↓ → navigate dropup or history
 - `src/utils/commandSuggestions.ts` — `QuickstartEntry` now has `template: string` (text inserted on palette click) and optional `multiline?: boolean` (informational metadata indicating a multi-line command)
@@ -357,17 +361,17 @@ This architecture eliminates O(hooks × messages) repeated parsing and provides 
 
 | File | Purpose | Lines |
 |---|---|---|
-| `src/protocol/events.ts` | 12-kind discriminated union type (`ProtocolEvent`) | 113 |
-| `src/protocol/classifier.ts` | Pure `classifyMessage(msgId, raw)` → `ProtocolEvent[]` (12 rules) | 181 |
+| `src/protocol/events.ts` | Discriminated union type (`ProtocolEvent`) for graph, upload, docs, create-node, and lifecycle messages | 136 |
+| `src/protocol/classifier.ts` | Pure `classifyMessage(msgId, raw)` → `ProtocolEvent[]` rule pipeline | 220 |
 | `src/protocol/bus.ts` | `ProtocolBus` — lightweight typed event emitter (~45 lines) | 45 |
 | `src/protocol/useProtocolKernel.ts` | React hook: watermark + classify + memoised map + bus emission | 73 |
 | `src/protocol/index.ts` | Barrel re-export | 18 |
 
-**Event kinds:** `graph.link`, `graph.mutation`, `payload.large`, `upload.invitation`, `upload.contentPath`, `command.echo`, `command.helpOrDescribe`, `command.importGraph`, `docs.response`, `json.response`, `lifecycle`, `unclassified`.
+**Event kinds:** `graph.link`, `graph.mutation`, `minigraph.createNode.textResult`, `graph.exported`, `graph.export.failed`, `payload.large`, `upload.invitation`, `upload.contentPath`, `command.echo`, `command.helpOrDescribe`, `command.importGraph`, `docs.response`, `json.response`, `lifecycle`, `unclassified`.
 
 **Key code locations:**
 - `src/protocol/events.ts` [L103](../src/protocol/events.ts#L103) — `export type ProtocolEvent` discriminated union
-- `src/protocol/classifier.ts` [L27](../src/protocol/classifier.ts#L27) — `export function classifyMessage(msgId, raw)`: returns an array (one message may match multiple rules, e.g. a graph-link that is also a mutation response)
+- `src/protocol/classifier.ts` [L27](../src/protocol/classifier.ts#L27) — `export function classifyMessage(msgId, raw)`: returns an array (one message may match multiple rules, e.g. a create-node success is both `graph.mutation` and `minigraph.createNode.textResult`)
 - `src/protocol/bus.ts` [L16](../src/protocol/bus.ts#L16) — `export class ProtocolBus`: `on(kind, handler)` returns an unsubscribe function; `emit(event)` fires all registered handlers for that `event.kind`; `clear()` removes all listeners
 - `src/protocol/useProtocolKernel.ts` [L33](../src/protocol/useProtocolKernel.ts#L33) — hook entry; [L40](../src/protocol/useProtocolKernel.ts#L40) — watermark init effect; [L47](../src/protocol/useProtocolKernel.ts#L47) — `classificationMap = useMemo(...)` over the full messages array; [L56](../src/protocol/useProtocolKernel.ts#L56) — watermark-gated bus emission effect
 - `src/components/Playground.tsx` [L88](../src/components/Playground.tsx#L88) — `busRef = useRef(new ProtocolBus())`; [L94](../src/components/Playground.tsx#L94) — `useProtocolKernel({ messages, bus })`
@@ -405,6 +409,49 @@ The Minigraph playground includes a resizable **Clipboard** sidebar (enabled whe
 
 ---
 
+### 3.16 UI Node Authoring (Create Node)
+The Minigraph playground exposes a UI path for creating nodes without requiring the user to hand-write the `create node ...` command. The feature is enabled by `supportsAuthoring: true` in the Minigraph playground config and is not mounted for JSON-Path.
+
+**Entry points:**
+- **Empty graph state** — when no graph data is loaded or the loaded graph has no nodes, the Graph tab shows a "Create Node" button. This opens the modal with `alias = root` and `nodeType = Root` as editable starting values.
+- **Existing graph pane** — right-clicking empty space in the ReactFlow pane opens a pointer-positioned context menu with "Create Node". This opens the same modal with blank alias/type fields.
+
+**Authoring model:**
+- The modal edits create-node form state: `alias`, optional `nodeType`, flat single-line property rows, and the source entry point.
+- Frontend validation checks the supported authoring surface before any raw text is sent: alias required, token format, reserved aliases, duplicate alias against the current graph snapshot, property key requirements, single-line property values, and final command size.
+- On submit, `buildCreateNodeCommand()` serialises the form values into the backend's existing multiline command grammar:
+
+```text
+create node {alias}
+with type {nodeType}
+with properties
+key=value
+```
+
+There is deliberately no JSON command payload. The command sent over WebSocket is raw text, identical in shape to a console-entered command.
+
+**Result handling:**
+- The modal does not optimistically mutate `graphData`.
+- `useGraphAuthoring` sends through `GraphAuthoringExecutor`, which delegates to `useWebSocket.sendRawText()`. This avoids adding the command to console history or echoing an extra local command row.
+- The Protocol Kernel classifies backend text results into `minigraph.createNode.textResult` events using `parseCreateNodeTextResult()`.
+- Accepted result (`"node {alias} created"`) closes the modal. Rejected duplicate result (`"node {alias} already exists"`) and generic `ERROR: ...` responses keep the modal open and show the backend message.
+- A 10-second timeout returns the modal to editing with an "outcome unknown" message; disconnect while open locks the fields and asks the user to refresh/check the graph before retrying.
+
+**Key code locations:**
+- `src/config/playgrounds.ts` — `supportsAuthoring: true` enables the feature for Minigraph only
+- `src/components/Playground.tsx` — creates `GraphAuthoringExecutor`, owns `useGraphAuthoring`, renders `GraphAuthoringModals`, and threads `onCreateNode` to `RightPanel`
+- `src/components/RightPanel/RightPanel.tsx` — forwards `supportsAuthoring`, `isConnected`, and `onCreateNode` to `GraphView`
+- `src/components/GraphView/GraphView.tsx` — renders the empty-state create button and the pane context-menu trigger
+- `src/components/GraphView/GraphContextMenu.tsx` — pointer-positioned menu for pane-level graph actions
+- `src/components/GraphAuthoring/useGraphAuthoring.ts` — create-node lifecycle state machine, validation invocation, submit timer, ProtocolBus result correlation, and disconnect handling
+- `src/components/GraphAuthoring/GraphAuthoringModals.tsx` — maps hook state to modal props
+- `src/components/NodeDialog/NodeDialog.tsx` — presentational modal for editing the create-node form
+- `src/graphActions/*` — pure form types, row helpers, validation, command builder, and executor adapter
+- `src/utils/messageParser.ts` — `parseCreateNodeTextResult()`
+- `src/protocol/classifier.ts` / `src/protocol/events.ts` — `minigraph.createNode.textResult` event
+
+---
+
 ## 4. Repository Layout
 
 ```
@@ -435,8 +482,8 @@ webapp/
 │   │   ├── useHistoryAutocomplete.ts  # History-based autocomplete for CommandInput dropup
 │   │   └── useAutocomplete.ts    # Template-based autocomplete (dormant — not currently wired to CommandInput)
 │   ├── protocol/                  # ★ Protocol Kernel — centralised message classification
-│   │   ├── events.ts             # ProtocolEvent discriminated union (14 event kinds incl. graph.exported, graph.export.failed)
-│   │   ├── classifier.ts         # classifyMessage() pure function (12 rules)
+│   │   ├── events.ts             # ProtocolEvent discriminated union (incl. create-node, graph export, upload events)
+│   │   ├── classifier.ts         # classifyMessage() pure function
 │   │   ├── bus.ts                # ProtocolBus typed event emitter
 │   │   ├── useProtocolKernel.ts  # React hook: watermark + classify + map + emit
 │   │   ├── index.ts              # Barrel re-export
@@ -444,6 +491,13 @@ webapp/
 │   │       ├── classifier.test.ts  # Golden transcript tests
 │   │       ├── bus.test.ts         # Bus unit tests
 │   │       └── fixtures/           # 12 JSON fixture files covering all event kinds
+│   ├── graphActions/              # ★ Create-node authoring helpers (form state → validation → raw command)
+│   │   ├── graphAuthoringExecutor.ts # Adapter boundary over useWebSocket.sendRawText()
+│   │   ├── minigraphCommandBuilder.ts# Serialises form state to multiline create-node command text
+│   │   ├── nodeAuthoringTypes.ts  # Create-node form / PropertyRow / source types
+│   │   ├── propertyRows.ts        # Default form values + property row id helpers
+│   │   ├── validation.ts          # Frontend validation for supported authoring surface
+│   │   └── __tests__/
 │   ├── clipboard/                 # ★ Clipboard module (IndexedDB + BroadcastChannel)
 │   │   ├── db.ts                 # IndexedDB schema + CRUD helpers
 │   │   ├── channel.ts            # BroadcastChannel wrapper for cross-tab sync
@@ -461,18 +515,23 @@ webapp/
 │   │   ├── RightPanel/           # Tab switcher (payload/preview/graph/graph-data)
 │   │   ├── Console/              # Message list + ConsoleMessage renderer
 │   │   ├── CommandInput/         # Text input + send button
-│   │   ├── GraphView/            # ReactFlow canvas + NodeTypes + ErrorBoundary
+│   │   ├── GraphAuthoring/       # Create-node lifecycle hook wrapper + modal mount
+│   │   ├── GraphView/            # ReactFlow canvas + NodeTypes + context menus + ErrorBoundary
 │   │   ├── GraphDataView/        # Raw JSON viewer for graph model
 │   │   ├── GraphToolbar/         # Graph name display + copy toolbar for graph panel
 │   │   ├── GraphSaveButton/      # Inline save-form button in header
 │   │   ├── SavedGraphsMenu/      # Dropdown list of saved graph bookmarks
-│   │   │   ├── MockUploadModal/      # Modal dialog for mock-data JSON upload
+│   │   ├── MockUploadModal/      # Modal dialog for mock-data JSON upload
+│   │   ├── NodeDialog/           # Create-node modal (presentational form editor)
 │   │   ├── ClipboardSidebar/     # Resizable clipboard panel (ClipboardSidebar + ClipboardItem + ClipboardDuplicateDialog)
 │   │   ├── HelpBrowser/          # Bundled help panel renderer (react-markdown)
 │   │   ├── PayloadEditor/        # Textarea + validation + SampleButtons
 │   │   └── NavMenu/              # Generic accessible dropdown menu
+│   ├── icons/
+│   │   ├── CloseIcon.svg         # Local SVG imported via ?react for close/delete controls
+│   │   └── TerminalPromptIcon.svg
 │   └── utils/
-│       ├── messageParser.ts      # ★ Message classification & pattern matching (extractGraphExportSuccess, detectGraphExportFailure)
+│       ├── messageParser.ts      # ★ Message classification & pattern matching (incl. create-node text results)
 │       ├── localHelpCommand.ts   # resolveBundledHelpTopic — pure local-help resolver
 │       ├── graphTransformer.ts   # Backend JSON → ReactFlow nodes + edges (BFS layout, cycle detection, orphan segregation, back-edge routing)
 │       ├── graphTypes.ts         # TypeScript interfaces + type guard
@@ -527,6 +586,7 @@ Each Playground instance:
   ├── useSavedGraphs        ← localStorage bookmark CRUD
   ├── useGraphSaveName      ← bus: command.importGraph → save-form pre-fill name
   ├── useClipboardContext   ← IndexedDB items + clipNode + confirmReplace
+  ├── useGraphAuthoring     ← create-node modal lifecycle + raw command submit + result correlation
   │
   ├── LeftPanel
   │   ├── Console           ← message list (ConsoleMessage per row)
@@ -535,11 +595,12 @@ Each Playground instance:
   │
   ├── RightPanel (tabbed: payload / graph / graph-data; receives graphName)
   │   ├── PayloadEditor     ← textarea + validation (JSON-Path only)
-  │   ├── GraphView         ← ReactFlow canvas (receives graphName; onClipNode wired when supportsClipboard)
+  │   ├── GraphView         ← ReactFlow canvas (receives graphName; clip/create-node context actions)
   │   ├── GraphDataView     ← raw JSON tree of graph model (receives graphName)
   │   └── HelpBrowser       ← bundled help panel (resizable overlay — not a tab)
   │
   ├── MockUploadModal       ← native <dialog>; JSON paste / drop / browse; POST
+  ├── GraphAuthoringModals  ← create-node modal mount (NodeDialog)
   │
   └── ClipboardSidebar      ← conditional third panel (only when supportsClipboard && clipboardOpen)
 
@@ -554,6 +615,7 @@ Each Playground instance:
                                     ├── useLargePayloadDownload.on('payload.large')
                                     ├── useAutoMockUpload.on('upload.invitation')
                                     ├── useGraphSaveName.on('command.importGraph')
+                                    ├── useGraphAuthoring.on('minigraph.createNode.textResult')
                                     └── useWebSocket.on('upload.contentPath')  [when bus provided]
 ```
 
@@ -591,6 +653,9 @@ interface PlaygroundConfig {
   storageKeySavedGraphs?: string;  // present → enables saved-graph bookmarks
   supportsUpload?:       boolean;  // present → enables REST upload handshake
   supportsClipboard?:    boolean;  // true → enables node clip/paste sidebar (Minigraph only)
+  supportsHelp?:         boolean;  // true → enables bundled help panel
+  supportsAuthoring?:    boolean;  // true → enables create-node UI authoring (Minigraph only)
+  storageKeyHelpTopic?:  string;   // localStorage key for the last help topic
   tabs:                  RightTab[]; // ordered list of right-panel tabs to show
 }
 ```
@@ -608,6 +673,8 @@ The file also exports shared runtime constants used across the app:
 The file also exports `SAMPLE_DATA: Record<string, string>` — a set of quick-load JSON/XML payloads for the `PayloadEditor`. Key format: `"<type>_<label>"` where the type prefix (`json` or `xml`) groups buttons by row and the label becomes button text (underscores become spaces). Adding a new entry causes a new button to appear automatically in the `PayloadEditor`.
 
 > **Maintainer tip:** To add a new playground, add one object to `PLAYGROUND_CONFIGS`. The route, nav link, connection dot, localStorage namespace, and right-panel tabs are all derived automatically.
+
+`supportsAuthoring` should be enabled only for a backend that accepts the Minigraph multiline command grammar. The UI authoring layer does not define a new protocol; it serialises to raw command text and sends it through the existing WebSocket command path.
 
 ---
 
@@ -644,10 +711,10 @@ A thin delegation layer that reads its slot from the context and adds purely loc
 
 - **Command input + history** via a local `useReducer` (not shared — intentionally resets on remount)
 - **Auto-scroll** via a `consoleRef` and a `useEffect` watching `messages`
-- **History navigation** with ↑/↓ arrow key handling; saves and restores the in-progress draft when entering/exiting history mode
+- **History navigation** with ↑/↓ arrow key handling; saves and restores the in-progress command when entering/exiting history mode
 - **`sendCommand()`**: sends the command, pushes to history, and — for the special `load` command — also sends the payload as a second WebSocket message
 - **Two-step upload handshake**: a `pendingUploadRef` is armed by `uploadPayload()` ([L272](../src/hooks/useWebSocket.ts#L272)). When a `ProtocolBus` is provided via the optional `bus?` prop ([L40](../src/hooks/useWebSocket.ts#L40)), the hook subscribes to `upload.contentPath` events ([L194](../src/hooks/useWebSocket.ts#L194)) for responsive detection. Otherwise, a legacy `useEffect` watches messages for the `extractUploadPath` pattern ([L230](../src/hooks/useWebSocket.ts#L230)) and fires the `fetch` POST.
-- **`sendRawText(text)`** ([L286](../src/hooks/useWebSocket.ts#L286)): sends without echoing to history, used by automation hooks for silent commands like `describe graph`
+- **`sendRawText(text)`** ([L286](../src/hooks/useWebSocket.ts#L286)): sends without echoing to history. Used by automation hooks for silent commands like `describe graph` and by the create-node authoring executor for modal-submitted raw command text. Returns `false` when the socket is not open, allowing callers to keep their UI state instead of assuming the send succeeded.
 
 ---
 
@@ -674,6 +741,7 @@ Key responsibilities:
 | Modal trigger element | `useRef<HTMLElement \| null>(null)` — captures `document.activeElement` before open; `.focus()` restored on close via `setTimeout` |
 | Successful upload paths | `useState<Set<string>>(new Set())` — keyed by POST path; drives ✅ badge on invitation rows; session-only (cleared with `clearMessages`) |
 | Graph display name | `graphDisplayName = useMemo(...)` — resolves root node's `name` property → `graphSaveName` fallback; threaded as `graphName` prop to `RightPanel` → `GraphView` / `GraphDataView` → `GraphToolbar` |
+| Graph authoring | `createGraphAuthoringExecutor(ws.sendRawText)` + `useGraphAuthoring({ bus, connected, graphData, executor })`; modal state rendered through `GraphAuthoringModals`; `openCreateNode` threaded to `RightPanel` → `GraphView` |
 | Graph save-form name | `useGraphSaveName(storageKey, bus)` — provides `defaultName`, `setLastSavedName`, `resetName`; see §3.13 |
 | Deferred graph export | `pendingSaveRef = useRef<PendingSave | null>(null)` where `PendingSave = { graphName, timeoutId }` — armed when connected save is sent; confirmed by `graph.exported` (name-matched), rejected by `graph.export.failed`, timeout (10 s), or disconnect |
 | Deferred JSON-Path send | `pendingJsonTransferRef = useRef<{ wsPath, json } | null>(null)` — last-write-wins mailbox; overwritten on each send while JSON-Path is `'connecting'`; consumed by a `useEffect` watching the slot once `phase === 'connected'` |
@@ -719,7 +787,9 @@ Key responsibilities:
 
 `useGraphData` normalizes the persisted tab value against the current `tabs` array before `RightPanel` renders. This prevents legacy localStorage entries from older UI versions from blanking the panel after a tab is removed. Example: an old Minigraph value of `preview` is migrated to `graph` because Minigraph now exposes only `graph` and `graph-data`.
 
-The four possible tabs:
+When `supportsAuthoring` is enabled, `RightPanel` forwards `isConnected` and `onCreateNode` into `GraphView`. The right panel does not own authoring state; it only passes the graph-tab affordance down to the renderer.
+
+The three possible tabs:
 
 | Tab key | Component | When shown |
 |---|---|---|
@@ -791,6 +861,18 @@ Displays a resolved `graphName` prop prominently (falls back to "Untitled"). Nod
 
 When `onClipNode` is wired (i.e. `supportsClipboard` is true in the playground config), right-clicking a node opens a context menu with a "Clip to Clipboard" option. This calls `onClipNode(node, connections)` which is threaded from `Playground.tsx` → `RightPanel` → `GraphView`.
 
+#### `src/components/GraphView/GraphView.tsx` — Create-node entry points
+
+When `supportsAuthoring`, `onCreateNode`, and `isConnected` are all truthy, the graph view exposes create-node actions:
+- Empty graph: the empty state renders a "Create Node" button. Clicking it calls `onCreateNode('empty-graph')`.
+- Existing graph: right-clicking the pane calls `onPaneContextMenu`, records `event.clientX` / `event.clientY`, and opens `GraphContextMenu` at the pointer location. Clicking "Create Node" calls `onCreateNode('pane-context-menu')`.
+
+The node context menu remains reserved for clipboard actions. Pane-level create-node and node-level clipboard clipping are separate menus so a right-click on a node never accidentally opens a create-node flow.
+
+#### `src/components/GraphView/GraphContextMenu.tsx`
+
+A lightweight, pointer-positioned menu for graph-pane actions. It focuses its first item on open, closes on outside pointer down or Escape, and does not trap focus. It is intentionally not centered like a modal; the `x`/`y` coordinates come from the user’s right-click.
+
 #### `src/components/GraphView/GraphViewErrorBoundary.tsx`
 
 A class-based error boundary that resets when its `key` prop changes. `GraphView` passes a `boundaryKey` derived from `graphData.nodes.map(n => n.alias)` — a corrected graph after a previous render failure renders cleanly without a page reload.
@@ -803,13 +885,13 @@ This layer centralises message classification so that hooks subscribe to typed e
 
 #### `src/protocol/events.ts` — Event type definitions
 
-A 12-kind discriminated union type `ProtocolEvent`. Each variant carries a `kind` tag, the originating `msgId`, plus kind-specific payloads (e.g. `GraphLinkEvent` includes `apiPath`; `LargePayloadEvent` includes `byteSize`, `apiPath`, and `filename` — the last path segment of `apiPath` with `.json` appended, reserved for a future download action). `ProtocolEventKind` is the union of all `kind` string literals.
+A discriminated union type `ProtocolEvent`. Each variant carries a `kind` tag, the originating `msgId`, plus kind-specific payloads (e.g. `GraphLinkEvent` includes `apiPath`; `LargePayloadEvent` includes `byteSize`, `apiPath`, and `filename` — the last path segment of `apiPath` with `.json` appended, reserved for a future download action). Create-node result correlation uses `CreateNodeTextResultEvent` with `kind: 'minigraph.createNode.textResult'`, `status`, `alias`, and the raw backend message. `ProtocolEventKind` is the union of all `kind` string literals.
 
 #### `src/protocol/classifier.ts` — Pure classification function
 
-`classifyMessage(msgId: number, raw: string): ProtocolEvent[]` ([L27](../src/protocol/classifier.ts#L27)) returns an **array** because a single message may match multiple rules (e.g. a graph-link that is also a mutation response). The 12 rules are applied in order; Rule 12 (`unclassified` at [L175](../src/protocol/classifier.ts#L175)) fires only when no other rule matched.
+`classifyMessage(msgId: number, raw: string): ProtocolEvent[]` ([L27](../src/protocol/classifier.ts#L27)) returns an **array** because a single message may match multiple rules (e.g. `"node root created"` is both a `graph.mutation` and a `minigraph.createNode.textResult`). The fallback `unclassified` rule fires only when no other rule matched.
 
-The classifier delegates to `messageParser.ts` predicates (`extractGraphApiPath`, `extractLargePayloadLink`, `extractMockUploadPath`, `extractUploadPath`, `isHelpOrDescribeCommand`, `detectMutation`, `extractImportGraphName`, `isGraphLinkMessage`, `isMarkdownCandidate`, `tryParseJSON`) — it adds no new parsing logic, only orchestrates existing parsers into a single classification pass.
+The classifier delegates to `messageParser.ts` predicates (`extractGraphApiPath`, `extractLargePayloadLink`, `extractMockUploadPath`, `extractUploadPath`, `isHelpOrDescribeCommand`, `detectMutation`, `parseCreateNodeTextResult`, `extractImportGraphName`, `isGraphLinkMessage`, `isMarkdownCandidate`, `tryParseJSON`) — it adds no new parsing logic, only orchestrates existing parsers into a single classification pass.
 
 #### `src/protocol/bus.ts` — Typed event emitter
 
@@ -896,6 +978,7 @@ The low-level classification engine for WebSocket messages. These functions are 
 | `isMockUploadMessage(raw)` | True for `"You may upload … -> POST /api/mock/..."` upload invitations |
 | `isHelpOrDescribeCommand(raw)` | True for `"> help ..."` and `"> describe <non-graph>"` echoes |
 | `detectMutation(raw)` | Returns `'node-mutation'`, `'import-graph'`, or `null` |
+| `parseCreateNodeTextResult(raw)` | Parses create-node backend text into `{status, alias, message}` for modal result correlation |
 | `extractGraphApiPath(raw)` | Regex extracts `/api/graph/model/{id}` |
 | `extractUploadPath(raw)` | Regex extracts `/api/json/content/{id}` (JSON-Path upload handshake) |
 | `extractMockUploadPath(raw)` | Regex extracts `/api/mock/{id}` from the mock-upload invitation |
@@ -904,7 +987,7 @@ The low-level classification engine for WebSocket messages. These functions are 
 **`detectMutation` matching rules** (important to understand for maintenance):
 
 ```
-'import-graph'   if lower includes 'graph model imported as draft'
+'import-graph'   if lower includes the backend import-graph success phrase
 'node-mutation'  if lower includes ' -> ' AND 'removed'         (connection delete)
 'node-mutation'  if lower.startsWith('node ') AND:
                     includes ' created'
@@ -1030,6 +1113,54 @@ See §3.13 for the full feature description and all code locations.
 
 ---
 
+### 6.13 Graph Authoring Layer
+
+The create-node UI is split into a pure domain layer, a lifecycle hook, and presentational components.
+
+#### `src/graphActions/*` — Pure authoring helpers
+
+This folder is intentionally independent of React. It contains:
+- `nodeAuthoringTypes.ts` — create-node form model, `PropertyRow`, and the source union (`'empty-graph' | 'pane-context-menu'`)
+- `propertyRows.ts` — deterministic default form values and row IDs used only for React rendering/error keys
+- `validation.ts` — frontend validation for the supported authoring surface; keeps the token rules aligned with backend name validation and checks final command size against `MAX_BUFFER`
+- `minigraphCommandBuilder.ts` — serialises valid form values into raw multiline Minigraph command text
+- `graphAuthoringExecutor.ts` — a thin interface and production adapter over `sendRawText`
+
+The builder is the single serialisation boundary. UI components should never concatenate the backend command directly.
+
+#### `src/components/GraphAuthoring/useGraphAuthoring.ts`
+
+Owns the create-node state machine:
+- `closed`
+- `open/editing`
+- `open/sending`
+
+It keeps the current form values, validation errors, the pending submit metadata (`alias`, `command`, `sentAt`), the backend/server message, and a `connectionLost` flag. It validates before building, builds before sending, and sends through `GraphAuthoringExecutor.execute(command)`.
+
+Result matching is best-effort and text-based: the hook subscribes to `bus.on('minigraph.createNode.textResult')` and matches accepted/rejected events by alias. This works because the backend already returns stable text responses for create-node outcomes:
+- `node {alias} created` → accepted
+- `node {alias} already exists` → rejected
+- `ERROR: ...` → error while a submit is pending
+
+The hook does not mutate `graphData` directly. Graph refresh is delegated to the existing auto-refresh path, because the accepted backend message also classifies as `graph.mutation`.
+
+Disconnect handling: a connected→disconnected transition clears the pending timer, keeps the dialog mounted, disables all fields, and shows a refresh/check-graph message.
+
+#### `src/components/NodeDialog/NodeDialog.tsx`
+
+A presentational modal that edits the create-node form and delegates submit/close/change intents upward. Important UI details:
+- The modal uses a fixed overlay element, not a native `<dialog>`, so pointer events are absorbed before underlying `react-resizable-panels` handles can drag.
+- Escape and backdrop click close only while not sending.
+- When a property row is added, focus moves to the new row's key input.
+- Remove-property and close controls use a local `CloseIcon.svg` imported through `?react`; CSS controls the hover/focus states, not the SVG itself.
+- When `lockReason === 'disconnected'`, all editable controls are disabled and the dialog shows the connection-lost message from the hook.
+
+#### `src/components/GraphAuthoring/GraphAuthoringModals.tsx`
+
+The mount adapter between hook state and modal props. It converts hook state into the modal's `lockReason` (`'sending'`, `'disconnected'`, or `null`) and returns `null` when the authoring state is closed.
+
+---
+
 ## 7. Key Engineering Decisions
 
 ### 7.1 WebSocket Context Above the Router
@@ -1130,7 +1261,21 @@ The hook has two distinct code paths:
 
 **Classify-once, emit-to-many:** Because `classifyMessage` is a pure function and `useProtocolKernel` classifies each message exactly once, all downstream hooks receive the same event objects. This prevents subtle bugs where two hooks would classify the same message differently (e.g. due to regex flag differences or parser updates that landed in one hook but not another).
 
-**Ref-wrapping for stable subscriptions:** Automation hooks read mutable state through refs (`connectedRef`, `sendRawTextRef`, `pinnedGraphPathRef`, `onAutoPinRef`) so their bus subscription callbacks never close over stale values. This is critical because the `bus.on()` subscription runs only once (the bus reference never changes), so the callback must be able to read current state without being a React dependency.
+**Ref-wrapping for stable subscriptions:** Automation hooks read mutable state through refs (`connectedRef`, `sendRawTextRef`, `pinnedGraphPathRef`, callback refs) so their bus subscription callbacks never close over stale values. This is critical because the `bus.on()` subscription runs only once (the bus reference never changes), so the callback must be able to read current state without being a React dependency.
+
+---
+
+### 7.12 Create-Node UI Uses the Existing Raw Command Protocol
+
+**Decision:** The create-node UI serialises form state into the existing multiline Minigraph command grammar and sends it with `sendRawText()`. It does not introduce a JSON command API.
+
+**Why:** The backend already owns command semantics in `GraphCommandService`. Reusing the command grammar keeps the UI authoring path behaviorally aligned with the console path and avoids a second protocol that would need separate backend validation, parsing, and error handling.
+
+**Single serialization boundary:** `minigraphCommandBuilder.ts` is the only file that turns form state into raw command text. `NodeDialog` edits form values only; `useGraphAuthoring` validates and calls the builder; the executor sends the final string.
+
+**No optimistic graph mutation:** The frontend waits for the backend text result and lets `useAutoGraphRefresh` fetch the updated graph after the accepted response classifies as `graph.mutation`. This avoids trying to locally mirror backend graph rules.
+
+**Custom overlay instead of native dialog:** `NodeDialog` uses a fixed overlay element to absorb pointer events before underlying `react-resizable-panels` handles can drag. A native `<dialog>` backdrop was not sufficient for this interaction in the existing panel layout.
 
 ---
 
@@ -1331,6 +1476,84 @@ WS echo: "> import graph from other-graph"
 
 ---
 
+### 8.8 Create Node UI Flow
+
+```
+Entry point A: empty graph state
+  GraphView renders "Create Node"
+  → user clicks button
+  → onCreateNode('empty-graph')
+  → useGraphAuthoring.openCreateNode()
+      create default form values for 'empty-graph'
+        alias = "root"
+        nodeType = "Root"
+        properties = [empty row]
+
+Entry point B: existing graph pane
+  User right-clicks empty ReactFlow pane
+  → GraphView.onPaneContextMenu(event)
+      event.preventDefault()
+      setPaneMenu({ x: event.clientX, y: event.clientY })
+  → GraphContextMenu renders at pointer position
+  → user clicks "Create Node"
+  → onCreateNode('pane-context-menu')
+  → useGraphAuthoring.openCreateNode()
+      create default form values for 'pane-context-menu'
+        alias = ""
+        nodeType = ""
+        properties = [empty row]
+
+User edits modal fields
+  → NodeDialog reports the updated form values
+  → useGraphAuthoring stores the latest form values
+      clears validation errors and server message
+
+User clicks Create Node
+  → useGraphAuthoring.submit()
+      validate form values with current graph data
+        checks alias, node type, flat property rows, duplicate alias, command budget
+      buildCreateNodeCommand(formValues)
+        create node {alias}
+        with type {nodeType}
+        with properties
+        key=value
+      executor.execute(command)
+        → ws.sendRawText(command)
+        → ctx.send(wsPath, command)
+      state.phase = "sending"
+      pendingSubmit = { alias, command, sentAt }
+      start 10 s timeout
+
+Backend response arrives over WebSocket
+  → WebSocketContext dispatches MESSAGE_RECEIVED
+  → useProtocolKernel.classifyMessage()
+      "node root created"
+        → graph.mutation
+        → minigraph.createNode.textResult { status: "accepted", alias: "root" }
+
+Accepted result
+  → useGraphAuthoring bus handler matches alias
+  → clear timeout
+  → close modal
+  → useAutoGraphRefresh sees graph.mutation
+  → sends silent "describe graph"
+  → graph.link response updates pinnedGraphPath
+  → useGraphData fetches and renders the updated graph
+
+Rejected/error result
+  → useGraphAuthoring clears pendingSubmit
+  → state.phase = "editing"
+  → serverMessage shown in NodeDialog
+  → user can edit and resubmit
+
+Disconnect while modal is open
+  → useGraphAuthoring detects connected → disconnected
+  → clear timeout
+  → connectionLost = true
+  → all fields/buttons disabled except close/cancel
+  → message tells the user to refresh/check graph before trying again
+```
+
 ## 9. State Ownership Map
 
 | State | Owner | Persistence | Notes |
@@ -1354,6 +1577,10 @@ WS echo: "> import graph from other-graph"
 | `clipboardOpen` | `useLocalStorage` in `Playground` | `localStorage` | Key `'clipboard-sidebar-open'`; persists sidebar open/closed state |
 | Duplicate dialog state | `useState` in `Playground` | Memory only | `null` = closed; non-null = `{ pendingItem, existingItem }` |
 | Graph display name | `useMemo` in `Playground` | Memory only | Derived: root node `name` property → `graphSaveName` fallback; threaded as `graphName` prop |
+| Graph authoring state | `useState` in `useGraphAuthoring` | Memory only | Closed/open modal state, form values, phase, pending submit, server message, connection-lost flag |
+| Graph authoring validation errors | `useState` in `useGraphAuthoring` | Memory only | Field-keyed errors; cleared on form edit and accepted submit |
+| Graph authoring submit timer | `useRef` in `useGraphAuthoring` | Memory only | 10-second timeout while a create-node submit is pending |
+| Property row focus refs | `useRef` in `NodeDialog` | Memory only | Focuses the new key input after Add Property; not persisted or sent |
 | Graph data | `useState` in `useGraphData` | Memory only | |
 | Right panel tab | `useLocalStorage` in `useGraphData` | `localStorage` | Keyed per playground; normalized against the current `tabs` array before render so removed legacy values are migrated to a valid tab |
 | Is refreshing | `useState` in `useGraphData` | Memory only | |
@@ -1461,6 +1688,17 @@ The Protocol Kernel's `classifier.ts` calls `detectMutation()` internally, so no
 5. Add golden transcript test cases in `src/protocol/__tests__/classifier.test.ts`
 6. Subscribe to the new event kind in the appropriate hook via `bus.on('new.kind', handler)`
 
+### Extend the create-node UI surface
+
+1. Add the new field to the create-node form model in `src/graphActions/nodeAuthoringTypes.ts`
+2. Initialise it in the default form-value helper in `propertyRows.ts`
+3. Add frontend validation in `validation.ts`
+4. Update `buildCreateNodeCommand()` in `minigraphCommandBuilder.ts` to serialise it into the backend's accepted command grammar
+5. Render/edit the field in `NodeDialog.tsx`
+6. Add or update `graphActions/__tests__` coverage for validation and command serialization
+
+Do not add backend-command string concatenation inside `NodeDialog` or `useGraphAuthoring`; keep `minigraphCommandBuilder.ts` as the single serialization boundary.
+
 ---
 
 ## 12. Pitfalls & Gotchas
@@ -1478,7 +1716,7 @@ The ring buffer drops old messages. Always identify pinned/processed messages by
 Without this guard, `"Graph instance created"` and `"Root node created because..."` trigger false-positive auto-refreshes. Do not remove the prefix check. See §3.5 and §6.10.
 
 ### P5 — `sendRawText` must be used for silent commands, not `sendCommand`
-`sendCommand` pushes to history and echoes the command — the echo would trigger `useAutoHelpNavigate`'s `describe` guard and open the help panel unexpectedly. `sendRawText` bypasses all that. See §7.5.
+`sendCommand` pushes to history and echoes the command — the echo would trigger `useAutoHelpNavigate`'s `describe` guard and open the help panel unexpectedly. `sendRawText` bypasses all that. Create-node UI authoring also uses `sendRawText`; keep checking its boolean return so the modal can remain open when the socket is unavailable. See §7.5 and §7.12.
 
 ### P6 — The centralised watermark in `useProtocolKernel` must initialise before the emission effect
 The watermark init effect ([L40](../src/protocol/useProtocolKernel.ts#L40)) must run *before* the bus emission effect ([L56](../src/protocol/useProtocolKernel.ts#L56)) at mount. React guarantees effects in a component run in declaration order on the first render, so declaring the watermark init first works. Merging them into a single effect would process historical messages as new events. See §7.4.
@@ -1502,12 +1740,21 @@ The upload invitation is plain text, so `isMarkdownCandidate` returns `true` for
 The `docs.response` classification rule in `classifier.ts` ([L155](../src/protocol/classifier.ts#L155)) excludes echoes, graph-links, mock-upload invitations, large-payload notices, JSON responses, and lifecycle messages. If a new message type is added that is plain text, it must also be excluded from `docs.response` to prevent it from being stolen as an auto-pin target. See §6.8 and §6.9.
 
 ### P13 — Bus subscription callbacks must read mutable state through refs
-Because `bus.on()` registers a callback only once (the bus `useRef` identity never changes), any React state read inside the callback would be stale after subsequent renders. All automation hooks use ref-wrapping (`connectedRef`, `sendRawTextRef`, `pinnedGraphPathRef`, `onAutoPinRef`) to access current values. Adding a new bus subscriber that reads state directly from closure will produce stale-closure bugs. See §7.11.
+Because `bus.on()` registers a callback only once (the bus `useRef` identity never changes), any React state read inside the callback would be stale after subsequent renders. All automation hooks use ref-wrapping (`connectedRef`, `sendRawTextRef`, `pinnedGraphPathRef`, callback refs) to access current values. Adding a new bus subscriber that reads state directly from closure will produce stale-closure bugs. See §7.11.
 
 ### P14 — `classificationMap` identity changes on every new message
 The `classificationMap` is a `useMemo` that re-derives when `messages` changes. Components that receive it as a prop will see a new `Map` reference on every new WebSocket message. This is intentional — React Compiler handles memoisation — but avoid using `classificationMap` as a `useEffect` dependency without wrapping the effect in additional guards, as it will fire on every message.
 
 ### P15 — Never allow saves while disconnected
 `useSavedGraphs` stores only the graph **name**, not the graph data. A bookmark without a matching server-side `{name}.json` export file cannot be loaded — `import graph from {name}` will fail after reconnect. `useSavedGraphWorkflow.handleSaveGraph` guards against disconnected calls with an early-return error toast; `GraphSaveButton` enforces `disabled={disabled || !connected}` at the UI level. If you add any new path that calls `saveGraph(name)` directly, ensure the caller is always connected first. See §3.10 and §6.12.
+
+### P16 — Keep create-node serialization out of UI components
+`NodeDialog` must stay a typed form editor. If a future field is added, update the form model, validation, and `buildCreateNodeCommand()` together. String-building command text in JSX or in event handlers will bypass validation, command-size checks, and tests. See §6.13 and §7.12.
+
+### P17 — Create-node result matching is text-based and alias-scoped
+`useGraphAuthoring` closes the modal only when a `minigraph.createNode.textResult` accepted/rejected event matches the pending alias. If backend success/error wording changes, update `parseCreateNodeTextResult()` and its classifier tests. Do not make the hook infer success from graph refresh alone; graph refresh is a downstream side effect, not submit confirmation. See §3.16 and §8.8.
+
+### P18 — The create-node modal must block panel resizing underneath
+The fixed overlay's `onPointerDown` prevents underlying `react-resizable-panels` handles from receiving drag gestures while the modal is open. If the modal structure changes, verify that resize handles under the overlay cannot move. See §6.13.
 
 ---

--- a/system/minigraph-playground-engine/webapp/src/clipboard/__tests__/dnd.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/clipboard/__tests__/dnd.test.ts
@@ -1,0 +1,56 @@
+import {
+  hasClipboardItemType,
+  MINIGRAPH_CLIPBOARD_ITEM_MIME,
+  readClipboardItemId,
+  writeClipboardItemDragData,
+} from '../dnd';
+
+class DataTransferStub {
+  effectAllowed = 'none';
+  private data = new Map<string, string>();
+
+  get types(): string[] {
+    return Array.from(this.data.keys());
+  }
+
+  setData(format: string, value: string): void {
+    this.data.set(format, value);
+  }
+
+  getData(format: string): string {
+    return this.data.get(format) ?? '';
+  }
+}
+
+describe('clipboard dnd helpers', () => {
+  it('detects only the exported clipboard mime type', () => {
+    expect(hasClipboardItemType([])).toBe(false);
+    expect(hasClipboardItemType(['text/plain'])).toBe(false);
+    expect(hasClipboardItemType(['text/plain', MINIGRAPH_CLIPBOARD_ITEM_MIME])).toBe(true);
+  });
+
+  it('writes only the clipboard item id under the exported mime type and sets copy semantics', () => {
+    const dataTransfer = new DataTransferStub();
+
+    writeClipboardItemDragData(dataTransfer as unknown as DataTransfer, 'item-123');
+
+    expect(dataTransfer.effectAllowed).toBe('copy');
+    expect(dataTransfer.types).toEqual([MINIGRAPH_CLIPBOARD_ITEM_MIME]);
+    expect(dataTransfer.getData(MINIGRAPH_CLIPBOARD_ITEM_MIME)).toBe('item-123');
+    expect(dataTransfer.getData('text/plain')).toBe('');
+  });
+
+  it('reads the stored clipboard item id and returns null for missing or empty payloads', () => {
+    const present = new DataTransferStub();
+    writeClipboardItemDragData(present as unknown as DataTransfer, 'item-456');
+
+    const missing = new DataTransferStub();
+    const empty = new DataTransferStub();
+    empty.setData(MINIGRAPH_CLIPBOARD_ITEM_MIME, '   ');
+
+    expect(readClipboardItemId(present as unknown as DataTransfer)).toBe('item-456');
+    expect(readClipboardItemId(missing as unknown as DataTransfer)).toBeNull();
+    expect(readClipboardItemId(empty as unknown as DataTransfer)).toBeNull();
+    expect(readClipboardItemId(null)).toBeNull();
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/clipboard/__tests__/paste.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/clipboard/__tests__/paste.test.ts
@@ -1,0 +1,56 @@
+import { buildNodeCommand } from '../commandBuilder';
+import { buildClipboardPastePlan } from '../paste';
+import type { ClipboardItemRecord } from '../db';
+import type { MinigraphGraphData } from '../../utils/graphTypes';
+
+function makeClipboardItem(alias: string): ClipboardItemRecord {
+  return {
+    id: `id-${alias}`,
+    clippedAt: '2026-05-07T00:00:00.000Z',
+    sourceWsPath: '/ws/minigraph',
+    sourceLabel: 'Minigraph',
+    node: {
+      alias,
+      types: ['Fetcher'],
+      properties: {
+        skill: 'graph.fetch',
+        lines: ['one', 'two'],
+      },
+    },
+    connections: [],
+  };
+}
+
+function makeGraphData(aliases: string[]): MinigraphGraphData {
+  return {
+    nodes: aliases.map(alias => ({
+      alias,
+      types: ['Fetcher'],
+      properties: {},
+    })),
+    connections: [],
+  };
+}
+
+describe('buildClipboardPastePlan', () => {
+  it('returns create when the alias is absent from the current graph', () => {
+    const item = makeClipboardItem('fetchpersondata');
+
+    expect(buildClipboardPastePlan(item, makeGraphData(['other-node'])).verb).toBe('create');
+    expect(buildClipboardPastePlan(item, null).verb).toBe('create');
+  });
+
+  it('returns update when the alias is present in the current graph', () => {
+    const item = makeClipboardItem('fetchpersondata');
+
+    expect(buildClipboardPastePlan(item, makeGraphData(['fetchpersondata'])).verb).toBe('update');
+  });
+
+  it('returns the exact command text produced by buildNodeCommand', () => {
+    const item = makeClipboardItem('fetchpersondata');
+    const graphData = makeGraphData(['fetchpersondata']);
+    const plan = buildClipboardPastePlan(item, graphData);
+
+    expect(plan.command).toBe(buildNodeCommand('update', item.node));
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/clipboard/dnd.ts
+++ b/system/minigraph-playground-engine/webapp/src/clipboard/dnd.ts
@@ -1,0 +1,20 @@
+export const MINIGRAPH_CLIPBOARD_ITEM_MIME = 'application/x-minigraph-clipboard-item';
+
+export function hasClipboardItemType(types: readonly string[]): boolean {
+  return types.includes(MINIGRAPH_CLIPBOARD_ITEM_MIME);
+}
+
+export function writeClipboardItemDragData(
+  dataTransfer: DataTransfer,
+  itemId: string,
+): void {
+  dataTransfer.effectAllowed = 'copy';
+  dataTransfer.setData(MINIGRAPH_CLIPBOARD_ITEM_MIME, itemId);
+}
+
+export function readClipboardItemId(
+  dataTransfer: DataTransfer | null,
+): string | null {
+  const itemId = dataTransfer?.getData(MINIGRAPH_CLIPBOARD_ITEM_MIME) ?? '';
+  return itemId.trim() ? itemId : null;
+}

--- a/system/minigraph-playground-engine/webapp/src/clipboard/paste.ts
+++ b/system/minigraph-playground-engine/webapp/src/clipboard/paste.ts
@@ -1,0 +1,22 @@
+import { buildNodeCommand } from './commandBuilder';
+import type { ClipboardItemRecord } from './db';
+import type { MinigraphGraphData } from '../utils/graphTypes';
+
+export interface ClipboardPastePlan {
+  verb: 'create' | 'update';
+  command: string;
+}
+
+export function buildClipboardPastePlan(
+  item: ClipboardItemRecord,
+  graphData: MinigraphGraphData | null,
+): ClipboardPastePlan {
+  const verb = graphData?.nodes.some(node => node.alias === item.node.alias)
+    ? 'update'
+    : 'create';
+
+  return {
+    verb,
+    command: buildNodeCommand(verb, item.node),
+  };
+}

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.module.css
@@ -1,86 +1,95 @@
-/* ── Item card ── */
-.card {
+.item {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 0.625rem 0.75rem;
   box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  position: relative;
 }
 
-.alias {
-  font-weight: 600;
-  font-size: 0.8125rem;
-  color: var(--text-primary);
-  margin-bottom: 0.25rem;
-  word-break: break-all;
+.previewFrame {
+  position: relative;
 }
 
-.meta {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  line-height: 1.4;
+.preview {
+  cursor: grab;
 }
 
-.propsLine {
-  display: block;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  max-width: 100%;
+.preview:active {
+  cursor: grabbing;
+}
+
+.previewShell {
+  width: 100%;
+}
+
+.metaBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .timestamp {
   font-size: 0.6875rem;
   color: var(--text-muted);
-  margin-top: 0.375rem;
 }
 
-/* ── Action buttons ── */
-.actions {
-  display: flex;
-  gap: 0.375rem;
-  margin-top: 0.5rem;
-}
-
-.pasteBtn,
-.inspectBtn,
-.removeBtn {
-  flex: 1;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  padding: 0.25rem 0.375rem;
-  font-size: 0.6875rem;
+.removeChrome {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+  border-radius: 999px;
+  padding: 0;
+  font: inherit;
+  line-height: 1;
   cursor: pointer;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  white-space: nowrap;
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(6px);
+  transform: translateY(-2px) scale(0.96);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  z-index: 1;
 }
 
-.pasteBtn:hover:not(:disabled) {
-  background: var(--primary-color);
-  color: #fff;
-  border-color: var(--primary-color);
+.removeIcon {
+  display: block;
+  flex: 0 0 auto;
+  width: 0.75rem;
+  height: 0.75rem;
+  pointer-events: none;
 }
 
-.inspectBtn:hover {
-  background: var(--bg-secondary);
-  border-color: var(--text-muted);
+.item:hover .removeChrome {
+  opacity: 0.85;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
 }
 
-.removeBtn:hover {
-  background: var(--danger-08);
-  color: var(--danger-color);
-  border-color: var(--danger-color);
+.removeChrome:hover {
+  opacity: 1;
 }
 
-.pasteBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.pasteBtn:focus-visible,
-.inspectBtn:focus-visible,
-.removeBtn:focus-visible {
+.removeChrome:focus-visible {
+  opacity: 1;
   outline: 2px solid var(--primary-color);
   outline-offset: 2px;
+}
+
+.preview:focus,
+.preview:focus-visible {
+  outline: none;
 }

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
@@ -8,10 +8,7 @@ import styles from './ClipboardItem.module.css';
 
 interface ClipboardItemProps {
   item: ClipboardItemRecord;
-  connected: boolean;
-  onPasteToInput: (item: ClipboardItemRecord) => void;
   onRemove: (itemId: string) => void;
-  onInspect: (item: ClipboardItemRecord) => void;
   onOpenMenu: (itemId: string, x: number, y: number) => void;
   onCloseMenu: () => void;
 }
@@ -19,7 +16,6 @@ interface ClipboardItemProps {
 export function ClipboardItem({
   item,
   onRemove,
-  onInspect,
   onOpenMenu,
   onCloseMenu,
 }: ClipboardItemProps) {

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItem.tsx
@@ -1,69 +1,92 @@
 import type { ClipboardItemRecord } from '../../clipboard/db';
+import { writeClipboardItemDragData } from '../../clipboard/dnd';
+import CloseIcon from '../../icons/CloseIcon.svg?react';
+import { MinigraphNodeBody } from '../GraphView/MinigraphNodeBody';
+import { getMinigraphNodeShellStyle } from '../../utils/minigraphNodeTheme';
 import { formatRelativeTime } from '../../utils/timeFormat';
 import styles from './ClipboardItem.module.css';
 
 interface ClipboardItemProps {
   item: ClipboardItemRecord;
   connected: boolean;
-  onPaste: (item: ClipboardItemRecord) => void;
-  onRemove: () => void;
-  onInspect: () => void;
+  onPasteToInput: (item: ClipboardItemRecord) => void;
+  onRemove: (itemId: string) => void;
+  onInspect: (item: ClipboardItemRecord) => void;
+  onOpenMenu: (itemId: string, x: number, y: number) => void;
+  onCloseMenu: () => void;
 }
 
-export function ClipboardItem({ item, connected, onPaste, onRemove, onInspect }: ClipboardItemProps) {
-  const { node, connections, clippedAt, sourceLabel } = item;
-  const primaryType = node.types[0] ?? '—';
-  const skill = node.properties.skill ?? '—';
+export function ClipboardItem({
+  item,
+  onRemove,
+  onInspect,
+  onOpenMenu,
+  onCloseMenu,
+}: ClipboardItemProps) {
+  const { node, clippedAt, sourceLabel } = item;
 
-  // Truncated props summary
-  const propKeys = Object.entries(node.properties)
-    .filter(([k]) => k !== 'skill')
-    .map(([k, v]) => {
-      const val = typeof v === 'string' ? v : JSON.stringify(v);
-      return `${k}=${val && val.length > 30 ? val.slice(0, 30) + '…' : val}`;
-    });
-  const propsSummary = propKeys.length > 0 ? propKeys.join(', ') : '—';
+  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    onCloseMenu();
+    writeClipboardItemDragData(event.dataTransfer, item.id);
+  };
 
-  // Connection counts
-  const outgoing = connections.filter(c => c.source === node.alias).length;
-  const incoming = connections.filter(c => c.target === node.alias).length;
-  const connSummary = `${connections.length} (${outgoing} out, ${incoming} in)`;
+  const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    onOpenMenu(item.id, event.clientX, event.clientY);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ContextMenu' || (event.key === 'F10' && event.shiftKey)) {
+      event.preventDefault();
+      const rect = event.currentTarget.getBoundingClientRect();
+      onOpenMenu(item.id, Math.round(rect.left + 8), Math.round(rect.top + 8));
+    }
+  };
 
   return (
-    <div className={styles.card}>
-      <div className={styles.alias}>{node.alias}</div>
-      <div className={styles.meta}>Type: {primaryType}</div>
-      <div className={styles.meta}>Skill: {skill}</div>
-      <div className={styles.meta} title={propsSummary}>
-        <span className={styles.propsLine}>Props: {propsSummary}</span>
-      </div>
-      <div className={styles.meta}>Connections: {connSummary}</div>
-      <div className={styles.timestamp}>
-        Clipped {formatRelativeTime(clippedAt)} from {sourceLabel}
-      </div>
-      <div className={styles.actions}>
+    <div className={styles.item}>
+      <div className={styles.previewFrame}>
         <button
-          className={styles.pasteBtn}
-          onClick={() => onPaste(item)}
-          disabled={!connected}
-          aria-label={`Paste node ${node.alias}`}
-        >
-          Paste
-        </button>
-        <button
-          className={styles.inspectBtn}
-          onClick={onInspect}
-          aria-label={`Inspect node ${node.alias}`}
-        >
-          Describe
-        </button>
-        <button
-          className={styles.removeBtn}
-          onClick={onRemove}
+          type="button"
+          className={styles.removeChrome}
+          draggable={false}
           aria-label={`Remove node ${node.alias} from clipboard`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onCloseMenu();
+            onRemove(item.id);
+          }}
         >
-          Remove
+          <CloseIcon className={styles.removeIcon} aria-hidden="true" focusable="false" />
         </button>
+
+        <div
+          className={styles.preview}
+          role="group"
+          draggable={true}
+          onDragStart={handleDragStart}
+          onContextMenu={handleContextMenu}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          aria-label={`Drag node ${node.alias} into the graph to paste`}
+        >
+          <div
+            className={styles.previewShell}
+            style={getMinigraphNodeShellStyle(node.types[0] ?? 'unknown')}
+          >
+            <MinigraphNodeBody
+              alias={node.alias}
+              nodeType={node.types[0] ?? 'unknown'}
+              properties={node.properties}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.metaBlock}>
+        <div className={styles.timestamp}>
+          Clipped {formatRelativeTime(clippedAt)} from {sourceLabel}
+        </div>
       </div>
     </div>
   );

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.module.css
@@ -1,0 +1,36 @@
+.menu {
+  position: fixed;
+  width: min(240px, calc(100vw - 32px));
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  z-index: 60;
+  padding: 0.25rem;
+}
+
+.menuItem {
+  width: 100%;
+  min-height: 2.25rem;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.875rem;
+  text-align: left;
+}
+
+.menuItem:hover:not(:disabled),
+.menuItem:focus-visible {
+  background: var(--autocomplete-highlight);
+}
+
+.menuItem:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.tsx
@@ -7,7 +7,7 @@ interface ClipboardItemContextMenuProps {
   y: number;
   canPasteToInput: boolean;
   onPasteToInput: () => void;
-  onDescribe: () => void;
+  onInspect: () => void;
   onClose: () => void;
 }
 
@@ -25,7 +25,7 @@ export function ClipboardItemContextMenu({
   y,
   canPasteToInput,
   onPasteToInput,
-  onDescribe,
+  onInspect,
   onClose,
 }: ClipboardItemContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -107,9 +107,9 @@ export function ClipboardItemContextMenu({
         role="menuitem"
         type="button"
         className={styles.menuItem}
-        onClick={onDescribe}
+        onClick={onInspect}
       >
-        Describe
+        Inspect
       </button>
     </div>
   );

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardItemContextMenu.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import styles from './ClipboardItemContextMenu.module.css';
+
+interface ClipboardItemContextMenuProps {
+  open: boolean;
+  x: number;
+  y: number;
+  canPasteToInput: boolean;
+  onPasteToInput: () => void;
+  onDescribe: () => void;
+  onClose: () => void;
+}
+
+const VIEWPORT_INSET = 16;
+
+function clampCoordinate(coordinate: number, size: number, viewportSize: number) {
+  const min = VIEWPORT_INSET;
+  const max = Math.max(VIEWPORT_INSET, viewportSize - size - VIEWPORT_INSET);
+  return Math.min(Math.max(coordinate, min), max);
+}
+
+export function ClipboardItemContextMenu({
+  open,
+  x,
+  y,
+  canPasteToInput,
+  onPasteToInput,
+  onDescribe,
+  onClose,
+}: ClipboardItemContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const pasteRef = useRef<HTMLButtonElement>(null);
+  const describeRef = useRef<HTMLButtonElement>(null);
+  const [position, setPosition] = useState({ left: x, top: y });
+
+  useLayoutEffect(() => {
+    if (!open || !menuRef.current) return;
+
+    const rect = menuRef.current.getBoundingClientRect();
+    setPosition({
+      left: clampCoordinate(x, rect.width, window.innerWidth),
+      top: clampCoordinate(y, rect.height, window.innerHeight),
+    });
+  }, [open, x, y]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (canPasteToInput) {
+      pasteRef.current?.focus();
+    } else {
+      describeRef.current?.focus();
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    const handleScrollOrResize = () => onClose();
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('scroll', handleScrollOrResize, true);
+    window.addEventListener('resize', handleScrollOrResize);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('scroll', handleScrollOrResize, true);
+      window.removeEventListener('resize', handleScrollOrResize);
+    };
+  }, [open, canPasteToInput, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className={styles.menu}
+      style={{ left: position.left, top: position.top }}
+      role="menu"
+      aria-label="Clipboard item actions"
+    >
+      <button
+        ref={pasteRef}
+        role="menuitem"
+        type="button"
+        className={styles.menuItem}
+        disabled={!canPasteToInput}
+        onClick={() => {
+          if (!canPasteToInput) return;
+          onPasteToInput();
+        }}
+      >
+        Paste to Input
+      </button>
+      <button
+        ref={describeRef}
+        role="menuitem"
+        type="button"
+        className={styles.menuItem}
+        onClick={onDescribe}
+      >
+        Describe
+      </button>
+    </div>
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
@@ -98,10 +98,7 @@ export default function ClipboardSidebar({ connected, onPasteToInput }: Clipboar
             <ClipboardItem
               key={item.id}
               item={item}
-              connected={connected}
-              onPasteToInput={onPasteToInput}
               onRemove={handleRemove}
-              onInspect={handleInspect}
               onOpenMenu={handleOpenItemMenu}
               onCloseMenu={handleCloseItemMenu}
             />
@@ -113,7 +110,7 @@ export default function ClipboardSidebar({ connected, onPasteToInput }: Clipboar
       {inspectItem && (
         <div className={styles.inspectPanel}>
           <div className={styles.inspectHeader}>
-            <span>Describe node {inspectItem.node.alias}</span>
+            <span>Inspect node {inspectItem.node.alias}</span>
             <button
               className={styles.inspectClose}
               onClick={() => setInspectItem(null)}
@@ -138,7 +135,7 @@ export default function ClipboardSidebar({ connected, onPasteToInput }: Clipboar
           y={activeItemMenu.y}
           canPasteToInput={connected}
           onPasteToInput={() => handlePasteToInputFromMenu(activeMenuItem)}
-          onDescribe={() => handleInspect(activeMenuItem)}
+          onInspect={() => handleInspect(activeMenuItem)}
           onClose={handleCloseItemMenu}
         />
       )}

--- a/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/ClipboardSidebar/ClipboardSidebar.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useClipboardContext } from '../../contexts/ClipboardContext';
 import type { ClipboardItemRecord } from '../../clipboard/db';
 import { ClipboardItem } from './ClipboardItem';
+import { ClipboardItemContextMenu } from './ClipboardItemContextMenu';
 import { ClipboardEmptyState } from './ClipboardEmptyState';
 import styles from './ClipboardSidebar.module.css';
 import { JsonView, darkStyles } from 'react-json-view-lite';
@@ -9,22 +10,78 @@ import 'react-json-view-lite/dist/index.css';
 
 interface ClipboardSidebarProps {
   connected: boolean;
-  onPaste: (item: ClipboardItemRecord) => void;
+  onPasteToInput: (item: ClipboardItemRecord) => void;
 }
 
-export default function ClipboardSidebar({ connected, onPaste }: ClipboardSidebarProps) {
+type ActiveClipboardMenuState = {
+  itemId: string;
+  x: number;
+  y: number;
+};
+
+export default function ClipboardSidebar({ connected, onPasteToInput }: ClipboardSidebarProps) {
   const clipboardCtx = useClipboardContext();
   const [inspectItem, setInspectItem] = useState<ClipboardItemRecord | null>(null);
+  const [activeItemMenu, setActiveItemMenu] = useState<ActiveClipboardMenuState | null>(null);
+
+  const handleOpenItemMenu = (itemId: string, x: number, y: number) => {
+    setActiveItemMenu({ itemId, x, y });
+  };
+
+  const handleCloseItemMenu = () => {
+    setActiveItemMenu(null);
+  };
+
+  const handlePasteToInputFromMenu = (item: ClipboardItemRecord) => {
+    handleCloseItemMenu();
+    onPasteToInput(item);
+  };
+
+  const handleInspect = (item: ClipboardItemRecord) => {
+    handleCloseItemMenu();
+    setInspectItem(current => (current?.id === item.id ? null : item));
+  };
+
+  const handleRemove = (itemId: string) => {
+    handleCloseItemMenu();
+    setInspectItem(current => (current?.id === itemId ? null : current));
+    void clipboardCtx.removeItem(itemId);
+  };
+
+  const handleClearAll = () => {
+    handleCloseItemMenu();
+    setInspectItem(null);
+    void clipboardCtx.clearAll();
+  };
+
+  useEffect(() => {
+    const itemIds = new Set(clipboardCtx.items.map(item => item.id));
+
+    if (activeItemMenu && !itemIds.has(activeItemMenu.itemId)) {
+      setActiveItemMenu(null);
+    }
+
+    if (inspectItem && !itemIds.has(inspectItem.id)) {
+      setInspectItem(null);
+    }
+  }, [clipboardCtx.items, activeItemMenu, inspectItem]);
+
+  const activeMenuItem = useMemo(
+    () => (activeItemMenu
+      ? clipboardCtx.items.find(item => item.id === activeItemMenu.itemId) ?? null
+      : null),
+    [activeItemMenu, clipboardCtx.items],
+  );
 
   return (
     <div className={styles.sidebar}>
       <div className={styles.header}>
-        <span className={styles.headerTitle}>Clipboard</span>
+        <span className={styles.headerTitle}>Workspace</span>
         {clipboardCtx.items.length > 0 && (
           <button
             className={styles.clearBtn}
-            onClick={() => clipboardCtx.clearAll()}
-            aria-label="Clear all clipboard items"
+            onClick={handleClearAll}
+            aria-label="Clear all workspace items"
           >
             Clear
           </button>
@@ -42,9 +99,11 @@ export default function ClipboardSidebar({ connected, onPaste }: ClipboardSideba
               key={item.id}
               item={item}
               connected={connected}
-              onPaste={onPaste}
-              onRemove={() => clipboardCtx.removeItem(item.id)}
-              onInspect={() => setInspectItem(inspectItem?.id === item.id ? null : item)}
+              onPasteToInput={onPasteToInput}
+              onRemove={handleRemove}
+              onInspect={handleInspect}
+              onOpenMenu={handleOpenItemMenu}
+              onCloseMenu={handleCloseItemMenu}
             />
           ))
         )}
@@ -70,6 +129,18 @@ export default function ClipboardSidebar({ connected, onPaste }: ClipboardSideba
             />
           </div>
         </div>
+      )}
+
+      {activeItemMenu && activeMenuItem && (
+        <ClipboardItemContextMenu
+          open={true}
+          x={activeItemMenu.x}
+          y={activeItemMenu.y}
+          canPasteToInput={connected}
+          onPasteToInput={() => handlePasteToInputFromMenu(activeMenuItem)}
+          onDescribe={() => handleInspect(activeMenuItem)}
+          onClose={handleCloseItemMenu}
+        />
       )}
     </div>
   );

--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
@@ -1,0 +1,42 @@
+import NodeDialog from '../NodeDialog/NodeDialog';
+import type { NodeDraft } from '../../graphActions/nodeAuthoringTypes';
+import type { AuthoringState } from './useGraphAuthoring';
+
+interface GraphAuthoringModalsProps {
+  state: AuthoringState;
+  validationErrors: Record<string, string>;
+  onDraftChange: (draft: NodeDraft) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}
+
+export default function GraphAuthoringModals({
+  state,
+  validationErrors,
+  onDraftChange,
+  onSubmit,
+  onClose,
+}: GraphAuthoringModalsProps) {
+  if (state.status === 'closed') return null;
+
+  const lockReason =
+    state.phase === 'sending'
+      ? 'sending'
+      : state.connectionLost
+        ? 'disconnected'
+        : null;
+
+  return (
+    <NodeDialog
+      open
+      draft={state.draft}
+      phase={state.phase}
+      lockReason={lockReason}
+      serverMessage={state.serverMessage}
+      validationErrors={validationErrors}
+      onDraftChange={onDraftChange}
+      onSubmit={onSubmit}
+      onClose={onClose}
+    />
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ProtocolBus } from '../../protocol/bus';
+import type { CreateNodeTextResultEvent } from '../../protocol/events';
+import type { MinigraphGraphData } from '../../utils/graphTypes';
+import type { CreateNodeTextResult } from '../../utils/messageParser';
+import type { GraphAuthoringExecutor } from '../../graphActions/graphAuthoringExecutor';
+import { buildCreateNodeCommand } from '../../graphActions/minigraphCommandBuilder';
+import type { NodeDraft, NodeDraftSource, NodeDraftValidationErrors } from '../../graphActions/nodeAuthoringTypes';
+import { createDefaultNodeDraft } from '../../graphActions/propertyRows';
+import { validateNodeDraft } from '../../graphActions/validation';
+
+export const DEFAULT_AUTHORING_TIMEOUT_MS = 10_000;
+
+export type AuthoringState =
+  | { status: 'closed' }
+  | {
+      status: 'open';
+      action: 'create-node';
+      phase: 'editing' | 'sending';
+      draft: NodeDraft;
+      pendingSubmit: PendingCreateNodeSubmit | null;
+      serverMessage: string | null;
+      connectionLost: boolean;
+    };
+
+export interface PendingCreateNodeSubmit {
+  alias: string;
+  command: string;
+  sentAt: string;
+}
+
+export interface UseGraphAuthoringOptions {
+  bus: ProtocolBus;
+  connected: boolean;
+  graphData: MinigraphGraphData | null;
+  executor: GraphAuthoringExecutor;
+  timeoutMs?: number;
+  onAccepted?: (result: CreateNodeTextResult) => void;
+}
+
+export interface UseGraphAuthoringReturn {
+  state: AuthoringState;
+  validationErrors: NodeDraftValidationErrors;
+  openCreateNode: (source: NodeDraftSource) => void;
+  updateDraft: (draft: NodeDraft) => void;
+  submit: () => void;
+  close: () => void;
+}
+
+const SEND_FAILURE_MESSAGE = 'Could not send the create-node command because the WebSocket is not open. The draft was preserved in this dialog.';
+const TIMEOUT_MESSAGE = 'The create-node command was sent, but no backend result was observed yet. The outcome is unknown.';
+const DISCONNECTED_EDITING_MESSAGE = 'Connection disconnected. This graph session may no longer be valid. Refresh the page and create the node again after the app reconnects.';
+const DISCONNECTED_SENDING_MESSAGE = 'Connection disconnected while the create-node command was pending. The outcome is unknown. Refresh the page and check the graph before trying again.';
+
+// Owns the complete create-node lifecycle: draft state, validation, raw-command
+// send, best-effort text-result matching, timeout handling, and disconnect
+// handling. UI components should call this hook instead of sending commands or
+// interpreting backend text themselves.
+export function useGraphAuthoring({
+  bus,
+  connected,
+  graphData,
+  executor,
+  timeoutMs = DEFAULT_AUTHORING_TIMEOUT_MS,
+  onAccepted,
+}: UseGraphAuthoringOptions): UseGraphAuthoringReturn {
+  const [state, setState] = useState<AuthoringState>({ status: 'closed' });
+  const [validationErrors, setValidationErrors] = useState<NodeDraftValidationErrors>({});
+
+  const stateRef = useRef(state);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wasConnectedRef = useRef(connected);
+  const graphDataRef = useRef(graphData);
+  const onAcceptedRef = useRef(onAccepted);
+
+  // ProtocolBus and timers can fire after render, so callbacks read refs for
+  // the latest state/context without re-subscribing on every draft keystroke.
+  useEffect(() => { stateRef.current = state; }, [state]);
+  useEffect(() => { graphDataRef.current = graphData; }, [graphData]);
+  useEffect(() => { onAcceptedRef.current = onAccepted; }, [onAccepted]);
+
+  const setAuthoringState = useCallback((next: AuthoringState) => {
+    stateRef.current = next;
+    setState(next);
+  }, []);
+
+  const clearPendingTimer = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const openCreateNode = useCallback((source: NodeDraftSource) => {
+    if (!connected) return;
+    const draft = createDefaultNodeDraft(source);
+    setValidationErrors({});
+    setAuthoringState({
+      status: 'open',
+      action: 'create-node',
+      phase: 'editing',
+      draft,
+      pendingSubmit: null,
+      serverMessage: null,
+      connectionLost: false,
+    });
+  }, [connected, setAuthoringState]);
+
+  const updateDraft = useCallback((draft: NodeDraft) => {
+    const current = stateRef.current;
+    if (current.status !== 'open') return;
+    if (current.phase === 'sending' || current.connectionLost) return;
+
+    setValidationErrors({});
+    setAuthoringState({
+      ...current,
+      draft,
+      pendingSubmit: null,
+      serverMessage: null,
+      connectionLost: false,
+    });
+  }, [setAuthoringState]);
+
+  const startSubmitTimer = useCallback(() => {
+    clearPendingTimer();
+    timeoutRef.current = setTimeout(() => {
+      const current = stateRef.current;
+      if (current.status !== 'open' || current.phase !== 'sending' || !current.pendingSubmit) return;
+      setAuthoringState({
+        ...current,
+        phase: 'editing',
+        serverMessage: TIMEOUT_MESSAGE,
+      });
+      timeoutRef.current = null;
+    }, timeoutMs);
+  }, [clearPendingTimer, setAuthoringState, timeoutMs]);
+
+  // Submit is intentionally conservative: validate first, build command second,
+  // call the executor third. No optimistic graph mutation happens here.
+  const submit = useCallback(() => {
+    const current = stateRef.current;
+    if (current.status !== 'open') return;
+    if (current.phase === 'sending') return;
+    if (current.connectionLost) return;
+    if (!connected) {
+      setAuthoringState({
+        ...current,
+        serverMessage: SEND_FAILURE_MESSAGE,
+      });
+      return;
+    }
+
+    const validation = validateNodeDraft(current.draft, { graphData: graphDataRef.current });
+    if (!validation.valid) {
+      setValidationErrors(validation.errors);
+      return;
+    }
+
+    let command: string;
+    try {
+      command = buildCreateNodeCommand(current.draft);
+    } catch (err) {
+      setValidationErrors({ command: err instanceof Error ? err.message : String(err) });
+      return;
+    }
+
+    const sent = executor.execute(command);
+    if (!sent) {
+      setAuthoringState({
+        ...current,
+        phase: 'editing',
+        pendingSubmit: null,
+        serverMessage: SEND_FAILURE_MESSAGE,
+      });
+      return;
+    }
+
+    const pending: PendingCreateNodeSubmit = {
+      alias: current.draft.alias.trim(),
+      command,
+      sentAt: new Date().toISOString(),
+    };
+    setValidationErrors({});
+    setAuthoringState({
+      ...current,
+      phase: 'sending',
+      pendingSubmit: pending,
+      serverMessage: null,
+      connectionLost: false,
+    });
+    startSubmitTimer();
+  }, [connected, executor, setAuthoringState, startSubmitTimer]);
+
+  const close = useCallback(() => {
+    const current = stateRef.current;
+    if (current.status !== 'open') return;
+    if (current.phase === 'sending') return;
+    clearPendingTimer();
+    setValidationErrors({});
+    setAuthoringState({ status: 'closed' });
+  }, [clearPendingTimer, setAuthoringState]);
+
+  useEffect(() => {
+    return bus.on('minigraph.createNode.textResult', (event: CreateNodeTextResultEvent) => {
+      const current = stateRef.current;
+      if (current.status !== 'open' || !current.pendingSubmit) return;
+
+      const pending = current.pendingSubmit;
+      if (event.status === 'accepted' && event.alias === pending.alias) {
+        clearPendingTimer();
+        setValidationErrors({});
+        setAuthoringState({ status: 'closed' });
+        onAcceptedRef.current?.({ status: event.status, alias: event.alias, message: event.message });
+        return;
+      }
+
+      if (event.status === 'rejected' && event.alias === pending.alias) {
+        clearPendingTimer();
+        setAuthoringState({
+          ...current,
+          phase: 'editing',
+          pendingSubmit: null,
+          serverMessage: event.message,
+        });
+        return;
+      }
+
+      if (event.status === 'error') {
+        clearPendingTimer();
+        setAuthoringState({
+          ...current,
+          phase: 'editing',
+          pendingSubmit: null,
+          serverMessage: `Backend returned an error while this submit was pending: ${event.message}`,
+        });
+      }
+    });
+  }, [bus, clearPendingTimer, setAuthoringState]);
+
+  // A disconnect changes the backend WebSocket session. The draft remains only
+  // in the currently open dialog; closing or refreshing discards it.
+  useEffect(() => {
+    if (wasConnectedRef.current && !connected) {
+      const current = stateRef.current;
+      if (current.status === 'open') {
+        clearPendingTimer();
+        const message = current.pendingSubmit ? DISCONNECTED_SENDING_MESSAGE : DISCONNECTED_EDITING_MESSAGE;
+        setAuthoringState({
+          ...current,
+          phase: 'editing',
+          pendingSubmit: null,
+          serverMessage: message,
+          connectionLost: true,
+        });
+      }
+    }
+    wasConnectedRef.current = connected;
+  }, [clearPendingTimer, connected, setAuthoringState]);
+
+  useEffect(() => {
+    return () => {
+      clearPendingTimer();
+    };
+  }, [clearPendingTimer]);
+
+  return {
+    state,
+    validationErrors,
+    openCreateNode,
+    updateDraft,
+    submit,
+    close,
+  };
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphContextMenu.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphContextMenu.module.css
@@ -1,0 +1,36 @@
+.menu {
+  position: fixed;
+  width: min(240px, calc(100vw - 32px));
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  z-index: 60;
+  padding: 0.25rem;
+}
+
+.menuItem {
+  width: 100%;
+  min-height: 2.25rem;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.875rem;
+  text-align: left;
+}
+
+.menuItem:hover:not(:disabled),
+.menuItem:focus-visible {
+  background: var(--autocomplete-highlight);
+}
+
+.menuItem:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphContextMenu.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphContextMenu.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+import styles from './GraphContextMenu.module.css';
+
+interface GraphContextMenuProps {
+  open: boolean;
+  x: number;
+  y: number;
+  canCreateNode: boolean;
+  onCreateNode: () => void;
+  onClose: () => void;
+}
+
+// Pane-level graph menu. GraphView owns the right-click coordinates; this
+// component only renders the pointer-positioned menu and dismissal behavior.
+export default function GraphContextMenu({
+  open,
+  x,
+  y,
+  canCreateNode,
+  onCreateNode,
+  onClose,
+}: GraphContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const firstItemRef = useRef<HTMLButtonElement>(null);
+
+  // This is a lightweight menu, not a modal: focus the first action, close on
+  // outside pointer down or Escape, and do not trap focus.
+  useEffect(() => {
+    if (!open) return;
+    firstItemRef.current?.focus();
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className={styles.menu}
+      style={{ left: x, top: y }}
+      role="menu"
+      aria-label="Graph actions"
+    >
+      <button
+        ref={firstItemRef}
+        role="menuitem"
+        type="button"
+        className={styles.menuItem}
+        disabled={!canCreateNode}
+        onClick={() => {
+          if (!canCreateNode) return;
+          onCreateNode();
+          onClose();
+        }}
+      >
+        Create Node
+      </button>
+    </div>
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
@@ -13,10 +13,18 @@
 }
 
 .graphWrapper {
-  position: relative; /* anchors the auto-refresh overlay — see refreshingOverlay */
+  position: relative; /* anchors absolute children inside the shared graph surface */
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
   background: var(--bg-primary, #1a1a2e);
+}
+
+.graphSurface {
+  position: relative;
+  flex: 1;
+  min-height: 0;
 }
 
 .empty {
@@ -35,6 +43,33 @@
 .emptyIcon {
   font-size: 2.5rem;
   opacity: 0.4;
+}
+
+.emptyCreateButton {
+  appearance: none;
+  background: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-radius: var(--radius-sm);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.85rem;
+}
+
+.emptyCreateButton:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+.emptyCreateButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.emptyHint {
+  color: var(--text-muted);
+  font-size: 0.78rem;
 }
 
 
@@ -76,6 +111,30 @@
   pointer-events: none;    /* allow pan/zoom events to pass through */
   z-index: 10;
   padding: 0.75rem;
+}
+
+.clipboardDropOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(21, 128, 61, 0.14);
+  border: 2px dashed rgba(134, 239, 172, 0.75);
+  pointer-events: none;
+  z-index: 20;
+  padding: 1rem;
+}
+
+.clipboardDropMessage {
+  background: rgba(15, 23, 42, 0.86);
+  border: 1px solid rgba(134, 239, 172, 0.55);
+  border-radius: var(--radius-sm);
+  color: #dcfce7;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.7rem 0.95rem;
 }
 
 /*

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -16,8 +16,10 @@ import { nodeTypes } from './NodeTypes';
 import { GraphViewErrorBoundary } from './GraphViewErrorBoundary';
 import { transformGraphData, type GraphNodeData, type GraphEdgeData } from '../../utils/graphTransformer';
 import type { MinigraphGraphData, MinigraphNode, MinigraphConnection } from '../../utils/graphTypes';
+import { hasClipboardItemType, readClipboardItemId } from '../../clipboard/dnd';
 import { findNodeByAlias, extractDirectConnections } from '../../clipboard/helpers';
 import GraphToolbar from '../GraphToolbar/GraphToolbar';
+import GraphContextMenu from './GraphContextMenu';
 import styles from './GraphView.module.css';
 
 interface GraphViewProps {
@@ -33,12 +35,28 @@ interface GraphViewProps {
   isRefreshing?:   boolean;
   /** Callback for "Clip to Clipboard" from the node context menu. */
   onClipNode?:     (node: MinigraphNode, connections: MinigraphConnection[]) => void;
+  onClipboardDrop?: (itemId: string) => void;
+  isConnected:     boolean;
+  supportsAuthoring?: boolean;
+  onCreateNode?:   (source: 'empty-graph' | 'pane-context-menu') => void;
 }
 
 const EMPTY_NODES: Node<GraphNodeData>[]  = [];
 const EMPTY_EDGES: Edge<GraphEdgeData>[]  = [];
 
-export default function GraphView({ graphData, graphName, onCopySuccess, onCopyError, onRenderError, isRefreshing = false, onClipNode }: GraphViewProps) {
+export default function GraphView({
+  graphData,
+  graphName,
+  onCopySuccess,
+  onCopyError,
+  onRenderError,
+  isRefreshing = false,
+  onClipNode,
+  onClipboardDrop,
+  isConnected,
+  supportsAuthoring = false,
+  onCreateNode,
+}: GraphViewProps) {
 
   // ── Context menu state ──────────────────────────────────────────────────
   const [contextMenu, setContextMenu] = useState<{
@@ -46,7 +64,17 @@ export default function GraphView({ graphData, graphName, onCopySuccess, onCopyE
     y: number;
     nodeAlias: string;
   } | null>(null);
+  const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(null);
+  const [clipboardDragActive, setClipboardDragActive] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const clipboardDragDepthRef = useRef(0);
+  const canCreateNode = Boolean(supportsAuthoring && onCreateNode && isConnected);
+  const canAcceptClipboardDrop = Boolean(onClipboardDrop && isConnected);
+
+  const resetClipboardDragState = useCallback(() => {
+    clipboardDragDepthRef.current = 0;
+    setClipboardDragActive(false);
+  }, []);
 
   // Dismiss context menu on outside click or Escape
   useEffect(() => {
@@ -69,6 +97,36 @@ export default function GraphView({ graphData, graphName, onCopySuccess, onCopyE
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [contextMenu]);
+
+  useEffect(() => {
+    if (!paneMenu) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPaneMenu(null);
+    };
+    const handleScrollOrResize = () => setPaneMenu(null);
+
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('scroll', handleScrollOrResize, true);
+    window.addEventListener('resize', handleScrollOrResize);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('scroll', handleScrollOrResize, true);
+      window.removeEventListener('resize', handleScrollOrResize);
+    };
+  }, [paneMenu]);
+
+  useEffect(() => {
+    const handleGlobalDragCleanup = () => resetClipboardDragState();
+
+    window.addEventListener('dragend', handleGlobalDragCleanup);
+    window.addEventListener('drop', handleGlobalDragCleanup);
+    return () => {
+      window.removeEventListener('dragend', handleGlobalDragCleanup);
+      window.removeEventListener('drop', handleGlobalDragCleanup);
+      resetClipboardDragState();
+    };
+  }, [resetClipboardDragState]);
 
   // Keep a stable ref so the useEffect below can fire the error callback without
   // needing onRenderError in the useMemo dependency array.
@@ -114,22 +172,53 @@ export default function GraphView({ graphData, graphName, onCopySuccess, onCopyE
     setEdges(initialEdges);
   }, [initialNodes, initialEdges, setNodes, setEdges]);
 
+  const handleClipboardDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!canAcceptClipboardDrop) return;
+    if (!hasClipboardItemType(Array.from(event.dataTransfer.types))) return;
+
+    event.preventDefault();
+    clipboardDragDepthRef.current += 1;
+    setClipboardDragActive(true);
+  };
+
+  const handleClipboardDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!canAcceptClipboardDrop) return;
+    if (!hasClipboardItemType(Array.from(event.dataTransfer.types))) return;
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setClipboardDragActive(true);
+  };
+
+  const handleClipboardDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!hasClipboardItemType(Array.from(event.dataTransfer.types))) return;
+
+    clipboardDragDepthRef.current = Math.max(0, clipboardDragDepthRef.current - 1);
+    if (clipboardDragDepthRef.current === 0) {
+      setClipboardDragActive(false);
+    }
+  };
+
+  const handleClipboardDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!canAcceptClipboardDrop) return;
+    if (!hasClipboardItemType(Array.from(event.dataTransfer.types))) return;
+
+    event.preventDefault();
+    const itemId = readClipboardItemId(event.dataTransfer);
+    resetClipboardDragState();
+    if (itemId) {
+      onClipboardDrop?.(itemId);
+    }
+  };
+
+  const hasGraphData = Boolean(graphData && graphData.nodes.length > 0);
+
   if (transformError) {
     return (
       <div className={styles.empty}>
         <span className={styles.emptyIcon}>⚠️</span>
         <span>Graph could not be rendered.</span>
         <span>{transformError}</span>
-      </div>
-    );
-  }
-
-  if (!graphData || graphData.nodes.length === 0) {
-    return (
-      <div className={styles.empty}>
-        <span className={styles.emptyIcon}>🕸️</span>
-        <span>No graph data yet.</span>
-        <span>Run <strong>describe graph</strong> or <strong>export graph</strong> in the playground.</span>
       </div>
     );
   }
@@ -142,88 +231,149 @@ export default function GraphView({ graphData, graphName, onCopySuccess, onCopyE
       onRenderError={onRenderError}
     >
       <div className={styles.graphWrapper} aria-busy={isRefreshing}>
-        <GraphToolbar
-          graphData={graphData}
-          graphName={graphName}
-          onCopySuccess={onCopySuccess}
-          onCopyError={onCopyError}
-        />
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          nodeTypes={nodeTypes}
-          fitView
-          fitViewOptions={{ padding: 0.25 }}
-          minZoom={0.2}
-          maxZoom={2.5}
-          // colorMode="dark" // enable for dark mode
-          proOptions={{ hideAttribution: false }}
-          onNodeContextMenu={(event, node) => {
-            if (!onClipNode) return;
-            event.preventDefault();
-            setContextMenu({ x: event.clientX, y: event.clientY, nodeAlias: node.data.alias });
-          }}
-          onPaneClick={() => setContextMenu(null)}
-        >
-          <Background variant={BackgroundVariant.Dots} gap={18} size={1} color="rgba(255,255,255,0.07)" />
-          <Controls showInteractive={false} />
-          <MiniMap
-            nodeColor={(node) => {
-              const colorMap: Record<string, string> = {
-                Root:        '#15803d',
-                End:         '#dc2626',
-                Fetcher:     '#2563eb',
-                mapper:      '#ea580c',
-                Math:        '#a16207',
-                JavaScript:  '#7e22ce',
-                Provider:    '#be185d',
-                Dictionary:  '#0e7490',
-                Join:        '#65a30d',
-                Extension:   '#4338ca',
-                Island:      '#475569',
-                Decision:    '#b45309',
-              };
-              return colorMap[node.type ?? ''] ?? '#6c7086';
-            }}
-            maskColor="rgba(0,0,0,0.3)"
-            style={{ background: '#fff' }}
+        {hasGraphData && graphData && (
+          <GraphToolbar
+            graphData={graphData}
+            graphName={graphName}
+            onCopySuccess={onCopySuccess}
+            onCopyError={onCopyError}
           />
-        </ReactFlow>
-        {isRefreshing && (
-          <div className={styles.refreshingOverlay}>
-            <div
-              className={styles.refreshingSpinner}
-              role="status"
-              aria-label="Graph refreshing"
-            />
-          </div>
         )}
-        {contextMenu && onClipNode && graphData && (
-          <div
-            ref={menuRef}
-            className={styles.contextMenu}
-            style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
-            role="menu"
-          >
-            <button
-              role="menuitem"
-              autoFocus
-              className={styles.contextMenuItem}
-              onClick={() => {
-                const node = findNodeByAlias(graphData, contextMenu.nodeAlias);
-                if (node) {
-                  const connections = extractDirectConnections(graphData, contextMenu.nodeAlias);
-                  onClipNode(node, connections);
-                }
+
+        <div
+          className={styles.graphSurface}
+          onDragEnter={handleClipboardDragEnter}
+          onDragOver={handleClipboardDragOver}
+          onDragLeave={handleClipboardDragLeave}
+          onDrop={handleClipboardDrop}
+        >
+          {hasGraphData ? (
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              nodeTypes={nodeTypes}
+              fitView
+              fitViewOptions={{ padding: 0.25 }}
+              minZoom={0.2}
+              maxZoom={2.5}
+              // colorMode="dark" // enable for dark mode
+              proOptions={{ hideAttribution: false }}
+              onNodeContextMenu={(event, node) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setPaneMenu(null);
+                if (!onClipNode) return;
+                setContextMenu({ x: event.clientX, y: event.clientY, nodeAlias: node.data.alias });
+              }}
+              onPaneContextMenu={(event) => {
+                event.preventDefault();
+                if (!canCreateNode) return;
                 setContextMenu(null);
+                setPaneMenu({ x: event.clientX, y: event.clientY });
+              }}
+              onPaneClick={() => {
+                setContextMenu(null);
+                setPaneMenu(null);
               }}
             >
-              Clip to Clipboard
-            </button>
-          </div>
-        )}
+              <Background variant={BackgroundVariant.Dots} gap={18} size={1} color="rgba(255,255,255,0.07)" />
+              <Controls showInteractive={false} />
+              <MiniMap
+                nodeColor={(node) => {
+                  const colorMap: Record<string, string> = {
+                    Root:        '#15803d',
+                    End:         '#dc2626',
+                    Fetcher:     '#2563eb',
+                    mapper:      '#ea580c',
+                    Math:        '#a16207',
+                    JavaScript:  '#7e22ce',
+                    Provider:    '#be185d',
+                    Dictionary:  '#0e7490',
+                    Join:        '#65a30d',
+                    Extension:   '#4338ca',
+                    Island:      '#475569',
+                    Decision:    '#b45309',
+                  };
+                  return colorMap[node.type ?? ''] ?? '#6c7086';
+                }}
+                maskColor="rgba(0,0,0,0.3)"
+                style={{ background: '#fff' }}
+              />
+            </ReactFlow>
+          ) : (
+            <div className={styles.empty}>
+              <span className={styles.emptyIcon}>🕸️</span>
+              <span>No graph data yet.</span>
+              <span>Run <strong>describe graph</strong> or <strong>export graph</strong> in the playground.</span>
+              {supportsAuthoring && onCreateNode && (
+                <>
+                  <button
+                    type="button"
+                    className={styles.emptyCreateButton}
+                    disabled={!isConnected}
+                    onClick={() => onCreateNode('empty-graph')}
+                  >
+                    Create Node
+                  </button>
+                  {!isConnected && (
+                    <span className={styles.emptyHint}>Connect WebSocket to create a node.</span>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {isRefreshing && (
+            <div className={styles.refreshingOverlay}>
+              <div
+                className={styles.refreshingSpinner}
+                role="status"
+                aria-label="Graph refreshing"
+              />
+            </div>
+          )}
+
+          {clipboardDragActive && (
+            <div className={styles.clipboardDropOverlay}>
+              <div className={styles.clipboardDropMessage}>Drop to paste workspace node</div>
+            </div>
+          )}
+
+          <GraphContextMenu
+            open={paneMenu !== null}
+            x={paneMenu?.x ?? 0}
+            y={paneMenu?.y ?? 0}
+            canCreateNode={canCreateNode}
+            onCreateNode={() => onCreateNode?.('pane-context-menu')}
+            onClose={() => setPaneMenu(null)}
+          />
+          {contextMenu && onClipNode && graphData && (
+            <div
+              ref={menuRef}
+              className={styles.contextMenu}
+              style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
+              role="menu"
+            >
+              <button
+                role="menuitem"
+                autoFocus
+                className={styles.contextMenuItem}
+                onClick={() => {
+                  const node = findNodeByAlias(graphData, contextMenu.nodeAlias);
+                  if (node) {
+                    const connections = extractDirectConnections(graphData, contextMenu.nodeAlias);
+                    onClipNode(node, connections);
+                  }
+                  setContextMenu(null);
+                }}
+              >
+                Clip to Clipboard
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </GraphViewErrorBoundary>
   );

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/MinigraphNodeBody.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/MinigraphNodeBody.tsx
@@ -1,0 +1,65 @@
+import { Fragment } from 'react';
+import { getMinigraphNodeTypeMeta } from '../../utils/minigraphNodeTheme';
+import styles from './NodeTypes.module.css';
+
+interface MinigraphNodeBodyProps {
+  alias: string;
+  nodeType: string;
+  properties: Record<string, unknown>;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.row}>
+      <span className={styles.label}>{label}</span>
+      <span className={styles.value} title={value}>{value}</span>
+    </div>
+  );
+}
+
+function PropertyRows({ properties }: { properties: Record<string, unknown> }) {
+  const entries = Object.entries(properties).filter(([, value]) => value !== undefined && value !== null);
+  if (entries.length === 0) return null;
+
+  return (
+    <>
+      {entries.map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return value.map((item, index) => {
+            const renderedValue = typeof item === 'string' ? item : JSON.stringify(item);
+            return (
+              <Row
+                key={`${key}-${index}`}
+                label={index === 0 ? key : ''}
+                value={renderedValue}
+              />
+            );
+          });
+        }
+
+        const renderedValue = typeof value === 'string' ? value : JSON.stringify(value);
+        return <Row key={key} label={key} value={renderedValue} />;
+      })}
+    </>
+  );
+}
+
+export function MinigraphNodeBody({ alias, nodeType, properties }: MinigraphNodeBodyProps) {
+  const meta = getMinigraphNodeTypeMeta(nodeType);
+
+  return (
+    <Fragment>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <span className={styles.icon}>{meta.icon}</span>
+          <span className={styles.alias}>{alias}</span>
+          <span className={styles.badge}>{meta.label}</span>
+        </div>
+
+        <div className={styles.body}>
+          <PropertyRows properties={properties} />
+        </div>
+      </div>
+    </Fragment>
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
@@ -1,66 +1,10 @@
 import { Handle, Position, NodeResizer, type NodeProps, type Node } from '@xyflow/react';
 import type { GraphNodeData } from '../../utils/graphTransformer';
+import { MinigraphNodeBody } from './MinigraphNodeBody';
 import styles from './NodeTypes.module.css';
 
 /** ReactFlow Node type for minigraph nodes. */
 export type MinigraphRFNode = Node<GraphNodeData>;
-
-// ─── Per-type metadata ────────────────────────────────────────────────────────
-const TYPE_META: Record<string, { icon: string; label: string }> = {
-  Root:        { icon: '🚀', label: 'Root'         },
-  End:         { icon: '🏁', label: 'End'          },
-  Fetcher:     { icon: '🌐', label: 'Fetcher'      },
-  mapper:      { icon: '🗺️', label: 'Mapper'       },
-  Math:        { icon: '🔢', label: 'Math'         },
-  JavaScript:  { icon: '📜', label: 'JavaScript'   },
-  Provider:    { icon: '🔌', label: 'Provider'     },
-  Dictionary:  { icon: '📖', label: 'Dictionary'   },
-  Join:        { icon: '🔀', label: 'Join'         },
-  Extension:   { icon: '🧩', label: 'Extension'    },
-  Island:      { icon: '🏝️', label: 'Island'       },
-  Decision:    { icon: '❓', label: 'Decision'     },
-};
-
-function getMeta(nodeType: string) {
-  return TYPE_META[nodeType] ?? { icon: '📦', label: nodeType };
-}
-
-// ─── Shared detail rows ───────────────────────────────────────────────────────
-
-/** Render a single key=value row. */
-function Row({ label, value }: { label: string; value: string }) {
-  return (
-    <div className={styles.row}>
-      <span className={styles.label}>{label}</span>
-      <span className={styles.value} title={value}>{value}</span>
-    </div>
-  );
-}
-
-/** Render all properties generically. Arrays get one row per element. */
-function PropertyRows({ properties }: { properties: Record<string, unknown> }) {
-  const entries = Object.entries(properties).filter(
-    ([, v]) => v !== undefined && v !== null,
-  );
-  if (entries.length === 0) return null;
-
-  return (
-    <>
-      {entries.map(([key, value]) => {
-        if (Array.isArray(value)) {
-          return value.map((item, i) => {
-            const str = typeof item === 'string' ? item : JSON.stringify(item);
-            return (
-              <Row key={`${key}-${i}`} label={i === 0 ? key : ''} value={str} />
-            );
-          });
-        }
-        const str = typeof value === 'string' ? value : JSON.stringify(value);
-        return <Row key={key} label={key} value={str} />;
-      })}
-    </>
-  );
-}
 
 // ─── Resizable node ───────────────────────────────────────────────────────────
 //
@@ -73,7 +17,6 @@ function PropertyRows({ properties }: { properties: Record<string, unknown> }) {
 //     needed (initialWidth/initialHeight tricks, CSS overrides for
 //     .react-flow__node-default, overflow:visible hacks, etc.).
 function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFNode>) {
-  const meta = getMeta(data.nodeType);
   return (
     <>
       {/* Resize handles — visible only when the node is selected */}
@@ -110,17 +53,11 @@ function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFN
         * border/background via node.style) and clips its own overflow.
         * width/height:100% make it track the wrapper when the user resizes.
         */}
-      <div className={styles.content}>
-        <div className={styles.header}>
-          <span className={styles.icon}>{meta.icon}</span>
-          <span className={styles.alias}>{data.alias}</span>
-          <span className={styles.badge}>{meta.label}</span>
-        </div>
-
-        <div className={styles.body}>
-          <PropertyRows properties={data.properties} />
-        </div>
-      </div>
+      <MinigraphNodeBody
+        alias={data.alias}
+        nodeType={data.nodeType}
+        properties={data.properties}
+      />
 
       {/* Source handles (right) — paired with target handles for best-effort edge spreading. */}
       {data.sourceHandles.map(({ id, offset }) => (

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
@@ -1,0 +1,374 @@
+.overlay {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  border: 0;
+  box-sizing: border-box;
+  color: var(--text-primary);
+  display: flex;
+  height: 100vh;
+  inset: 0;
+  justify-content: center;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  padding: 1rem;
+  position: fixed;
+  touch-action: none;
+  width: 100vw;
+  z-index: 1000;
+}
+
+.panel {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 32px);
+  overflow: hidden;
+  touch-action: auto;
+  width: min(520px, calc(100vw - 32px));
+}
+
+.header {
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+}
+
+.title {
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.iconButton,
+.removeButton {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font: inherit;
+  height: 2rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  position: relative;
+  transition: color 0.12s ease;
+  width: 2rem;
+}
+
+.iconButton::before,
+.removeButton::before {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  content: "";
+  height: 1.625rem;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: background-color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  width: 1.625rem;
+}
+
+.buttonIcon {
+  display: block;
+  flex: 0 0 auto;
+  height: 0.875rem;
+  position: relative;
+  width: 0.875rem;
+  z-index: 1;
+}
+
+.iconButton:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.iconButton:hover:not(:disabled)::before {
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+}
+
+.iconButton:active:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.iconButton:active:not(:disabled)::before {
+  background: var(--border-color);
+  border-color: var(--border-color);
+}
+
+.iconButton:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.removeButton:hover:not(:disabled) {
+  color: var(--danger-color);
+}
+
+.removeButton:hover:not(:disabled)::before {
+  background: var(--danger-08);
+  border-color: var(--danger-30);
+  box-shadow: 0 0 0 2px var(--danger-08);
+}
+
+.removeButton:active:not(:disabled)::before {
+  background: var(--danger-30);
+  border-color: var(--danger-color);
+}
+
+.removeButton:focus-visible {
+  outline: 2px solid var(--danger-color);
+  outline-offset: 2px;
+}
+
+.iconButton:disabled,
+.removeButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.875rem;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+}
+
+.field,
+.propertyField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.label {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+}
+
+.input {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+  color: var(--text-primary);
+  font: inherit;
+  height: 2.5rem;
+  line-height: 1.25rem;
+  padding: 0.5625rem 0.625rem;
+  width: 100%;
+}
+
+.input:focus {
+  border-color: var(--input-focus-border);
+  outline: 2px solid var(--primary-color);
+  outline-offset: 1px;
+}
+
+.input[aria-invalid="true"] {
+  border-color: var(--danger-color);
+}
+
+.input:disabled,
+.input:read-only {
+  background: var(--disabled-bg);
+  color: var(--text-secondary);
+}
+
+.properties {
+  --property-action-size: 2rem;
+  --property-field-gap: 0.25rem;
+  --property-label-line: 1.25rem;
+  --property-input-action-half-delta: 0.25rem;
+  --property-remove-offset: calc(
+    var(--property-label-line) +
+    var(--property-field-gap) +
+    var(--property-input-action-half-delta)
+  );
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.propertiesHeader {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-start;
+}
+
+.sectionTitle {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.propertyRows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.propertyActions {
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: 11rem minmax(0, 1fr) var(--property-action-size);
+  padding-top: 0.125rem;
+}
+
+.propertyRow {
+  align-items: flex-start;
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: 11rem minmax(0, 1fr) var(--property-action-size);
+}
+
+.removeButton {
+  margin-top: var(--property-remove-offset);
+}
+
+.message,
+.warningMessage,
+.errorMessage {
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  padding: 0.55rem 0.7rem;
+  word-break: break-word;
+}
+
+.message {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.warningMessage {
+  background: var(--warning-08);
+  border: 1px solid var(--warning-30);
+  color: var(--text-primary);
+}
+
+.errorMessage {
+  background: var(--danger-08);
+  border: 1px solid var(--danger-30);
+  color: var(--danger-color);
+}
+
+.errorText {
+  color: var(--danger-color);
+  font-size: 0.75rem;
+}
+
+.footer {
+  align-items: center;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: 0.875rem 1.25rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  appearance: none;
+  border-radius: var(--radius-sm);
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 0.875rem;
+  height: 2.25rem;
+  line-height: 1.25rem;
+  padding: 0.45rem 0.8rem;
+}
+
+.primaryButton {
+  background: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  color: #fff;
+}
+
+.primaryButton:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+.secondaryButton {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.secondaryButton:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.addPropertyButton {
+  align-items: center;
+  border-style: dashed;
+  color: var(--text-secondary);
+  display: inline-flex;
+  gap: 0.375rem;
+  grid-column: 1 / 3;
+  justify-content: center;
+  width: 100%;
+}
+
+.addPropertyButton:hover:not(:disabled) {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+@media (max-width: 560px) {
+  .propertyRow {
+    grid-template-columns: minmax(0, 1fr) var(--property-action-size);
+    padding-right: 2.5rem;
+    position: relative;
+  }
+
+  .propertyField {
+    grid-column: 1 / -1;
+  }
+
+  .removeButton {
+    margin-top: 0;
+    position: absolute;
+    right: 0;
+    top: var(--property-remove-offset);
+  }
+
+  .propertyActions {
+    grid-template-columns: minmax(0, 1fr);
+    padding-right: 2.5rem;
+  }
+
+  .addPropertyButton {
+    grid-column: 1;
+  }
+}

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
@@ -31,6 +31,13 @@
   width: min(520px, calc(100vw - 32px));
 }
 
+.form {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .header {
   align-items: center;
   border-bottom: 1px solid var(--border-color);

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
@@ -79,6 +79,12 @@ export default function NodeDialog({
     event.stopPropagation();
   }, []);
 
+  const handleFormSubmit = useCallback((event: React.SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (controlsDisabled) return;
+    onSubmit();
+  }, [controlsDisabled, onSubmit]);
+
   const updateDraft = useCallback((patch: Partial<NodeDraft>) => {
     onDraftChange({ ...draft, ...patch });
   }, [draft, onDraftChange]);
@@ -138,139 +144,140 @@ export default function NodeDialog({
           </button>
         </header>
 
-        <div className={styles.body}>
-          {serverMessage && !disconnected && (
-            <div className={styles.message} role="status">
-              {serverMessage}
-            </div>
-          )}
-          {validationErrors.command && (
-            <div className={styles.errorMessage} role="alert">
-              {validationErrors.command}
-            </div>
-          )}
-          {disconnected && (
-            <div className={styles.warningMessage} role="status">
-              {serverMessage ?? 'Connection disconnected. Refresh the page and create the node again after the app reconnects.'}
-            </div>
-          )}
-
-          <label className={styles.field}>
-            <span className={styles.label}>Alias</span>
-            <input
-              ref={aliasRef}
-              className={styles.input}
-              value={draft.alias}
-              disabled={controlsDisabled}
-              aria-invalid={Boolean(validationErrors.alias)}
-              aria-describedby={validationErrors.alias ? 'node-alias-error' : undefined}
-              onChange={(event) => updateDraft({ alias: event.target.value })}
-            />
-            {validationErrors.alias && (
-              <span id="node-alias-error" className={styles.errorText}>{validationErrors.alias}</span>
+        <form className={styles.form} onSubmit={handleFormSubmit}>
+          <div className={styles.body}>
+            {serverMessage && !disconnected && (
+              <div className={styles.message} role="status">
+                {serverMessage}
+              </div>
             )}
-          </label>
-
-          <label className={styles.field}>
-            <span className={styles.label}>Node Type</span>
-            <input
-              className={styles.input}
-              value={draft.nodeType}
-              disabled={controlsDisabled}
-              aria-invalid={Boolean(validationErrors.nodeType)}
-              aria-describedby={validationErrors.nodeType ? 'node-type-error' : undefined}
-              onChange={(event) => updateDraft({ nodeType: event.target.value })}
-            />
-            {validationErrors.nodeType && (
-              <span id="node-type-error" className={styles.errorText}>{validationErrors.nodeType}</span>
+            {validationErrors.command && (
+              <div className={styles.errorMessage} role="alert">
+                {validationErrors.command}
+              </div>
             )}
-          </label>
+            {disconnected && (
+              <div className={styles.warningMessage} role="status">
+                {serverMessage ?? 'Connection disconnected. Refresh the page and create the node again after the app reconnects.'}
+              </div>
+            )}
 
-          <section className={styles.properties} aria-labelledby="node-properties-title">
-            <div className={styles.propertiesHeader}>
-              <h3 id="node-properties-title" className={styles.sectionTitle}>Properties</h3>
-            </div>
-
-            <div className={styles.propertyRows}>
-              {draft.properties.map((row) => {
-                const keyError = validationErrors[getValidationErrorKeyForProperty(row.id, 'key')];
-                const valueError = validationErrors[getValidationErrorKeyForProperty(row.id, 'value')];
-                return (
-                  <div key={row.id} className={styles.propertyRow}>
-                    <label className={styles.propertyField}>
-                      <span className={styles.label}>Key</span>
-                      <input
-                        ref={(element) => {
-                          if (element) {
-                            propertyKeyRefs.current.set(row.id, element);
-                          } else {
-                            propertyKeyRefs.current.delete(row.id);
-                          }
-                        }}
-                        className={styles.input}
-                        value={row.key}
-                        disabled={controlsDisabled}
-                        aria-invalid={Boolean(keyError)}
-                        onChange={(event) => updateProperty(row.id, { key: event.target.value })}
-                      />
-                      {keyError && <span className={styles.errorText}>{keyError}</span>}
-                    </label>
-                    <label className={styles.propertyField}>
-                      <span className={styles.label}>Value</span>
-                      <input
-                        className={styles.input}
-                        value={row.value}
-                        disabled={controlsDisabled}
-                        aria-invalid={Boolean(valueError)}
-                        onChange={(event) => updateProperty(row.id, { value: event.target.value })}
-                      />
-                      {valueError && <span className={styles.errorText}>{valueError}</span>}
-                    </label>
-                    <button
-                      type="button"
-                      className={styles.removeButton}
-                      aria-label="Remove property"
-                      disabled={controlsDisabled}
-                      onClick={() => removeProperty(row.id)}
-                    >
-                      <CloseIcon className={styles.buttonIcon} aria-hidden="true" focusable="false" />
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-            <div className={styles.propertyActions}>
-              <button
-                type="button"
-                className={`${styles.secondaryButton} ${styles.addPropertyButton}`}
+            <label className={styles.field}>
+              <span className={styles.label}>Alias</span>
+              <input
+                ref={aliasRef}
+                className={styles.input}
+                value={draft.alias}
                 disabled={controlsDisabled}
-                onClick={addProperty}
-              >
-                <span aria-hidden="true">+</span>
-                <span>Add Property</span>
-              </button>
-            </div>
-          </section>
-        </div>
+                aria-invalid={Boolean(validationErrors.alias)}
+                aria-describedby={validationErrors.alias ? 'node-alias-error' : undefined}
+                onChange={(event) => updateDraft({ alias: event.target.value })}
+              />
+              {validationErrors.alias && (
+                <span id="node-alias-error" className={styles.errorText}>{validationErrors.alias}</span>
+              )}
+            </label>
 
-        <footer className={styles.footer}>
-          <button
-            type="button"
-            className={styles.secondaryButton}
-            onClick={onClose}
-            disabled={sending}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className={styles.primaryButton}
-            disabled={controlsDisabled}
-            onClick={onSubmit}
-          >
-            {sending ? 'Creating...' : 'Create Node'}
-          </button>
-        </footer>
+            <label className={styles.field}>
+              <span className={styles.label}>Node Type</span>
+              <input
+                className={styles.input}
+                value={draft.nodeType}
+                disabled={controlsDisabled}
+                aria-invalid={Boolean(validationErrors.nodeType)}
+                aria-describedby={validationErrors.nodeType ? 'node-type-error' : undefined}
+                onChange={(event) => updateDraft({ nodeType: event.target.value })}
+              />
+              {validationErrors.nodeType && (
+                <span id="node-type-error" className={styles.errorText}>{validationErrors.nodeType}</span>
+              )}
+            </label>
+
+            <section className={styles.properties} aria-labelledby="node-properties-title">
+              <div className={styles.propertiesHeader}>
+                <h3 id="node-properties-title" className={styles.sectionTitle}>Properties</h3>
+              </div>
+
+              <div className={styles.propertyRows}>
+                {draft.properties.map((row) => {
+                  const keyError = validationErrors[getValidationErrorKeyForProperty(row.id, 'key')];
+                  const valueError = validationErrors[getValidationErrorKeyForProperty(row.id, 'value')];
+                  return (
+                    <div key={row.id} className={styles.propertyRow}>
+                      <label className={styles.propertyField}>
+                        <span className={styles.label}>Key</span>
+                        <input
+                          ref={(element) => {
+                            if (element) {
+                              propertyKeyRefs.current.set(row.id, element);
+                            } else {
+                              propertyKeyRefs.current.delete(row.id);
+                            }
+                          }}
+                          className={styles.input}
+                          value={row.key}
+                          disabled={controlsDisabled}
+                          aria-invalid={Boolean(keyError)}
+                          onChange={(event) => updateProperty(row.id, { key: event.target.value })}
+                        />
+                        {keyError && <span className={styles.errorText}>{keyError}</span>}
+                      </label>
+                      <label className={styles.propertyField}>
+                        <span className={styles.label}>Value</span>
+                        <input
+                          className={styles.input}
+                          value={row.value}
+                          disabled={controlsDisabled}
+                          aria-invalid={Boolean(valueError)}
+                          onChange={(event) => updateProperty(row.id, { value: event.target.value })}
+                        />
+                        {valueError && <span className={styles.errorText}>{valueError}</span>}
+                      </label>
+                      <button
+                        type="button"
+                        className={styles.removeButton}
+                        aria-label="Remove property"
+                        disabled={controlsDisabled}
+                        onClick={() => removeProperty(row.id)}
+                      >
+                        <CloseIcon className={styles.buttonIcon} aria-hidden="true" focusable="false" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className={styles.propertyActions}>
+                <button
+                  type="button"
+                  className={`${styles.secondaryButton} ${styles.addPropertyButton}`}
+                  disabled={controlsDisabled}
+                  onClick={addProperty}
+                >
+                  <span aria-hidden="true">+</span>
+                  <span>Add Property</span>
+                </button>
+              </div>
+            </section>
+          </div>
+
+          <footer className={styles.footer}>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={onClose}
+              disabled={sending}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={styles.primaryButton}
+              disabled={controlsDisabled}
+            >
+              {sending ? 'Creating...' : 'Create Node'}
+            </button>
+          </footer>
+        </form>
       </div>
     </div>
   );

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { NodeDraft } from '../../graphActions/nodeAuthoringTypes';
+import { createPropertyRow } from '../../graphActions/propertyRows';
+import { getValidationErrorKeyForProperty } from '../../graphActions/validation';
+import CloseIcon from '../../icons/CloseIcon.svg?react';
+import styles from './NodeDialog.module.css';
+
+interface NodeDialogProps {
+  open: boolean;
+  draft: NodeDraft;
+  phase: 'editing' | 'sending';
+  lockReason: null | 'sending' | 'disconnected';
+  serverMessage: string | null;
+  validationErrors: Record<string, string>;
+  onDraftChange: (draft: NodeDraft) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}
+
+// Presentational modal only. It edits a NodeDraft and reports submit/close
+// intents upward; useGraphAuthoring owns validation, transport, and result handling.
+export default function NodeDialog({
+  open,
+  draft,
+  phase,
+  lockReason,
+  serverMessage,
+  validationErrors,
+  onDraftChange,
+  onSubmit,
+  onClose,
+}: NodeDialogProps) {
+  const aliasRef = useRef<HTMLInputElement>(null);
+  const propertyKeyRefs = useRef(new Map<string, HTMLInputElement>());
+  const pendingFocusPropertyIdRef = useRef<string | null>(null);
+  const sending = phase === 'sending';
+  const disconnected = lockReason === 'disconnected';
+  const controlsDisabled = sending || disconnected;
+
+  // The overlay is a real fixed element, not a native dialog backdrop, so it
+  // reliably absorbs pointer events before underlying resize handles can drag.
+  useEffect(() => {
+    if (!open) return;
+    aliasRef.current?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      if (!sending) onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose, open, sending]);
+
+  useEffect(() => {
+    const rowId = pendingFocusPropertyIdRef.current;
+    if (!rowId) return;
+
+    const input = propertyKeyRefs.current.get(rowId);
+    if (!input) return;
+
+    input.focus();
+    pendingFocusPropertyIdRef.current = null;
+  }, [draft.properties]);
+
+  const handleOverlayPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const handleOverlayClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!sending) onClose();
+  }, [onClose, sending]);
+
+  const stopPanelPointer = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  const updateDraft = useCallback((patch: Partial<NodeDraft>) => {
+    onDraftChange({ ...draft, ...patch });
+  }, [draft, onDraftChange]);
+
+  const updateProperty = useCallback((rowId: string, patch: { key?: string; value?: string }) => {
+    onDraftChange({
+      ...draft,
+      properties: draft.properties.map((row) => row.id === rowId ? { ...row, ...patch } : row),
+    });
+  }, [draft, onDraftChange]);
+
+  const addProperty = useCallback(() => {
+    const nextRow = createPropertyRow();
+    pendingFocusPropertyIdRef.current = nextRow.id;
+    onDraftChange({
+      ...draft,
+      properties: [...draft.properties, nextRow],
+    });
+  }, [draft, onDraftChange]);
+
+  const removeProperty = useCallback((rowId: string) => {
+    const nextRows = draft.properties.filter((row) => row.id !== rowId);
+    onDraftChange({
+      ...draft,
+      properties: nextRows.length > 0 ? nextRows : [createPropertyRow()],
+    });
+  }, [draft, onDraftChange]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={styles.overlay}
+      onPointerDown={handleOverlayPointerDown}
+      onClick={handleOverlayClick}
+    >
+      <div
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="node-dialog-title"
+        onPointerDown={stopPanelPointer}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className={styles.header}>
+          <div>
+            <h2 id="node-dialog-title" className={styles.title}>Create Node</h2>
+          </div>
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Close create node dialog"
+            onClick={onClose}
+            disabled={sending}
+          >
+            <CloseIcon className={styles.buttonIcon} aria-hidden="true" focusable="false" />
+          </button>
+        </header>
+
+        <div className={styles.body}>
+          {serverMessage && !disconnected && (
+            <div className={styles.message} role="status">
+              {serverMessage}
+            </div>
+          )}
+          {validationErrors.command && (
+            <div className={styles.errorMessage} role="alert">
+              {validationErrors.command}
+            </div>
+          )}
+          {disconnected && (
+            <div className={styles.warningMessage} role="status">
+              {serverMessage ?? 'Connection disconnected. Refresh the page and create the node again after the app reconnects.'}
+            </div>
+          )}
+
+          <label className={styles.field}>
+            <span className={styles.label}>Alias</span>
+            <input
+              ref={aliasRef}
+              className={styles.input}
+              value={draft.alias}
+              disabled={controlsDisabled}
+              aria-invalid={Boolean(validationErrors.alias)}
+              aria-describedby={validationErrors.alias ? 'node-alias-error' : undefined}
+              onChange={(event) => updateDraft({ alias: event.target.value })}
+            />
+            {validationErrors.alias && (
+              <span id="node-alias-error" className={styles.errorText}>{validationErrors.alias}</span>
+            )}
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Node Type</span>
+            <input
+              className={styles.input}
+              value={draft.nodeType}
+              disabled={controlsDisabled}
+              aria-invalid={Boolean(validationErrors.nodeType)}
+              aria-describedby={validationErrors.nodeType ? 'node-type-error' : undefined}
+              onChange={(event) => updateDraft({ nodeType: event.target.value })}
+            />
+            {validationErrors.nodeType && (
+              <span id="node-type-error" className={styles.errorText}>{validationErrors.nodeType}</span>
+            )}
+          </label>
+
+          <section className={styles.properties} aria-labelledby="node-properties-title">
+            <div className={styles.propertiesHeader}>
+              <h3 id="node-properties-title" className={styles.sectionTitle}>Properties</h3>
+            </div>
+
+            <div className={styles.propertyRows}>
+              {draft.properties.map((row) => {
+                const keyError = validationErrors[getValidationErrorKeyForProperty(row.id, 'key')];
+                const valueError = validationErrors[getValidationErrorKeyForProperty(row.id, 'value')];
+                return (
+                  <div key={row.id} className={styles.propertyRow}>
+                    <label className={styles.propertyField}>
+                      <span className={styles.label}>Key</span>
+                      <input
+                        ref={(element) => {
+                          if (element) {
+                            propertyKeyRefs.current.set(row.id, element);
+                          } else {
+                            propertyKeyRefs.current.delete(row.id);
+                          }
+                        }}
+                        className={styles.input}
+                        value={row.key}
+                        disabled={controlsDisabled}
+                        aria-invalid={Boolean(keyError)}
+                        onChange={(event) => updateProperty(row.id, { key: event.target.value })}
+                      />
+                      {keyError && <span className={styles.errorText}>{keyError}</span>}
+                    </label>
+                    <label className={styles.propertyField}>
+                      <span className={styles.label}>Value</span>
+                      <input
+                        className={styles.input}
+                        value={row.value}
+                        disabled={controlsDisabled}
+                        aria-invalid={Boolean(valueError)}
+                        onChange={(event) => updateProperty(row.id, { value: event.target.value })}
+                      />
+                      {valueError && <span className={styles.errorText}>{valueError}</span>}
+                    </label>
+                    <button
+                      type="button"
+                      className={styles.removeButton}
+                      aria-label="Remove property"
+                      disabled={controlsDisabled}
+                      onClick={() => removeProperty(row.id)}
+                    >
+                      <CloseIcon className={styles.buttonIcon} aria-hidden="true" focusable="false" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+            <div className={styles.propertyActions}>
+              <button
+                type="button"
+                className={`${styles.secondaryButton} ${styles.addPropertyButton}`}
+                disabled={controlsDisabled}
+                onClick={addProperty}
+              >
+                <span aria-hidden="true">+</span>
+                <span>Add Property</span>
+              </button>
+            </div>
+          </section>
+        </div>
+
+        <footer className={styles.footer}>
+          <button
+            type="button"
+            className={styles.secondaryButton}
+            onClick={onClose}
+            disabled={sending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={styles.primaryButton}
+            disabled={controlsDisabled}
+            onClick={onSubmit}
+          >
+            {sending ? 'Creating...' : 'Create Node'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -17,7 +17,8 @@ import { useSavedGraphs } from '../hooks/useSavedGraphs';
 import { useGraphSaveName } from '../hooks/useGraphSaveName';
 import { useSavedGraphWorkflow } from '../hooks/useSavedGraphWorkflow';
 import { usePinnedGraphPath } from '../hooks/usePinnedGraphPath';
-import { buildNodeCommand } from '../clipboard/commandBuilder';
+import { buildClipboardPastePlan } from '../clipboard/paste';
+import { createGraphAuthoringExecutor } from '../graphActions/graphAuthoringExecutor';
 import { ToastContainer } from './Toast';
 import Navigation from './Navigation';
 import GraphSaveButton from './GraphSaveButton/GraphSaveButton';
@@ -25,6 +26,8 @@ import SavedGraphsMenu from './SavedGraphsMenu/SavedGraphsMenu';
 import RightPanel from './RightPanel/RightPanel';
 import LeftPanel from './LeftPanel/LeftPanel';
 import { MockUploadModal } from './MockUploadModal/MockUploadModal';
+import GraphAuthoringModals from './GraphAuthoring/GraphAuthoringModals';
+import { useGraphAuthoring } from './GraphAuthoring/useGraphAuthoring';
 import ClipboardSidebar from './ClipboardSidebar/ClipboardSidebar';
 import HelpBrowser from './HelpBrowser/HelpBrowser';
 import { ClipboardDuplicateDialog } from './ClipboardSidebar/ClipboardDuplicateDialog';
@@ -43,7 +46,7 @@ interface PlaygroundProps {
 }
 
 export default function Playground({ config }: PlaygroundProps) {
-  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeyTab, storageKeySavedGraphs, supportsUpload, supportsClipboard, supportsHelp, tabs } = config;
+  const { title, wsPath, storageKeyPayload, storageKeyHistory, storageKeyTab, storageKeySavedGraphs, supportsUpload, supportsClipboard, supportsHelp, supportsAuthoring, tabs } = config;
 
   const navigate = useNavigate();
 
@@ -240,12 +243,26 @@ export default function Playground({ config }: PlaygroundProps) {
   } | null>(null);
 
   const handlePasteToInput = useCallback((item: ClipboardItemRecord) => {
-    const existsLocally = graphData?.nodes.some(n => n.alias === item.node.alias) ?? false;
-    const verb = existsLocally ? 'update' : 'create';
-    const command = buildNodeCommand(verb, item.node);
-    ws.setCommand(command);
-    addToast(`${verb === 'create' ? 'Create' : 'Update'} command for "${item.node.alias}" pasted to input`, 'info');
+    const plan = buildClipboardPastePlan(item, graphData);
+    ws.setCommand(plan.command);
+    addToast(`${plan.verb === 'create' ? 'Create' : 'Update'} command for "${item.node.alias}" pasted to input`, 'info');
   }, [graphData, ws.setCommand, addToast]);
+
+  const handleClipboardDrop = useCallback((itemId: string) => {
+    const item = clipboardCtx.items.find(entry => entry.id === itemId);
+    if (!item) {
+      addToast('Clipboard item is no longer available. It may have been removed in another tab.', 'error');
+      return;
+    }
+
+    const plan = buildClipboardPastePlan(item, graphData);
+    if (!ws.sendRawText(plan.command)) {
+      addToast('Could not send clipboard paste command because the WebSocket is not open.', 'error');
+      return;
+    }
+
+    addToast(`Clipboard node "${item.node.alias}" sent as ${plan.verb}. Waiting for backend response.`, 'info');
+  }, [clipboardCtx.items, graphData, ws.sendRawText, addToast]);
 
   const handleClipNode = useCallback(async (
     node: MinigraphNode,
@@ -299,11 +316,26 @@ export default function Playground({ config }: PlaygroundProps) {
   // ── Resolved graph display name ────────────────────────────────────────────
   // Priority: root node's "name" property (from graph data) → defaultName from
   // the save-name hook (lastSavedName → importedName → untitled-{n}).
-  const graphDisplayName = useMemo(() => {
+  const reliableGraphName = useMemo(() => {
     const rootNode = graphData?.nodes.find(n => n.types.includes('Root'));
     const rootName = typeof rootNode?.properties?.name === 'string' ? rootNode.properties.name : undefined;
-    return rootName ?? graphSaveName;
-  }, [graphData, graphSaveName]);
+    return rootName?.trim() ? rootName : null;
+  }, [graphData]);
+
+  const graphDisplayName = reliableGraphName ?? graphSaveName;
+
+  // ── Graph authoring ───────────────────────────────────────────────────────
+  const graphAuthoringExecutor = useMemo(
+    () => createGraphAuthoringExecutor(ws.sendRawText),
+    [ws.sendRawText],
+  );
+
+  const graphAuthoring = useGraphAuthoring({
+    bus,
+    connected: ws.connected,
+    graphData,
+    executor: graphAuthoringExecutor,
+  });
 
   // ── Saved graph workflow ──────────────────────────────────────────────────
   // Note: must be called AFTER useAutoGraphRefresh — both listen on graph.link
@@ -367,6 +399,16 @@ export default function Playground({ config }: PlaygroundProps) {
         />
       )}
 
+      {supportsAuthoring && (
+        <GraphAuthoringModals
+          state={graphAuthoring.state}
+          validationErrors={graphAuthoring.validationErrors}
+          onDraftChange={graphAuthoring.updateDraft}
+          onSubmit={graphAuthoring.submit}
+          onClose={graphAuthoring.close}
+        />
+      )}
+
       <header className={styles.header}>
         <h1 className={styles.title}>{title}</h1>
         <div className={styles.headerActions}>
@@ -391,10 +433,10 @@ export default function Playground({ config }: PlaygroundProps) {
             <button
               className={styles.clipboardToggle}
               onClick={() => setClipboardOpen(prev => !prev)}
-              aria-label={clipboardOpen ? 'Close clipboard sidebar' : 'Open clipboard sidebar'}
+              aria-label={clipboardOpen ? 'Close workspace sidebar' : 'Open workspace sidebar'}
               aria-pressed={clipboardOpen}
             >
-              Clipboard{clipboardCtx.items.length > 0 ? ` (${clipboardCtx.items.length})` : ''}
+              Workspace{clipboardCtx.items.length > 0 ? ` (${clipboardCtx.items.length})` : ''}
             </button>
           )}
           <Navigation addToast={addToast} />
@@ -490,6 +532,10 @@ export default function Playground({ config }: PlaygroundProps) {
             onGraphDataCopyError={() => addToast('Copy failed', 'error')}
             isGraphRefreshing={isRefreshing}
             onClipNode={supportsClipboard ? handleClipNode : undefined}
+            onClipboardDrop={supportsClipboard ? handleClipboardDrop : undefined}
+            isConnected={ws.connected}
+            supportsAuthoring={supportsAuthoring}
+            onCreateNode={supportsAuthoring ? graphAuthoring.openCreateNode : undefined}
             helpPanel={supportsHelp && helpOpen ? (
               (onToggleMaximize: () => void, isMaximized: boolean) => (
                 <HelpBrowser
@@ -509,7 +555,7 @@ export default function Playground({ config }: PlaygroundProps) {
             <Panel defaultSize="20%" minSize="10%" maxSize="40%">
               <ClipboardSidebar
                 connected={ws.connected}
-                onPaste={handlePasteToInput}
+                onPasteToInput={handlePasteToInput}
               />
             </Panel>
           </>

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.module.css
@@ -58,6 +58,12 @@
   display: none;
 }
 
+.graphContent {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* ── Vertical split group (tab content + help panel) ────────────── */
 .rightPanelGroup {
   display: flex;

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
@@ -31,6 +31,10 @@ interface RightPanelProps {
   isGraphRefreshing?:      boolean;
   /** Callback for "Clip to Clipboard" from the node context menu in GraphView. */
   onClipNode?:             (node: MinigraphNode, connections: MinigraphConnection[]) => void;
+  onClipboardDrop?:        (itemId: string) => void;
+  isConnected:             boolean;
+  supportsAuthoring?:      boolean;
+  onCreateNode?:           (source: 'empty-graph' | 'pane-context-menu') => void;
   /**
    * When provided and non-null, the right panel renders a vertical split:
    * top = tab content, bottom = help panel.  Accepts either a plain ReactNode
@@ -63,6 +67,10 @@ export default function RightPanel({
   onGraphDataCopyError,
   isGraphRefreshing,
   onClipNode,
+  onClipboardDrop,
+  isConnected,
+  supportsAuthoring,
+  onCreateNode,
   helpPanel,
 }: RightPanelProps) {
   const uid              = useId();
@@ -138,15 +146,21 @@ export default function RightPanel({
           tabIndex={activeTab === 'graph' ? 0 : -1}
           className={`${styles.tabBody}${activeTab !== 'graph' ? ` ${styles.tabBodyHidden}` : ''}`}
         >
-          <GraphView
-            graphData={graphData}
-            graphName={graphName}
-            onRenderError={onGraphRenderError}
-            isRefreshing={isGraphRefreshing}
-            onCopySuccess={onGraphDataCopySuccess}
-            onCopyError={onGraphDataCopyError}
-            onClipNode={onClipNode}
-          />
+          <div className={styles.graphContent}>
+            <GraphView
+              graphData={graphData}
+              graphName={graphName}
+              onRenderError={onGraphRenderError}
+              isRefreshing={isGraphRefreshing}
+              onCopySuccess={onGraphDataCopySuccess}
+              onCopyError={onGraphDataCopyError}
+              onClipNode={onClipNode}
+              onClipboardDrop={onClipboardDrop}
+              isConnected={isConnected}
+              supportsAuthoring={supportsAuthoring}
+              onCreateNode={onCreateNode}
+            />
+          </div>
         </div>
       )}
 

--- a/system/minigraph-playground-engine/webapp/src/config/playgrounds.ts
+++ b/system/minigraph-playground-engine/webapp/src/config/playgrounds.ts
@@ -45,6 +45,7 @@ export interface PlaygroundConfig {
   supportsUpload?:       boolean;    // true when the backend supports POST /api/json/content/{id} upload
   supportsClipboard?:    boolean;    // true when clip/paste features are enabled (Minigraph only)
   supportsHelp?:         boolean;    // true when the help panel is available (Minigraph only)
+  supportsAuthoring?:    boolean;    // true when UI graph authoring is enabled (Minigraph only)
   /**
    * localStorage key for the last-viewed help topic.
    * Only used when the playground includes the 'help' tab.
@@ -89,6 +90,7 @@ export const PLAYGROUND_CONFIGS: PlaygroundConfig[] = [
     storageKeyHelpTopic: 'minigraph-help-topic',
     supportsClipboard: true,
     supportsHelp: true,
+    supportsAuthoring: true,
     // Minigraph works with graph commands and text responses; it has no payload input.
     tabs: ['graph', 'graph-data'],
   },

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/graphAuthoringExecutor.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/graphAuthoringExecutor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGraphAuthoringExecutor } from '../graphAuthoringExecutor';
+
+describe('createGraphAuthoringExecutor', () => {
+  it('delegates raw command text and returns the send boolean', () => {
+    const sendRawText = vi.fn(() => true);
+    const executor = createGraphAuthoringExecutor(sendRawText);
+
+    expect(executor.execute('create node root')).toBe(true);
+    expect(sendRawText).toHaveBeenCalledWith('create node root');
+  });
+
+  it('surfaces send failure', () => {
+    const executor = createGraphAuthoringExecutor(() => false);
+    expect(executor.execute('create node root')).toBe(false);
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildCreateNodeCommand } from '../minigraphCommandBuilder';
+import type { NodeDraft } from '../nodeAuthoringTypes';
+
+function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
+  return {
+    alias: 'root',
+    nodeType: 'Root',
+    properties: [
+      { id: 'p1', key: 'name', value: 'demo' },
+      { id: 'p2', key: '', value: '' },
+    ],
+    source: 'empty-graph',
+    ...overrides,
+  };
+}
+
+describe('buildCreateNodeCommand', () => {
+  it('emits backend create-node command text without trailing newline', () => {
+    expect(buildCreateNodeCommand(draft())).toBe([
+      'create node root',
+      'with type Root',
+      'with properties',
+      'name=demo',
+    ].join('\n'));
+  });
+
+  it('omits node type and properties when blank', () => {
+    expect(buildCreateNodeCommand(draft({
+      nodeType: '  ',
+      properties: [{ id: 'p1', key: ' ', value: ' ' }],
+    }))).toBe('create node root');
+  });
+
+  it('preserves property row order and allows blank values', () => {
+    expect(buildCreateNodeCommand(draft({
+      properties: [
+        { id: 'p1', key: 'first', value: 'one' },
+        { id: 'p2', key: 'second', value: '' },
+      ],
+    }))).toBe([
+      'create node root',
+      'with type Root',
+      'with properties',
+      'first=one',
+      'second=',
+    ].join('\n'));
+  });
+
+  it('rejects alias line injection before serialization', () => {
+    expect(() => buildCreateNodeCommand(draft({ alias: 'root\nwith properties' }))).toThrow();
+  });
+
+  it('rejects node type line injection before serialization', () => {
+    expect(() => buildCreateNodeCommand(draft({ nodeType: 'Root\rwith properties' }))).toThrow();
+  });
+
+  it('rejects property keys containing equals before serialization', () => {
+    expect(() => buildCreateNodeCommand(draft({
+      properties: [{ id: 'p1', key: 'bad=key', value: 'value' }],
+    }))).toThrow();
+  });
+
+  it('rejects property value newline injection', () => {
+    expect(() => buildCreateNodeCommand(draft({
+      properties: [{ id: 'p1', key: 'name', value: 'demo\nwith properties' }],
+    }))).toThrow();
+  });
+
+  it('rejects multiline property delimiters', () => {
+    expect(() => buildCreateNodeCommand(draft({
+      properties: [{ id: 'p1', key: 'name', value: "'''demo" }],
+    }))).toThrow();
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { getValidationErrorKeyForProperty, validateNodeDraft } from '../validation';
+import type { NodeDraft } from '../nodeAuthoringTypes';
+
+function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
+  return {
+    alias: 'node-1',
+    nodeType: 'Fetcher',
+    properties: [],
+    source: 'pane-context-menu',
+    ...overrides,
+  };
+}
+
+describe('validateNodeDraft', () => {
+  it('requires alias', () => {
+    const result = validateNodeDraft(draft({ alias: '   ' }));
+    expect(result.errors.alias).toBeDefined();
+  });
+
+  it('rejects reserved aliases case-insensitively', () => {
+    const result = validateNodeDraft(draft({ alias: 'Input' }));
+    expect(result.errors.alias).toContain('reserved');
+  });
+
+  it('rejects duplicate aliases known in current graph data case-insensitively', () => {
+    const result = validateNodeDraft(draft({ alias: 'Root' }), {
+      graphData: {
+        nodes: [{ alias: 'root', types: ['Root'], properties: {} }],
+        connections: [],
+      },
+    });
+    expect(result.errors.alias).toContain('already exists');
+  });
+
+  it('rejects invalid node type token', () => {
+    const result = validateNodeDraft(draft({ nodeType: 'Root.Type' }));
+    expect(result.errors.nodeType).toBeDefined();
+  });
+
+  it('ignores fully blank property rows', () => {
+    const result = validateNodeDraft(draft({
+      properties: [{ id: 'p1', key: ' ', value: ' ' }],
+    }));
+    expect(result.valid).toBe(true);
+  });
+
+  it('allows a non-blank key with blank value', () => {
+    const result = validateNodeDraft(draft({
+      properties: [{ id: 'p1', key: 'name', value: ' ' }],
+    }));
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a blank key with non-blank value', () => {
+    const result = validateNodeDraft(draft({
+      properties: [{ id: 'p1', key: ' ', value: 'demo' }],
+    }));
+    expect(result.errors[getValidationErrorKeyForProperty('p1', 'key')]).toBeDefined();
+  });
+
+  it('rejects property keys outside the backend name token', () => {
+    const result = validateNodeDraft(draft({
+      properties: [{ id: 'p1', key: 'a.b', value: 'demo' }],
+    }));
+    expect(result.errors[getValidationErrorKeyForProperty('p1', 'key')]).toBeDefined();
+  });
+
+  it('rejects multiline and triple-quote property values', () => {
+    const newline = validateNodeDraft(draft({
+      properties: [{ id: 'p1', key: 'name', value: 'a\nb' }],
+    }));
+    const tripleQuote = validateNodeDraft(draft({
+      properties: [{ id: 'p2', key: 'name', value: "a'''b" }],
+    }));
+    expect(newline.errors[getValidationErrorKeyForProperty('p1', 'value')]).toBeDefined();
+    expect(tripleQuote.errors[getValidationErrorKeyForProperty('p2', 'value')]).toBeDefined();
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/graphActions/graphAuthoringExecutor.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/graphAuthoringExecutor.ts
@@ -1,0 +1,18 @@
+// Thin boundary between the authoring lifecycle and the transport layer.
+// useGraphAuthoring depends on this interface so it can be tested with a fake
+// executor and does not need to import or understand the WebSocket hook.
+export interface GraphAuthoringExecutor {
+  execute(commandText: string): boolean;
+}
+
+// Production adapter for the raw command transport. It delegates to sendRawText
+// and preserves its boolean "accepted by open socket" result.
+export function createGraphAuthoringExecutor(
+  sendRawText: (text: string) => boolean,
+): GraphAuthoringExecutor {
+  return {
+    execute(commandText) {
+      return sendRawText(commandText);
+    },
+  };
+}

--- a/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
@@ -1,0 +1,39 @@
+import type { NodeDraft } from './nodeAuthoringTypes';
+import { validateCommandSize, validateNodeDraft } from './validation';
+
+// Single serialization boundary for create-node UI authoring. Callers pass a
+// typed draft; only this builder is allowed to produce backend raw command text
+// so validation and injection guards stay centralized.
+export function buildCreateNodeCommand(draft: NodeDraft): string {
+  const validation = validateNodeDraft(draft);
+  if (!validation.valid) {
+    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node draft.');
+  }
+
+  const alias = draft.alias.trim();
+  const nodeType = draft.nodeType.trim();
+  const propertyRows = draft.properties
+    .map((row) => ({ key: row.key.trim(), value: row.value.trim() }))
+    .filter((row) => row.key || row.value);
+
+  // Match the existing multiline command grammar consumed by
+  // GraphCommandService.handleMultiLineCommand.
+  const lines = [`create node ${alias}`];
+  if (nodeType) {
+    lines.push(`with type ${nodeType}`);
+  }
+  if (propertyRows.length > 0) {
+    lines.push('with properties');
+    for (const row of propertyRows) {
+      lines.push(`${row.key}=${row.value}`);
+    }
+  }
+
+  const command = lines.join('\n');
+  const sizeValidation = validateCommandSize(command);
+  if (!sizeValidation.valid) {
+    throw new Error(sizeValidation.errors.command);
+  }
+
+  return command;
+}

--- a/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
@@ -1,0 +1,16 @@
+export type NodeDraftSource = 'empty-graph' | 'pane-context-menu';
+
+export interface PropertyRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface NodeDraft {
+  alias: string;
+  nodeType: string;
+  properties: PropertyRow[];
+  source: NodeDraftSource;
+}
+
+export type NodeDraftValidationErrors = Record<string, string>;

--- a/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
@@ -1,0 +1,21 @@
+import type { NodeDraft, NodeDraftSource, PropertyRow } from './nodeAuthoringTypes';
+
+let rowCounter = 0;
+
+// Row ids are only for React rendering and field-error keys. They are never
+// sent to the backend.
+export function createPropertyRow(key = '', value = ''): PropertyRow {
+  rowCounter += 1;
+  return { id: `property-row-${rowCounter}`, key, value };
+}
+
+// First-node authoring uses deterministic defaults. They are starting values
+// only; normal validation still runs after the user edits or submits.
+export function createDefaultNodeDraft(source: NodeDraftSource): NodeDraft {
+  return {
+    alias: source === 'empty-graph' ? 'root' : '',
+    nodeType: source === 'empty-graph' ? 'Root' : '',
+    properties: [createPropertyRow()],
+    source,
+  };
+}

--- a/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
@@ -1,0 +1,94 @@
+import { MAX_BUFFER } from '../config/playgrounds';
+import type { MinigraphGraphData } from '../utils/graphTypes';
+import type { NodeDraft, NodeDraftValidationErrors } from './nodeAuthoringTypes';
+
+// Keep this token rule aligned with GraphProperties.validateName on the backend.
+// The backend remains authoritative; this only blocks obviously invalid drafts
+// before they can become raw command text.
+export const NODE_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+// Mirrors MiniGraph's reserved alias list so the modal can show immediate field
+// feedback instead of relying on a later generic backend ERROR response.
+export const RESERVED_ALIASES = new Set([
+  'input',
+  'output',
+  'model',
+  'response',
+  'result',
+  'parameter',
+  'none',
+  'next',
+  'api',
+  'error',
+]);
+
+export interface NodeDraftValidationOptions {
+  graphData?: MinigraphGraphData | null;
+}
+
+export interface NodeDraftValidationResult {
+  valid: boolean;
+  errors: NodeDraftValidationErrors;
+}
+
+export function getValidationErrorKeyForProperty(rowId: string, field: 'key' | 'value'): string {
+  return `properties.${rowId}.${field}`;
+}
+
+// Validate the supported authoring surface: alias, optional node type, and flat
+// single-line scalar properties. Duplicate aliases from graphData are advisory
+// because graphData is a staleable frontend projection.
+export function validateNodeDraft(
+  draft: NodeDraft,
+  options: NodeDraftValidationOptions = {},
+): NodeDraftValidationResult {
+  const errors: NodeDraftValidationErrors = {};
+  const alias = draft.alias.trim();
+  const nodeType = draft.nodeType.trim();
+
+  if (!alias) {
+    errors.alias = 'Alias is required.';
+  } else if (!NODE_NAME_RE.test(alias)) {
+    errors.alias = 'Use only letters, numbers, underscore, and hyphen.';
+  } else if (RESERVED_ALIASES.has(alias.toLowerCase())) {
+    errors.alias = `"${alias}" is reserved.`;
+  } else if (options.graphData?.nodes.some((node) => node.alias.toLowerCase() === alias.toLowerCase())) {
+    errors.alias = `Node "${alias}" already exists in the current graph.`;
+  }
+
+  if (nodeType && !NODE_NAME_RE.test(nodeType)) {
+    errors.nodeType = 'Use only letters, numbers, underscore, and hyphen.';
+  }
+
+  for (const row of draft.properties) {
+    const key = row.key.trim();
+    const value = row.value.trim();
+    if (!key && !value) continue;
+
+    if (!key && value) {
+      errors[getValidationErrorKeyForProperty(row.id, 'key')] = 'Property key is required when value is present.';
+    } else if (!NODE_NAME_RE.test(key)) {
+      errors[getValidationErrorKeyForProperty(row.id, 'key')] = 'Use only letters, numbers, underscore, and hyphen.';
+    }
+
+    if (value.includes('\r') || value.includes('\n')) {
+      errors[getValidationErrorKeyForProperty(row.id, 'value')] = 'Property value must be a single line.';
+    } else if (value.includes("'''")) {
+      errors[getValidationErrorKeyForProperty(row.id, 'value')] = "Property value cannot contain '''.";
+    }
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors };
+}
+
+// The command budget belongs to the WebSocket command path, so size is checked
+// after serialization rather than estimating from individual fields.
+export function validateCommandSize(commandText: string): NodeDraftValidationResult {
+  if (commandText.length <= MAX_BUFFER) return { valid: true, errors: {} };
+  return {
+    valid: false,
+    errors: {
+      command: 'The node command is too large. Shorten property values before submitting.',
+    },
+  };
+}

--- a/system/minigraph-playground-engine/webapp/src/hooks/useWebSocket.ts
+++ b/system/minigraph-playground-engine/webapp/src/hooks/useWebSocket.ts
@@ -61,7 +61,7 @@ export interface UseWebSocketReturn {
   copyMessages:     () => void;
   clearMessages:    () => void;
   uploadPayload:    () => void;
-  sendRawText:      (text: string) => void;
+  sendRawText:      (text: string) => boolean;
   /** Append a local-only message to this slot's console (no WebSocket round-trip). */
   appendMessage:    (raw: string) => void;
   /** Ordered command history for this playground slot (newest-first). */
@@ -303,9 +303,9 @@ export function useWebSocket({ wsPath, storageKeyHistory, payload, addToast, bus
   // --- Public: send raw text directly over the WebSocket without echoing to the console ---
   // Unlike sendCommand(), this bypasses the command-echo and history logic.
   // Used by useAutoGraphRefresh to silently send "describe graph" after a mutation.
-  const sendRawText = useCallback((text: string) => {
-    if (phase !== 'connected') return;
-    ctx.send(wsPath, text);
+  const sendRawText = useCallback((text: string): boolean => {
+    if (phase !== 'connected') return false;
+    return ctx.send(wsPath, text);
   }, [ctx, wsPath, phase]);
 
   // --- Console helpers ---

--- a/system/minigraph-playground-engine/webapp/src/icons/CloseIcon.svg
+++ b/system/minigraph-playground-engine/webapp/src/icons/CloseIcon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"
+     width="16" height="16" stroke="currentColor" stroke-width="1.8"
+     stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4.75" y1="4.75" x2="11.25" y2="11.25" />
+  <line x1="11.25" y1="4.75" x2="4.75" y2="11.25" />
+</svg>

--- a/system/minigraph-playground-engine/webapp/src/protocol/__tests__/classifier.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/__tests__/classifier.test.ts
@@ -104,4 +104,27 @@ describe('classifier — invariants', () => {
     expect(kinds).toContain('json.response');
     expect(kinds).not.toContain('lifecycle');
   });
+
+  it('emits create-node text result without replacing graph.mutation', () => {
+    const events = classifyMessage(1, 'node root created');
+    const kinds = events.map(e => e.kind);
+    expect(kinds).toContain('minigraph.createNode.textResult');
+    expect(kinds).toContain('graph.mutation');
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.createNode.textResult',
+      status: 'accepted',
+      alias: 'root',
+      message: 'node root created',
+    }));
+  });
+
+  it('emits duplicate create-node text result as rejected', () => {
+    const events = classifyMessage(1, 'node root already exists');
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.createNode.textResult',
+      status: 'rejected',
+      alias: 'root',
+      message: 'node root already exists',
+    }));
+  });
 });

--- a/system/minigraph-playground-engine/webapp/src/protocol/classifier.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/classifier.ts
@@ -12,6 +12,7 @@ import {
   isMarkdownCandidate,
   extractGraphExportSuccess,
   detectGraphExportFailure,
+  parseCreateNodeTextResult,
 } from '../utils/messageParser';
 
 const KNOWN_LIFECYCLE_TYPES = new Set(['info', 'error', 'ping', 'welcome']);
@@ -137,6 +138,18 @@ export function classifyMessage(msgId: number, raw: string): ProtocolEvent[] {
       ...base,
       kind: 'graph.mutation',
       mutationType: mutation,
+    });
+  }
+
+  // ── Rule 7a: Minigraph create-node text result ────────────────────────────
+  const createNodeResult = parseCreateNodeTextResult(raw);
+  if (createNodeResult) {
+    events.push({
+      ...base,
+      kind: 'minigraph.createNode.textResult',
+      status: createNodeResult.status,
+      alias: createNodeResult.alias,
+      message: createNodeResult.message,
     });
   }
 

--- a/system/minigraph-playground-engine/webapp/src/protocol/events.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/events.ts
@@ -22,6 +22,13 @@ export interface GraphMutationEvent extends ProtocolEventBase {
   mutationType: 'node-mutation' | 'import-graph';
 }
 
+export interface CreateNodeTextResultEvent extends ProtocolEventBase {
+  kind: 'minigraph.createNode.textResult';
+  status: 'accepted' | 'rejected' | 'error';
+  alias: string | null;
+  message: string;
+}
+
 export interface LargePayloadEvent extends ProtocolEventBase {
   kind: 'payload.large';
   apiPath: string;
@@ -111,6 +118,7 @@ export interface UnclassifiedEvent extends ProtocolEventBase {
 export type ProtocolEvent =
   | GraphLinkEvent
   | GraphMutationEvent
+  | CreateNodeTextResultEvent
   | GraphExportedEvent
   | GraphExportFailedEvent
   | LargePayloadEvent

--- a/system/minigraph-playground-engine/webapp/src/utils/__tests__/messageParser.createNodeTextResult.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/__tests__/messageParser.createNodeTextResult.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseCreateNodeTextResult } from '../messageParser';
+
+describe('parseCreateNodeTextResult', () => {
+  it('parses accepted create-node text', () => {
+    expect(parseCreateNodeTextResult('node root created')).toEqual({
+      status: 'accepted',
+      alias: 'root',
+      message: 'node root created',
+    });
+  });
+
+  it('parses duplicate create-node text as rejected', () => {
+    expect(parseCreateNodeTextResult('node root already exists')).toEqual({
+      status: 'rejected',
+      alias: 'root',
+      message: 'node root already exists',
+    });
+  });
+
+  it('parses generic backend errors without alias', () => {
+    expect(parseCreateNodeTextResult('ERROR: alias is reserved')).toEqual({
+      status: 'error',
+      alias: null,
+      message: 'ERROR: alias is reserved',
+    });
+  });
+
+  it('ignores command echoes and unrelated node operations', () => {
+    expect(parseCreateNodeTextResult('> create node root')).toBeNull();
+    expect(parseCreateNodeTextResult('node root updated')).toBeNull();
+    expect(parseCreateNodeTextResult('{"type":"info"}')).toBeNull();
+  });
+});

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -1,6 +1,6 @@
 import { MarkerType, type Node, type Edge } from '@xyflow/react';
-import type { CSSProperties } from 'react';
 import type { MinigraphGraphData } from './graphTypes';
+import { getMinigraphNodeShellStyle } from './minigraphNodeTheme';
 
 /** Data bag attached to every ReactFlow node we create. */
 export interface GraphNodeData extends Record<string, unknown> {
@@ -39,52 +39,6 @@ const ROW_GAP            = 60;   // vertical gap between nodes stacked in the sa
 const COL_GAP            = 120;  // horizontal gap between columns (levels)
 const SECTION_GAP        = 120;  // vertical gap between main flow and first segregated row
 const SEGREGATED_ROW_GAP = 80;   // vertical gap between successive segregated rows
-
-// ─── Per-type visual style ───────────────────────────────────────────────────
-// Because MinigraphNode renders as a React Fragment (no wrapper <div>),
-// the React Flow wrapper element IS the visible shell.  We apply its visual
-// style via `node.style` so NodeResizer can resize it directly — the exact
-// pattern shown in https://reactflow.dev/examples/nodes/node-resizer.
-//
-// Per-type accent colours are passed as the CSS custom property --node-accent.
-// The component's CSS module reads that variable for the header background,
-// badge colours, and border — keeping the component itself colour-agnostic and
-// following the CSS-variables theming approach described in the React Flow
-// theming guide: https://reactflow.dev/learn/customization/theming
-const BASE_NODE_STYLE: CSSProperties = {
-  boxSizing:    'border-box',
-  borderRadius: '8px',
-  borderWidth:  '1.5px',
-  borderStyle:  'solid',
-  background:   'var(--bg-secondary, #1e1e2e)',
-  color:        'var(--text-primary, #cdd6f4)',
-  fontSize:     '0.75rem',
-  boxShadow:    '0 2px 8px rgba(0,0,0,0.45)',
-  // overflow:visible so NodeResizer handles (absolutely positioned outside the
-  // wrapper bounds) are not clipped — clipping them is what prevents resizing.
-  overflow:     'visible',
-  // Reset the 10px padding React Flow's built-in stylesheet injects on
-  // .react-flow__node-default / -output / -group.
-  padding:      0,
-};
-
-// Accent colours per node type.  Only the accent value differs between types;
-// everything else is shared via BASE_NODE_STYLE.
-const NODE_ACCENT: Record<string, string> = {
-  Root:        '#15803d',   // green-700
-  End:         '#dc2626',   // red-600
-  Fetcher:     '#2563eb',   // blue-600
-  mapper:      '#ea580c',   // orange-600
-  Math:        '#a16207',   // yellow-700
-  JavaScript:  '#7e22ce',   // purple-700
-  Provider:    '#be185d',   // pink-700
-  Dictionary:  '#0e7490',   // cyan-700
-  Join:        '#65a30d',   // lime-700
-  Extension:   '#4338ca',   // indigo-700
-  Island:      '#475569',   // slate-600
-  Decision:    '#b45309',   // amber-700
-};
-const UNKNOWN_ACCENT = '#6c7086';
 
 // ─── Edge styling constants ──────────────────────────────────────────────────
 // EDGE_STROKE: --text-muted (rgb 148 163 184) at 42% opacity — slate-400 tinted stroke
@@ -173,17 +127,6 @@ function edgeHandleOffset(index: number, total: number): number {
 function nodeHeightForHandleCount(handleCount: number): number {
   if (handleCount <= 1) return NODE_HEIGHT;
   return Math.max(NODE_HEIGHT, ((handleCount - 1) * EDGE_HANDLE_GAP) + (EDGE_HANDLE_PADDING * 2));
-}
-
-function nodeStyle(nodeType: string): CSSProperties {
-  const accent = NODE_ACCENT[nodeType] ?? UNKNOWN_ACCENT;
-  return {
-    ...BASE_NODE_STYLE,
-    borderColor: accent,
-    // Expose the accent as a CSS custom property so the CSS module can theme
-    // the header, badge, and any other child elements without touching JS.
-    ['--node-accent' as string]: accent,
-  };
 }
 
 // ─── Layout node classification ─────────────────────────────────────────────
@@ -587,7 +530,7 @@ export function transformGraphData(
       position: positions.get(n.alias) ?? { x: 0, y: 0 },
       width:  NODE_WIDTH,
       height: nodeHeight,
-      style: nodeStyle(n.types[0] ?? 'unknown'),
+      style: getMinigraphNodeShellStyle(n.types[0] ?? 'unknown'),
       data: {
         alias:         n.alias,
         nodeType:      n.types[0] ?? 'unknown',

--- a/system/minigraph-playground-engine/webapp/src/utils/messageParser.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/messageParser.ts
@@ -290,6 +290,40 @@ export function extractImportGraphName(raw: string): string | null {
  */
 export type MutationKind = 'node-mutation' | 'import-graph';
 
+export type CreateNodeTextResultStatus = 'accepted' | 'rejected' | 'error';
+
+export interface CreateNodeTextResult {
+  status: CreateNodeTextResultStatus;
+  alias: string | null;
+  message: string;
+}
+
+export const CREATE_NODE_CREATED_RE = /^node ([A-Za-z0-9_-]+) created$/;
+export const CREATE_NODE_ALREADY_EXISTS_RE = /^node ([A-Za-z0-9_-]+) already exists$/;
+export const ERROR_RE = /^ERROR: (.+)$/;
+
+export function parseCreateNodeTextResult(raw: string): CreateNodeTextResult | null {
+  const text = raw.trim();
+  if (text.startsWith('> ')) return null;
+
+  const created = text.match(CREATE_NODE_CREATED_RE);
+  if (created) {
+    return { status: 'accepted', alias: created[1], message: text };
+  }
+
+  const alreadyExists = text.match(CREATE_NODE_ALREADY_EXISTS_RE);
+  if (alreadyExists) {
+    return { status: 'rejected', alias: alreadyExists[1], message: text };
+  }
+
+  const error = text.match(ERROR_RE);
+  if (error) {
+    return { status: 'error', alias: null, message: text };
+  }
+
+  return null;
+}
+
 /**
  * Inspects a single raw WebSocket message string and returns whether it
  * represents a graph mutation that should trigger an auto-refresh.
@@ -338,4 +372,3 @@ export function detectMutation(raw: string): MutationKind | null {
 
   return null;
 }
-

--- a/system/minigraph-playground-engine/webapp/src/utils/minigraphNodeTheme.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/minigraphNodeTheme.ts
@@ -1,0 +1,64 @@
+import type { CSSProperties } from 'react';
+
+export interface MinigraphNodeTypeMeta {
+  icon: string;
+  label: string;
+}
+
+const TYPE_META: Record<string, MinigraphNodeTypeMeta> = {
+  Root:        { icon: '🚀', label: 'Root' },
+  End:         { icon: '🏁', label: 'End' },
+  Fetcher:     { icon: '🌐', label: 'Fetcher' },
+  mapper:      { icon: '🗺️', label: 'Mapper' },
+  Math:        { icon: '🔢', label: 'Math' },
+  JavaScript:  { icon: '📜', label: 'JavaScript' },
+  Provider:    { icon: '🔌', label: 'Provider' },
+  Dictionary:  { icon: '📖', label: 'Dictionary' },
+  Join:        { icon: '🔀', label: 'Join' },
+  Extension:   { icon: '🧩', label: 'Extension' },
+  Island:      { icon: '🏝️', label: 'Island' },
+  Decision:    { icon: '❓', label: 'Decision' },
+};
+
+const BASE_NODE_STYLE: CSSProperties = {
+  boxSizing: 'border-box',
+  borderRadius: '8px',
+  borderWidth: '1.5px',
+  borderStyle: 'solid',
+  background: 'var(--bg-secondary, #1e1e2e)',
+  color: 'var(--text-primary, #cdd6f4)',
+  fontSize: '0.75rem',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.45)',
+  overflow: 'visible',
+  padding: 0,
+};
+
+const NODE_ACCENT: Record<string, string> = {
+  Root: '#15803d',
+  End: '#dc2626',
+  Fetcher: '#2563eb',
+  mapper: '#ea580c',
+  Math: '#a16207',
+  JavaScript: '#7e22ce',
+  Provider: '#be185d',
+  Dictionary: '#0e7490',
+  Join: '#65a30d',
+  Extension: '#4338ca',
+  Island: '#475569',
+  Decision: '#b45309',
+};
+
+const UNKNOWN_ACCENT = '#6c7086';
+
+export function getMinigraphNodeTypeMeta(nodeType: string): MinigraphNodeTypeMeta {
+  return TYPE_META[nodeType] ?? { icon: '📦', label: nodeType };
+}
+
+export function getMinigraphNodeShellStyle(nodeType: string): CSSProperties {
+  const accent = NODE_ACCENT[nodeType] ?? UNKNOWN_ACCENT;
+  return {
+    ...BASE_NODE_STYLE,
+    borderColor: accent,
+    ['--node-accent' as string]: accent,
+  };
+}


### PR DESCRIPTION
This PR adds a Minigraph create-node authoring flow and upgrades workspace clipboard interactions.

- Adds create-node entry points from the empty graph state and graph-pane context menu, with modal validation and raw command serialization
- Extends protocol parsing to correlate create-node backend text results and keep authoring state in sync
- Adds workspace node drag/drop and item context-menu actions, including paste-to-input and direct graph drop
- Refactors shared node rendering/theme helpers and updates supporting tests and technical docs