### PR TITLE
Add node edit and delete actions to graph UI

### DIFF
--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
@@ -29,6 +29,8 @@ export default function GraphAuthoringModals({
   return (
     <NodeDialog
       open
+      mode={state.action === 'edit-node' ? 'edit' : 'create'}
+      aliasReadOnly={state.action === 'edit-node'}
       draft={state.draft}
       phase={state.phase}
       lockReason={lockReason}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/GraphAuthoringModals.tsx
@@ -1,11 +1,11 @@
 import NodeDialog from '../NodeDialog/NodeDialog';
-import type { NodeDraft } from '../../graphActions/nodeAuthoringTypes';
+import type { NodeFormState } from '../../graphActions/nodeAuthoringTypes';
 import type { AuthoringState } from './useGraphAuthoring';
 
 interface GraphAuthoringModalsProps {
   state: AuthoringState;
   validationErrors: Record<string, string>;
-  onDraftChange: (draft: NodeDraft) => void;
+  onFormStateChange: (formState: NodeFormState) => void;
   onSubmit: () => void;
   onClose: () => void;
 }
@@ -13,7 +13,7 @@ interface GraphAuthoringModalsProps {
 export default function GraphAuthoringModals({
   state,
   validationErrors,
-  onDraftChange,
+  onFormStateChange,
   onSubmit,
   onClose,
 }: GraphAuthoringModalsProps) {
@@ -31,12 +31,12 @@ export default function GraphAuthoringModals({
       open
       mode={state.action === 'edit-node' ? 'edit' : 'create'}
       aliasReadOnly={state.action === 'edit-node'}
-      draft={state.draft}
+      formState={state.formState}
       phase={state.phase}
       lockReason={lockReason}
       serverMessage={state.serverMessage}
       validationErrors={validationErrors}
-      onDraftChange={onDraftChange}
+      onFormStateChange={onFormStateChange}
       onSubmit={onSubmit}
       onClose={onClose}
     />

--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
@@ -1,29 +1,48 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ProtocolBus } from '../../protocol/bus';
-import type { CreateNodeTextResultEvent } from '../../protocol/events';
-import type { MinigraphGraphData } from '../../utils/graphTypes';
-import type { CreateNodeTextResult } from '../../utils/messageParser';
+import type { NodeActionTextResultEvent } from '../../protocol/events';
+import type { MinigraphGraphData, MinigraphNode } from '../../utils/graphTypes';
+import type { NodeActionTextResult } from '../../utils/messageParser';
 import type { GraphAuthoringExecutor } from '../../graphActions/graphAuthoringExecutor';
-import { buildCreateNodeCommand } from '../../graphActions/minigraphCommandBuilder';
-import type { NodeDraft, NodeDraftSource, NodeDraftValidationErrors } from '../../graphActions/nodeAuthoringTypes';
-import { createDefaultNodeDraft } from '../../graphActions/propertyRows';
-import { validateNodeDraft } from '../../graphActions/validation';
+import {
+  buildCreateNodeCommand,
+  buildDeleteNodeCommand,
+  buildUpdateNodeCommand,
+} from '../../graphActions/minigraphCommandBuilder';
+import type {
+  NodeAction,
+  NodeDraft,
+  NodeDraftSource,
+  NodeDraftValidationErrors,
+} from '../../graphActions/nodeAuthoringTypes';
+import { createDefaultNodeDraft, createEditNodeDraft } from '../../graphActions/propertyRows';
+import { validateDeleteNodeAlias, validateNodeDraft } from '../../graphActions/validation';
 
 export const DEFAULT_AUTHORING_TIMEOUT_MS = 10_000;
 
+type EditableNodeAction = Extract<NodeAction, 'create-node' | 'edit-node'>;
+type CreateNodeDraftSource = Exclude<NodeDraftSource, 'edit-node'>;
+type UserMessageType = 'info' | 'success' | 'error';
+
 export type AuthoringState =
-  | { status: 'closed' }
+  | {
+      status: 'closed';
+      pendingSubmit: PendingNodeActionSubmit | null;
+      serverMessage: string | null;
+    }
   | {
       status: 'open';
-      action: 'create-node';
+      action: EditableNodeAction;
       phase: 'editing' | 'sending';
       draft: NodeDraft;
-      pendingSubmit: PendingCreateNodeSubmit | null;
+      originalAlias: string | null;
+      pendingSubmit: PendingNodeActionSubmit | null;
       serverMessage: string | null;
       connectionLost: boolean;
     };
 
-export interface PendingCreateNodeSubmit {
+export interface PendingNodeActionSubmit {
+  action: NodeAction;
   alias: string;
   command: string;
   sentAt: string;
@@ -35,26 +54,75 @@ export interface UseGraphAuthoringOptions {
   graphData: MinigraphGraphData | null;
   executor: GraphAuthoringExecutor;
   timeoutMs?: number;
-  onAccepted?: (result: CreateNodeTextResult) => void;
+  onAccepted?: (result: NodeActionTextResult) => void;
+  onUserMessage?: (message: string, type?: UserMessageType) => void;
 }
 
 export interface UseGraphAuthoringReturn {
   state: AuthoringState;
   validationErrors: NodeDraftValidationErrors;
-  openCreateNode: (source: NodeDraftSource) => void;
+  openCreateNode: (source: CreateNodeDraftSource) => void;
+  openEditNode: (node: MinigraphNode) => void;
+  deleteNode: (node: MinigraphNode) => void;
   updateDraft: (draft: NodeDraft) => void;
   submit: () => void;
   close: () => void;
 }
 
-const SEND_FAILURE_MESSAGE = 'Could not send the create-node command because the WebSocket is not open. The draft was preserved in this dialog.';
-const TIMEOUT_MESSAGE = 'The create-node command was sent, but no backend result was observed yet. The outcome is unknown.';
-const DISCONNECTED_EDITING_MESSAGE = 'Connection disconnected. This graph session may no longer be valid. Refresh the page and create the node again after the app reconnects.';
-const DISCONNECTED_SENDING_MESSAGE = 'Connection disconnected while the create-node command was pending. The outcome is unknown. Refresh the page and check the graph before trying again.';
+const PENDING_ACTION_MESSAGE = 'A node action is already pending. Wait for it to finish before starting another.';
+const CREATE_SEND_FAILURE_MESSAGE = 'Could not send the create-node command because the WebSocket is not open. The draft was preserved in this dialog.';
+const EDIT_SEND_FAILURE_MESSAGE = 'Could not send the edit-node command because the WebSocket is not open. Your changes remain in this dialog.';
+const DELETE_SEND_FAILURE_MESSAGE = 'Could not send the delete-node command because the WebSocket is not open.';
+const NODE_UNAVAILABLE_MESSAGE = 'This node is no longer available in the current graph.';
+const CREATE_DISCONNECTED_EDITING_MESSAGE = 'Connection disconnected. Refresh the page and create the node again after the app reconnects.';
+const EDIT_DISCONNECTED_EDITING_MESSAGE = 'Connection disconnected. Refresh the page and edit the node again after the app reconnects.';
+const PENDING_DISCONNECTED_MESSAGE = 'Connection disconnected while the node action was pending. The outcome is unknown. Refresh the page and check the graph before trying again.';
 
-// Owns the complete create-node lifecycle: draft state, validation, raw-command
-// send, best-effort text-result matching, timeout handling, and disconnect
-// handling. UI components should call this hook instead of sending commands or
+const CLOSED_STATE: AuthoringState = { status: 'closed', pendingSubmit: null, serverMessage: null };
+
+function getPendingSubmit(state: AuthoringState): PendingNodeActionSubmit | null {
+  return state.pendingSubmit;
+}
+
+function getSendFailureMessage(action: NodeAction): string {
+  if (action === 'edit-node') return EDIT_SEND_FAILURE_MESSAGE;
+  if (action === 'delete-node') return DELETE_SEND_FAILURE_MESSAGE;
+  return CREATE_SEND_FAILURE_MESSAGE;
+}
+
+function getTimeoutMessage(action: NodeAction): string {
+  return `The ${action} command was sent, but no backend result was observed yet. The outcome is unknown.`;
+}
+
+function getDisconnectedEditingMessage(action: EditableNodeAction): string {
+  return action === 'edit-node'
+    ? EDIT_DISCONNECTED_EDITING_MESSAGE
+    : CREATE_DISCONNECTED_EDITING_MESSAGE;
+}
+
+function aliasesMatch(left: string | null, right: string): boolean {
+  return left?.trim().toLowerCase() === right.trim().toLowerCase();
+}
+
+function findCurrentNodeByAlias(
+  graphData: MinigraphGraphData | null,
+  alias: string,
+): MinigraphNode | null {
+  return graphData?.nodes.find((node) => node.alias.toLowerCase() === alias.toLowerCase()) ?? null;
+}
+
+function eventMatchesPendingAction(
+  event: NodeActionTextResultEvent,
+  pending: PendingNodeActionSubmit,
+): boolean {
+  if (event.status === 'error') return true;
+  if (!aliasesMatch(event.alias, pending.alias)) return false;
+  return event.action === null || event.action === pending.action;
+}
+
+// Owns the complete node-authoring lifecycle: draft state, validation,
+// raw-command send, text-result matching, timeout handling, and disconnect
+// handling. UI components call this hook instead of sending commands or
 // interpreting backend text themselves.
 export function useGraphAuthoring({
   bus,
@@ -63,8 +131,9 @@ export function useGraphAuthoring({
   executor,
   timeoutMs = DEFAULT_AUTHORING_TIMEOUT_MS,
   onAccepted,
+  onUserMessage,
 }: UseGraphAuthoringOptions): UseGraphAuthoringReturn {
-  const [state, setState] = useState<AuthoringState>({ status: 'closed' });
+  const [state, setState] = useState<AuthoringState>(CLOSED_STATE);
   const [validationErrors, setValidationErrors] = useState<NodeDraftValidationErrors>({});
 
   const stateRef = useRef(state);
@@ -72,12 +141,18 @@ export function useGraphAuthoring({
   const wasConnectedRef = useRef(connected);
   const graphDataRef = useRef(graphData);
   const onAcceptedRef = useRef(onAccepted);
+  const onUserMessageRef = useRef(onUserMessage);
 
   // ProtocolBus and timers can fire after render, so callbacks read refs for
   // the latest state/context without re-subscribing on every draft keystroke.
   useEffect(() => { stateRef.current = state; }, [state]);
   useEffect(() => { graphDataRef.current = graphData; }, [graphData]);
   useEffect(() => { onAcceptedRef.current = onAccepted; }, [onAccepted]);
+  useEffect(() => { onUserMessageRef.current = onUserMessage; }, [onUserMessage]);
+
+  const notifyUser = useCallback((message: string, type: UserMessageType = 'error') => {
+    onUserMessageRef.current?.(message, type);
+  }, []);
 
   const setAuthoringState = useCallback((next: AuthoringState) => {
     stateRef.current = next;
@@ -91,8 +166,35 @@ export function useGraphAuthoring({
     }
   }, []);
 
-  const openCreateNode = useCallback((source: NodeDraftSource) => {
+  const startSubmitTimer = useCallback(() => {
+    clearPendingTimer();
+    timeoutRef.current = setTimeout(() => {
+      const current = stateRef.current;
+      const pending = getPendingSubmit(current);
+      if (!pending) return;
+
+      if (current.status === 'open') {
+        setAuthoringState({
+          ...current,
+          phase: 'editing',
+          pendingSubmit: null,
+          serverMessage: getTimeoutMessage(pending.action),
+        });
+      } else {
+        setAuthoringState(CLOSED_STATE);
+        notifyUser(getTimeoutMessage(pending.action), 'error');
+      }
+      timeoutRef.current = null;
+    }, timeoutMs);
+  }, [clearPendingTimer, notifyUser, setAuthoringState, timeoutMs]);
+
+  const openCreateNode = useCallback((source: CreateNodeDraftSource) => {
     if (!connected) return;
+    if (getPendingSubmit(stateRef.current)) {
+      notifyUser(PENDING_ACTION_MESSAGE, 'error');
+      return;
+    }
+
     const draft = createDefaultNodeDraft(source);
     setValidationErrors({});
     setAuthoringState({
@@ -100,11 +202,88 @@ export function useGraphAuthoring({
       action: 'create-node',
       phase: 'editing',
       draft,
+      originalAlias: null,
       pendingSubmit: null,
       serverMessage: null,
       connectionLost: false,
     });
-  }, [connected, setAuthoringState]);
+  }, [connected, notifyUser, setAuthoringState]);
+
+  const openEditNode = useCallback((node: MinigraphNode) => {
+    if (!connected) {
+      notifyUser(EDIT_DISCONNECTED_EDITING_MESSAGE, 'error');
+      return;
+    }
+    if (getPendingSubmit(stateRef.current)) {
+      notifyUser(PENDING_ACTION_MESSAGE, 'error');
+      return;
+    }
+
+    const currentNode = findCurrentNodeByAlias(graphDataRef.current, node.alias);
+    if (!currentNode) {
+      notifyUser(NODE_UNAVAILABLE_MESSAGE, 'error');
+      return;
+    }
+
+    const conversion = createEditNodeDraft(currentNode);
+    if (!conversion.valid || !conversion.draft) {
+      notifyUser(conversion.message ?? 'This node cannot be edited in the UI.', 'error');
+      return;
+    }
+
+    setValidationErrors({});
+    setAuthoringState({
+      status: 'open',
+      action: 'edit-node',
+      phase: 'editing',
+      draft: conversion.draft,
+      originalAlias: currentNode.alias,
+      pendingSubmit: null,
+      serverMessage: null,
+      connectionLost: false,
+    });
+  }, [connected, notifyUser, setAuthoringState]);
+
+  const deleteNode = useCallback((node: MinigraphNode) => {
+    if (!connected) {
+      notifyUser(DELETE_SEND_FAILURE_MESSAGE, 'error');
+      return;
+    }
+    if (getPendingSubmit(stateRef.current)) {
+      notifyUser(PENDING_ACTION_MESSAGE, 'error');
+      return;
+    }
+
+    const validation = validateDeleteNodeAlias(node.alias, { graphData: graphDataRef.current });
+    if (!validation.valid) {
+      notifyUser(Object.values(validation.errors)[0] ?? 'Invalid node alias.', 'error');
+      return;
+    }
+
+    let command: string;
+    try {
+      command = buildDeleteNodeCommand(node.alias, { graphData: graphDataRef.current });
+    } catch (err) {
+      notifyUser(err instanceof Error ? err.message : String(err), 'error');
+      return;
+    }
+
+    const sent = executor.execute(command);
+    if (!sent) {
+      notifyUser(DELETE_SEND_FAILURE_MESSAGE, 'error');
+      return;
+    }
+
+    const pending: PendingNodeActionSubmit = {
+      action: 'delete-node',
+      alias: node.alias.trim(),
+      command,
+      sentAt: new Date().toISOString(),
+    };
+    setValidationErrors({});
+    setAuthoringState({ status: 'closed', pendingSubmit: pending, serverMessage: null });
+    startSubmitTimer();
+  }, [connected, executor, notifyUser, setAuthoringState, startSubmitTimer]);
 
   const updateDraft = useCallback((draft: NodeDraft) => {
     const current = stateRef.current;
@@ -121,44 +300,42 @@ export function useGraphAuthoring({
     });
   }, [setAuthoringState]);
 
-  const startSubmitTimer = useCallback(() => {
-    clearPendingTimer();
-    timeoutRef.current = setTimeout(() => {
-      const current = stateRef.current;
-      if (current.status !== 'open' || current.phase !== 'sending' || !current.pendingSubmit) return;
-      setAuthoringState({
-        ...current,
-        phase: 'editing',
-        serverMessage: TIMEOUT_MESSAGE,
-      });
-      timeoutRef.current = null;
-    }, timeoutMs);
-  }, [clearPendingTimer, setAuthoringState, timeoutMs]);
-
-  // Submit is intentionally conservative: validate first, build command second,
-  // call the executor third. No optimistic graph mutation happens here.
   const submit = useCallback(() => {
     const current = stateRef.current;
     if (current.status !== 'open') return;
     if (current.phase === 'sending') return;
     if (current.connectionLost) return;
+
+    const action = current.action;
     if (!connected) {
       setAuthoringState({
         ...current,
-        serverMessage: SEND_FAILURE_MESSAGE,
+        serverMessage: getSendFailureMessage(action),
       });
       return;
     }
 
-    const validation = validateNodeDraft(current.draft, { graphData: graphDataRef.current });
+    const validation = validateNodeDraft(
+      current.draft,
+      action === 'edit-node'
+        ? { mode: 'edit', originalAlias: current.originalAlias }
+        : { graphData: graphDataRef.current },
+    );
     if (!validation.valid) {
       setValidationErrors(validation.errors);
       return;
     }
 
     let command: string;
+    let pendingAlias: string;
     try {
-      command = buildCreateNodeCommand(current.draft);
+      if (action === 'edit-node') {
+        pendingAlias = current.originalAlias?.trim() ?? '';
+        command = buildUpdateNodeCommand(current.draft, pendingAlias);
+      } else {
+        pendingAlias = current.draft.alias.trim();
+        command = buildCreateNodeCommand(current.draft);
+      }
     } catch (err) {
       setValidationErrors({ command: err instanceof Error ? err.message : String(err) });
       return;
@@ -170,13 +347,14 @@ export function useGraphAuthoring({
         ...current,
         phase: 'editing',
         pendingSubmit: null,
-        serverMessage: SEND_FAILURE_MESSAGE,
+        serverMessage: getSendFailureMessage(action),
       });
       return;
     }
 
-    const pending: PendingCreateNodeSubmit = {
-      alias: current.draft.alias.trim(),
+    const pending: PendingNodeActionSubmit = {
+      action,
+      alias: pendingAlias,
       command,
       sentAt: new Date().toISOString(),
     };
@@ -197,54 +375,58 @@ export function useGraphAuthoring({
     if (current.phase === 'sending') return;
     clearPendingTimer();
     setValidationErrors({});
-    setAuthoringState({ status: 'closed' });
+    setAuthoringState(CLOSED_STATE);
   }, [clearPendingTimer, setAuthoringState]);
 
   useEffect(() => {
-    return bus.on('minigraph.createNode.textResult', (event: CreateNodeTextResultEvent) => {
+    return bus.on('minigraph.nodeAction.textResult', (event: NodeActionTextResultEvent) => {
       const current = stateRef.current;
-      if (current.status !== 'open' || !current.pendingSubmit) return;
+      const pending = getPendingSubmit(current);
+      if (!pending || !eventMatchesPendingAction(event, pending)) return;
 
-      const pending = current.pendingSubmit;
-      if (event.status === 'accepted' && event.alias === pending.alias) {
-        clearPendingTimer();
+      clearPendingTimer();
+
+      if (event.status === 'accepted') {
         setValidationErrors({});
-        setAuthoringState({ status: 'closed' });
-        onAcceptedRef.current?.({ status: event.status, alias: event.alias, message: event.message });
-        return;
-      }
-
-      if (event.status === 'rejected' && event.alias === pending.alias) {
-        clearPendingTimer();
-        setAuthoringState({
-          ...current,
-          phase: 'editing',
-          pendingSubmit: null,
-          serverMessage: event.message,
+        setAuthoringState(CLOSED_STATE);
+        onAcceptedRef.current?.({
+          status: event.status,
+          action: event.action,
+          alias: event.alias,
+          message: event.message,
         });
         return;
       }
 
-      if (event.status === 'error') {
-        clearPendingTimer();
+      if (current.status === 'open') {
         setAuthoringState({
           ...current,
           phase: 'editing',
           pendingSubmit: null,
-          serverMessage: `Backend returned an error while this submit was pending: ${event.message}`,
+          serverMessage: event.status === 'error'
+            ? `Backend returned an error while this submit was pending: ${event.message}`
+            : event.message,
         });
+      } else {
+        setAuthoringState(CLOSED_STATE);
+        notifyUser(event.message, 'error');
       }
     });
-  }, [bus, clearPendingTimer, setAuthoringState]);
+  }, [bus, clearPendingTimer, notifyUser, setAuthoringState]);
 
-  // A disconnect changes the backend WebSocket session. The draft remains only
-  // in the currently open dialog; closing or refreshing discards it.
+  // A disconnect changes the backend WebSocket session. Open modal values are
+  // intentionally memory-only; if the connection is lost, fields are locked and
+  // the user must refresh before trying the action again.
   useEffect(() => {
     if (wasConnectedRef.current && !connected) {
       const current = stateRef.current;
+      const pending = getPendingSubmit(current);
+
       if (current.status === 'open') {
         clearPendingTimer();
-        const message = current.pendingSubmit ? DISCONNECTED_SENDING_MESSAGE : DISCONNECTED_EDITING_MESSAGE;
+        const message = pending
+          ? PENDING_DISCONNECTED_MESSAGE
+          : getDisconnectedEditingMessage(current.action);
         setAuthoringState({
           ...current,
           phase: 'editing',
@@ -252,10 +434,14 @@ export function useGraphAuthoring({
           serverMessage: message,
           connectionLost: true,
         });
+      } else if (pending) {
+        clearPendingTimer();
+        setAuthoringState(CLOSED_STATE);
+        notifyUser(PENDING_DISCONNECTED_MESSAGE, 'error');
       }
     }
     wasConnectedRef.current = connected;
-  }, [clearPendingTimer, connected, setAuthoringState]);
+  }, [clearPendingTimer, connected, notifyUser, setAuthoringState]);
 
   useEffect(() => {
     return () => {
@@ -267,6 +453,8 @@ export function useGraphAuthoring({
     state,
     validationErrors,
     openCreateNode,
+    openEditNode,
+    deleteNode,
     updateDraft,
     submit,
     close,

--- a/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphAuthoring/useGraphAuthoring.ts
@@ -11,17 +11,17 @@ import {
 } from '../../graphActions/minigraphCommandBuilder';
 import type {
   NodeAction,
-  NodeDraft,
-  NodeDraftSource,
-  NodeDraftValidationErrors,
+  NodeFormState,
+  NodeFormSource,
+  NodeFormValidationErrors,
 } from '../../graphActions/nodeAuthoringTypes';
-import { createDefaultNodeDraft, createEditNodeDraft } from '../../graphActions/propertyRows';
-import { validateDeleteNodeAlias, validateNodeDraft } from '../../graphActions/validation';
+import { createDefaultNodeFormState, createEditNodeFormState } from '../../graphActions/propertyRows';
+import { validateDeleteNodeAlias, validateNodeFormState } from '../../graphActions/validation';
 
 export const DEFAULT_AUTHORING_TIMEOUT_MS = 10_000;
 
 type EditableNodeAction = Extract<NodeAction, 'create-node' | 'edit-node'>;
-type CreateNodeDraftSource = Exclude<NodeDraftSource, 'edit-node'>;
+type CreateNodeFormSource = Exclude<NodeFormSource, 'edit-node'>;
 type UserMessageType = 'info' | 'success' | 'error';
 
 export type AuthoringState =
@@ -34,7 +34,7 @@ export type AuthoringState =
       status: 'open';
       action: EditableNodeAction;
       phase: 'editing' | 'sending';
-      draft: NodeDraft;
+      formState: NodeFormState;
       originalAlias: string | null;
       pendingSubmit: PendingNodeActionSubmit | null;
       serverMessage: string | null;
@@ -60,17 +60,17 @@ export interface UseGraphAuthoringOptions {
 
 export interface UseGraphAuthoringReturn {
   state: AuthoringState;
-  validationErrors: NodeDraftValidationErrors;
-  openCreateNode: (source: CreateNodeDraftSource) => void;
+  validationErrors: NodeFormValidationErrors;
+  openCreateNode: (source: CreateNodeFormSource) => void;
   openEditNode: (node: MinigraphNode) => void;
   deleteNode: (node: MinigraphNode) => void;
-  updateDraft: (draft: NodeDraft) => void;
+  updateFormState: (formState: NodeFormState) => void;
   submit: () => void;
   close: () => void;
 }
 
 const PENDING_ACTION_MESSAGE = 'A node action is already pending. Wait for it to finish before starting another.';
-const CREATE_SEND_FAILURE_MESSAGE = 'Could not send the create-node command because the WebSocket is not open. The draft was preserved in this dialog.';
+const CREATE_SEND_FAILURE_MESSAGE = 'Could not send the create-node command because the WebSocket is not open. The form values remain in this dialog.';
 const EDIT_SEND_FAILURE_MESSAGE = 'Could not send the edit-node command because the WebSocket is not open. Your changes remain in this dialog.';
 const DELETE_SEND_FAILURE_MESSAGE = 'Could not send the delete-node command because the WebSocket is not open.';
 const NODE_UNAVAILABLE_MESSAGE = 'This node is no longer available in the current graph.';
@@ -120,7 +120,7 @@ function eventMatchesPendingAction(
   return event.action === null || event.action === pending.action;
 }
 
-// Owns the complete node-authoring lifecycle: draft state, validation,
+// Owns the complete node-authoring lifecycle: form state, validation,
 // raw-command send, text-result matching, timeout handling, and disconnect
 // handling. UI components call this hook instead of sending commands or
 // interpreting backend text themselves.
@@ -134,7 +134,7 @@ export function useGraphAuthoring({
   onUserMessage,
 }: UseGraphAuthoringOptions): UseGraphAuthoringReturn {
   const [state, setState] = useState<AuthoringState>(CLOSED_STATE);
-  const [validationErrors, setValidationErrors] = useState<NodeDraftValidationErrors>({});
+  const [validationErrors, setValidationErrors] = useState<NodeFormValidationErrors>({});
 
   const stateRef = useRef(state);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -144,7 +144,7 @@ export function useGraphAuthoring({
   const onUserMessageRef = useRef(onUserMessage);
 
   // ProtocolBus and timers can fire after render, so callbacks read refs for
-  // the latest state/context without re-subscribing on every draft keystroke.
+  // the latest state/context without re-subscribing on every form keystroke.
   useEffect(() => { stateRef.current = state; }, [state]);
   useEffect(() => { graphDataRef.current = graphData; }, [graphData]);
   useEffect(() => { onAcceptedRef.current = onAccepted; }, [onAccepted]);
@@ -188,20 +188,20 @@ export function useGraphAuthoring({
     }, timeoutMs);
   }, [clearPendingTimer, notifyUser, setAuthoringState, timeoutMs]);
 
-  const openCreateNode = useCallback((source: CreateNodeDraftSource) => {
+  const openCreateNode = useCallback((source: CreateNodeFormSource) => {
     if (!connected) return;
     if (getPendingSubmit(stateRef.current)) {
       notifyUser(PENDING_ACTION_MESSAGE, 'error');
       return;
     }
 
-    const draft = createDefaultNodeDraft(source);
+    const formState = createDefaultNodeFormState(source);
     setValidationErrors({});
     setAuthoringState({
       status: 'open',
       action: 'create-node',
       phase: 'editing',
-      draft,
+      formState,
       originalAlias: null,
       pendingSubmit: null,
       serverMessage: null,
@@ -225,8 +225,8 @@ export function useGraphAuthoring({
       return;
     }
 
-    const conversion = createEditNodeDraft(currentNode);
-    if (!conversion.valid || !conversion.draft) {
+    const conversion = createEditNodeFormState(currentNode);
+    if (!conversion.valid || !conversion.formState) {
       notifyUser(conversion.message ?? 'This node cannot be edited in the UI.', 'error');
       return;
     }
@@ -236,7 +236,7 @@ export function useGraphAuthoring({
       status: 'open',
       action: 'edit-node',
       phase: 'editing',
-      draft: conversion.draft,
+      formState: conversion.formState,
       originalAlias: currentNode.alias,
       pendingSubmit: null,
       serverMessage: null,
@@ -285,7 +285,7 @@ export function useGraphAuthoring({
     startSubmitTimer();
   }, [connected, executor, notifyUser, setAuthoringState, startSubmitTimer]);
 
-  const updateDraft = useCallback((draft: NodeDraft) => {
+  const updateFormState = useCallback((formState: NodeFormState) => {
     const current = stateRef.current;
     if (current.status !== 'open') return;
     if (current.phase === 'sending' || current.connectionLost) return;
@@ -293,7 +293,7 @@ export function useGraphAuthoring({
     setValidationErrors({});
     setAuthoringState({
       ...current,
-      draft,
+      formState,
       pendingSubmit: null,
       serverMessage: null,
       connectionLost: false,
@@ -315,8 +315,8 @@ export function useGraphAuthoring({
       return;
     }
 
-    const validation = validateNodeDraft(
-      current.draft,
+    const validation = validateNodeFormState(
+      current.formState,
       action === 'edit-node'
         ? { mode: 'edit', originalAlias: current.originalAlias }
         : { graphData: graphDataRef.current },
@@ -331,10 +331,10 @@ export function useGraphAuthoring({
     try {
       if (action === 'edit-node') {
         pendingAlias = current.originalAlias?.trim() ?? '';
-        command = buildUpdateNodeCommand(current.draft, pendingAlias);
+        command = buildUpdateNodeCommand(current.formState, pendingAlias);
       } else {
-        pendingAlias = current.draft.alias.trim();
-        command = buildCreateNodeCommand(current.draft);
+        pendingAlias = current.formState.alias.trim();
+        command = buildCreateNodeCommand(current.formState);
       }
     } catch (err) {
       setValidationErrors({ command: err instanceof Error ? err.message : String(err) });
@@ -455,7 +455,7 @@ export function useGraphAuthoring({
     openCreateNode,
     openEditNode,
     deleteNode,
-    updateDraft,
+    updateFormState,
     submit,
     close,
   };

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.module.css
@@ -153,37 +153,3 @@
 @keyframes graphRefreshSpin {
   to { transform: rotate(360deg); }
 }
-
-/* ── Node context menu ──────────────────────────────────────────────────── */
-
-.contextMenu {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-md);
-  z-index: 50;
-  min-width: 160px;
-  padding: 0.25rem 0;
-}
-
-.contextMenuItem {
-  display: block;
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  background: none;
-  border: none;
-  text-align: left;
-  font-size: 0.8125rem;
-  color: var(--text-primary, #0f172a);
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.contextMenuItem:hover {
-  background: var(--autocomplete-highlight);
-}
-
-.contextMenuItem:focus-visible {
-  outline: 2px solid var(--primary-color);
-  outline-offset: -2px;
-}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -20,6 +20,7 @@ import { hasClipboardItemType, readClipboardItemId } from '../../clipboard/dnd';
 import { findNodeByAlias, extractDirectConnections } from '../../clipboard/helpers';
 import GraphToolbar from '../GraphToolbar/GraphToolbar';
 import GraphContextMenu from './GraphContextMenu';
+import NodeContextMenu from './NodeContextMenu';
 import styles from './GraphView.module.css';
 
 interface GraphViewProps {
@@ -39,6 +40,8 @@ interface GraphViewProps {
   isConnected:     boolean;
   supportsAuthoring?: boolean;
   onCreateNode?:   (source: 'empty-graph' | 'pane-context-menu') => void;
+  onEditNode?:     (node: MinigraphNode) => void;
+  onDeleteNode?:   (node: MinigraphNode) => void;
 }
 
 const EMPTY_NODES: Node<GraphNodeData>[]  = [];
@@ -56,6 +59,8 @@ export default function GraphView({
   isConnected,
   supportsAuthoring = false,
   onCreateNode,
+  onEditNode,
+  onDeleteNode,
 }: GraphViewProps) {
 
   // ── Context menu state ──────────────────────────────────────────────────
@@ -66,37 +71,18 @@ export default function GraphView({
   } | null>(null);
   const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(null);
   const [clipboardDragActive, setClipboardDragActive] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
   const clipboardDragDepthRef = useRef(0);
   const canCreateNode = Boolean(supportsAuthoring && onCreateNode && isConnected);
+  const canClipNode = Boolean(onClipNode);
+  const canEditNode = Boolean(supportsAuthoring && onEditNode && isConnected);
+  const canDeleteNode = Boolean(supportsAuthoring && onDeleteNode && isConnected);
+  const canOpenNodeContextMenu = canClipNode || canEditNode || canDeleteNode;
   const canAcceptClipboardDrop = Boolean(onClipboardDrop && isConnected);
 
   const resetClipboardDragState = useCallback(() => {
     clipboardDragDepthRef.current = 0;
     setClipboardDragActive(false);
   }, []);
-
-  // Dismiss context menu on outside click or Escape
-  useEffect(() => {
-    if (!contextMenu) return;
-
-    const handleDismiss = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as globalThis.Node)) {
-        setContextMenu(null);
-      }
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setContextMenu(null);
-    };
-
-    document.addEventListener('mousedown', handleDismiss);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handleDismiss);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [contextMenu]);
 
   useEffect(() => {
     if (!paneMenu) return;
@@ -212,6 +198,9 @@ export default function GraphView({
   };
 
   const hasGraphData = Boolean(graphData && graphData.nodes.length > 0);
+  const contextNode = contextMenu && graphData
+    ? findNodeByAlias(graphData, contextMenu.nodeAlias)
+    : null;
 
   if (transformError) {
     return (
@@ -264,7 +253,7 @@ export default function GraphView({
                 event.preventDefault();
                 event.stopPropagation();
                 setPaneMenu(null);
-                if (!onClipNode) return;
+                if (!canOpenNodeContextMenu) return;
                 setContextMenu({ x: event.clientX, y: event.clientY, nodeAlias: node.data.alias });
               }}
               onPaneContextMenu={(event) => {
@@ -349,30 +338,29 @@ export default function GraphView({
             onCreateNode={() => onCreateNode?.('pane-context-menu')}
             onClose={() => setPaneMenu(null)}
           />
-          {contextMenu && onClipNode && graphData && (
-            <div
-              ref={menuRef}
-              className={styles.contextMenu}
-              style={{ position: 'fixed', top: contextMenu.y, left: contextMenu.x }}
-              role="menu"
-            >
-              <button
-                role="menuitem"
-                autoFocus
-                className={styles.contextMenuItem}
-                onClick={() => {
-                  const node = findNodeByAlias(graphData, contextMenu.nodeAlias);
-                  if (node) {
-                    const connections = extractDirectConnections(graphData, contextMenu.nodeAlias);
-                    onClipNode(node, connections);
-                  }
-                  setContextMenu(null);
-                }}
-              >
-                Clip to Clipboard
-              </button>
-            </div>
-          )}
+          <NodeContextMenu
+            open={contextMenu !== null && contextNode !== null && canOpenNodeContextMenu}
+            x={contextMenu?.x ?? 0}
+            y={contextMenu?.y ?? 0}
+            nodeAlias={contextMenu?.nodeAlias ?? ''}
+            canClipNode={canClipNode && contextNode !== null}
+            canEditNode={canEditNode && contextNode !== null}
+            canDeleteNode={canDeleteNode && contextNode !== null}
+            onClipNode={() => {
+              if (!contextNode || !graphData) return;
+              const connections = extractDirectConnections(graphData, contextNode.alias);
+              onClipNode?.(contextNode, connections);
+            }}
+            onEditNode={() => {
+              if (!contextNode) return;
+              onEditNode?.(contextNode);
+            }}
+            onDeleteNode={() => {
+              if (!contextNode) return;
+              onDeleteNode?.(contextNode);
+            }}
+            onClose={() => setContextMenu(null)}
+          />
         </div>
       </div>
     </GraphViewErrorBoundary>

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -34,7 +34,7 @@ interface GraphViewProps {
   onRenderError?:  (message: string) => void;
   /** When true, renders a semi-transparent overlay with a spinner to indicate a background re-fetch. */
   isRefreshing?:   boolean;
-  /** Callback for "Clip to Clipboard" from the node context menu. */
+  /** Callback for "Clip to Workspace" from the node context menu. */
   onClipNode?:     (node: MinigraphNode, connections: MinigraphConnection[]) => void;
   onClipboardDrop?: (itemId: string) => void;
   isConnected:     boolean;

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.module.css
@@ -1,0 +1,68 @@
+.menu {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  padding: 0.25rem;
+  position: fixed;
+  width: min(240px, calc(100vw - 32px));
+  z-index: 70;
+}
+
+.menuItem {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: 0.875rem;
+  justify-content: flex-start;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+  text-align: left;
+  width: 100%;
+}
+
+.menuItem:hover,
+.menuItem:focus-visible {
+  background: var(--autocomplete-highlight);
+}
+
+.menuItem:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 1px;
+}
+
+.dangerItem {
+  color: var(--danger-color);
+}
+
+.dangerItem:hover,
+.dangerItem:focus-visible {
+  background: var(--danger-08);
+}
+
+.dangerItem:focus-visible {
+  outline-color: var(--danger-color);
+}
+
+.confirmation {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.25rem;
+}
+
+.confirmationText {
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  padding: 0.25rem 0.4rem;
+  word-break: break-word;
+}
+
+.confirmationActions {
+  display: grid;
+  gap: 0.25rem;
+}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.tsx
@@ -151,7 +151,7 @@ export default function NodeContextMenu({
                 onClose();
               }}
             >
-              Clip to Clipboard
+              Clip to Workspace
             </button>
           )}
           {canEditNode && (

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeContextMenu.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import styles from './NodeContextMenu.module.css';
+
+interface NodeContextMenuProps {
+  open: boolean;
+  x: number;
+  y: number;
+  nodeAlias: string;
+  canClipNode: boolean;
+  canEditNode: boolean;
+  canDeleteNode: boolean;
+  onClipNode: () => void;
+  onEditNode: () => void;
+  onDeleteNode: () => void;
+  onClose: () => void;
+}
+
+const VIEWPORT_MARGIN = 8;
+
+// Node-level menu for actions that require a concrete graph node. This stays
+// separate from GraphContextMenu, which is reserved for pane-level actions.
+export default function NodeContextMenu({
+  open,
+  x,
+  y,
+  nodeAlias,
+  canClipNode,
+  canEditNode,
+  canDeleteNode,
+  onClipNode,
+  onEditNode,
+  onDeleteNode,
+  onClose,
+}: NodeContextMenuProps) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [position, setPosition] = useState({ left: x, top: y });
+  const menuRef = useRef<HTMLDivElement>(null);
+  const firstItemRef = useRef<HTMLButtonElement>(null);
+  const confirmDeleteRef = useRef<HTMLButtonElement>(null);
+  const hasAnyAction = canClipNode || canEditNode || canDeleteNode;
+
+  useLayoutEffect(() => {
+    if (open) setConfirmingDelete(false);
+  }, [nodeAlias, open, x, y]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    const menu = menuRef.current;
+    if (!menu) {
+      setPosition({ left: x, top: y });
+      return;
+    }
+
+    const rect = menu.getBoundingClientRect();
+    const maxLeft = Math.max(VIEWPORT_MARGIN, window.innerWidth - rect.width - VIEWPORT_MARGIN);
+    const maxTop = Math.max(VIEWPORT_MARGIN, window.innerHeight - rect.height - VIEWPORT_MARGIN);
+    setPosition({
+      left: Math.min(Math.max(x, VIEWPORT_MARGIN), maxLeft),
+      top: Math.min(Math.max(y, VIEWPORT_MARGIN), maxTop),
+    });
+  }, [canClipNode, canDeleteNode, canEditNode, confirmingDelete, nodeAlias, open, x, y]);
+
+  useEffect(() => {
+    if (!open) {
+      setConfirmingDelete(false);
+      return;
+    }
+
+    if (confirmingDelete) {
+      confirmDeleteRef.current?.focus();
+    } else {
+      firstItemRef.current?.focus();
+    }
+  }, [confirmingDelete, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    const handleScrollOrResize = () => onClose();
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('scroll', handleScrollOrResize, true);
+    window.addEventListener('resize', handleScrollOrResize);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('scroll', handleScrollOrResize, true);
+      window.removeEventListener('resize', handleScrollOrResize);
+    };
+  }, [onClose, open]);
+
+  if (!open || !hasAnyAction) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className={styles.menu}
+      style={{ left: position.left, top: position.top }}
+      role="menu"
+      aria-label={`Node actions for ${nodeAlias}`}
+    >
+      {confirmingDelete ? (
+        <div className={styles.confirmation} role="group" aria-label={`Confirm delete ${nodeAlias}`}>
+          <div className={styles.confirmationText}>Delete "{nodeAlias}"?</div>
+          <div className={styles.confirmationActions}>
+            <button
+              ref={confirmDeleteRef}
+              type="button"
+              className={`${styles.menuItem} ${styles.dangerItem}`}
+              onClick={() => {
+                onDeleteNode();
+                onClose();
+              }}
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              className={styles.menuItem}
+              onClick={() => setConfirmingDelete(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {canClipNode && (
+            <button
+              ref={firstItemRef}
+              role="menuitem"
+              type="button"
+              className={styles.menuItem}
+              onClick={() => {
+                onClipNode();
+                onClose();
+              }}
+            >
+              Clip to Clipboard
+            </button>
+          )}
+          {canEditNode && (
+            <button
+              ref={canClipNode ? undefined : firstItemRef}
+              role="menuitem"
+              type="button"
+              className={styles.menuItem}
+              onClick={() => {
+                onEditNode();
+                onClose();
+              }}
+            >
+              Edit Node
+            </button>
+          )}
+          {canDeleteNode && (
+            <button
+              ref={!canClipNode && !canEditNode ? firstItemRef : undefined}
+              role="menuitem"
+              type="button"
+              className={`${styles.menuItem} ${styles.dangerItem}`}
+              onClick={() => setConfirmingDelete(true)}
+            >
+              Delete Node
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.module.css
@@ -186,6 +186,14 @@
   width: 100%;
 }
 
+.textarea {
+  height: auto;
+  min-height: 2.5rem;
+  overflow-y: auto;
+  resize: vertical;
+  white-space: pre-wrap;
+}
+
 .input:focus {
   border-color: var(--input-focus-border);
   outline: 2px solid var(--primary-color);

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
@@ -7,6 +7,8 @@ import styles from './NodeDialog.module.css';
 
 interface NodeDialogProps {
   open: boolean;
+  mode: 'create' | 'edit';
+  aliasReadOnly: boolean;
   draft: NodeDraft;
   phase: 'editing' | 'sending';
   lockReason: null | 'sending' | 'disconnected';
@@ -17,10 +19,23 @@ interface NodeDialogProps {
   onClose: () => void;
 }
 
+const MIN_TEXTAREA_ROWS = 2;
+const MAX_TEXTAREA_ROWS = 8;
+const APPROX_TEXTAREA_CHARS_PER_ROW = 42;
+
+function estimateTextareaRows(value: string): number {
+  const rows = value.split('\n').reduce((total, line) => {
+    return total + Math.max(1, Math.ceil(line.length / APPROX_TEXTAREA_CHARS_PER_ROW));
+  }, 0);
+  return Math.min(Math.max(rows, MIN_TEXTAREA_ROWS), MAX_TEXTAREA_ROWS);
+}
+
 // Presentational modal only. It edits a NodeDraft and reports submit/close
 // intents upward; useGraphAuthoring owns validation, transport, and result handling.
 export default function NodeDialog({
   open,
+  mode,
+  aliasReadOnly,
   draft,
   phase,
   lockReason,
@@ -31,17 +46,30 @@ export default function NodeDialog({
   onClose,
 }: NodeDialogProps) {
   const aliasRef = useRef<HTMLInputElement>(null);
+  const nodeTypeRef = useRef<HTMLInputElement>(null);
   const propertyKeyRefs = useRef(new Map<string, HTMLInputElement>());
   const pendingFocusPropertyIdRef = useRef<string | null>(null);
+  const editingExistingNode = mode === 'edit';
   const sending = phase === 'sending';
   const disconnected = lockReason === 'disconnected';
   const controlsDisabled = sending || disconnected;
+  const title = editingExistingNode ? 'Edit Node' : 'Create Node';
+  const closeLabel = editingExistingNode ? 'Close edit node dialog' : 'Close create node dialog';
+  const submitLabel = editingExistingNode ? 'Save Changes' : 'Create Node';
+  const sendingLabel = editingExistingNode ? 'Saving...' : 'Creating...';
+  const disconnectedMessage = editingExistingNode
+    ? 'Connection disconnected. Refresh the page and edit the node again after the app reconnects.'
+    : 'Connection disconnected. Refresh the page and create the node again after the app reconnects.';
 
   // The overlay is a real fixed element, not a native dialog backdrop, so it
   // reliably absorbs pointer events before underlying resize handles can drag.
   useEffect(() => {
     if (!open) return;
-    aliasRef.current?.focus();
+    if (editingExistingNode) {
+      nodeTypeRef.current?.focus();
+    } else {
+      aliasRef.current?.focus();
+    }
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       event.preventDefault();
@@ -51,7 +79,7 @@ export default function NodeDialog({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onClose, open, sending]);
+  }, [editingExistingNode, onClose, open, sending]);
 
   useEffect(() => {
     const rowId = pendingFocusPropertyIdRef.current;
@@ -131,12 +159,12 @@ export default function NodeDialog({
       >
         <header className={styles.header}>
           <div>
-            <h2 id="node-dialog-title" className={styles.title}>Create Node</h2>
+            <h2 id="node-dialog-title" className={styles.title}>{title}</h2>
           </div>
           <button
             type="button"
             className={styles.iconButton}
-            aria-label="Close create node dialog"
+            aria-label={closeLabel}
             onClick={onClose}
             disabled={sending}
           >
@@ -158,7 +186,7 @@ export default function NodeDialog({
             )}
             {disconnected && (
               <div className={styles.warningMessage} role="status">
-                {serverMessage ?? 'Connection disconnected. Refresh the page and create the node again after the app reconnects.'}
+                {serverMessage ?? disconnectedMessage}
               </div>
             )}
 
@@ -169,6 +197,7 @@ export default function NodeDialog({
                 className={styles.input}
                 value={draft.alias}
                 disabled={controlsDisabled}
+                readOnly={aliasReadOnly}
                 aria-invalid={Boolean(validationErrors.alias)}
                 aria-describedby={validationErrors.alias ? 'node-alias-error' : undefined}
                 onChange={(event) => updateDraft({ alias: event.target.value })}
@@ -181,6 +210,7 @@ export default function NodeDialog({
             <label className={styles.field}>
               <span className={styles.label}>Node Type</span>
               <input
+                ref={nodeTypeRef}
                 className={styles.input}
                 value={draft.nodeType}
                 disabled={controlsDisabled}
@@ -202,6 +232,7 @@ export default function NodeDialog({
                 {draft.properties.map((row) => {
                   const keyError = validationErrors[getValidationErrorKeyForProperty(row.id, 'key')];
                   const valueError = validationErrors[getValidationErrorKeyForProperty(row.id, 'value')];
+                  const valueRows = estimateTextareaRows(row.value);
                   return (
                     <div key={row.id} className={styles.propertyRow}>
                       <label className={styles.propertyField}>
@@ -224,13 +255,24 @@ export default function NodeDialog({
                       </label>
                       <label className={styles.propertyField}>
                         <span className={styles.label}>Value</span>
-                        <input
-                          className={styles.input}
-                          value={row.value}
-                          disabled={controlsDisabled}
-                          aria-invalid={Boolean(valueError)}
-                          onChange={(event) => updateProperty(row.id, { value: event.target.value })}
-                        />
+                        {editingExistingNode ? (
+                          <textarea
+                            className={`${styles.input} ${styles.textarea}`}
+                            value={row.value}
+                            disabled={controlsDisabled}
+                            rows={valueRows}
+                            aria-invalid={Boolean(valueError)}
+                            onChange={(event) => updateProperty(row.id, { value: event.target.value })}
+                          />
+                        ) : (
+                          <input
+                            className={styles.input}
+                            value={row.value}
+                            disabled={controlsDisabled}
+                            aria-invalid={Boolean(valueError)}
+                            onChange={(event) => updateProperty(row.id, { value: event.target.value })}
+                          />
+                        )}
                         {valueError && <span className={styles.errorText}>{valueError}</span>}
                       </label>
                       <button
@@ -274,7 +316,7 @@ export default function NodeDialog({
               className={styles.primaryButton}
               disabled={controlsDisabled}
             >
-              {sending ? 'Creating...' : 'Create Node'}
+              {sending ? sendingLabel : submitLabel}
             </button>
           </footer>
         </form>

--- a/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/NodeDialog/NodeDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import type { NodeDraft } from '../../graphActions/nodeAuthoringTypes';
+import type { NodeFormState } from '../../graphActions/nodeAuthoringTypes';
 import { createPropertyRow } from '../../graphActions/propertyRows';
 import { getValidationErrorKeyForProperty } from '../../graphActions/validation';
 import CloseIcon from '../../icons/CloseIcon.svg?react';
@@ -9,12 +9,12 @@ interface NodeDialogProps {
   open: boolean;
   mode: 'create' | 'edit';
   aliasReadOnly: boolean;
-  draft: NodeDraft;
+  formState: NodeFormState;
   phase: 'editing' | 'sending';
   lockReason: null | 'sending' | 'disconnected';
   serverMessage: string | null;
   validationErrors: Record<string, string>;
-  onDraftChange: (draft: NodeDraft) => void;
+  onFormStateChange: (formState: NodeFormState) => void;
   onSubmit: () => void;
   onClose: () => void;
 }
@@ -30,18 +30,18 @@ function estimateTextareaRows(value: string): number {
   return Math.min(Math.max(rows, MIN_TEXTAREA_ROWS), MAX_TEXTAREA_ROWS);
 }
 
-// Presentational modal only. It edits a NodeDraft and reports submit/close
+// Presentational modal only. It edits a NodeFormState and reports submit/close
 // intents upward; useGraphAuthoring owns validation, transport, and result handling.
 export default function NodeDialog({
   open,
   mode,
   aliasReadOnly,
-  draft,
+  formState,
   phase,
   lockReason,
   serverMessage,
   validationErrors,
-  onDraftChange,
+  onFormStateChange,
   onSubmit,
   onClose,
 }: NodeDialogProps) {
@@ -90,7 +90,7 @@ export default function NodeDialog({
 
     input.focus();
     pendingFocusPropertyIdRef.current = null;
-  }, [draft.properties]);
+  }, [formState.properties]);
 
   const handleOverlayPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -113,33 +113,33 @@ export default function NodeDialog({
     onSubmit();
   }, [controlsDisabled, onSubmit]);
 
-  const updateDraft = useCallback((patch: Partial<NodeDraft>) => {
-    onDraftChange({ ...draft, ...patch });
-  }, [draft, onDraftChange]);
+  const updateFormState = useCallback((patch: Partial<NodeFormState>) => {
+    onFormStateChange({ ...formState, ...patch });
+  }, [formState, onFormStateChange]);
 
   const updateProperty = useCallback((rowId: string, patch: { key?: string; value?: string }) => {
-    onDraftChange({
-      ...draft,
-      properties: draft.properties.map((row) => row.id === rowId ? { ...row, ...patch } : row),
+    onFormStateChange({
+      ...formState,
+      properties: formState.properties.map((row) => row.id === rowId ? { ...row, ...patch } : row),
     });
-  }, [draft, onDraftChange]);
+  }, [formState, onFormStateChange]);
 
   const addProperty = useCallback(() => {
     const nextRow = createPropertyRow();
     pendingFocusPropertyIdRef.current = nextRow.id;
-    onDraftChange({
-      ...draft,
-      properties: [...draft.properties, nextRow],
+    onFormStateChange({
+      ...formState,
+      properties: [...formState.properties, nextRow],
     });
-  }, [draft, onDraftChange]);
+  }, [formState, onFormStateChange]);
 
   const removeProperty = useCallback((rowId: string) => {
-    const nextRows = draft.properties.filter((row) => row.id !== rowId);
-    onDraftChange({
-      ...draft,
+    const nextRows = formState.properties.filter((row) => row.id !== rowId);
+    onFormStateChange({
+      ...formState,
       properties: nextRows.length > 0 ? nextRows : [createPropertyRow()],
     });
-  }, [draft, onDraftChange]);
+  }, [formState, onFormStateChange]);
 
   if (!open) return null;
 
@@ -195,12 +195,12 @@ export default function NodeDialog({
               <input
                 ref={aliasRef}
                 className={styles.input}
-                value={draft.alias}
+                value={formState.alias}
                 disabled={controlsDisabled}
                 readOnly={aliasReadOnly}
                 aria-invalid={Boolean(validationErrors.alias)}
                 aria-describedby={validationErrors.alias ? 'node-alias-error' : undefined}
-                onChange={(event) => updateDraft({ alias: event.target.value })}
+                onChange={(event) => updateFormState({ alias: event.target.value })}
               />
               {validationErrors.alias && (
                 <span id="node-alias-error" className={styles.errorText}>{validationErrors.alias}</span>
@@ -212,11 +212,11 @@ export default function NodeDialog({
               <input
                 ref={nodeTypeRef}
                 className={styles.input}
-                value={draft.nodeType}
+                value={formState.nodeType}
                 disabled={controlsDisabled}
                 aria-invalid={Boolean(validationErrors.nodeType)}
                 aria-describedby={validationErrors.nodeType ? 'node-type-error' : undefined}
-                onChange={(event) => updateDraft({ nodeType: event.target.value })}
+                onChange={(event) => updateFormState({ nodeType: event.target.value })}
               />
               {validationErrors.nodeType && (
                 <span id="node-type-error" className={styles.errorText}>{validationErrors.nodeType}</span>
@@ -229,7 +229,7 @@ export default function NodeDialog({
               </div>
 
               <div className={styles.propertyRows}>
-                {draft.properties.map((row) => {
+                {formState.properties.map((row) => {
                   const keyError = validationErrors[getValidationErrorKeyForProperty(row.id, 'key')];
                   const valueError = validationErrors[getValidationErrorKeyForProperty(row.id, 'value')];
                   const valueRows = estimateTextareaRows(row.value);

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -404,7 +404,7 @@ export default function Playground({ config }: PlaygroundProps) {
         <GraphAuthoringModals
           state={graphAuthoring.state}
           validationErrors={graphAuthoring.validationErrors}
-          onDraftChange={graphAuthoring.updateDraft}
+          onFormStateChange={graphAuthoring.updateFormState}
           onSubmit={graphAuthoring.submit}
           onClose={graphAuthoring.close}
         />

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -276,7 +276,7 @@ export default function Playground({ config }: PlaygroundProps) {
 
       switch (result.status) {
         case 'added':
-          addToast(`Node "${node.alias}" clipped to clipboard`, 'success');
+          addToast(`Node "${node.alias}" clipped to workspace`, 'success');
           break;
         case 'duplicate':
           setDuplicateDialogState({

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -335,6 +335,7 @@ export default function Playground({ config }: PlaygroundProps) {
     connected: ws.connected,
     graphData,
     executor: graphAuthoringExecutor,
+    onUserMessage: addToast,
   });
 
   // ── Saved graph workflow ──────────────────────────────────────────────────
@@ -536,6 +537,8 @@ export default function Playground({ config }: PlaygroundProps) {
             isConnected={ws.connected}
             supportsAuthoring={supportsAuthoring}
             onCreateNode={supportsAuthoring ? graphAuthoring.openCreateNode : undefined}
+            onEditNode={supportsAuthoring ? graphAuthoring.openEditNode : undefined}
+            onDeleteNode={supportsAuthoring ? graphAuthoring.deleteNode : undefined}
             helpPanel={supportsHelp && helpOpen ? (
               (onToggleMaximize: () => void, isMaximized: boolean) => (
                 <HelpBrowser

--- a/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/RightPanel/RightPanel.tsx
@@ -35,6 +35,8 @@ interface RightPanelProps {
   isConnected:             boolean;
   supportsAuthoring?:      boolean;
   onCreateNode?:           (source: 'empty-graph' | 'pane-context-menu') => void;
+  onEditNode?:             (node: MinigraphNode) => void;
+  onDeleteNode?:           (node: MinigraphNode) => void;
   /**
    * When provided and non-null, the right panel renders a vertical split:
    * top = tab content, bottom = help panel.  Accepts either a plain ReactNode
@@ -71,6 +73,8 @@ export default function RightPanel({
   isConnected,
   supportsAuthoring,
   onCreateNode,
+  onEditNode,
+  onDeleteNode,
   helpPanel,
 }: RightPanelProps) {
   const uid              = useId();
@@ -159,6 +163,8 @@ export default function RightPanel({
               isConnected={isConnected}
               supportsAuthoring={supportsAuthoring}
               onCreateNode={onCreateNode}
+              onEditNode={onEditNode}
+              onDeleteNode={onDeleteNode}
             />
           </div>
         </div>

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCreateNodeCommand } from '../minigraphCommandBuilder';
+import { buildCreateNodeCommand, buildDeleteNodeCommand, buildUpdateNodeCommand } from '../minigraphCommandBuilder';
 import type { NodeDraft } from '../nodeAuthoringTypes';
 
 function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
@@ -71,5 +71,66 @@ describe('buildCreateNodeCommand', () => {
     expect(() => buildCreateNodeCommand(draft({
       properties: [{ id: 'p1', key: 'name', value: "'''demo" }],
     }))).toThrow();
+  });
+});
+
+describe('buildUpdateNodeCommand', () => {
+  it('emits backend update-node command text against the original alias', () => {
+    expect(buildUpdateNodeCommand(draft({
+      alias: 'display-only',
+      nodeType: 'Fetcher',
+      properties: [{ id: 'p1', key: 'name', value: 'updated' }],
+      source: 'edit-node',
+    }), 'root')).toBe([
+      'update node root',
+      'with type Fetcher',
+      'with properties',
+      'name=updated',
+    ].join('\n'));
+  });
+
+  it('omits node type and properties when blank', () => {
+    expect(buildUpdateNodeCommand(draft({
+      nodeType: ' ',
+      properties: [{ id: 'p1', key: ' ', value: ' ' }],
+      source: 'edit-node',
+    }), 'root')).toBe('update node root');
+  });
+
+  it('rejects invalid original aliases before serialization', () => {
+    expect(() => buildUpdateNodeCommand(draft({ source: 'edit-node' }), 'root\nwith properties')).toThrow();
+  });
+
+  it('emits flattened path keys and multiline values for edit mode', () => {
+    expect(buildUpdateNodeCommand(draft({
+      nodeType: 'Evaluator',
+      properties: [
+        { id: 'p1', key: 'mapping[0]', value: 'text(hello) -> output.body' },
+        { id: 'p2', key: 'statement[0]', value: 'IF: true\nTHEN: next' },
+      ],
+      source: 'edit-node',
+    }), 'root')).toBe([
+      'update node root',
+      'with type Evaluator',
+      'with properties',
+      'mapping[0]=text(hello) -> output.body',
+      "statement[0]='''",
+      'IF: true\nTHEN: next',
+      "'''",
+    ].join('\n'));
+  });
+});
+
+describe('buildDeleteNodeCommand', () => {
+  it('emits backend delete-node command text', () => {
+    expect(buildDeleteNodeCommand('root')).toBe('delete node root');
+  });
+
+  it('trims alias input', () => {
+    expect(buildDeleteNodeCommand('  root  ')).toBe('delete node root');
+  });
+
+  it('rejects invalid aliases before serialization', () => {
+    expect(() => buildDeleteNodeCommand('root\nwith properties')).toThrow();
   });
 });

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/minigraphCommandBuilder.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildCreateNodeCommand, buildDeleteNodeCommand, buildUpdateNodeCommand } from '../minigraphCommandBuilder';
-import type { NodeDraft } from '../nodeAuthoringTypes';
+import type { NodeFormState } from '../nodeAuthoringTypes';
 
-function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
+function formState(overrides: Partial<NodeFormState> = {}): NodeFormState {
   return {
     alias: 'root',
     nodeType: 'Root',
@@ -17,7 +17,7 @@ function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
 
 describe('buildCreateNodeCommand', () => {
   it('emits backend create-node command text without trailing newline', () => {
-    expect(buildCreateNodeCommand(draft())).toBe([
+    expect(buildCreateNodeCommand(formState())).toBe([
       'create node root',
       'with type Root',
       'with properties',
@@ -26,14 +26,14 @@ describe('buildCreateNodeCommand', () => {
   });
 
   it('omits node type and properties when blank', () => {
-    expect(buildCreateNodeCommand(draft({
+    expect(buildCreateNodeCommand(formState({
       nodeType: '  ',
       properties: [{ id: 'p1', key: ' ', value: ' ' }],
     }))).toBe('create node root');
   });
 
   it('preserves property row order and allows blank values', () => {
-    expect(buildCreateNodeCommand(draft({
+    expect(buildCreateNodeCommand(formState({
       properties: [
         { id: 'p1', key: 'first', value: 'one' },
         { id: 'p2', key: 'second', value: '' },
@@ -48,27 +48,27 @@ describe('buildCreateNodeCommand', () => {
   });
 
   it('rejects alias line injection before serialization', () => {
-    expect(() => buildCreateNodeCommand(draft({ alias: 'root\nwith properties' }))).toThrow();
+    expect(() => buildCreateNodeCommand(formState({ alias: 'root\nwith properties' }))).toThrow();
   });
 
   it('rejects node type line injection before serialization', () => {
-    expect(() => buildCreateNodeCommand(draft({ nodeType: 'Root\rwith properties' }))).toThrow();
+    expect(() => buildCreateNodeCommand(formState({ nodeType: 'Root\rwith properties' }))).toThrow();
   });
 
   it('rejects property keys containing equals before serialization', () => {
-    expect(() => buildCreateNodeCommand(draft({
+    expect(() => buildCreateNodeCommand(formState({
       properties: [{ id: 'p1', key: 'bad=key', value: 'value' }],
     }))).toThrow();
   });
 
   it('rejects property value newline injection', () => {
-    expect(() => buildCreateNodeCommand(draft({
+    expect(() => buildCreateNodeCommand(formState({
       properties: [{ id: 'p1', key: 'name', value: 'demo\nwith properties' }],
     }))).toThrow();
   });
 
   it('rejects multiline property delimiters', () => {
-    expect(() => buildCreateNodeCommand(draft({
+    expect(() => buildCreateNodeCommand(formState({
       properties: [{ id: 'p1', key: 'name', value: "'''demo" }],
     }))).toThrow();
   });
@@ -76,7 +76,7 @@ describe('buildCreateNodeCommand', () => {
 
 describe('buildUpdateNodeCommand', () => {
   it('emits backend update-node command text against the original alias', () => {
-    expect(buildUpdateNodeCommand(draft({
+    expect(buildUpdateNodeCommand(formState({
       alias: 'display-only',
       nodeType: 'Fetcher',
       properties: [{ id: 'p1', key: 'name', value: 'updated' }],
@@ -90,7 +90,7 @@ describe('buildUpdateNodeCommand', () => {
   });
 
   it('omits node type and properties when blank', () => {
-    expect(buildUpdateNodeCommand(draft({
+    expect(buildUpdateNodeCommand(formState({
       nodeType: ' ',
       properties: [{ id: 'p1', key: ' ', value: ' ' }],
       source: 'edit-node',
@@ -98,11 +98,11 @@ describe('buildUpdateNodeCommand', () => {
   });
 
   it('rejects invalid original aliases before serialization', () => {
-    expect(() => buildUpdateNodeCommand(draft({ source: 'edit-node' }), 'root\nwith properties')).toThrow();
+    expect(() => buildUpdateNodeCommand(formState({ source: 'edit-node' }), 'root\nwith properties')).toThrow();
   });
 
   it('emits flattened path keys and multiline values for edit mode', () => {
-    expect(buildUpdateNodeCommand(draft({
+    expect(buildUpdateNodeCommand(formState({
       nodeType: 'Evaluator',
       properties: [
         { id: 'p1', key: 'mapping[0]', value: 'text(hello) -> output.body' },

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getValidationErrorKeyForProperty, validateNodeDraft } from '../validation';
+import { createEditNodeDraft } from '../propertyRows';
+import { getValidationErrorKeyForProperty, validateDeleteNodeAlias, validateNodeDraft } from '../validation';
 import type { NodeDraft } from '../nodeAuthoringTypes';
 
 function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
@@ -75,5 +76,124 @@ describe('validateNodeDraft', () => {
     }));
     expect(newline.errors[getValidationErrorKeyForProperty('p1', 'value')]).toBeDefined();
     expect(tripleQuote.errors[getValidationErrorKeyForProperty('p2', 'value')]).toBeDefined();
+  });
+});
+
+describe('validateNodeDraft edit mode', () => {
+  it('does not duplicate-check the display alias', () => {
+    const result = validateNodeDraft(draft({ alias: 'Root', source: 'edit-node' }), {
+      mode: 'edit',
+      originalAlias: 'root',
+      graphData: {
+        nodes: [{ alias: 'root', types: ['Root'], properties: {} }],
+        connections: [],
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects unsupported original aliases', () => {
+    const result = validateNodeDraft(draft({ source: 'edit-node' }), {
+      mode: 'edit',
+      originalAlias: 'bad.alias',
+    });
+    expect(result.errors.alias).toBeDefined();
+  });
+
+  it('allows flattened path keys and multiline values', () => {
+    const result = validateNodeDraft(draft({
+      source: 'edit-node',
+      properties: [
+        { id: 'p1', key: 'mapping[0]', value: 'text(hello) -> output.body' },
+        { id: 'p2', key: 'config.items[10].value', value: 'line one\nline two' },
+      ],
+    }), {
+      mode: 'edit',
+      originalAlias: 'root',
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects malformed flattened path keys', () => {
+    const result = validateNodeDraft(draft({
+      source: 'edit-node',
+      properties: [{ id: 'p1', key: 'mapping[]', value: 'demo' }],
+    }), {
+      mode: 'edit',
+      originalAlias: 'root',
+    });
+    expect(result.errors[getValidationErrorKeyForProperty('p1', 'key')]).toBeDefined();
+  });
+});
+
+describe('validateDeleteNodeAlias', () => {
+  it('requires the selected alias to exist in current graph data when provided', () => {
+    const result = validateDeleteNodeAlias('missing', {
+      graphData: {
+        nodes: [{ alias: 'root', types: ['Root'], properties: {} }],
+        connections: [],
+      },
+    });
+    expect(result.errors.alias).toContain('no longer available');
+  });
+
+  it('accepts an existing alias', () => {
+    const result = validateDeleteNodeAlias('root', {
+      graphData: {
+        nodes: [{ alias: 'root', types: ['Root'], properties: {} }],
+        connections: [],
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('createEditNodeDraft', () => {
+  it('converts flat scalar properties to editable rows', () => {
+    const result = createEditNodeDraft({
+      alias: 'root',
+      types: ['Root'],
+      properties: { name: 'demo', active: true, count: 3 },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.draft).toMatchObject({
+      alias: 'root',
+      nodeType: 'Root',
+      source: 'edit-node',
+    });
+    expect(result.draft?.properties.map(row => [row.key, row.value])).toEqual([
+      ['name', 'demo'],
+      ['active', 'true'],
+      ['count', '3'],
+    ]);
+  });
+
+  it('flattens arrays, nested objects, and multiline leaf values', () => {
+    const result = createEditNodeDraft({
+      alias: 'root',
+      types: ['Root'],
+      properties: {
+        mapping: ['text(hello) -> output.body', 'text(done) -> output.status'],
+        config: { items: [{ value: 'one' }, { value: 'two\nlines' }] },
+      },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.draft?.properties.map(row => [row.key, row.value])).toEqual([
+      ['mapping[0]', 'text(hello) -> output.body'],
+      ['mapping[1]', 'text(done) -> output.status'],
+      ['config.items[0].value', 'one'],
+      ['config.items[1].value', 'two\nlines'],
+    ]);
+  });
+
+  it('rejects edit surfaces that cannot be represented safely', () => {
+    const multipleTypes = createEditNodeDraft({ alias: 'root', types: ['Root', 'Other'], properties: {} });
+    const invalidKey = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: { 'bad key': true } } });
+    const emptyArray = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: [] } });
+    const tripleQuote = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: "a'''b" } });
+    expect(multipleTypes.valid).toBe(false);
+    expect(invalidKey.valid).toBe(false);
+    expect(emptyArray.valid).toBe(false);
+    expect(tripleQuote.valid).toBe(false);
   });
 });

--- a/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/__tests__/validation.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createEditNodeDraft } from '../propertyRows';
-import { getValidationErrorKeyForProperty, validateDeleteNodeAlias, validateNodeDraft } from '../validation';
-import type { NodeDraft } from '../nodeAuthoringTypes';
+import { createEditNodeFormState } from '../propertyRows';
+import { getValidationErrorKeyForProperty, validateDeleteNodeAlias, validateNodeFormState } from '../validation';
+import type { NodeFormState } from '../nodeAuthoringTypes';
 
-function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
+function formState(overrides: Partial<NodeFormState> = {}): NodeFormState {
   return {
     alias: 'node-1',
     nodeType: 'Fetcher',
@@ -13,19 +13,19 @@ function draft(overrides: Partial<NodeDraft> = {}): NodeDraft {
   };
 }
 
-describe('validateNodeDraft', () => {
+describe('validateNodeFormState', () => {
   it('requires alias', () => {
-    const result = validateNodeDraft(draft({ alias: '   ' }));
+    const result = validateNodeFormState(formState({ alias: '   ' }));
     expect(result.errors.alias).toBeDefined();
   });
 
   it('rejects reserved aliases case-insensitively', () => {
-    const result = validateNodeDraft(draft({ alias: 'Input' }));
+    const result = validateNodeFormState(formState({ alias: 'Input' }));
     expect(result.errors.alias).toContain('reserved');
   });
 
   it('rejects duplicate aliases known in current graph data case-insensitively', () => {
-    const result = validateNodeDraft(draft({ alias: 'Root' }), {
+    const result = validateNodeFormState(formState({ alias: 'Root' }), {
       graphData: {
         nodes: [{ alias: 'root', types: ['Root'], properties: {} }],
         connections: [],
@@ -35,43 +35,43 @@ describe('validateNodeDraft', () => {
   });
 
   it('rejects invalid node type token', () => {
-    const result = validateNodeDraft(draft({ nodeType: 'Root.Type' }));
+    const result = validateNodeFormState(formState({ nodeType: 'Root.Type' }));
     expect(result.errors.nodeType).toBeDefined();
   });
 
   it('ignores fully blank property rows', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       properties: [{ id: 'p1', key: ' ', value: ' ' }],
     }));
     expect(result.valid).toBe(true);
   });
 
   it('allows a non-blank key with blank value', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       properties: [{ id: 'p1', key: 'name', value: ' ' }],
     }));
     expect(result.valid).toBe(true);
   });
 
   it('rejects a blank key with non-blank value', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       properties: [{ id: 'p1', key: ' ', value: 'demo' }],
     }));
     expect(result.errors[getValidationErrorKeyForProperty('p1', 'key')]).toBeDefined();
   });
 
   it('rejects property keys outside the backend name token', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       properties: [{ id: 'p1', key: 'a.b', value: 'demo' }],
     }));
     expect(result.errors[getValidationErrorKeyForProperty('p1', 'key')]).toBeDefined();
   });
 
   it('rejects multiline and triple-quote property values', () => {
-    const newline = validateNodeDraft(draft({
+    const newline = validateNodeFormState(formState({
       properties: [{ id: 'p1', key: 'name', value: 'a\nb' }],
     }));
-    const tripleQuote = validateNodeDraft(draft({
+    const tripleQuote = validateNodeFormState(formState({
       properties: [{ id: 'p2', key: 'name', value: "a'''b" }],
     }));
     expect(newline.errors[getValidationErrorKeyForProperty('p1', 'value')]).toBeDefined();
@@ -79,9 +79,9 @@ describe('validateNodeDraft', () => {
   });
 });
 
-describe('validateNodeDraft edit mode', () => {
+describe('validateNodeFormState edit mode', () => {
   it('does not duplicate-check the display alias', () => {
-    const result = validateNodeDraft(draft({ alias: 'Root', source: 'edit-node' }), {
+    const result = validateNodeFormState(formState({ alias: 'Root', source: 'edit-node' }), {
       mode: 'edit',
       originalAlias: 'root',
       graphData: {
@@ -93,7 +93,7 @@ describe('validateNodeDraft edit mode', () => {
   });
 
   it('rejects unsupported original aliases', () => {
-    const result = validateNodeDraft(draft({ source: 'edit-node' }), {
+    const result = validateNodeFormState(formState({ source: 'edit-node' }), {
       mode: 'edit',
       originalAlias: 'bad.alias',
     });
@@ -101,7 +101,7 @@ describe('validateNodeDraft edit mode', () => {
   });
 
   it('allows flattened path keys and multiline values', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       source: 'edit-node',
       properties: [
         { id: 'p1', key: 'mapping[0]', value: 'text(hello) -> output.body' },
@@ -115,7 +115,7 @@ describe('validateNodeDraft edit mode', () => {
   });
 
   it('rejects malformed flattened path keys', () => {
-    const result = validateNodeDraft(draft({
+    const result = validateNodeFormState(formState({
       source: 'edit-node',
       properties: [{ id: 'p1', key: 'mapping[]', value: 'demo' }],
     }), {
@@ -148,20 +148,20 @@ describe('validateDeleteNodeAlias', () => {
   });
 });
 
-describe('createEditNodeDraft', () => {
+describe('createEditNodeFormState', () => {
   it('converts flat scalar properties to editable rows', () => {
-    const result = createEditNodeDraft({
+    const result = createEditNodeFormState({
       alias: 'root',
       types: ['Root'],
       properties: { name: 'demo', active: true, count: 3 },
     });
     expect(result.valid).toBe(true);
-    expect(result.draft).toMatchObject({
+    expect(result.formState).toMatchObject({
       alias: 'root',
       nodeType: 'Root',
       source: 'edit-node',
     });
-    expect(result.draft?.properties.map(row => [row.key, row.value])).toEqual([
+    expect(result.formState?.properties.map(row => [row.key, row.value])).toEqual([
       ['name', 'demo'],
       ['active', 'true'],
       ['count', '3'],
@@ -169,7 +169,7 @@ describe('createEditNodeDraft', () => {
   });
 
   it('flattens arrays, nested objects, and multiline leaf values', () => {
-    const result = createEditNodeDraft({
+    const result = createEditNodeFormState({
       alias: 'root',
       types: ['Root'],
       properties: {
@@ -178,7 +178,7 @@ describe('createEditNodeDraft', () => {
       },
     });
     expect(result.valid).toBe(true);
-    expect(result.draft?.properties.map(row => [row.key, row.value])).toEqual([
+    expect(result.formState?.properties.map(row => [row.key, row.value])).toEqual([
       ['mapping[0]', 'text(hello) -> output.body'],
       ['mapping[1]', 'text(done) -> output.status'],
       ['config.items[0].value', 'one'],
@@ -187,10 +187,10 @@ describe('createEditNodeDraft', () => {
   });
 
   it('rejects edit surfaces that cannot be represented safely', () => {
-    const multipleTypes = createEditNodeDraft({ alias: 'root', types: ['Root', 'Other'], properties: {} });
-    const invalidKey = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: { 'bad key': true } } });
-    const emptyArray = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: [] } });
-    const tripleQuote = createEditNodeDraft({ alias: 'root', types: ['Root'], properties: { name: "a'''b" } });
+    const multipleTypes = createEditNodeFormState({ alias: 'root', types: ['Root', 'Other'], properties: {} });
+    const invalidKey = createEditNodeFormState({ alias: 'root', types: ['Root'], properties: { name: { 'bad key': true } } });
+    const emptyArray = createEditNodeFormState({ alias: 'root', types: ['Root'], properties: { name: [] } });
+    const tripleQuote = createEditNodeFormState({ alias: 'root', types: ['Root'], properties: { name: "a'''b" } });
     expect(multipleTypes.valid).toBe(false);
     expect(invalidKey.valid).toBe(false);
     expect(emptyArray.valid).toBe(false);

--- a/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
@@ -1,5 +1,32 @@
 import type { NodeDraft } from './nodeAuthoringTypes';
-import { validateCommandSize, validateNodeDraft } from './validation';
+import { validateCommandSize, validateDeleteNodeAlias, validateNodeDraft, type DeleteNodeValidationOptions } from './validation';
+
+function getSerializablePropertyRows(draft: NodeDraft, preserveValue = false) {
+  return draft.properties
+    .map((row) => ({
+      key: row.key.trim(),
+      value: preserveValue ? row.value.replace(/\r\n/g, '\n').replace(/\r/g, '\n') : row.value.trim(),
+    }))
+    .filter((row) => row.key || row.value.trim());
+}
+
+function assertValidCommandSize(command: string): void {
+  const sizeValidation = validateCommandSize(command);
+  if (!sizeValidation.valid) {
+    throw new Error(sizeValidation.errors.command);
+  }
+}
+
+function appendSerializedProperty(lines: string[], key: string, value: string): void {
+  if (value.includes('\n')) {
+    lines.push(`${key}='''`);
+    lines.push(value);
+    lines.push("'''");
+    return;
+  }
+
+  lines.push(`${key}=${value}`);
+}
 
 // Single serialization boundary for create-node UI authoring. Callers pass a
 // typed draft; only this builder is allowed to produce backend raw command text
@@ -12,9 +39,7 @@ export function buildCreateNodeCommand(draft: NodeDraft): string {
 
   const alias = draft.alias.trim();
   const nodeType = draft.nodeType.trim();
-  const propertyRows = draft.properties
-    .map((row) => ({ key: row.key.trim(), value: row.value.trim() }))
-    .filter((row) => row.key || row.value);
+  const propertyRows = getSerializablePropertyRows(draft);
 
   // Match the existing multiline command grammar consumed by
   // GraphCommandService.handleMultiLineCommand.
@@ -25,15 +50,50 @@ export function buildCreateNodeCommand(draft: NodeDraft): string {
   if (propertyRows.length > 0) {
     lines.push('with properties');
     for (const row of propertyRows) {
-      lines.push(`${row.key}=${row.value}`);
+      appendSerializedProperty(lines, row.key, row.value);
     }
   }
 
   const command = lines.join('\n');
-  const sizeValidation = validateCommandSize(command);
-  if (!sizeValidation.valid) {
-    throw new Error(sizeValidation.errors.command);
+  assertValidCommandSize(command);
+
+  return command;
+}
+
+export function buildUpdateNodeCommand(draft: NodeDraft, originalAliasInput: string): string {
+  const originalAlias = originalAliasInput.trim();
+  const validation = validateNodeDraft(draft, { mode: 'edit', originalAlias });
+  if (!validation.valid) {
+    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node draft.');
   }
 
+  const nodeType = draft.nodeType.trim();
+  const propertyRows = getSerializablePropertyRows(draft, true);
+
+  const lines = [`update node ${originalAlias}`];
+  if (nodeType) {
+    lines.push(`with type ${nodeType}`);
+  }
+  if (propertyRows.length > 0) {
+    lines.push('with properties');
+    for (const row of propertyRows) {
+      appendSerializedProperty(lines, row.key, row.value);
+    }
+  }
+
+  const command = lines.join('\n');
+  assertValidCommandSize(command);
+  return command;
+}
+
+export function buildDeleteNodeCommand(aliasInput: string, options: DeleteNodeValidationOptions = {}): string {
+  const alias = aliasInput.trim();
+  const validation = validateDeleteNodeAlias(alias, options);
+  if (!validation.valid) {
+    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node alias.');
+  }
+
+  const command = `delete node ${alias}`;
+  assertValidCommandSize(command);
   return command;
 }

--- a/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/minigraphCommandBuilder.ts
@@ -1,8 +1,8 @@
-import type { NodeDraft } from './nodeAuthoringTypes';
-import { validateCommandSize, validateDeleteNodeAlias, validateNodeDraft, type DeleteNodeValidationOptions } from './validation';
+import type { NodeFormState } from './nodeAuthoringTypes';
+import { validateCommandSize, validateDeleteNodeAlias, validateNodeFormState, type DeleteNodeValidationOptions } from './validation';
 
-function getSerializablePropertyRows(draft: NodeDraft, preserveValue = false) {
-  return draft.properties
+function getSerializablePropertyRows(formState: NodeFormState, preserveValue = false) {
+  return formState.properties
     .map((row) => ({
       key: row.key.trim(),
       value: preserveValue ? row.value.replace(/\r\n/g, '\n').replace(/\r/g, '\n') : row.value.trim(),
@@ -28,18 +28,18 @@ function appendSerializedProperty(lines: string[], key: string, value: string): 
   lines.push(`${key}=${value}`);
 }
 
-// Single serialization boundary for create-node UI authoring. Callers pass a
-// typed draft; only this builder is allowed to produce backend raw command text
-// so validation and injection guards stay centralized.
-export function buildCreateNodeCommand(draft: NodeDraft): string {
-  const validation = validateNodeDraft(draft);
+// Single serialization boundary for node UI authoring. Callers pass typed form
+// state; only this builder is allowed to produce backend raw command text so
+// validation and injection guards stay centralized.
+export function buildCreateNodeCommand(formState: NodeFormState): string {
+  const validation = validateNodeFormState(formState);
   if (!validation.valid) {
-    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node draft.');
+    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node form state.');
   }
 
-  const alias = draft.alias.trim();
-  const nodeType = draft.nodeType.trim();
-  const propertyRows = getSerializablePropertyRows(draft);
+  const alias = formState.alias.trim();
+  const nodeType = formState.nodeType.trim();
+  const propertyRows = getSerializablePropertyRows(formState);
 
   // Match the existing multiline command grammar consumed by
   // GraphCommandService.handleMultiLineCommand.
@@ -60,15 +60,15 @@ export function buildCreateNodeCommand(draft: NodeDraft): string {
   return command;
 }
 
-export function buildUpdateNodeCommand(draft: NodeDraft, originalAliasInput: string): string {
+export function buildUpdateNodeCommand(formState: NodeFormState, originalAliasInput: string): string {
   const originalAlias = originalAliasInput.trim();
-  const validation = validateNodeDraft(draft, { mode: 'edit', originalAlias });
+  const validation = validateNodeFormState(formState, { mode: 'edit', originalAlias });
   if (!validation.valid) {
-    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node draft.');
+    throw new Error(Object.values(validation.errors)[0] ?? 'Invalid node form state.');
   }
 
-  const nodeType = draft.nodeType.trim();
-  const propertyRows = getSerializablePropertyRows(draft, true);
+  const nodeType = formState.nodeType.trim();
+  const propertyRows = getSerializablePropertyRows(formState, true);
 
   const lines = [`update node ${originalAlias}`];
   if (nodeType) {

--- a/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
@@ -1,4 +1,5 @@
-export type NodeDraftSource = 'empty-graph' | 'pane-context-menu';
+export type NodeDraftSource = 'empty-graph' | 'pane-context-menu' | 'edit-node';
+export type NodeAction = 'create-node' | 'edit-node' | 'delete-node';
 
 export interface PropertyRow {
   id: string;
@@ -14,3 +15,9 @@ export interface NodeDraft {
 }
 
 export type NodeDraftValidationErrors = Record<string, string>;
+
+export interface NodeDraftConversionResult {
+  valid: boolean;
+  draft: NodeDraft | null;
+  message: string | null;
+}

--- a/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/nodeAuthoringTypes.ts
@@ -1,4 +1,4 @@
-export type NodeDraftSource = 'empty-graph' | 'pane-context-menu' | 'edit-node';
+export type NodeFormSource = 'empty-graph' | 'pane-context-menu' | 'edit-node';
 export type NodeAction = 'create-node' | 'edit-node' | 'delete-node';
 
 export interface PropertyRow {
@@ -7,17 +7,17 @@ export interface PropertyRow {
   value: string;
 }
 
-export interface NodeDraft {
+export interface NodeFormState {
   alias: string;
   nodeType: string;
   properties: PropertyRow[];
-  source: NodeDraftSource;
+  source: NodeFormSource;
 }
 
-export type NodeDraftValidationErrors = Record<string, string>;
+export type NodeFormValidationErrors = Record<string, string>;
 
-export interface NodeDraftConversionResult {
+export interface NodeFormConversionResult {
   valid: boolean;
-  draft: NodeDraft | null;
+  formState: NodeFormState | null;
   message: string | null;
 }

--- a/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
@@ -1,6 +1,6 @@
 import type { MinigraphNode } from '../utils/graphTypes';
 import { isValidPropertyPath, NODE_NAME_RE } from './validation';
-import type { NodeDraft, NodeDraftConversionResult, NodeDraftSource, PropertyRow } from './nodeAuthoringTypes';
+import type { NodeFormState, NodeFormConversionResult, NodeFormSource, PropertyRow } from './nodeAuthoringTypes';
 
 let rowCounter = 0;
 
@@ -13,7 +13,7 @@ export function createPropertyRow(key = '', value = ''): PropertyRow {
 
 // First-node authoring uses deterministic defaults. They are starting values
 // only; normal validation still runs after the user edits or submits.
-export function createDefaultNodeDraft(source: NodeDraftSource): NodeDraft {
+export function createDefaultNodeFormState(source: NodeFormSource): NodeFormState {
   return {
     alias: source === 'empty-graph' ? 'root' : '',
     nodeType: source === 'empty-graph' ? 'Root' : '',
@@ -57,26 +57,26 @@ function flattenPropertyValue(path: string, value: unknown, rows: PropertyRow[])
 // Converts the rendered graph node into the flat path/value rows consumed by
 // the backend update command. Arrays and nested objects use the same path
 // grammar emitted by the console `edit node` command, e.g. mapping[0] or a.b.
-export function createEditNodeDraft(node: MinigraphNode): NodeDraftConversionResult {
+export function createEditNodeFormState(node: MinigraphNode): NodeFormConversionResult {
   if (!NODE_NAME_RE.test(node.alias)) {
-    return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+    return { valid: false, formState: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
   }
 
   if (node.types.length > 1) {
-    return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+    return { valid: false, formState: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
   }
 
   const propertyEntries = Object.entries(node.properties);
   const properties: PropertyRow[] = [];
   for (const [key, value] of propertyEntries) {
     if (!flattenPropertyValue(key, value, properties)) {
-      return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+      return { valid: false, formState: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
     }
   }
 
   return {
     valid: true,
-    draft: {
+    formState: {
       alias: node.alias,
       nodeType: node.types[0] ?? '',
       properties: properties.length > 0 ? properties : [createPropertyRow()],

--- a/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/propertyRows.ts
@@ -1,4 +1,6 @@
-import type { NodeDraft, NodeDraftSource, PropertyRow } from './nodeAuthoringTypes';
+import type { MinigraphNode } from '../utils/graphTypes';
+import { isValidPropertyPath, NODE_NAME_RE } from './validation';
+import type { NodeDraft, NodeDraftConversionResult, NodeDraftSource, PropertyRow } from './nodeAuthoringTypes';
 
 let rowCounter = 0;
 
@@ -17,5 +19,69 @@ export function createDefaultNodeDraft(source: NodeDraftSource): NodeDraft {
     nodeType: source === 'empty-graph' ? 'Root' : '',
     properties: [createPropertyRow()],
     source,
+  };
+}
+
+const UNSUPPORTED_EDIT_NODE_MESSAGE =
+  'This node contains data that cannot be safely represented in the edit form. Use the console edit command for this node.';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toEditableValue(value: unknown): string {
+  if (value === null) return 'null';
+  return String(value);
+}
+
+function flattenPropertyValue(path: string, value: unknown, rows: PropertyRow[]): boolean {
+  if (!isValidPropertyPath(path)) return false;
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return false;
+    return value.every((item, index) => flattenPropertyValue(`${path}[${index}]`, item, rows));
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return false;
+    return entries.every(([key, item]) => flattenPropertyValue(`${path}.${key}`, item, rows));
+  }
+
+  const stringValue = toEditableValue(value);
+  if (stringValue.includes("'''")) return false;
+  rows.push(createPropertyRow(path, stringValue));
+  return true;
+}
+
+// Converts the rendered graph node into the flat path/value rows consumed by
+// the backend update command. Arrays and nested objects use the same path
+// grammar emitted by the console `edit node` command, e.g. mapping[0] or a.b.
+export function createEditNodeDraft(node: MinigraphNode): NodeDraftConversionResult {
+  if (!NODE_NAME_RE.test(node.alias)) {
+    return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+  }
+
+  if (node.types.length > 1) {
+    return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+  }
+
+  const propertyEntries = Object.entries(node.properties);
+  const properties: PropertyRow[] = [];
+  for (const [key, value] of propertyEntries) {
+    if (!flattenPropertyValue(key, value, properties)) {
+      return { valid: false, draft: null, message: UNSUPPORTED_EDIT_NODE_MESSAGE };
+    }
+  }
+
+  return {
+    valid: true,
+    draft: {
+      alias: node.alias,
+      nodeType: node.types[0] ?? '',
+      properties: properties.length > 0 ? properties : [createPropertyRow()],
+      source: 'edit-node',
+    },
+    message: null,
   };
 }

--- a/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
@@ -6,6 +6,7 @@ import type { NodeDraft, NodeDraftValidationErrors } from './nodeAuthoringTypes'
 // The backend remains authoritative; this only blocks obviously invalid drafts
 // before they can become raw command text.
 export const NODE_NAME_RE = /^[A-Za-z0-9_-]+$/;
+const PROPERTY_PATH_SEGMENT_RE = /^[A-Za-z0-9_-]+(?:\[(?:0|[1-9]\d*)\])*$/;
 
 // Mirrors MiniGraph's reserved alias list so the modal can show immediate field
 // feedback instead of relying on a later generic backend ERROR response.
@@ -24,6 +25,8 @@ export const RESERVED_ALIASES = new Set([
 
 export interface NodeDraftValidationOptions {
   graphData?: MinigraphGraphData | null;
+  mode?: 'create' | 'edit';
+  originalAlias?: string | null;
 }
 
 export interface NodeDraftValidationResult {
@@ -35,25 +38,43 @@ export function getValidationErrorKeyForProperty(rowId: string, field: 'key' | '
   return `properties.${rowId}.${field}`;
 }
 
-// Validate the supported authoring surface: alias, optional node type, and flat
-// single-line scalar properties. Duplicate aliases from graphData are advisory
+export function isValidPropertyPath(path: string): boolean {
+  return path.split('.').every((segment) => PROPERTY_PATH_SEGMENT_RE.test(segment));
+}
+
+function isValidPropertyKey(key: string, mode: 'create' | 'edit'): boolean {
+  return mode === 'edit' ? isValidPropertyPath(key) : NODE_NAME_RE.test(key);
+}
+
+// Validate the supported authoring surface: alias, optional node type, and
+// command-safe property rows. Duplicate aliases from graphData are advisory
 // because graphData is a staleable frontend projection.
 export function validateNodeDraft(
   draft: NodeDraft,
   options: NodeDraftValidationOptions = {},
 ): NodeDraftValidationResult {
   const errors: NodeDraftValidationErrors = {};
+  const mode = options.mode ?? 'create';
   const alias = draft.alias.trim();
+  const originalAlias = options.originalAlias?.trim() ?? '';
   const nodeType = draft.nodeType.trim();
 
-  if (!alias) {
-    errors.alias = 'Alias is required.';
-  } else if (!NODE_NAME_RE.test(alias)) {
-    errors.alias = 'Use only letters, numbers, underscore, and hyphen.';
-  } else if (RESERVED_ALIASES.has(alias.toLowerCase())) {
-    errors.alias = `"${alias}" is reserved.`;
-  } else if (options.graphData?.nodes.some((node) => node.alias.toLowerCase() === alias.toLowerCase())) {
-    errors.alias = `Node "${alias}" already exists in the current graph.`;
+  if (mode === 'edit') {
+    if (!originalAlias) {
+      errors.alias = 'Original alias is required.';
+    } else if (!NODE_NAME_RE.test(originalAlias)) {
+      errors.alias = 'Use only letters, numbers, underscore, and hyphen.';
+    }
+  } else {
+    if (!alias) {
+      errors.alias = 'Alias is required.';
+    } else if (!NODE_NAME_RE.test(alias)) {
+      errors.alias = 'Use only letters, numbers, underscore, and hyphen.';
+    } else if (RESERVED_ALIASES.has(alias.toLowerCase())) {
+      errors.alias = `"${alias}" is reserved.`;
+    } else if (options.graphData?.nodes.some((node) => node.alias.toLowerCase() === alias.toLowerCase())) {
+      errors.alias = `Node "${alias}" already exists in the current graph.`;
+    }
   }
 
   if (nodeType && !NODE_NAME_RE.test(nodeType)) {
@@ -67,15 +88,39 @@ export function validateNodeDraft(
 
     if (!key && value) {
       errors[getValidationErrorKeyForProperty(row.id, 'key')] = 'Property key is required when value is present.';
-    } else if (!NODE_NAME_RE.test(key)) {
-      errors[getValidationErrorKeyForProperty(row.id, 'key')] = 'Use only letters, numbers, underscore, and hyphen.';
+    } else if (!isValidPropertyKey(key, mode)) {
+      errors[getValidationErrorKeyForProperty(row.id, 'key')] = mode === 'edit'
+        ? 'Use a property name or dot/bracket path, for example mapping[0] or config.value.'
+        : 'Use only letters, numbers, underscore, and hyphen.';
     }
 
-    if (value.includes('\r') || value.includes('\n')) {
+    if (mode === 'create' && (value.includes('\r') || value.includes('\n'))) {
       errors[getValidationErrorKeyForProperty(row.id, 'value')] = 'Property value must be a single line.';
     } else if (value.includes("'''")) {
       errors[getValidationErrorKeyForProperty(row.id, 'value')] = "Property value cannot contain '''.";
     }
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors };
+}
+
+export interface DeleteNodeValidationOptions {
+  graphData?: MinigraphGraphData | null;
+}
+
+export function validateDeleteNodeAlias(
+  aliasInput: string,
+  options: DeleteNodeValidationOptions = {},
+): NodeDraftValidationResult {
+  const errors: NodeDraftValidationErrors = {};
+  const alias = aliasInput.trim();
+
+  if (!alias) {
+    errors.alias = 'Alias is required.';
+  } else if (!NODE_NAME_RE.test(alias)) {
+    errors.alias = 'Use only letters, numbers, underscore, and hyphen.';
+  } else if (options.graphData && !options.graphData.nodes.some((node) => node.alias.toLowerCase() === alias.toLowerCase())) {
+    errors.alias = `Node "${alias}" is no longer available in the current graph.`;
   }
 
   return { valid: Object.keys(errors).length === 0, errors };

--- a/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
+++ b/system/minigraph-playground-engine/webapp/src/graphActions/validation.ts
@@ -1,10 +1,10 @@
 import { MAX_BUFFER } from '../config/playgrounds';
 import type { MinigraphGraphData } from '../utils/graphTypes';
-import type { NodeDraft, NodeDraftValidationErrors } from './nodeAuthoringTypes';
+import type { NodeFormState, NodeFormValidationErrors } from './nodeAuthoringTypes';
 
 // Keep this token rule aligned with GraphProperties.validateName on the backend.
-// The backend remains authoritative; this only blocks obviously invalid drafts
-// before they can become raw command text.
+// The backend remains authoritative; this only blocks obviously invalid form
+// input before it can become raw command text.
 export const NODE_NAME_RE = /^[A-Za-z0-9_-]+$/;
 const PROPERTY_PATH_SEGMENT_RE = /^[A-Za-z0-9_-]+(?:\[(?:0|[1-9]\d*)\])*$/;
 
@@ -23,15 +23,15 @@ export const RESERVED_ALIASES = new Set([
   'error',
 ]);
 
-export interface NodeDraftValidationOptions {
+export interface NodeFormValidationOptions {
   graphData?: MinigraphGraphData | null;
   mode?: 'create' | 'edit';
   originalAlias?: string | null;
 }
 
-export interface NodeDraftValidationResult {
+export interface NodeFormValidationResult {
   valid: boolean;
-  errors: NodeDraftValidationErrors;
+  errors: NodeFormValidationErrors;
 }
 
 export function getValidationErrorKeyForProperty(rowId: string, field: 'key' | 'value'): string {
@@ -49,15 +49,15 @@ function isValidPropertyKey(key: string, mode: 'create' | 'edit'): boolean {
 // Validate the supported authoring surface: alias, optional node type, and
 // command-safe property rows. Duplicate aliases from graphData are advisory
 // because graphData is a staleable frontend projection.
-export function validateNodeDraft(
-  draft: NodeDraft,
-  options: NodeDraftValidationOptions = {},
-): NodeDraftValidationResult {
-  const errors: NodeDraftValidationErrors = {};
+export function validateNodeFormState(
+  formState: NodeFormState,
+  options: NodeFormValidationOptions = {},
+): NodeFormValidationResult {
+  const errors: NodeFormValidationErrors = {};
   const mode = options.mode ?? 'create';
-  const alias = draft.alias.trim();
+  const alias = formState.alias.trim();
   const originalAlias = options.originalAlias?.trim() ?? '';
-  const nodeType = draft.nodeType.trim();
+  const nodeType = formState.nodeType.trim();
 
   if (mode === 'edit') {
     if (!originalAlias) {
@@ -81,7 +81,7 @@ export function validateNodeDraft(
     errors.nodeType = 'Use only letters, numbers, underscore, and hyphen.';
   }
 
-  for (const row of draft.properties) {
+  for (const row of formState.properties) {
     const key = row.key.trim();
     const value = row.value.trim();
     if (!key && !value) continue;
@@ -111,8 +111,8 @@ export interface DeleteNodeValidationOptions {
 export function validateDeleteNodeAlias(
   aliasInput: string,
   options: DeleteNodeValidationOptions = {},
-): NodeDraftValidationResult {
-  const errors: NodeDraftValidationErrors = {};
+): NodeFormValidationResult {
+  const errors: NodeFormValidationErrors = {};
   const alias = aliasInput.trim();
 
   if (!alias) {
@@ -128,7 +128,7 @@ export function validateDeleteNodeAlias(
 
 // The command budget belongs to the WebSocket command path, so size is checked
 // after serialization rather than estimating from individual fields.
-export function validateCommandSize(commandText: string): NodeDraftValidationResult {
+export function validateCommandSize(commandText: string): NodeFormValidationResult {
   if (commandText.length <= MAX_BUFFER) return { valid: true, errors: {} };
   return {
     valid: false,

--- a/system/minigraph-playground-engine/webapp/src/protocol/__tests__/classifier.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/__tests__/classifier.test.ts
@@ -108,8 +108,16 @@ describe('classifier — invariants', () => {
   it('emits create-node text result without replacing graph.mutation', () => {
     const events = classifyMessage(1, 'node root created');
     const kinds = events.map(e => e.kind);
+    expect(kinds).toContain('minigraph.nodeAction.textResult');
     expect(kinds).toContain('minigraph.createNode.textResult');
     expect(kinds).toContain('graph.mutation');
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.nodeAction.textResult',
+      status: 'accepted',
+      action: 'create-node',
+      alias: 'root',
+      message: 'node root created',
+    }));
     expect(events).toContainEqual(expect.objectContaining({
       kind: 'minigraph.createNode.textResult',
       status: 'accepted',
@@ -121,10 +129,50 @@ describe('classifier — invariants', () => {
   it('emits duplicate create-node text result as rejected', () => {
     const events = classifyMessage(1, 'node root already exists');
     expect(events).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.nodeAction.textResult',
+      status: 'rejected',
+      action: 'create-node',
+      alias: 'root',
+      message: 'node root already exists',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
       kind: 'minigraph.createNode.textResult',
       status: 'rejected',
       alias: 'root',
       message: 'node root already exists',
+    }));
+  });
+
+  it('emits edit/delete node-action text results without create compatibility events', () => {
+    const updated = classifyMessage(1, 'node root updated');
+    expect(updated).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.nodeAction.textResult',
+      status: 'accepted',
+      action: 'edit-node',
+      alias: 'root',
+      message: 'node root updated',
+    }));
+    expect(updated.map(e => e.kind)).not.toContain('minigraph.createNode.textResult');
+
+    const deleted = classifyMessage(1, 'node root deleted');
+    expect(deleted).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.nodeAction.textResult',
+      status: 'accepted',
+      action: 'delete-node',
+      alias: 'root',
+      message: 'node root deleted',
+    }));
+    expect(deleted.map(e => e.kind)).not.toContain('minigraph.createNode.textResult');
+  });
+
+  it('emits not-found node-action text result as rejected', () => {
+    const events = classifyMessage(1, 'node root not found');
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'minigraph.nodeAction.textResult',
+      status: 'rejected',
+      action: null,
+      alias: 'root',
+      message: 'node root not found',
     }));
   });
 });

--- a/system/minigraph-playground-engine/webapp/src/protocol/__tests__/fixtures/multi-event.json
+++ b/system/minigraph-playground-engine/webapp/src/protocol/__tests__/fixtures/multi-event.json
@@ -44,7 +44,7 @@
   {
     "name": "node mutation IS also docs.response (intentional — not in exclusion set)",
     "raw": "Node my-node created",
-    "expectedKinds": ["graph.mutation", "docs.response"],
-    "expectedLength": 2
+    "expectedKinds": ["graph.mutation", "minigraph.nodeAction.textResult", "minigraph.createNode.textResult", "docs.response"],
+    "expectedLength": 4
   }
 ]

--- a/system/minigraph-playground-engine/webapp/src/protocol/classifier.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/classifier.ts
@@ -12,7 +12,7 @@ import {
   isMarkdownCandidate,
   extractGraphExportSuccess,
   detectGraphExportFailure,
-  parseCreateNodeTextResult,
+  parseNodeActionTextResult,
 } from '../utils/messageParser';
 
 const KNOWN_LIFECYCLE_TYPES = new Set(['info', 'error', 'ping', 'welcome']);
@@ -141,15 +141,30 @@ export function classifyMessage(msgId: number, raw: string): ProtocolEvent[] {
     });
   }
 
-  // ── Rule 7a: Minigraph create-node text result ────────────────────────────
-  const createNodeResult = parseCreateNodeTextResult(raw);
-  if (createNodeResult) {
+  // ── Rule 7a: Minigraph node-action text result ────────────────────────────
+  const nodeActionResult = parseNodeActionTextResult(raw);
+  if (nodeActionResult) {
+    events.push({
+      ...base,
+      kind: 'minigraph.nodeAction.textResult',
+      status: nodeActionResult.status,
+      action: nodeActionResult.action,
+      alias: nodeActionResult.alias,
+      message: nodeActionResult.message,
+    });
+  }
+
+  // ── Rule 7b: Backward-compatible create-node text result ─────────────────
+  if (
+    nodeActionResult &&
+    (nodeActionResult.action === 'create-node' || nodeActionResult.status === 'error')
+  ) {
     events.push({
       ...base,
       kind: 'minigraph.createNode.textResult',
-      status: createNodeResult.status,
-      alias: createNodeResult.alias,
-      message: createNodeResult.message,
+      status: nodeActionResult.status,
+      alias: nodeActionResult.alias,
+      message: nodeActionResult.message,
     });
   }
 

--- a/system/minigraph-playground-engine/webapp/src/protocol/events.ts
+++ b/system/minigraph-playground-engine/webapp/src/protocol/events.ts
@@ -29,6 +29,14 @@ export interface CreateNodeTextResultEvent extends ProtocolEventBase {
   message: string;
 }
 
+export interface NodeActionTextResultEvent extends ProtocolEventBase {
+  kind: 'minigraph.nodeAction.textResult';
+  status: 'accepted' | 'rejected' | 'error';
+  action: 'create-node' | 'edit-node' | 'delete-node' | null;
+  alias: string | null;
+  message: string;
+}
+
 export interface LargePayloadEvent extends ProtocolEventBase {
   kind: 'payload.large';
   apiPath: string;
@@ -119,6 +127,7 @@ export type ProtocolEvent =
   | GraphLinkEvent
   | GraphMutationEvent
   | CreateNodeTextResultEvent
+  | NodeActionTextResultEvent
   | GraphExportedEvent
   | GraphExportFailedEvent
   | LargePayloadEvent

--- a/system/minigraph-playground-engine/webapp/src/utils/__tests__/messageParser.createNodeTextResult.test.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/__tests__/messageParser.createNodeTextResult.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseCreateNodeTextResult } from '../messageParser';
+import { parseCreateNodeTextResult, parseNodeActionTextResult } from '../messageParser';
 
 describe('parseCreateNodeTextResult', () => {
   it('parses accepted create-node text', () => {
@@ -30,5 +30,47 @@ describe('parseCreateNodeTextResult', () => {
     expect(parseCreateNodeTextResult('> create node root')).toBeNull();
     expect(parseCreateNodeTextResult('node root updated')).toBeNull();
     expect(parseCreateNodeTextResult('{"type":"info"}')).toBeNull();
+  });
+});
+
+describe('parseNodeActionTextResult', () => {
+  it('parses create, edit, and delete accepted text', () => {
+    expect(parseNodeActionTextResult('node root created')).toMatchObject({
+      status: 'accepted',
+      action: 'create-node',
+      alias: 'root',
+    });
+    expect(parseNodeActionTextResult('Node root updated')).toMatchObject({
+      status: 'accepted',
+      action: 'edit-node',
+      alias: 'root',
+    });
+    expect(parseNodeActionTextResult('node root deleted')).toMatchObject({
+      status: 'accepted',
+      action: 'delete-node',
+      alias: 'root',
+    });
+  });
+
+  it('parses rejected and generic error text', () => {
+    expect(parseNodeActionTextResult('node root already exists')).toMatchObject({
+      status: 'rejected',
+      action: 'create-node',
+      alias: 'root',
+    });
+    expect(parseNodeActionTextResult('node root not found')).toMatchObject({
+      status: 'rejected',
+      action: null,
+      alias: 'root',
+    });
+    expect(parseNodeActionTextResult('ERROR: bad command')).toMatchObject({
+      status: 'error',
+      action: null,
+      alias: null,
+    });
+  });
+
+  it('ignores echoed commands', () => {
+    expect(parseNodeActionTextResult('> update node root...')).toBeNull();
   });
 });

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -37,6 +37,7 @@ const NODE_WIDTH  = 240;
 const NODE_HEIGHT = 100; // rough estimate; ResizeObserver will correct it post-mount
 const ROW_GAP            = 60;   // vertical gap between nodes stacked in the same column
 const COL_GAP            = 120;  // horizontal gap between columns (levels)
+const COMPONENT_GAP      = 360;  // horizontal gap between independent flow trees
 const SECTION_GAP        = 120;  // vertical gap between main flow and first segregated row
 const SEGREGATED_ROW_GAP = 80;   // vertical gap between successive segregated rows
 
@@ -146,7 +147,7 @@ const MODULE_SKILLS = new Set(['graph.math', 'graph.js']);
 const SEGREGATED_ROW_ORDER: readonly string[] = [
   'Dictionary',   // data extraction contracts from API responses
   'Provider',     // reusable API endpoint configurations
-    'Module',       // reusable computation blocks (EXECUTE keyword)
+  'Module',       // reusable computation blocks (EXECUTE keyword)
   'Entity',       // skill-less data-holder nodes (business domain objects)
 ];
 
@@ -154,6 +155,52 @@ const SEGREGATED_ROW_ORDER: readonly string[] = [
 // Layout categories returned by classifyNode.  'flow' nodes participate in the
 // main BFS layout; all other categories are placed in segregated rows below.
 type LayoutCategory = 'flow' | 'Dictionary' | 'Provider' | 'Entity' | 'Module' | '__unknown__';
+type MinigraphNodeModel = MinigraphGraphData['nodes'][number];
+
+interface FlowComponent {
+  aliases: string[];
+  nodes: MinigraphNodeModel[];
+  hasRoot: boolean;
+  hasEnd: boolean;
+  sortKey: string;
+}
+
+const FLOW_COMPONENT_LAYOUT_ORDER = {
+  ROOT_TREE: 0,
+  DEFAULT_TREE: 1,
+  END_TREE: 2,
+} as const;
+
+// Root-like nodes define the primary execution tree. When several disconnected
+// flow trees exist, this component is anchored first so graph reading starts on
+// the left from the graph entry point.
+function isRootLikeNode(node: MinigraphNodeModel): boolean {
+  return node.alias.toLowerCase() === 'root' ||
+    node.types.includes('Root') ||
+    node.types.includes('entry_point');
+}
+
+// End-like nodes are terminal-only branches in some imported models. Ranking
+// their component last keeps those completion/error branches on the right.
+function isEndLikeNode(node: MinigraphNodeModel): boolean {
+  return node.alias.toLowerCase() === 'end' || node.types.includes('End');
+}
+
+// Keep component ordering policy centralized: root tree first, ordinary trees
+// next, terminal/end tree last. The numeric values are only sort ranks.
+function getFlowComponentRank(component: FlowComponent): number {
+  if (component.hasRoot) return FLOW_COMPONENT_LAYOUT_ORDER.ROOT_TREE;
+  if (component.hasEnd) return FLOW_COMPONENT_LAYOUT_ORDER.END_TREE;
+  return FLOW_COMPONENT_LAYOUT_ORDER.DEFAULT_TREE;
+}
+
+// Sort disconnected flow trees before assigning global columns. Components with
+// the same semantic rank use their first alias for deterministic visual order.
+function compareFlowComponents(a: FlowComponent, b: FlowComponent): number {
+  const rankDiff = getFlowComponentRank(a) - getFlowComponentRank(b);
+  if (rankDiff !== 0) return rankDiff;
+  return a.sortKey.localeCompare(b.sortKey);
+}
 
 /**
  * Classify a node into its layout category.
@@ -195,15 +242,20 @@ function classifyNode(
  *  1. Classify every node via classifyNode (uses type, skill, and connection
  *     participation — see its JSDoc for the full priority chain).
  *     Partition into "flow" vs segregated categories.
- *  2. Assign flow nodes a "level" (column) via BFS from root seeds.
- *  3. Within each level, stack flow nodes vertically, centred at y = 0.
- *  4. Compute the bounding box of the main flow, then place each segregated
+ *  2. Split flow nodes into connected components so independent trees do not
+ *     collapse into one shared column set.
+ *  3. Sort components left-to-right: root component first, end-only component
+ *     last, all other components alphabetically in the middle.
+ *  4. Assign each component its own BFS "level" columns from root-like or
+ *     in-degree-zero seeds. Within each local level, stack nodes vertically,
+ *     centred at y = 0.
+ *  5. Compute the bounding box of the main flow, then place each segregated
  *     category in its own horizontal row below it, left-aligned with the flow.
  *
  * Segregated row order: Dictionary → Provider → Module → Entity → __unknown__.
  *
- * If no root is found (no entry_point and no flow node lacking incoming edges)
- * all flow nodes are placed on level 0 so the graph is still renderable.
+ * If a component has no natural seed (no root-like, entry_point, or in-degree
+ * zero node), its first alias is used so cyclic components remain renderable.
  */
 function computeLayout(
   nodes: MinigraphGraphData['nodes'],
@@ -231,13 +283,16 @@ function computeLayout(
     else segregatedNodes.push(n);
   }
 
-  // ── Step 2: BFS layout for flow nodes ─────────────────────────────────────
+  // ── Step 2: Build directed/undirected flow adjacency ──────────────────────
   const flowAliases = new Set(flowNodes.map(n => n.alias));
+  const nodeByAlias = new Map(flowNodes.map(n => [n.alias, n]));
   const outEdges    = new Map<string, string[]>();
+  const undirectedEdges = new Map<string, Set<string>>();
   const inDegree    = new Map<string, number>();
 
   for (const n of flowNodes) {
     outEdges.set(n.alias, []);
+    undirectedEdges.set(n.alias, new Set());
     inDegree.set(n.alias, 0);
   }
 
@@ -246,15 +301,19 @@ function computeLayout(
     // segregated nodes do not influence BFS level assignment.
     if (!flowAliases.has(conn.source) || !flowAliases.has(conn.target)) continue;
     outEdges.get(conn.source)?.push(conn.target);
+    undirectedEdges.get(conn.source)?.add(conn.target);
+    undirectedEdges.get(conn.target)?.add(conn.source);
     inDegree.set(conn.target, (inDegree.get(conn.target) ?? 0) + 1);
   }
 
-  // Seeds: flow nodes with in-degree 0, or explicitly typed as entry_point
-  const seeds = flowNodes
-    .filter(n => inDegree.get(n.alias) === 0 || n.types.includes('entry_point'))
+  // Seeds: flow nodes with in-degree 0, or explicitly typed as entry_point.
+  // These are used for cycle detection only. Each component chooses its own
+  // seeds again during placement.
+  const allSeeds = flowNodes
+    .filter(n => inDegree.get(n.alias) === 0 || n.types.includes('entry_point') || isRootLikeNode(n))
     .map(n => n.alias);
 
-  // ── Cycle detection: find back-edges via iterative DFS ────────────────
+  // ── Cycle detection: find back-edges via iterative DFS ────────────────────
   // Back-edges (edges pointing to an ancestor in the DFS tree) cause the
   // BFS level-assignment loop below to run forever — each node in a cycle
   // endlessly re-enqueues the other with ever-increasing levels.  We detect
@@ -293,65 +352,139 @@ function computeLayout(
       }
     }
 
-    // Prefer starting from seeds so the DFS tree mirrors the BFS flow
-    for (const s of seeds) dfsFrom(s);
+    // Prefer starting from seeds so the DFS tree mirrors the BFS flow.
+    for (const s of allSeeds) dfsFrom(s);
     for (const n of flowNodes) dfsFrom(n.alias);
   }
 
-  const levelOf = new Map<string, number>();
-  const queue: string[] = [...seeds];
-  seeds.forEach(s => levelOf.set(s, 0));
+  // ── Step 3: Connected components for independent flow trees ───────────────
+  const components: FlowComponent[] = [];
+  const seen = new Set<string>();
 
-  // BFS to assign levels
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    const currentLevel = levelOf.get(current) ?? 0;
-    for (const neighbor of outEdges.get(current) ?? []) {
-      // Skip back-edges — they create cycles and are excluded from layout
-      // assignment but are still rendered as visual edges in the output.
-      if (backEdges.has(`${current}\t${neighbor}`)) continue;
-      // Only advance the level; never move a node to a shallower level
-      if (!levelOf.has(neighbor) || levelOf.get(neighbor)! <= currentLevel) {
-        levelOf.set(neighbor, currentLevel + 1);
-        queue.push(neighbor);
+  for (const start of Array.from(flowAliases).sort()) {
+    if (seen.has(start)) continue;
+
+    const aliases: string[] = [];
+    const stack = [start];
+    seen.add(start);
+
+    while (stack.length > 0) {
+      const alias = stack.pop()!;
+      aliases.push(alias);
+      for (const neighbor of undirectedEdges.get(alias) ?? []) {
+        if (seen.has(neighbor)) continue;
+        seen.add(neighbor);
+        stack.push(neighbor);
       }
     }
-  }
 
-  // Flow nodes that BFS never visited (disconnected) go to the last level + 1
-  const maxLevel = levelOf.size > 0 ? Math.max(...levelOf.values()) : 0;
-  for (const n of flowNodes) {
-    if (!levelOf.has(n.alias)) levelOf.set(n.alias, maxLevel + 1);
-  }
+    aliases.sort();
+    const componentNodes = aliases
+      .map(alias => nodeByAlias.get(alias))
+      .filter((node): node is MinigraphNodeModel => Boolean(node));
 
-  // Group flow nodes by level
-  const byLevel = new Map<number, string[]>();
-  for (const [alias, level] of levelOf) {
-    if (!byLevel.has(level)) byLevel.set(level, []);
-    byLevel.get(level)!.push(alias);
-  }
-
-  // Assign pixel positions for the main flow — centred at y = 0 per column.
-  // Per-node heights prevent overlap when nodes are taller than NODE_HEIGHT.
-  const positions = new Map<string, { x: number; y: number }>();
-  for (const [level, aliases] of byLevel) {
-    const totalHeight = aliases.reduce(
-      (sum, alias) => sum + (nodeHeights.get(alias) ?? NODE_HEIGHT),
-      0,
-    ) + Math.max(0, aliases.length - 1) * ROW_GAP;
-
-    let cursorY = -totalHeight / 2;
-    aliases.forEach((alias) => {
-      const nodeHeight = nodeHeights.get(alias) ?? NODE_HEIGHT;
-      positions.set(alias, {
-        x: level * (NODE_WIDTH + COL_GAP),
-        y: cursorY,
-      });
-      cursorY += nodeHeight + ROW_GAP;
+    components.push({
+      aliases,
+      nodes: componentNodes,
+      hasRoot: componentNodes.some(isRootLikeNode),
+      hasEnd: componentNodes.some(isEndLikeNode),
+      sortKey: aliases[0] ?? '',
     });
   }
 
-  // ── Step 3: Bounding box of the main flow ──────────────────────────────────
+  components.sort(compareFlowComponents);
+
+  // ── Step 4: BFS layout for each component, placed left-to-right ───────────
+  const levelOf = new Map<string, number>();
+  const positions = new Map<string, { x: number; y: number }>();
+  let componentLevelOffset = 0;
+  let componentXOffset = 0;
+
+  for (const component of components) {
+    const componentAliases = new Set(component.aliases);
+    const componentSeeds = component.nodes
+      .filter(n => inDegree.get(n.alias) === 0 || n.types.includes('entry_point') || isRootLikeNode(n))
+      .map(n => n.alias)
+      .sort();
+
+    // Cyclic components may have no natural in-degree-zero node. Seed from the
+    // first alias so they remain renderable instead of collapsing into orphans.
+    if (componentSeeds.length === 0 && component.aliases.length > 0) {
+      componentSeeds.push(component.aliases[0]);
+    }
+
+    const localLevelOf = new Map<string, number>();
+    const queue: string[] = [...componentSeeds];
+    componentSeeds.forEach(seed => localLevelOf.set(seed, 0));
+
+    // BFS to assign local levels within the component. This preserves the
+    // original left-to-right topological flow, but prevents independent trees
+    // from sharing the same column set.
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const currentLevel = localLevelOf.get(current) ?? 0;
+      for (const neighbor of outEdges.get(current) ?? []) {
+        // Skip cross-component edges defensively; components were built from
+        // the same flow adjacency, so this should only guard stale input.
+        if (!componentAliases.has(neighbor)) continue;
+        // Skip back-edges — they create cycles and are excluded from layout
+        // assignment but are still rendered as visual edges in the output.
+        if (backEdges.has(`${current}\t${neighbor}`)) continue;
+        // Only advance the level; never move a node to a shallower level.
+        if (!localLevelOf.has(neighbor) || localLevelOf.get(neighbor)! <= currentLevel) {
+          localLevelOf.set(neighbor, currentLevel + 1);
+          queue.push(neighbor);
+        }
+      }
+    }
+
+    // Flow nodes that BFS never visited stay in this component and move to the
+    // last local level + 1. This keeps cyclic or disconnected-within-component
+    // data renderable instead of dropping nodes from the layout.
+    const maxLocalLevel = localLevelOf.size > 0 ? Math.max(...localLevelOf.values()) : 0;
+    for (const alias of component.aliases) {
+      if (!localLevelOf.has(alias)) localLevelOf.set(alias, maxLocalLevel + 1);
+    }
+
+    const byLocalLevel = new Map<number, string[]>();
+    for (const [alias, level] of localLevelOf) {
+      if (!byLocalLevel.has(level)) byLocalLevel.set(level, []);
+      byLocalLevel.get(level)!.push(alias);
+    }
+
+    // Assign pixel positions for this component's flow — centred at y = 0 per
+    // local column. Per-node heights prevent overlap when nodes are taller than
+    // NODE_HEIGHT. componentXOffset gives each independent tree a fixed pixel
+    // gap from the previous tree instead of tying tree spacing to column count.
+    let componentMaxX = componentXOffset;
+    for (const [localLevel, aliases] of [...byLocalLevel].sort(([a], [b]) => a - b)) {
+      const sortedAliases = aliases.slice().sort();
+      const totalHeight = sortedAliases.reduce(
+        (sum, alias) => sum + (nodeHeights.get(alias) ?? NODE_HEIGHT),
+        0,
+      ) + Math.max(0, sortedAliases.length - 1) * ROW_GAP;
+
+      let cursorY = -totalHeight / 2;
+      const globalLevel = componentLevelOffset + localLevel;
+      const x = componentXOffset + localLevel * (NODE_WIDTH + COL_GAP);
+      componentMaxX = Math.max(componentMaxX, x);
+      sortedAliases.forEach((alias) => {
+        const nodeHeight = nodeHeights.get(alias) ?? NODE_HEIGHT;
+        levelOf.set(alias, globalLevel);
+        positions.set(alias, {
+          x,
+          y: cursorY,
+        });
+        cursorY += nodeHeight + ROW_GAP;
+      });
+    }
+
+    const componentMaxLevel = localLevelOf.size > 0 ? Math.max(...localLevelOf.values()) : 0;
+    componentLevelOffset += componentMaxLevel + 1;
+    componentXOffset = componentMaxX + NODE_WIDTH + COMPONENT_GAP;
+  }
+
+  // ── Step 5: Bounding box of the main flow ─────────────────────────────────
   // Used to anchor the vertical start of the segregated rows.
   let mainMaxY = 0;
   for (const [alias, pos] of positions) {
@@ -360,7 +493,7 @@ function computeLayout(
   // If there are no flow nodes at all, start at y = 0 with no section gap.
   let nextRowY = mainMaxY + (positions.size > 0 ? SECTION_GAP : 0);
 
-  // ── Step 4: Segregated rows ────────────────────────────────────────────────
+  // ── Step 6: Segregated rows ───────────────────────────────────────────────
   // Group segregated nodes by their layout category (already computed in Step 1).
   const groupMap = new Map<string, string[]>();
   for (const key of SEGREGATED_ROW_ORDER) groupMap.set(key, []);

--- a/system/minigraph-playground-engine/webapp/src/utils/messageParser.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/messageParser.ts
@@ -291,6 +291,8 @@ export function extractImportGraphName(raw: string): string | null {
 export type MutationKind = 'node-mutation' | 'import-graph';
 
 export type CreateNodeTextResultStatus = 'accepted' | 'rejected' | 'error';
+export type NodeActionTextResultStatus = 'accepted' | 'rejected' | 'error';
+export type NodeActionTextResultAction = 'create-node' | 'edit-node' | 'delete-node' | null;
 
 export interface CreateNodeTextResult {
   status: CreateNodeTextResultStatus;
@@ -298,27 +300,62 @@ export interface CreateNodeTextResult {
   message: string;
 }
 
-export const CREATE_NODE_CREATED_RE = /^node ([A-Za-z0-9_-]+) created$/;
-export const CREATE_NODE_ALREADY_EXISTS_RE = /^node ([A-Za-z0-9_-]+) already exists$/;
+export interface NodeActionTextResult {
+  status: NodeActionTextResultStatus;
+  action: NodeActionTextResultAction;
+  alias: string | null;
+  message: string;
+}
+
+export const NODE_CREATED_RE = /^node ([A-Za-z0-9_-]+) created$/i;
+export const NODE_ALREADY_EXISTS_RE = /^node ([A-Za-z0-9_-]+) already exists$/i;
+export const NODE_UPDATED_RE = /^node ([A-Za-z0-9_-]+) updated$/i;
+export const NODE_DELETED_RE = /^node ([A-Za-z0-9_-]+) deleted$/i;
+export const NODE_NOT_FOUND_RE = /^node ([A-Za-z0-9_-]+) not found$/i;
 export const ERROR_RE = /^ERROR: (.+)$/;
 
-export function parseCreateNodeTextResult(raw: string): CreateNodeTextResult | null {
+export function parseNodeActionTextResult(raw: string): NodeActionTextResult | null {
   const text = raw.trim();
   if (text.startsWith('> ')) return null;
 
-  const created = text.match(CREATE_NODE_CREATED_RE);
+  const created = text.match(NODE_CREATED_RE);
   if (created) {
-    return { status: 'accepted', alias: created[1], message: text };
+    return { status: 'accepted', action: 'create-node', alias: created[1], message: text };
   }
 
-  const alreadyExists = text.match(CREATE_NODE_ALREADY_EXISTS_RE);
+  const alreadyExists = text.match(NODE_ALREADY_EXISTS_RE);
   if (alreadyExists) {
-    return { status: 'rejected', alias: alreadyExists[1], message: text };
+    return { status: 'rejected', action: 'create-node', alias: alreadyExists[1], message: text };
+  }
+
+  const updated = text.match(NODE_UPDATED_RE);
+  if (updated) {
+    return { status: 'accepted', action: 'edit-node', alias: updated[1], message: text };
+  }
+
+  const deleted = text.match(NODE_DELETED_RE);
+  if (deleted) {
+    return { status: 'accepted', action: 'delete-node', alias: deleted[1], message: text };
+  }
+
+  const notFound = text.match(NODE_NOT_FOUND_RE);
+  if (notFound) {
+    return { status: 'rejected', action: null, alias: notFound[1], message: text };
   }
 
   const error = text.match(ERROR_RE);
   if (error) {
-    return { status: 'error', alias: null, message: text };
+    return { status: 'error', action: null, alias: null, message: text };
+  }
+
+  return null;
+}
+
+export function parseCreateNodeTextResult(raw: string): CreateNodeTextResult | null {
+  const result = parseNodeActionTextResult(raw);
+  if (!result) return null;
+  if (result.action === 'create-node' || result.status === 'error') {
+    return { status: result.status, alias: result.alias, message: result.message };
   }
 
   return null;


### PR DESCRIPTION
Implements node-level context menu actions for edit and delete.

Adds Edit Node modal with pre-populated node data and read-only alias
Adds inline delete confirmation from the node context menu
Sends update node and delete node through the existing raw WebSocket command path
Supports flattened array/object properties and multiline edit values
Adds generic node-action result parsing while preserving create-node compatibility
Updates validation, command builder, and protocol tests