### PR TITLE
Route companion commands through singleton GraphCommandService

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommand.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommand.java
@@ -53,14 +53,16 @@ public class PostCompanionCommand implements TypedLambdaFunction<AsyncHttpReques
         var route = id.replace('-', '.');
         var inRoute = route + ".in";
         var outRoute = route + ".out";
+        // use the singleton version of the GraphCommandService to eliminate chance of racing condition
         var po = new PostOffice(headers, instance);
         po.send(new EventEnvelope()
-                .setTo(GraphCommandService.ROUTE)
+                .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
                 .setBody(Map.of(
                         "type", "command",
                         "in", inRoute,
                         "out", outRoute,
                         "message", command)));
+        // immediately inform caller that the request has been accepted for orderly execution
         return new EventEnvelope()
                 .setHeader("Content-Type", "application/json")
                 .setBody(Map.of(

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @PreLoad(route = GraphCommandService.ROUTE, instances=50)
 public class GraphCommandService extends GraphLambdaFunction {
     public static final String ROUTE = "graph.command.service";
+    public static final String SINGLETON_COMMAND_HANDLER = "graph.command.singleton";
     private static final Logger log = LoggerFactory.getLogger(GraphCommandService.class);
     private static final ManagedCache cachedMessage = ManagedCache.createCache("last.ws.message", 1000);
     private static final String DEFAULT_TEMP_DIR = "/tmp/graph";
@@ -103,7 +104,10 @@ public class GraphCommandService extends GraphLambdaFunction {
         // initial housekeeping to remove expired temp graph from previous session
         housekeeping();
         // schedule housekeeping for ongoing clean up of expired temp graphs
-        Platform.getInstance().getVertx().setPeriodic(10000, l -> housekeeping());
+        var platform = Platform.getInstance();
+        platform.getVertx().setPeriodic(10000, l -> housekeeping());
+        // create a singleton version of this composable function for orderly execution of requests from AI companion
+        platform.registerPrivate(SINGLETON_COMMAND_HANDLER, this, 1);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Add a private singleton route (`graph.command.singleton`) for `GraphCommandService`, registered with a single instance at startup.
- `PostCompanionCommand` now sends AI companion command events to the singleton route so they execute serially instead of being distributed across the 50 pooled instances, eliminating a race condition on shared graph state.

## Test plan
- [x] Run `mvn test -f system/minigraph-playground-engine/pom.xml`
- [x] Issue a sequence of AI companion commands via the playground UI and confirm they execute in order without interleaving
- [x] Confirm normal (non-companion) traffic to `graph.command.service` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)