### PR TITLE
fix: serde thread-safety + SonarQube/IDE cleanup (minimalist-kafka, schema-registry-standalone, sync-over-async)

### DIFF
--- a/extensions/sync-over-async/src/main/java/org/platformlambda/sync/ReturnRouteCoordinator.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/sync/ReturnRouteCoordinator.java
@@ -91,13 +91,6 @@ public class ReturnRouteCoordinator implements AutoCloseable {
     }
 
     /**
-     * Originating pod: block for the response. On timeout, do one final Redis read so a dropped Pub/Sub
-     * notification still resolves the request before giving up.
-     *
-     * @return the response payload
-     * @throws TimeoutException if no response arrived (and none is in Redis) within {@code timeoutMillis}
-     */
-    /**
      * Originating pod, await-by-cid: used when {@code begin} and the await run as separate flow tasks, so the
      * caller no longer holds the future returned by {@link #begin}. Looks the future up by correlation-id and
      * blocks on it. If the entry is already gone (the response arrived and completed it between the two tasks),
@@ -118,6 +111,13 @@ public class ReturnRouteCoordinator implements AutoCloseable {
         throw new IllegalStateException("No pending request for " + correlationId);
     }
 
+    /**
+     * Originating pod: block on the supplied future for the response. On timeout, do one final Redis read so a
+     * dropped Pub/Sub notification still resolves the request before giving up.
+     *
+     * @return the response payload
+     * @throws TimeoutException if no response arrived (and none is in Redis) within {@code timeoutMillis}
+     */
     public String awaitResponse(String correlationId, CompletableFuture<String> future, long timeoutMillis)
             throws InterruptedException, TimeoutException {
         try {

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/async/EmbeddedKafka.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/async/EmbeddedKafka.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,8 +41,9 @@ import java.util.Properties;
  * kafka-standalone} module's {@code EmbeddedKafka}. Two changes make it safe to run inside the reactor
  * build:
  * <ul>
- *   <li><b>Dynamic ports</b> - the standalone hardcodes {@code 9092}/{@code 9093}, which would collide
- *       with a developer's local Kafka or a parallel module; this allocates free ports instead.</li>
+ *   <li><b>Fixed high ports</b> ({@code 19192}/{@code 19193}) - predictable (if a port is in use the test
+ *       fails fast rather than picking a surprise port), and high enough to avoid the standalone's
+ *       {@code 9092}/{@code 9093}, which would collide with a developer's local Kafka.</li>
  *   <li><b>KRaft storage formatting</b> - Kafka 4.x rejects the legacy {@code meta.properties} format, so
  *       storage is formatted with the official {@link Formatter} before {@link KafkaRaftServer#startup()}.</li>
  * </ul>
@@ -55,6 +55,8 @@ import java.util.Properties;
 final class EmbeddedKafka implements AutoCloseable {
 
     private static final int NODE_ID = 1;
+    private static final int BROKER_PORT = 19192;
+    private static final int CONTROLLER_PORT = 19193;
     private static final String CONTROLLER_LISTENER = "CONTROLLER";
     private static final String LOG_DIR = "/tmp/soa-kafka";
 
@@ -64,13 +66,11 @@ final class EmbeddedKafka implements AutoCloseable {
 
     EmbeddedKafka() {
         try {
-            int brokerPort = freePort();
-            int controllerPort = freePort();
-            this.bootstrapServers = "127.0.0.1:" + brokerPort;
+            this.bootstrapServers = "127.0.0.1:" + BROKER_PORT;
             this.logDir = prepareLogDir();
             formatStorage(logDir);
             this.server = new KafkaRaftServer(
-                    new KafkaConfig(brokerConfig(brokerPort, controllerPort, logDir)), Time.SYSTEM);
+                    new KafkaConfig(brokerConfig(BROKER_PORT, CONTROLLER_PORT, logDir)), Time.SYSTEM);
             this.server.startup();
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to start embedded Kafka", e);
@@ -126,12 +126,6 @@ final class EmbeddedKafka implements AutoCloseable {
                     .run();
         } catch (Exception e) {
             throw new IllegalStateException("Unable to format embedded Kafka storage", e);
-        }
-    }
-
-    private static int freePort() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
         }
     }
 

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisTestBase.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisTestBase.java
@@ -26,13 +26,13 @@ import redis.embedded.RedisServer;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.ServerSocket;
 
 /**
- * Boots a real (embedded) {@code redis-server} on a free port for the duration of the test class and
+ * Boots a real (embedded) {@code redis-server} on a fixed high port for the duration of the test class and
  * exposes a Lettuce client to it. The bundled binary covers macOS arm64/amd64 and Linux arm64/amd64,
  * so the return-route mechanism is exercised against genuine Redis semantics (incl. Pub/Sub) with no
- * Docker dependency.
+ * Docker dependency. The port is fixed (predictable: if it is in use the test fails fast) and high enough
+ * to avoid a developer's local Redis on {@code 6379}.
  *
  * <p>The working directory is pinned to {@code /tmp/soa-redis} - the same transient {@code /tmp} location
  * the {@code redis-standalone} helper uses (cloud-native pattern). It is <b>wiped and recreated before the
@@ -44,6 +44,8 @@ public abstract class RedisTestBase {
 
     /** Transient working directory for Redis data; shared with the redis-standalone helper. */
     protected static final String REDIS_DATA_DIR = "/tmp/soa-redis";
+    // fixed high port (predictable; avoids a developer's local Redis on 6379)
+    private static final int REDIS_PORT = 16379;
 
     protected static RedisServer redisServer;
     protected static RedisClient redisClient;
@@ -53,7 +55,7 @@ public abstract class RedisTestBase {
     @SuppressWarnings("java:S5443")
     @BeforeAll
     static void startRedis() throws IOException {
-        redisPort = freePort();
+        redisPort = REDIS_PORT;
         // wipe the transient store and recreate it, so each run begins from a clean slate
         File dir = new File(REDIS_DATA_DIR);
         Utility.getInstance().cleanupDir(dir);
@@ -75,12 +77,6 @@ public abstract class RedisTestBase {
         }
         if (redisServer != null) {
             redisServer.stop();
-        }
-    }
-
-    private static int freePort() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
         }
     }
 }

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/GetSchemaFunction.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/GetSchemaFunction.java
@@ -24,6 +24,8 @@ import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.util.Utility;
 import org.platformlambda.helpers.registry.store.SchemaStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +40,7 @@ import java.util.Map;
  */
 @PreLoad(route = "schema.registry.get", instances = 10)
 public class GetSchemaFunction implements TypedLambdaFunction<AsyncHttpRequest, EventEnvelope> {
+    private static final Logger log = LoggerFactory.getLogger(GetSchemaFunction.class);
 
     private final SchemaStore store = SchemaStore.getInstance();
     private final Utility util = Utility.getInstance();
@@ -46,11 +49,13 @@ public class GetSchemaFunction implements TypedLambdaFunction<AsyncHttpRequest, 
     public EventEnvelope handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
         String idStr = input.getPathParameter("id");
         if (idStr == null || !util.isDigits(idStr)) {
+            log.warn("GET /schemas/ids/{} -> 404 (invalid id)", idStr);
             return ApiError.of(404, ApiError.SCHEMA_NOT_FOUND, "Schema not found");
         }
         int id = util.str2int(idStr);
         SchemaStore.SchemaEntry entry = store.get(id);
         if (entry == null) {
+            log.warn("GET /schemas/ids/{} -> 404 (not found)", id);
             return ApiError.of(404, ApiError.SCHEMA_NOT_FOUND, "Schema " + id + " not found");
         }
         Map<String, Object> response = new HashMap<>();
@@ -59,6 +64,7 @@ public class GetSchemaFunction implements TypedLambdaFunction<AsyncHttpRequest, 
         if (!SchemaStore.AVRO_TYPE.equals(entry.schemaType())) {
             response.put("schemaType", entry.schemaType());
         }
+        log.info("GET /schemas/ids/{} -> 200 (schemaType={})", id, entry.schemaType());
         return new EventEnvelope().setStatus(200).setBody(response);
     }
 }

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/RegisterSchemaFunction.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/RegisterSchemaFunction.java
@@ -25,6 +25,8 @@ import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.helpers.registry.store.SchemaStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -41,6 +43,7 @@ import java.util.Map;
  */
 @PreLoad(route = "schema.registry.register", instances = 10)
 public class RegisterSchemaFunction implements TypedLambdaFunction<AsyncHttpRequest, EventEnvelope> {
+    private static final Logger log = LoggerFactory.getLogger(RegisterSchemaFunction.class);
 
     private static final String SCHEMA = "schema";
     private static final String SCHEMA_TYPE = "schemaType";
@@ -51,14 +54,17 @@ public class RegisterSchemaFunction implements TypedLambdaFunction<AsyncHttpRequ
     public EventEnvelope handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
         String subject = input.getPathParameter("subject");
         if (subject == null || subject.isEmpty()) {
+            log.warn("POST /subjects/{}/versions -> 404 (subject not found)", subject);
             return ApiError.of(404, ApiError.SUBJECT_NOT_FOUND, "Subject not found");
         }
         if (!(input.getBody() instanceof Map)) {
+            log.warn("POST /subjects/{}/versions -> 422 (missing request body)", subject);
             return ApiError.of(422, ApiError.INVALID_SCHEMA, "Invalid schema: missing request body");
         }
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) input.getBody();
         if (!(body.get(SCHEMA) instanceof String schema) || schema.isEmpty()) {
+            log.warn("POST /subjects/{}/versions -> 422 ('schema' string is required)", subject);
             return ApiError.of(422, ApiError.INVALID_SCHEMA, "Invalid schema: 'schema' string is required");
         }
         Object typeObj = body.getOrDefault(SCHEMA_TYPE, SchemaStore.AVRO_TYPE);
@@ -67,9 +73,11 @@ public class RegisterSchemaFunction implements TypedLambdaFunction<AsyncHttpRequ
         // documents, so a well-formedness check approximates that faithfully without bundling a parser
         // per schema language. Protobuf IDL is not JSON, so it is accepted as-is.
         if (!SchemaStore.PROTOBUF_TYPE.equalsIgnoreCase(schemaType) && malformedJson(schema)) {
+            log.warn("POST /subjects/{}/versions (schemaType={}) -> 422 (not well-formed JSON)", subject, schemaType);
             return ApiError.of(422, ApiError.INVALID_SCHEMA, "Invalid schema: not well-formed JSON");
         }
         int id = store.register(schema, schemaType);
+        log.info("POST /subjects/{}/versions (schemaType={}) -> 200 id={}", subject, schemaType, id);
         return new EventEnvelope().setStatus(200).setBody(Map.of("id", id));
     }
 

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/store/SchemaStore.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/store/SchemaStore.java
@@ -53,7 +53,6 @@ public class SchemaStore {
     private static final SchemaStore instance = new SchemaStore();
 
     public static final String AVRO_TYPE = "AVRO";
-    public static final String JSON_TYPE = "JSON";
     public static final String PROTOBUF_TYPE = "PROTOBUF";
 
     private final ConcurrentMap<Integer, SchemaEntry> idToSchema = new ConcurrentHashMap<>();
@@ -76,16 +75,6 @@ public class SchemaStore {
 
     public static SchemaStore getInstance() {
         return instance;
-    }
-    
-    /**
-     * Clear the store (mostly for testing).
-     */
-    public void clear() {
-        idToSchema.clear();
-        hashToId.clear();
-        idGenerator.set(1);
-        saveToDisk();
     }
 
     private String getHash(String typeAndSchema) {
@@ -114,54 +103,55 @@ public class SchemaStore {
         return idToSchema.get(id);
     }
     
-    @SuppressWarnings("unchecked")
     private void loadFromDisk() {
         File dir = new File(storeDir);
         if (!dir.exists() && !dir.mkdirs()) {
             log.warn("Failed to create directory: {}", storeDir);
             return;
         }
-
         Path filePath = Path.of(storeFile);
         if (!Files.exists(filePath)) {
             return;
         }
-        
         try {
             String json = Files.readString(filePath);
-            if (json.isEmpty()) {
-                return;
-            }
-            
-            Object parsed = org.platformlambda.core.serializers.SimpleMapper.getInstance().getMapper().readValue(json, Object.class);
-            if (parsed instanceof Map) {
-                Map<String, Object> map = (Map<String, Object>) parsed;
-                int maxId = 0;
-                for (Map.Entry<String, Object> entry : map.entrySet()) {
-                    int id = util.str2int(entry.getKey());
-                    if (entry.getValue() instanceof Map) {
-                        Map<String, String> schemaMap = (Map<String, String>) entry.getValue();
-                        String schema = schemaMap.get("schema");
-                        String type = schemaMap.getOrDefault("schemaType", AVRO_TYPE);
-                        if (schemaMap.containsKey("schema_type")) {
-                             type = schemaMap.get("schema_type");
-                        }
-                        
-                        idToSchema.put(id, new SchemaEntry(schema, type));
-                        hashToId.put(getHash(type + ":" + schema), id);
-                        if (id > maxId) {
-                            maxId = id;
-                        }
-                    }
-                }
-                if (maxId > 0) {
-                    idGenerator.set(maxId + 1);
-                }
-                log.info("Loaded {} schemas from disk. Next ID will be {}", idToSchema.size(), idGenerator.get());
+            if (!json.isEmpty()) {
+                loadEntries(json);
             }
         } catch (IOException e) {
             log.warn("Failed to load schemas from disk: {}", e.getMessage());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void loadEntries(String json) throws IOException {
+        Object parsed = org.platformlambda.core.serializers.SimpleMapper.getInstance()
+                .getMapper().readValue(json, Object.class);
+        if (!(parsed instanceof Map)) {
+            return;
+        }
+        int maxId = 0;
+        for (Map.Entry<String, Object> entry : ((Map<String, Object>) parsed).entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                int id = util.str2int(entry.getKey());
+                loadEntry(id, (Map<String, String>) entry.getValue());
+                maxId = Math.max(maxId, id);
+            }
+        }
+        if (maxId > 0) {
+            idGenerator.set(maxId + 1);
+        }
+        log.info("Loaded {} schemas from disk. Next ID will be {}", idToSchema.size(), idGenerator.get());
+    }
+
+    private void loadEntry(int id, Map<String, String> schemaMap) {
+        String schema = schemaMap.get("schema");
+        // accept either "schemaType" (canonical) or a legacy "schema_type"; default to AVRO.
+        String type = schemaMap.containsKey("schema_type")
+                ? schemaMap.get("schema_type")
+                : schemaMap.getOrDefault("schemaType", AVRO_TYPE);
+        idToSchema.put(id, new SchemaEntry(schema, type));
+        hashToId.put(getHash(type + ":" + schema), id);
     }
     
     private void saveToDisk() {

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-06-29T23:17:47Z | agent: Claude Code (2026-06-29-231747)
+- **last_session:** 2026-06-30T03:12:58Z | agent: Claude Code (2026-06-30-031258)
 - **last_review:** 2026-06-29 | through 2026-06-29-223651.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -83,15 +83,18 @@
   `AvroSchemaSerde` (`AvroConversions`: Map⇄GenericRecord, serialize walks the schema so absent fields take
   their defaults), `ProtobufSchemaSerde` (`ProtobufConversions`: Map⇄DynamicMessage reflectively, no codegen;
   proto3 implicit defaults). The codec dispatches by the `schema-type` header on produce / the registered
-  type on consume; producer + consumer are type-generic. **All three serdes (JSON + Avro + Protobuf) done,
-  tested (49 tests, 85% gate), and demoed end-to-end** (`EmbeddedSchemaRegistry` test helper +
-  sync-over-async-demo `json/avro/protobuf-topic-1/2` paths, all three manually validated via continuous-trace
-  telemetry). Only remaining task: document the schema headers in the kafka-flow-adapter guide (see
-  [[thread-schema-registry-avro-protobuf]]). Shipped alongside Kafka-flow-adapter hardening: a flow's own
-  `ttl` is the deadline (no `kafka.flow.timeout.ms`); success = HTTP 200, else retry→DLQ; a failed DLQ write
+  type on consume; producer + consumer are type-generic. **Thread-safety (2026-06-30):** the Confluent serdes
+  are NOT thread-safe, so `SchemaCodec` is a **factory** — `newEncoder()`/`newDecoder()` mint owner-confined
+  serde sets (serializers per producer worker-`instance`, deserializers per consumer), and
+  `simple.kafka.notification` is `@KernelThreadRunner` (the serdes use `synchronized` → would pin a VT carrier).
+  **All three serdes (JSON + Avro + Protobuf) done, tested (49 tests, 85% gate), demoed end-to-end, and
+  documented** (`EmbeddedSchemaRegistry` test helper + sync-over-async-demo `json/avro/protobuf-topic-1/2`
+  paths, all manually validated via continuous-trace telemetry; kafka-flow-adapter guide has the schema
+  section). Shipped alongside Kafka-flow-adapter hardening: a flow's own `ttl` is the deadline (no
+  `kafka.flow.timeout.ms`); success = HTTP < 400 (2xx/3xx), else retry→DLQ; a failed DLQ write
   drops-with-ERROR + commits (no recovery storm) bounded by `kafka.dlq.timeout.ms`. Builds on
   [[standalone-schema-registry-mock]].
-  <!-- id: minimalist-kafka-schema-registry | created: 2026-06-29 | last_used: 2026-06-29 | uses: 5 | tier: active | origin: 2026-06-29-010147 -->
+  <!-- id: minimalist-kafka-schema-registry | created: 2026-06-29 | last_used: 2026-06-30 | uses: 6 | tier: active | origin: 2026-06-29-010147 -->
 
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker
   returns.** `EventEmitter.traces` is keyed by `Thread.currentThread().threadId()+instance+route`, and

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-06-30T03:49:56Z | agent: Claude Code (2026-06-30-034956)
+- **last_session:** 2026-06-30T04:51:51Z | agent: Claude Code (2026-06-30-045151)
 - **last_review:** 2026-06-29 | through 2026-06-29-223651.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -87,14 +87,19 @@
   are NOT thread-safe, so `SchemaCodec` is a **factory** — `newEncoder()`/`newDecoder()` mint owner-confined
   serde sets (serializers per producer worker-`instance`, deserializers per consumer), and
   `simple.kafka.notification` is `@KernelThreadRunner` (the serdes use `synchronized` → would pin a VT carrier).
-  **All three serdes (JSON + Avro + Protobuf) done, tested (49 tests, 85% gate), demoed end-to-end, and
+  **Gotcha (fat jar only):** Confluent serdes resolve config classes (the default `context.name.strategy` →
+  `NullContextNameStrategy`) via the **thread context classloader**; building/using them off the app-classloader
+  thread (e.g. the `@KernelThreadRunner` ForkJoinPool worker) throws `ConfigException: ...could not be found`.
+  Fix: `SchemaCodec.withSerdeClassLoader(...)` pins `AbstractKafkaSchemaSerDeConfig`'s classloader as the TCCL
+  around build + serialize/decode. Flat-classpath unit tests can't reproduce it.
+  **All three serdes (JSON + Avro + Protobuf) done, tested (50 tests, 85% gate), demoed end-to-end, and
   documented** (`EmbeddedSchemaRegistry` test helper + sync-over-async-demo `json/avro/protobuf-topic-1/2`
   paths, all manually validated via continuous-trace telemetry; kafka-flow-adapter guide has the schema
   section). Shipped alongside Kafka-flow-adapter hardening: a flow's own `ttl` is the deadline (no
   `kafka.flow.timeout.ms`); success = HTTP < 400 (2xx/3xx), else retry→DLQ; a failed DLQ write
   drops-with-ERROR + commits (no recovery storm) bounded by `kafka.dlq.timeout.ms`. Builds on
   [[standalone-schema-registry-mock]].
-  <!-- id: minimalist-kafka-schema-registry | created: 2026-06-29 | last_used: 2026-06-30 | uses: 6 | tier: active | origin: 2026-06-29-010147 -->
+  <!-- id: minimalist-kafka-schema-registry | created: 2026-06-29 | last_used: 2026-06-30 | uses: 7 | tier: active | origin: 2026-06-29-010147 -->
 
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker
   returns.** `EventEmitter.traces` is keyed by `Thread.currentThread().threadId()+instance+route`, and

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-06-30T03:12:58Z | agent: Claude Code (2026-06-30-031258)
+- **last_session:** 2026-06-30T03:49:56Z | agent: Claude Code (2026-06-30-034956)
 - **last_review:** 2026-06-29 | through 2026-06-29-223651.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 

--- a/memory/sessions/2026-06-30-031258.md
+++ b/memory/sessions/2026-06-30-031258.md
@@ -1,0 +1,42 @@
+# Session (2026-06-30T03:12:58.000Z)
+
+**Agent:** Claude Code
+
+Resolved a batch of SonarQube + IDE findings Eric raised (with a `code-review.md` spec + screenshots)
+across three modules, on branch `chore/sonar-ide-cleanup` (off `main`). One architectural item, the rest
+mechanical. All green; PR pending (EMU blocks `gh` PR creation).
+
+## The one that mattered — serde thread-safety (commit `0d37022f`)
+- **Real bug, not a nit.** The Confluent serializers/deserializers are **not thread-safe**, but the codec
+  shared them: one serializer per schema-id across all 10 producer virtual-thread workers, and one
+  `volatile` deserializer across all consumer threads → races under load.
+- **Fix (Eric's design, confirmed via AskUserQuestion).** `SchemaCodec` became a **factory**: shared
+  thread-safe parts (cached registry client + `schemaTypeOf`) stay on the singleton; `newEncoder()` /
+  `newDecoder()` mint **owner-confined** serde sets. Producer keeps one `Encoder` per worker `instance`
+  (single-flight); consumer keeps one `Decoder` for its single poll thread. `@KernelThreadRunner` on
+  `simple.kafka.notification` (Confluent serdes use `synchronized` → would pin a VT carrier; kernel thread
+  avoids that). Dropped the volatile DCL in the serdes (confined → plain lazy), clearing the
+  "volatile not enough" flag. The S2095 on the field-stored serdes is a genuine false positive
+  (owner-lifetime, not method-local) → suppressed with rationale.
+
+## Mechanical (per the review)
+- minimalist-kafka: flow success `== 200` → `< 400` (2xx/3xx) + javadoc; enhanced `switch` + merge
+  `BYTES`/`FIXED` + `instanceof` pattern vars + rename `record` locals (Avro/Protobuf conversions);
+  `//`→`/* */` (KafkaFlowAutoStart); route comments → method Javadoc (EmbeddedSchemaRegistry); removed unused
+  `KafkaTestSupport.newProducer/newConsumer`; `assertThrows` single-invocation lambdas.
+- schema-registry-standalone (`7211f02c`): INFO/WARN access-log-style activity logs in Get/RegisterSchemaFunction
+  (schema-id + status, accepted + rejected); `SchemaStore` lost unused `JSON_TYPE` + `clear()`, and
+  `loadFromDisk` was split (cognitive complexity 21 → ≤15).
+- sync-over-async (`f6bfa769`): `ReturnRouteCoordinator` — moved the orphaned Javadoc onto the 3-arg
+  `awaitResponse` it actually documents (clears the dangling-Javadoc flag).
+- **Fixed test ports** (Eric's call: predictable > collision-proof): EmbeddedKafka 19092/19093 (mini) &
+  19192/19193 (soa, high to dodge a dev's local 9092), EmbeddedSchemaRegistry 18081, embedded Redis 16379.
+- Left as-is: typos (false positives, per Eric); `SchemaStore` "Singleton detected" (by design).
+
+## Validated
+- minimalist-kafka 49 + 85% gate; schema-registry-standalone 7; sync-over-async 32 + gate. Fixed ports
+  rebind cleanly across the sequential Redis/Kafka test classes (no BindException). Demo compiles against the
+  new `Encoder`/`Decoder` API. No stale `SchemaCodec.serialize/decode` callers.
+
+## Memory References
+- Referenced: [[minimalist-kafka-schema-registry]] (the codec these changes harden).

--- a/memory/sessions/2026-06-30-034956.md
+++ b/memory/sessions/2026-06-30-034956.md
@@ -1,0 +1,33 @@
+# Session (2026-06-30T03:49:56.000Z)
+
+**Agent:** Claude Code
+
+Continuation of the SonarQube/IDE cleanup (branch `chore/sonar-ide-cleanup`) — three review-follow-up
+polish rounds on the schema serdes, all driven by Eric's incremental review. Comment/structure only;
+49 minimalist-kafka tests stayed green throughout.
+
+## Rounds
+- **Eager `final` deserializers** (`5eb4e0f0`): each serde holds exactly one deserializer, so declare it
+  `final` + build it in the constructor (vs. lazy double-checked init) - simpler, safely published. Per-id
+  serializer map stays lazy. Trade-off accepted: an Encoder's serde eagerly builds a deserializer it never
+  uses (cheap - config only, no I/O/threads).
+- **`//` → Javadoc style** (`45c0ba28`): Eric clarified the IDE smell is *consecutive* `//` lines. Converted
+  those blocks to Javadoc and **dropped the serde `@SuppressWarnings(java:S2095)`** (after the eager-final
+  refactor the deserializer is a ctor-assigned final field → Sonar treats it as owned, so the suppression was
+  no longer earning its keep). Left pre-existing consecutive-`//` on unchanged lines alone (not new issues).
+- **Javadoc completeness** (`14d3d75d`): a `/**` block that documents a method must carry its
+  `@param`/`@return`/`@throws` - completed them across the schema package (SchemaCodec + Encoder/Decoder,
+  the 3 serdes, AvroConversions/ProtobufConversions, the SchemaSerde contract, SchemaType.from) +
+  EmbeddedSchemaRegistry.handle. One private test-helper Javadoc reverted to a single-line `//` (inline
+  S2095 rationale, not API doc).
+
+## Discussed (no code change)
+- Why a serializer-per-schema-id: `use.schema.id` is fixed at serializer construct time (no per-call
+  override in Confluent's API), and a topic can carry many ids (strategy-agnostic) → cache one per id.
+
+## State
+- Branch `chore/sonar-ide-cleanup` = 8 commits; minimalist-kafka 49 + 85% gate, schema-registry-standalone 7,
+  sync-over-async 32 + gate; all green. PR opened by Eric from the GitHub compare UI (EMU blocks `gh`).
+
+## Memory References
+- Referenced: [[minimalist-kafka-schema-registry]] (the codec these polish rounds refined).

--- a/memory/sessions/2026-06-30-045151.md
+++ b/memory/sessions/2026-06-30-045151.md
@@ -1,0 +1,37 @@
+# Session (2026-06-30T04:51:51.000Z)
+
+**Agent:** Claude Code
+
+Fixed a fat-jar-only regression from the SonarQube/IDE cleanup PR, surfaced by Eric's manual
+multi-terminal run. Branch `chore/sonar-ide-cleanup` (commit `99e010fc`). **All three wire formats
+(JSON, Avro, Protobuf) now confirmed working end-to-end by Eric** after the fix.
+
+## The bug — thread context classloader (TCCL) + @KernelThreadRunner
+- Symptom (fat jar only): `ConfigException: Invalid value io.confluent.kafka.serializers.context.
+  NullContextNameStrategy for configuration context.name.strategy: Class ... could not be found
+  [in thread "ForkJoinPool-1-worker-1"]`; on the first call it showed as a 408 (the failed publish
+  → `sync.await` timed out at 30s).
+- Root cause: Confluent serde config validation resolves classes (e.g. the default
+  `context.name.strategy` → `NullContextNameStrategy`) via the **thread context** classloader. This PR
+  changed serdes from "built once at startup on the platform thread (app classloader)" to
+  "built **per-owner, lazily, on the calling thread**" + put the producer under `@KernelThreadRunner`,
+  whose ForkJoinPool worker's TCCL is **not** the Spring Boot app classloader → class lookup fails.
+- Invisible to unit tests: surefire's flat classpath finds the class regardless of TCCL. It only bit the
+  fat jar (nested-jar `LaunchedURLClassLoader`).
+- Affected the **producer path for all three schema types** (the first serde built in `newEncoder()`),
+  not just Protobuf.
+
+## Fix
+- `SchemaCodec.withSerdeClassLoader(Supplier)`: pins `AbstractKafkaSchemaSerDeConfig.class.getClassLoader()`
+  (the classloader that has the Confluent serde classes) as the TCCL around serde build + serialize/decode,
+  restoring the caller's after. Wrapped `newEncoder`/`newDecoder`/`Encoder.serialize`/`Decoder.decode`.
+- New test asserts the TCCL is restored after serialize+decode (no leak of the serde classloader). 50 tests
+  green, coverage held.
+
+## Durable lesson
+Captured in [[minimalist-kafka-schema-registry]]: **Confluent serdes resolve config classes via the TCCL**,
+so any code that builds/uses them off the app-classloader thread (e.g. `@KernelThreadRunner`, a custom pool)
+must pin the serde classloader as the TCCL for the duration. Unit tests on a flat classpath won't catch it.
+
+## Memory References
+- Referenced: [[minimalist-kafka-schema-registry]]

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAutoStart.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAutoStart.java
@@ -67,8 +67,11 @@ public class KafkaFlowAutoStart implements EntryPoint {
                 new KafkaRequestPublisher(new KafkaProducer<>(KafkaClientConfig.producerProperties(config)));
         KafkaRuntime.setPublisher(publisher);
 
-        // Optional Confluent Schema Registry codec (null when schema.registry.url is not configured);
-        // shared by simple.kafka.notification (produce) and the flow adapter (consume).
+        /*
+         * Optional Confluent Schema Registry codec (null when schema.registry.url is not configured). A shared
+         * factory: simple.kafka.notification (produce) and the flow adapter (consume) each mint their own
+         * owner-confined encoder/decoder from it, since the Confluent serdes are not thread-safe.
+         */
         SchemaCodec schemaCodec = SchemaCodec.fromConfig(config);
         KafkaRuntime.setSchemaCodec(schemaCodec);
 

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -97,8 +97,11 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private final long dlqTimeout;   // confirm-write timeout for the dead-letter publish (broker ack)
     private final RetryPolicy retryPolicy;
     private final Integer partition;   // null = group-managed subscribe; non-null = pin this partition
-    // null = raw byte[] body; non-null = decode Confluent-framed value. Owned by this consumer's single poll
-    // thread (the Confluent deserializers are not thread-safe), minted from the shared SchemaCodec factory.
+    /**
+     * {@code null} = raw byte[] body; non-null = decode Confluent-framed values to a Map. Owned by this
+     * consumer's single poll thread (the Confluent deserializers are not thread-safe), minted from the shared
+     * {@link SchemaCodec} factory.
+     */
     private final SchemaCodec.Decoder decoder;
     private final String deadLetterTopic;
     private final ExecutorService loop;

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -62,9 +62,9 @@ import java.util.concurrent.TimeoutException;
  * offset stays uncommitted and Kafka redelivers the message to a surviving instance in the group - the
  * deliberate resilience-over-throughput tradeoff for the consume side.</p>
  *
- * <p><b>Flow outcome.</b> A flow <b>succeeds</b> when it replies with status 200; any other status - or a
- * thrown exception, including a timeout when it does not reply within its {@code ttl} (the flow's {@code ttl}
- * is the deadline, since Kafka has no inherent request timeout) - is a <b>failure</b>.</p>
+ * <p><b>Flow outcome.</b> A flow <b>succeeds</b> when it replies with a status below 400 (a 2xx/3xx); any
+ * 4xx/5xx status - or a thrown exception, including a timeout when it does not reply within its {@code ttl}
+ * (the flow's {@code ttl} is the deadline, since Kafka has no inherent request timeout) - is a <b>failure</b>.</p>
  *
  * <p><b>Flow-failure handling.</b> A failure is retried up to {@link RetryPolicy#maxRetries()} times; if it
  * still fails, the original message is routed to the per-topic dead-letter topic ({@code <topic><dlqSuffix>},
@@ -97,7 +97,9 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private final long dlqTimeout;   // confirm-write timeout for the dead-letter publish (broker ack)
     private final RetryPolicy retryPolicy;
     private final Integer partition;   // null = group-managed subscribe; non-null = pin this partition
-    private final SchemaCodec schemaCodec;   // null = raw byte[] body; non-null = decode Confluent-framed value
+    // null = raw byte[] body; non-null = decode Confluent-framed value. Owned by this consumer's single poll
+    // thread (the Confluent deserializers are not thread-safe), minted from the shared SchemaCodec factory.
+    private final SchemaCodec.Decoder decoder;
     private final String deadLetterTopic;
     private final ExecutorService loop;
 
@@ -112,7 +114,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
         this.dlqTimeout = dlqTimeout;
         this.retryPolicy = retryPolicy;
         this.partition = partition;
-        this.schemaCodec = schemaCodec;
+        this.decoder = schemaCodec == null ? null : schemaCodec.newDecoder();
         // per-topic DLQ; a blank suffix falls back to .dlq so the DLQ can never equal the source topic
         String suffix = retryPolicy.dlqSuffix();
         this.deadLetterTopic = topic + (suffix == null || suffix.isBlank() ? DLQ_SUFFIX : suffix);
@@ -171,11 +173,11 @@ public class KafkaFlowConsumer implements AutoCloseable {
      */
     boolean routeToFlow(ConsumerRecord<String, byte[]> consumerRecord) {
         Map<String, Object> dataset = toDataset(consumerRecord);
-        if (schemaCodec != null) {
+        if (decoder != null) {
             // Decode the Confluent-framed value to a Map for the flow. A decode failure is a poison
             // message (retrying won't help), so dead-letter the RAW record immediately.
             try {
-                dataset.put(BODY, schemaCodec.decode(topic, consumerRecord.value()));
+                dataset.put(BODY, decoder.decode(topic, consumerRecord.value()));
             } catch (RuntimeException e) {
                 log.warn("Failed to decode schema-framed message on '{}'; routing to {}",
                         topic, deadLetterTopic, e);
@@ -206,7 +208,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
     }
 
     /**
-     * Invoke the flow with bounded retry, then dead-letter. A failure is a non-200 reply or a thrown
+     * Invoke the flow with bounded retry, then dead-letter. A failure is a 4xx/5xx reply or a thrown
      * exception (flow/transport error, or a timeout when the flow does not reply within its ttl).
      *
      * @return whether the offset may be committed (see {@link #writeToDeadLetter}); false only on shutdown.
@@ -218,8 +220,8 @@ public class KafkaFlowConsumer implements AutoCloseable {
             Throwable cause;
             try {
                 EventEnvelope response = invokeFlow(forward, traceId, tracePath);
-                if (response.getStatus() == 200) {
-                    return true;   // the flow finished normally -> acknowledge (commit) and move on
+                if (response.getStatus() < 400) {
+                    return true;   // the flow finished normally (2xx/3xx) -> acknowledge (commit) and move on
                 }
                 cause = new IllegalStateException("flow " + flowId + " returned status " + response.getStatus());
             } catch (InterruptedException e) {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
@@ -18,6 +18,7 @@
 
 package org.platformlambda.mini.kafka;
 
+import org.platformlambda.core.annotations.KernelThreadRunner;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.models.TraceInfo;
 import org.platformlambda.core.models.TypedLambdaFunction;
@@ -32,6 +33,8 @@ import reactor.core.publisher.Mono;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Kafka Notification Function - a minimalist composable function that publishes a Post Office event to a
@@ -52,9 +55,20 @@ import java.util.Map;
  * (RPC) therefore learns whether the publish succeeded - a publish failure propagates back as an error -
  * while a {@code po.send} (async) caller simply doesn't observe it. The Mono is realized as {@code null}
  * (a {@code Void} body) on success.</p>
+ *
+ * <p><b>{@code @KernelThreadRunner}.</b> When the Schema Registry is used, this function builds Confluent
+ * serializers, which use {@code synchronized} internally and are not thread-safe. Running on a kernel thread
+ * (rather than a virtual thread) avoids pinning a virtual-thread carrier on those {@code synchronized}
+ * sections, and each worker instance is single-flight - so each instance keeps its <b>own</b>
+ * {@link SchemaCodec.Encoder} (in {@link #encoders}, keyed by instance), guaranteeing a Confluent serializer
+ * is never touched by two threads at once.</p>
  */
+@KernelThreadRunner
 @PreLoad(route = "simple.kafka.notification", instances = 10)
 public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono<Void>> {
+
+    // one Encoder per worker instance (an instance is single-flight) -> owner-confined Confluent serializers.
+    private final ConcurrentMap<Integer, SchemaCodec.Encoder> encoders = new ConcurrentHashMap<>();
 
     @Override
     public Mono<Void> handleEvent(Map<String, String> headers, byte[] body, int instance) {
@@ -78,16 +92,16 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
         if (traceparent != null) {
             kafkaHeaders.put(W3cTrace.TRACEPARENT, traceparent.getBytes(StandardCharsets.UTF_8));
         }
-        byte[] payload = encode(topic, headers, body);
+        byte[] payload = encode(topic, headers, body, instance);
         return KafkaRuntime.publisher().publish(topic, partition, kafkaHeaders, payload);
     }
 
     /**
-     * When a {@code schema-id} header is present, serialize the body into the Confluent wire format via the
-     * shared {@link SchemaCodec} (the schema is pre-registered; identified by id). Otherwise the body is
-     * published as raw byte[] - the default minimalist behavior.
+     * When a {@code schema-id} header is present, serialize the body into the Confluent wire format via this
+     * instance's own {@link SchemaCodec.Encoder} (the schema is pre-registered; identified by id). Otherwise
+     * the body is published as raw byte[] - the default minimalist behavior.
      */
-    private static byte[] encode(String topic, Map<String, String> headers, byte[] body) {
+    private byte[] encode(String topic, Map<String, String> headers, byte[] body, int instance) {
         String schemaId = headers.get(KafkaHeaders.SCHEMA_ID);
         if (schemaId == null) {
             return body;
@@ -104,7 +118,8 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
         SchemaType type = SchemaType.from(headers.get(KafkaHeaders.SCHEMA_TYPE));
         // The body is the structured value to encode (for JSON, a JSON document); parse it for the serializer.
         Object value = SimpleMapper.getInstance().getMapper().readValue(body, Object.class);
-        return codec.serialize(topic, type, Integer.parseInt(schemaId.trim()), value);
+        SchemaCodec.Encoder encoder = encoders.computeIfAbsent(instance, i -> codec.newEncoder());
+        return encoder.serialize(topic, type, Integer.parseInt(schemaId.trim()), value);
     }
 
     /** Build a W3C traceparent from this function's current trace context (null if tracing is off). */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
@@ -75,8 +75,7 @@ final class AvroConversions {
             if (map.containsKey(field.name())) {
                 genericRecord.put(field.pos(), toAvro(map.get(field.name()), field.schema()));
             } else {
-                // No value supplied: use the field's schema default (throws if the field has no default,
-                // which is the correct Avro behavior - a required field must be present).
+                // absent field -> its schema default (Avro throws if a no-default field is missing, as required)
                 genericRecord.put(field.pos(), GenericData.get().getDefaultValue(field));
             }
         }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
@@ -48,7 +48,13 @@ final class AvroConversions {
 
     private AvroConversions() { }
 
-    /** Build the Avro representation of {@code value} against {@code schema}, applying field defaults. */
+    /**
+     * Build the Avro representation of {@code value} against {@code schema}, applying field defaults.
+     *
+     * @param value  the plain Java value (a {@code Map} for a record, a {@code Collection} for an array, etc.)
+     * @param schema the Avro schema to build against
+     * @return the Avro object graph ({@code GenericRecord}, {@code GenericArray}, primitive, ...)
+     */
     static Object toAvro(Object value, Schema schema) {
         return switch (schema.getType()) {
             case RECORD -> toRecord(value, schema);
@@ -115,7 +121,12 @@ final class AvroConversions {
         return out;
     }
 
-    /** Render a decoded Avro value back to plain Java ({@code Map}/{@code List}/{@code String}/primitive). */
+    /**
+     * Render a decoded Avro value back to plain Java.
+     *
+     * @param value a decoded Avro value ({@code GenericRecord}, {@code Utf8}, {@code Collection}, primitive, ...)
+     * @return the plain-Java equivalent ({@code Map}/{@code List}/{@code String}/primitive)
+     */
     static Object fromAvro(Object value) {
         if (value instanceof GenericRecord genericRecord) {
             Map<String, Object> map = new LinkedHashMap<>();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroConversions.java
@@ -50,51 +50,37 @@ final class AvroConversions {
 
     /** Build the Avro representation of {@code value} against {@code schema}, applying field defaults. */
     static Object toAvro(Object value, Schema schema) {
-        switch (schema.getType()) {
-            case RECORD:
-                return toRecord(value, schema);
-            case UNION:
-                return toUnion(value, schema);
-            case ARRAY:
-                return toArray(value, schema);
-            case MAP:
-                return toMap(value, schema);
-            case ENUM:
-                return new GenericData.EnumSymbol(schema, String.valueOf(value));
-            case BYTES:
-            case FIXED:
-                return value instanceof byte[] bytes ? ByteBuffer.wrap(bytes) : value;
-            case STRING:
-                return value == null ? null : value.toString();
-            case INT:
-                return value instanceof Number n ? n.intValue() : value;
-            case LONG:
-                return value instanceof Number n ? n.longValue() : value;
-            case FLOAT:
-                return value instanceof Number n ? n.floatValue() : value;
-            case DOUBLE:
-                return value instanceof Number n ? n.doubleValue() : value;
-            default:
-                return value;   // BOOLEAN, NULL
-        }
+        return switch (schema.getType()) {
+            case RECORD -> toRecord(value, schema);
+            case UNION -> toUnion(value, schema);
+            case ARRAY -> toArray(value, schema);
+            case MAP -> toMap(value, schema);
+            case ENUM -> new GenericData.EnumSymbol(schema, String.valueOf(value));
+            case BYTES, FIXED -> value instanceof byte[] bytes ? ByteBuffer.wrap(bytes) : value;
+            case STRING -> value == null ? null : value.toString();
+            case INT -> value instanceof Number n ? n.intValue() : value;
+            case LONG -> value instanceof Number n ? n.longValue() : value;
+            case FLOAT -> value instanceof Number n ? n.floatValue() : value;
+            case DOUBLE -> value instanceof Number n ? n.doubleValue() : value;
+            default -> value;   // BOOLEAN, NULL
+        };
     }
 
     private static GenericRecord toRecord(Object value, Schema schema) {
-        if (!(value instanceof Map)) {
+        if (!(value instanceof Map<?, ?> map)) {
             throw new IllegalArgumentException("expected a Map for Avro record " + schema.getFullName());
         }
-        Map<?, ?> map = (Map<?, ?>) value;
-        GenericRecord record = new GenericData.Record(schema);
+        GenericRecord genericRecord = new GenericData.Record(schema);
         for (Schema.Field field : schema.getFields()) {
             if (map.containsKey(field.name())) {
-                record.put(field.pos(), toAvro(map.get(field.name()), field.schema()));
+                genericRecord.put(field.pos(), toAvro(map.get(field.name()), field.schema()));
             } else {
                 // No value supplied: use the field's schema default (throws if the field has no default,
                 // which is the correct Avro behavior - a required field must be present).
-                record.put(field.pos(), GenericData.get().getDefaultValue(field));
+                genericRecord.put(field.pos(), GenericData.get().getDefaultValue(field));
             }
         }
-        return record;
+        return genericRecord;
     }
 
     private static Object toUnion(Object value, Schema schema) {
@@ -111,10 +97,9 @@ final class AvroConversions {
     }
 
     private static GenericData.Array<Object> toArray(Object value, Schema schema) {
-        if (!(value instanceof Collection)) {
+        if (!(value instanceof Collection<?> items)) {
             throw new IllegalArgumentException("expected a Collection for Avro array");
         }
-        Collection<?> items = (Collection<?>) value;
         GenericData.Array<Object> array = new GenericData.Array<>(items.size(), schema);
         for (Object item : items) {
             array.add(toAvro(item, schema.getElementType()));
@@ -123,20 +108,20 @@ final class AvroConversions {
     }
 
     private static Map<String, Object> toMap(Object value, Schema schema) {
-        if (!(value instanceof Map)) {
+        if (!(value instanceof Map<?, ?> map)) {
             throw new IllegalArgumentException("expected a Map for Avro map");
         }
         Map<String, Object> out = new LinkedHashMap<>();
-        ((Map<?, ?>) value).forEach((k, v) -> out.put(String.valueOf(k), toAvro(v, schema.getValueType())));
+        map.forEach((k, v) -> out.put(String.valueOf(k), toAvro(v, schema.getValueType())));
         return out;
     }
 
     /** Render a decoded Avro value back to plain Java ({@code Map}/{@code List}/{@code String}/primitive). */
     static Object fromAvro(Object value) {
-        if (value instanceof GenericRecord record) {
+        if (value instanceof GenericRecord genericRecord) {
             Map<String, Object> map = new LinkedHashMap<>();
-            for (Schema.Field field : record.getSchema().getFields()) {
-                map.put(field.name(), fromAvro(record.get(field.pos())));
+            for (Schema.Field field : genericRecord.getSchema().getFields()) {
+                map.put(field.name(), fromAvro(genericRecord.get(field.pos())));
             }
             return map;
         }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
@@ -39,14 +39,18 @@ import java.util.concurrent.ConcurrentMap;
  * built against the pre-registered schema (resolved by id) - see {@link AvroConversions} - so a field absent
  * from the {@code Map} takes its schema default. On decode the deserializer yields a {@code GenericRecord}
  * (generic, not specific - no generated classes) which is rendered back to a {@code Map}.</p>
+ *
+ * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
+ * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
+ * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
  */
 class AvroSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time)
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
     private final ConcurrentMap<Integer, KafkaAvroSerializer> serializers = new ConcurrentHashMap<>();
-    private volatile KafkaAvroDeserializer deserializer;
+    private KafkaAvroDeserializer deserializer;
 
     AvroSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
@@ -55,8 +59,8 @@ class AvroSchemaSerde implements SchemaSerde {
 
     @Override
     public byte[] serialize(String topic, int schemaId, Object value) {
-        Object record = AvroConversions.toAvro(value, avroSchemaById(schemaId).rawSchema());
-        return serializers.computeIfAbsent(schemaId, this::newSerializer).serialize(topic, record);
+        Object avroRecord = AvroConversions.toAvro(value, avroSchemaById(schemaId).rawSchema());
+        return serializers.computeIfAbsent(schemaId, this::newSerializer).serialize(topic, avroRecord);
     }
 
     @Override
@@ -78,6 +82,9 @@ class AvroSchemaSerde implements SchemaSerde {
         }
     }
 
+    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
+    // closing it here would tear down a still-in-use serializer.
+    @SuppressWarnings("java:S2095")
     private KafkaAvroSerializer newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
@@ -90,15 +97,13 @@ class AvroSchemaSerde implements SchemaSerde {
         return new KafkaAvroSerializer(client, cfg);
     }
 
+    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
+    @SuppressWarnings("java:S2095")
     private KafkaAvroDeserializer deserializer() {
         if (deserializer == null) {
-            synchronized (this) {
-                if (deserializer == null) {
-                    Map<String, Object> cfg = new HashMap<>();
-                    cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-                    deserializer = new KafkaAvroDeserializer(client, cfg);
-                }
-            }
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+            deserializer = new KafkaAvroDeserializer(client, cfg);
         }
         return deserializer;
     }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
@@ -40,22 +40,19 @@ import java.util.concurrent.ConcurrentMap;
  * from the {@code Map} takes its schema default. On decode the deserializer yields a {@code GenericRecord}
  * (generic, not specific - no generated classes) which is rendered back to a {@code Map}.</p>
  *
- * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
- * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
- * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
+ * <p><b>Confinement &amp; lifetime.</b> The Confluent serdes are not thread-safe; one instance of this class
+ * is owned by a single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the serializers and
+ * deserializer are only ever touched by one thread - no synchronization needed. They are kept for the life of
+ * this serde (not per-call resources), so they are intentionally not closed here: the per-id serializers are
+ * cached lazily and the single deserializer is built eagerly in the constructor.</p>
  */
 class AvroSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
-    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaAvroSerializer> serializers = new ConcurrentHashMap<>();
     private final KafkaAvroDeserializer deserializer;
 
-    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
-    // owner-confined serde - not method-local resources - so they are not closed here.
-    @SuppressWarnings("java:S2095")
     AvroSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
@@ -89,16 +86,16 @@ class AvroSchemaSerde implements SchemaSerde {
         }
     }
 
-    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
-    // closing it here would tear down a still-in-use serializer.
-    @SuppressWarnings("java:S2095")
+    /**
+     * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
+     * GenericRecord is built against that exact schema, so strict compatibility checks against a value-derived
+     * schema are off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     */
     private KafkaAvroSerializer newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
         cfg.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.USE_SCHEMA_ID, schemaId);
-        // we serialize a pre-registered schema by id; the GenericRecord is built against that exact schema,
-        // so do not enforce strict compatibility checks against a schema derived from the value.
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaAvroSerializer(client, cfg);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
@@ -73,7 +73,13 @@ class AvroSchemaSerde implements SchemaSerde {
         return AvroConversions.fromAvro(deserializer.deserialize(topic, data));
     }
 
-    /** Resolve a pre-registered Avro schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
+    /**
+     * Resolve a pre-registered Avro schema by global id (cached by {@link FileCachedSchemaRegistryClient}).
+     *
+     * @param schemaId the global schema id
+     * @return the registered schema as an {@link AvroSchema}
+     * @throws IllegalStateException if the id is unresolvable or registered as a non-Avro type
+     */
     private AvroSchema avroSchemaById(int schemaId) {
         try {
             ParsedSchema schema = client.getSchemaById(schemaId);
@@ -90,6 +96,9 @@ class AvroSchemaSerde implements SchemaSerde {
      * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
      * GenericRecord is built against that exact schema, so strict compatibility checks against a value-derived
      * schema are off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     *
+     * @param schemaId the global schema id to pin via {@code use.schema.id}
+     * @return a serializer configured for that id
      */
     private KafkaAvroSerializer newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/AvroSchemaSerde.java
@@ -48,13 +48,20 @@ class AvroSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
+    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaAvroSerializer> serializers = new ConcurrentHashMap<>();
-    private KafkaAvroDeserializer deserializer;
+    private final KafkaAvroDeserializer deserializer;
 
+    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
+    // owner-confined serde - not method-local resources - so they are not closed here.
+    @SuppressWarnings("java:S2095")
     AvroSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+        this.deserializer = new KafkaAvroDeserializer(client, cfg);
     }
 
     @Override
@@ -66,7 +73,7 @@ class AvroSchemaSerde implements SchemaSerde {
     @Override
     public Object decode(String topic, byte[] data) {
         // generic reader (default) -> GenericRecord; render it to a plain Map for the flow body.
-        return AvroConversions.fromAvro(deserializer().deserialize(topic, data));
+        return AvroConversions.fromAvro(deserializer.deserialize(topic, data));
     }
 
     /** Resolve a pre-registered Avro schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
@@ -95,16 +102,5 @@ class AvroSchemaSerde implements SchemaSerde {
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaAvroSerializer(client, cfg);
-    }
-
-    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
-    @SuppressWarnings("java:S2095")
-    private KafkaAvroDeserializer deserializer() {
-        if (deserializer == null) {
-            Map<String, Object> cfg = new HashMap<>();
-            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-            deserializer = new KafkaAvroDeserializer(client, cfg);
-        }
-        return deserializer;
     }
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
@@ -39,6 +39,10 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * The {@link SchemaType#JSON} serde: wraps Confluent's {@link KafkaJsonSchemaSerializer}/
  * {@link KafkaJsonSchemaDeserializer}.
+ *
+ * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
+ * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
+ * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
  */
 class JsonSchemaSerde implements SchemaSerde {
 
@@ -46,9 +50,9 @@ class JsonSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time)
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
     private final ConcurrentMap<Integer, KafkaJsonSchemaSerializer<Object>> serializers = new ConcurrentHashMap<>();
-    private volatile KafkaJsonSchemaDeserializer<Object> deserializer;
+    private KafkaJsonSchemaDeserializer<Object> deserializer;
 
     JsonSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
@@ -84,6 +88,9 @@ class JsonSchemaSerde implements SchemaSerde {
         }
     }
 
+    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
+    // closing it here would tear down a still-in-use serializer.
+    @SuppressWarnings("java:S2095")
     private KafkaJsonSchemaSerializer<Object> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
@@ -96,15 +103,13 @@ class JsonSchemaSerde implements SchemaSerde {
         return new KafkaJsonSchemaSerializer<>(client, cfg);
     }
 
+    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
+    @SuppressWarnings("java:S2095")
     private KafkaJsonSchemaDeserializer<Object> deserializer() {
         if (deserializer == null) {
-            synchronized (this) {
-                if (deserializer == null) {
-                    Map<String, Object> cfg = new HashMap<>();
-                    cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-                    deserializer = new KafkaJsonSchemaDeserializer<>(client, cfg);
-                }
-            }
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+            deserializer = new KafkaJsonSchemaDeserializer<>(client, cfg);
         }
         return deserializer;
     }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
@@ -50,13 +50,20 @@ class JsonSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
+    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaJsonSchemaSerializer<Object>> serializers = new ConcurrentHashMap<>();
-    private KafkaJsonSchemaDeserializer<Object> deserializer;
+    private final KafkaJsonSchemaDeserializer<Object> deserializer;
 
+    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
+    // owner-confined serde - not method-local resources - so they are not closed here.
+    @SuppressWarnings("java:S2095")
     JsonSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+        this.deserializer = new KafkaJsonSchemaDeserializer<>(client, cfg);
     }
 
     @Override
@@ -72,7 +79,7 @@ class JsonSchemaSerde implements SchemaSerde {
 
     @Override
     public Object decode(String topic, byte[] data) {
-        return toMap(deserializer().deserialize(topic, data));
+        return toMap(deserializer.deserialize(topic, data));
     }
 
     /** Resolve a pre-registered JSON schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
@@ -101,17 +108,6 @@ class JsonSchemaSerde implements SchemaSerde {
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaJsonSchemaSerializer<>(client, cfg);
-    }
-
-    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
-    @SuppressWarnings("java:S2095")
-    private KafkaJsonSchemaDeserializer<Object> deserializer() {
-        if (deserializer == null) {
-            Map<String, Object> cfg = new HashMap<>();
-            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-            deserializer = new KafkaJsonSchemaDeserializer<>(client, cfg);
-        }
-        return deserializer;
     }
 
     /** Normalize the deserializer output to a {@code Map} for the flow dataset body. */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
@@ -40,9 +40,11 @@ import java.util.concurrent.ConcurrentMap;
  * The {@link SchemaType#JSON} serde: wraps Confluent's {@link KafkaJsonSchemaSerializer}/
  * {@link KafkaJsonSchemaDeserializer}.
  *
- * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
- * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
- * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
+ * <p><b>Confinement &amp; lifetime.</b> The Confluent serdes are not thread-safe; one instance of this class
+ * is owned by a single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the serializers and
+ * deserializer are only ever touched by one thread - no synchronization needed. They are kept for the life of
+ * this serde (not per-call resources), so they are intentionally not closed here: the per-id serializers are
+ * cached lazily and the single deserializer is built eagerly in the constructor.</p>
  */
 class JsonSchemaSerde implements SchemaSerde {
 
@@ -50,14 +52,9 @@ class JsonSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
-    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaJsonSchemaSerializer<Object>> serializers = new ConcurrentHashMap<>();
     private final KafkaJsonSchemaDeserializer<Object> deserializer;
 
-    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
-    // owner-confined serde - not method-local resources - so they are not closed here.
-    @SuppressWarnings("java:S2095")
     JsonSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
@@ -68,10 +65,12 @@ class JsonSchemaSerde implements SchemaSerde {
 
     @Override
     public byte[] serialize(String topic, int schemaId, Object value) {
-        // Envelope the value with its (pre-registered) schema, so the serializer uses that schema directly
-        // instead of DERIVING one from the value's Map<String,Object> type - the derivation can't introspect
-        // the Object-typed map values (noisy "Unable to process java.lang.Object" warnings) and is wasted
-        // work. use.schema.id still pins the wire id and resolves via getSchemaById (no subject lookup).
+        /*
+         * Envelope the value with its (pre-registered) schema, so the serializer uses that schema directly
+         * instead of DERIVING one from the value's Map<String,Object> type - the derivation can't introspect
+         * the Object-typed map values (noisy "Unable to process java.lang.Object" warnings) and is wasted
+         * work. use.schema.id still pins the wire id and resolves via getSchemaById (no subject lookup).
+         */
         JsonNode node = JSON.valueToTree(value);
         Object enveloped = JsonSchemaUtils.envelope(jsonSchemaById(schemaId), node);
         return serializers.computeIfAbsent(schemaId, this::newSerializer).serialize(topic, enveloped);
@@ -95,16 +94,16 @@ class JsonSchemaSerde implements SchemaSerde {
         }
     }
 
-    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
-    // closing it here would tear down a still-in-use serializer.
-    @SuppressWarnings("java:S2095")
+    /**
+     * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
+     * registered schema is authoritative, so strict compatibility checks against a value-derived schema are
+     * off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     */
     private KafkaJsonSchemaSerializer<Object> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
         cfg.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.USE_SCHEMA_ID, schemaId);
-        // we serialize a pre-registered schema by id; do not enforce strict compatibility checks against
-        // a schema derived from the value (the registered schema is authoritative).
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaJsonSchemaSerializer<>(client, cfg);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
@@ -81,7 +81,13 @@ class JsonSchemaSerde implements SchemaSerde {
         return toMap(deserializer.deserialize(topic, data));
     }
 
-    /** Resolve a pre-registered JSON schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
+    /**
+     * Resolve a pre-registered JSON schema by global id (cached by {@link FileCachedSchemaRegistryClient}).
+     *
+     * @param schemaId the global schema id
+     * @return the registered schema as a {@link JsonSchema}
+     * @throws IllegalStateException if the id is unresolvable or registered as a non-JSON type
+     */
     private JsonSchema jsonSchemaById(int schemaId) {
         try {
             ParsedSchema schema = client.getSchemaById(schemaId);
@@ -98,6 +104,9 @@ class JsonSchemaSerde implements SchemaSerde {
      * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
      * registered schema is authoritative, so strict compatibility checks against a value-derived schema are
      * off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     *
+     * @param schemaId the global schema id to pin via {@code use.schema.id}
+     * @return a serializer configured for that id
      */
     private KafkaJsonSchemaSerializer<Object> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufConversions.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufConversions.java
@@ -46,7 +46,15 @@ final class ProtobufConversions {
 
     private ProtobufConversions() { }
 
-    /** Build a {@link DynamicMessage} for {@code value} against {@code descriptor}. */
+    /**
+     * Build a {@link DynamicMessage} for {@code value} against {@code descriptor}.
+     *
+     * @param value      the message as a {@code Map} of field-name to value
+     * @param descriptor the message descriptor to build against
+     * @return the populated {@link DynamicMessage}
+     * @throws IllegalArgumentException if {@code value} is not a {@code Map}, or a repeated field is not a
+     *                                  {@code Collection}
+     */
     static DynamicMessage toMessage(Object value, Descriptor descriptor) {
         if (!(value instanceof Map<?, ?> map)) {
             throw new IllegalArgumentException("expected a Map for protobuf message " + descriptor.getFullName());
@@ -85,7 +93,12 @@ final class ProtobufConversions {
         };
     }
 
-    /** Render a decoded protobuf {@link Message} back to a plain {@code Map}. */
+    /**
+     * Render a decoded protobuf {@link Message} back to a plain {@code Map}.
+     *
+     * @param message the decoded protobuf message
+     * @return the message as a {@code Map} of field-name to plain-Java value
+     */
     static Map<String, Object> fromMessage(Message message) {
         Map<String, Object> out = new LinkedHashMap<>();
         for (FieldDescriptor field : message.getDescriptorForType().getFields()) {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufConversions.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufConversions.java
@@ -48,10 +48,9 @@ final class ProtobufConversions {
 
     /** Build a {@link DynamicMessage} for {@code value} against {@code descriptor}. */
     static DynamicMessage toMessage(Object value, Descriptor descriptor) {
-        if (!(value instanceof Map)) {
+        if (!(value instanceof Map<?, ?> map)) {
             throw new IllegalArgumentException("expected a Map for protobuf message " + descriptor.getFullName());
         }
-        Map<?, ?> map = (Map<?, ?>) value;
         DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
         for (FieldDescriptor field : descriptor.getFields()) {
             Object fieldValue = map.get(field.getName());
@@ -73,26 +72,17 @@ final class ProtobufConversions {
     }
 
     private static Object toField(Object value, FieldDescriptor field) {
-        switch (field.getJavaType()) {
-            case INT:
-                return value instanceof Number n ? n.intValue() : value;
-            case LONG:
-                return value instanceof Number n ? n.longValue() : value;
-            case FLOAT:
-                return value instanceof Number n ? n.floatValue() : value;
-            case DOUBLE:
-                return value instanceof Number n ? n.doubleValue() : value;
-            case STRING:
-                return String.valueOf(value);
-            case BYTE_STRING:
-                return value instanceof byte[] bytes ? ByteString.copyFrom(bytes) : value;
-            case ENUM:
-                return field.getEnumType().findValueByName(String.valueOf(value));
-            case MESSAGE:
-                return toMessage(value, field.getMessageType());
-            default:
-                return value;   // BOOLEAN
-        }
+        return switch (field.getJavaType()) {
+            case INT -> value instanceof Number n ? n.intValue() : value;
+            case LONG -> value instanceof Number n ? n.longValue() : value;
+            case FLOAT -> value instanceof Number n ? n.floatValue() : value;
+            case DOUBLE -> value instanceof Number n ? n.doubleValue() : value;
+            case STRING -> String.valueOf(value);
+            case BYTE_STRING -> value instanceof byte[] bytes ? ByteString.copyFrom(bytes) : value;
+            case ENUM -> field.getEnumType().findValueByName(String.valueOf(value));
+            case MESSAGE -> toMessage(value, field.getMessageType());
+            default -> value;   // BOOLEAN
+        };
     }
 
     /** Render a decoded protobuf {@link Message} back to a plain {@code Map}. */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
@@ -43,22 +43,19 @@ import java.util.concurrent.ConcurrentMap;
  * rendered back to a {@code Map}. (Confluent's protobuf wire format adds a message-index header after the
  * id; the serde handles that framing - this codec only reads the leading magic byte + global id.)</p>
  *
- * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
- * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
- * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
+ * <p><b>Confinement &amp; lifetime.</b> The Confluent serdes are not thread-safe; one instance of this class
+ * is owned by a single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the serializers and
+ * deserializer are only ever touched by one thread - no synchronization needed. They are kept for the life of
+ * this serde (not per-call resources), so they are intentionally not closed here: the per-id serializers are
+ * cached lazily and the single deserializer is built eagerly in the constructor.</p>
  */
 class ProtobufSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
-    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaProtobufSerializer<Message>> serializers = new ConcurrentHashMap<>();
     private final KafkaProtobufDeserializer<Message> deserializer;
 
-    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
-    // owner-confined serde - not method-local resources - so they are not closed here.
-    @SuppressWarnings("java:S2095")
     ProtobufSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
@@ -93,16 +90,16 @@ class ProtobufSchemaSerde implements SchemaSerde {
         }
     }
 
-    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
-    // closing it here would tear down a still-in-use serializer.
-    @SuppressWarnings("java:S2095")
+    /**
+     * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
+     * DynamicMessage is built against that exact schema, so strict compatibility checks against a value-derived
+     * schema are off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     */
     private KafkaProtobufSerializer<Message> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
         cfg.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.USE_SCHEMA_ID, schemaId);
-        // we serialize a pre-registered schema by id; the DynamicMessage is built against that exact schema,
-        // so do not enforce strict compatibility checks against a schema derived from the value.
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaProtobufSerializer<>(client, cfg);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
@@ -51,13 +51,21 @@ class ProtobufSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined,
+    // lazily populated per id. There is only ever one deserializer, so it is built eagerly.
     private final ConcurrentMap<Integer, KafkaProtobufSerializer<Message>> serializers = new ConcurrentHashMap<>();
-    private KafkaProtobufDeserializer<Message> deserializer;
+    private final KafkaProtobufDeserializer<Message> deserializer;
 
+    // S2095: the deserializer (and the per-id serializers in newSerializer) are kept for the life of this
+    // owner-confined serde - not method-local resources - so they are not closed here.
+    @SuppressWarnings("java:S2095")
     ProtobufSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+        // no specific.protobuf.value.type -> deserialize to a generic DynamicMessage
+        this.deserializer = new KafkaProtobufDeserializer<>(client, cfg);
     }
 
     @Override
@@ -69,7 +77,7 @@ class ProtobufSchemaSerde implements SchemaSerde {
     @Override
     public Object decode(String topic, byte[] data) {
         // generic reader -> DynamicMessage; render it to a plain Map for the flow body.
-        return ProtobufConversions.fromMessage(deserializer().deserialize(topic, data));
+        return ProtobufConversions.fromMessage(deserializer.deserialize(topic, data));
     }
 
     /** Resolve a pre-registered Protobuf schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
@@ -98,17 +106,5 @@ class ProtobufSchemaSerde implements SchemaSerde {
         cfg.put(AbstractKafkaSchemaSerDeConfig.ID_COMPATIBILITY_STRICT, false);
         cfg.put(AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false);
         return new KafkaProtobufSerializer<>(client, cfg);
-    }
-
-    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
-    @SuppressWarnings("java:S2095")
-    private KafkaProtobufDeserializer<Message> deserializer() {
-        if (deserializer == null) {
-            Map<String, Object> cfg = new HashMap<>();
-            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-            // no specific.protobuf.value.type -> deserialize to a generic DynamicMessage
-            deserializer = new KafkaProtobufDeserializer<>(client, cfg);
-        }
-        return deserializer;
     }
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
@@ -77,7 +77,13 @@ class ProtobufSchemaSerde implements SchemaSerde {
         return ProtobufConversions.fromMessage(deserializer.deserialize(topic, data));
     }
 
-    /** Resolve a pre-registered Protobuf schema by global id (cached by {@link FileCachedSchemaRegistryClient}). */
+    /**
+     * Resolve a pre-registered Protobuf schema by global id (cached by {@link FileCachedSchemaRegistryClient}).
+     *
+     * @param schemaId the global schema id
+     * @return the registered schema as a {@link ProtobufSchema}
+     * @throws IllegalStateException if the id is unresolvable or registered as a non-Protobuf type
+     */
     private ProtobufSchema protobufSchemaById(int schemaId) {
         try {
             ParsedSchema schema = client.getSchemaById(schemaId);
@@ -94,6 +100,9 @@ class ProtobufSchemaSerde implements SchemaSerde {
      * Build the serializer for {@code schemaId}, pinned to that global id via {@code use.schema.id} (the
      * DynamicMessage is built against that exact schema, so strict compatibility checks against a value-derived
      * schema are off, and auto-register is off). Cached and reused for the life of this serde - one per id.
+     *
+     * @param schemaId the global schema id to pin via {@code use.schema.id}
+     * @return a serializer configured for that id
      */
     private KafkaProtobufSerializer<Message> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ProtobufSchemaSerde.java
@@ -42,14 +42,18 @@ import java.util.concurrent.ConcurrentMap;
  * so no generated classes are needed. On decode the deserializer yields a {@code DynamicMessage} which is
  * rendered back to a {@code Map}. (Confluent's protobuf wire format adds a message-index header after the
  * id; the serde handles that framing - this codec only reads the leading magic byte + global id.)</p>
+ *
+ * <p><b>Confinement.</b> The Confluent serdes are not thread-safe; one instance of this class is owned by a
+ * single-flight {@link SchemaCodec.Encoder}/{@link SchemaCodec.Decoder}, so the cached serializers (per id)
+ * and the lazily-built deserializer are only ever touched by one thread - no synchronization needed.</p>
  */
 class ProtobufSchemaSerde implements SchemaSerde {
 
     private final SchemaRegistryClient client;
     private final String registryUrl;
-    // one serializer per global schema id (use.schema.id is fixed at configure time)
+    // one serializer per global schema id (use.schema.id is fixed at configure time); owner-confined
     private final ConcurrentMap<Integer, KafkaProtobufSerializer<Message>> serializers = new ConcurrentHashMap<>();
-    private volatile KafkaProtobufDeserializer<Message> deserializer;
+    private KafkaProtobufDeserializer<Message> deserializer;
 
     ProtobufSchemaSerde(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
@@ -81,6 +85,9 @@ class ProtobufSchemaSerde implements SchemaSerde {
         }
     }
 
+    // S2095: the serializer is cached for the life of this owner-confined serde (not a method-local resource);
+    // closing it here would tear down a still-in-use serializer.
+    @SuppressWarnings("java:S2095")
     private KafkaProtobufSerializer<Message> newSerializer(int schemaId) {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
@@ -93,16 +100,14 @@ class ProtobufSchemaSerde implements SchemaSerde {
         return new KafkaProtobufSerializer<>(client, cfg);
     }
 
+    // S2095: the deserializer is cached for the life of this owner-confined serde (see newSerializer).
+    @SuppressWarnings("java:S2095")
     private KafkaProtobufDeserializer<Message> deserializer() {
         if (deserializer == null) {
-            synchronized (this) {
-                if (deserializer == null) {
-                    Map<String, Object> cfg = new HashMap<>();
-                    cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
-                    // no specific.protobuf.value.type -> deserialize to a generic DynamicMessage
-                    deserializer = new KafkaProtobufDeserializer<>(client, cfg);
-                }
-            }
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
+            // no specific.protobuf.value.type -> deserialize to a generic DynamicMessage
+            deserializer = new KafkaProtobufDeserializer<>(client, cfg);
         }
         return deserializer;
     }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -77,14 +77,23 @@ public class SchemaCodec {
     }
 
     /**
-     * Build a codec from application config, or return {@code null} when {@code schema.registry.url} is not
-     * set (schema features simply stay off - the library keeps its raw byte[] behavior).
+     * Build a codec from application config (schema features stay off when {@code schema.registry.url} is
+     * unset - the library keeps its raw byte[] behavior).
+     *
+     * @param config the application configuration (read for {@code schema.registry.url} and the cache settings)
+     * @return a codec, or {@code null} when {@code schema.registry.url} is unset/blank
      */
     public static SchemaCodec fromConfig(AppConfigReader config) {
         return fromConfig(config, config.getProperty(REGISTRY_URL));
     }
 
-    /** Build a codec for an explicit registry URL (used by tests); {@code null}/blank URL ⇒ {@code null}. */
+    /**
+     * Build a codec for an explicit registry URL (used by tests).
+     *
+     * @param config      configuration source for the cache dir/TTL settings
+     * @param registryUrl the Schema Registry URL; a {@code null}/blank value disables schema features
+     * @return a codec, or {@code null} when {@code registryUrl} is {@code null}/blank
+     */
     public static SchemaCodec fromConfig(ConfigBase config, String registryUrl) {
         if (registryUrl == null || registryUrl.isBlank()) {
             return null;
@@ -109,7 +118,9 @@ public class SchemaCodec {
         return new SchemaCodec(client, registryUrl);
     }
 
-    /** A fresh, owner-confined serde set (one {@link SchemaSerde} per type) over the shared registry client. */
+    /**
+     * @return a fresh, owner-confined serde set (one {@link SchemaSerde} per type) over the shared client
+     */
     private Map<SchemaType, SchemaSerde> newSerdes() {
         Map<SchemaType, SchemaSerde> serdes = new EnumMap<>(SchemaType.class);
         serdes.put(SchemaType.JSON, new JsonSchemaSerde(client, registryUrl));
@@ -118,27 +129,44 @@ public class SchemaCodec {
         return serdes;
     }
 
-    /** Mint an {@link Encoder} for one producer owner (e.g. one {@code simple.kafka.notification} instance). */
+    /**
+     * @return a new {@link Encoder} for one producer owner (e.g. one {@code simple.kafka.notification} instance)
+     */
     public Encoder newEncoder() {
         return new Encoder(newSerdes());
     }
 
-    /** Mint a {@link Decoder} for one consumer owner (one {@link org.platformlambda.mini.kafka.KafkaFlowConsumer}). */
+    /**
+     * @return a new {@link Decoder} for one consumer owner (one
+     *         {@link org.platformlambda.mini.kafka.KafkaFlowConsumer})
+     */
     public Decoder newDecoder() {
         return new Decoder(this, newSerdes());
     }
 
-    /** True if the bytes are Confluent-framed (magic byte + 4-byte id + payload). */
+    /**
+     * @param data the bytes to inspect (may be {@code null})
+     * @return {@code true} if the bytes are Confluent-framed (magic byte + 4-byte id + payload)
+     */
     public static boolean isFramed(byte[] data) {
         return data != null && data.length >= 5 && data[0] == MAGIC_BYTE;
     }
 
-    /** The global schema id embedded in framed bytes. */
+    /**
+     * @param data Confluent-framed bytes (see {@link #isFramed})
+     * @return the global schema id embedded in the frame
+     */
     public static int schemaId(byte[] data) {
         return ByteBuffer.wrap(data, 1, 4).getInt();
     }
 
-    /** Look up the registered {@code schemaType} for a global id (shared, thread-safe, disk-cached). */
+    /**
+     * Look up the registered {@code schemaType} for a global id (shared, thread-safe, disk-cached).
+     *
+     * @param id the global schema id
+     * @return the schema's {@link SchemaType}
+     * @throws IllegalStateException if the id cannot be resolved against the registry
+     */
     SchemaType schemaTypeOf(int id) {
         try {
             ParsedSchema schema = client.getSchemaById(id);
@@ -156,7 +184,11 @@ public class SchemaCodec {
         return serde;
     }
 
-    /** Visible for tests: the shared registry client (file-cached). */
+    /**
+     * Visible for tests.
+     *
+     * @return the shared (file-cached) registry client
+     */
     public SchemaRegistryClient client() {
         return client;
     }
@@ -175,6 +207,13 @@ public class SchemaCodec {
         /**
          * Serialize using the serde for {@code type}. The schema is fetched by id and NOT registered
          * (auto-register off), so no subject/strategy is involved.
+         *
+         * @param topic    the destination topic (a serde may derive its subject from it)
+         * @param type     the schema type that selects the serde
+         * @param schemaId the pre-registered global schema id to frame with
+         * @param value    the value to serialize (typically a {@code Map})
+         * @return the Confluent-framed bytes
+         * @throws UnsupportedOperationException if {@code type} has no registered serde
          */
         public byte[] serialize(String topic, SchemaType type, int schemaId, Object value) {
             return serde(serdes, type).serialize(topic, schemaId, value);
@@ -195,8 +234,13 @@ public class SchemaCodec {
         }
 
         /**
-         * Read the embedded id, look up the registered {@code schemaType}, and dispatch to the matching serde,
-         * returning a {@code Map}. Throws for unframed bytes or a schema type not yet supported.
+         * Read the embedded id, look up the registered {@code schemaType}, and dispatch to the matching serde.
+         *
+         * @param topic the source topic
+         * @param data  the Confluent-framed bytes
+         * @return the decoded value as a {@code Map}
+         * @throws IllegalArgumentException      if {@code data} is not Confluent-framed
+         * @throws UnsupportedOperationException if the embedded schema type has no registered serde
          */
         public Object decode(String topic, byte[] data) {
             if (!isFramed(data)) {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -92,9 +92,11 @@ public class SchemaCodec {
         File cacheDir = new File(config.getProperty(CACHE_DIR, DEFAULT_CACHE_DIR));
         long ttlMillis = 1000L * Utility.getInstance()
                 .getDurationInSeconds(config.getProperty(CACHE_TTL, DEFAULT_CACHE_TTL));
-        // The schema cache is rebuildable from the registry, so clear it at startup - a stale entry (e.g.
-        // after the registry's schemas changed between runs) is never served. It re-populates on demand and
-        // TTL-expires within the run. (Unlike the registry's data store, a cache has no durable mode.)
+        /*
+         * The schema cache is rebuildable from the registry, so clear it at startup - a stale entry (e.g.
+         * after the registry's schemas changed between runs) is never served. It re-populates on demand and
+         * TTL-expires within the run. (Unlike the registry's data store, a cache has no durable mode.)
+         */
         Utility.getInstance().cleanupDir(cacheDir);
         Map<String, Object> srConfig = new HashMap<>();
         srConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -38,6 +38,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Bridges the minimalist {@code byte[]} Kafka transport to the Confluent Schema Registry wire format
@@ -68,12 +69,33 @@ public class SchemaCodec {
     private static final int IDENTITY_MAP_CAPACITY = 1000;
     private static final byte MAGIC_BYTE = 0x0;
 
+    /**
+     * The classloader that loaded the Confluent serde classes. Confluent's config validation resolves classes
+     * (e.g. the default {@code context.name.strategy} → {@code NullContextNameStrategy}) via the <b>thread
+     * context</b> classloader. When the producer runs on a {@code @KernelThreadRunner} pool thread - whose
+     * context classloader is not the application's - that lookup fails, so a serde build/use is wrapped with
+     * {@link #withSerdeClassLoader} to set this for the duration of the call and restore the previous one after.
+     */
+    private static final ClassLoader SERDE_CLASSLOADER = AbstractKafkaSchemaSerDeConfig.class.getClassLoader();
+
     private final SchemaRegistryClient client;
     private final String registryUrl;
 
     SchemaCodec(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
         this.registryUrl = registryUrl;
+    }
+
+    /** Run {@code action} with the Confluent serde classloader as the thread context classloader. */
+    private static <T> T withSerdeClassLoader(Supplier<T> action) {
+        Thread thread = Thread.currentThread();
+        ClassLoader previous = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(SERDE_CLASSLOADER);
+            return action.get();
+        } finally {
+            thread.setContextClassLoader(previous);
+        }
     }
 
     /**
@@ -133,7 +155,7 @@ public class SchemaCodec {
      * @return a new {@link Encoder} for one producer owner (e.g. one {@code simple.kafka.notification} instance)
      */
     public Encoder newEncoder() {
-        return new Encoder(newSerdes());
+        return withSerdeClassLoader(() -> new Encoder(newSerdes()));
     }
 
     /**
@@ -141,7 +163,7 @@ public class SchemaCodec {
      *         {@link org.platformlambda.mini.kafka.KafkaFlowConsumer})
      */
     public Decoder newDecoder() {
-        return new Decoder(this, newSerdes());
+        return withSerdeClassLoader(() -> new Decoder(this, newSerdes()));
     }
 
     /**
@@ -216,7 +238,7 @@ public class SchemaCodec {
          * @throws UnsupportedOperationException if {@code type} has no registered serde
          */
         public byte[] serialize(String topic, SchemaType type, int schemaId, Object value) {
-            return serde(serdes, type).serialize(topic, schemaId, value);
+            return withSerdeClassLoader(() -> serde(serdes, type).serialize(topic, schemaId, value));
         }
     }
 
@@ -246,7 +268,7 @@ public class SchemaCodec {
             if (!isFramed(data)) {
                 throw new IllegalArgumentException("payload is not Confluent schema-framed (missing magic byte)");
             }
-            return serde(serdes, codec.schemaTypeOf(schemaId(data))).decode(topic, data);
+            return withSerdeClassLoader(() -> serde(serdes, codec.schemaTypeOf(schemaId(data))).decode(topic, data));
         }
     }
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -44,15 +44,18 @@ import java.util.Map;
  * ({@code [magic 0x00][4-byte global id][payload]}) using Confluent's <b>own</b> serializers as a library -
  * no reinvented codec.
  *
- * <p><b>Produce</b> ({@link #serialize}) is driven by a caller-supplied global {@code schemaId} (schemas are
+ * <p><b>Produce</b> ({@link Encoder}) is driven by a caller-supplied global {@code schemaId} (schemas are
  * pre-registered; the producer never computes a subject or registers), so it is subject-naming-strategy
- * agnostic and a topic can carry many record types. <b>Consume</b> ({@link #decode}) reads the embedded id,
+ * agnostic and a topic can carry many record types. <b>Consume</b> ({@link Decoder}) reads the embedded id,
  * looks up the registered schema's {@code schemaType}, and dispatches to the matching deserializer.</p>
  *
- * <p>Each {@link SchemaType} is handled by a {@link SchemaSerde} kept in {@link #serdes}; this codec just
- * picks one (by the {@code schema-type} header on produce, by the registered type on consume). JSON, Avro,
- * and Protobuf are wired. The shared {@link SchemaRegistryClient} is a {@link FileCachedSchemaRegistryClient},
- * so schema lookups by id are cached on disk (TTL-bounded).</p>
+ * <p><b>Thread model.</b> The Confluent serializers/deserializers are <b>not thread-safe</b>, so this codec is
+ * a <b>factory</b>, not a shared (de)serializer holder: the shared, thread-safe parts - the
+ * {@link FileCachedSchemaRegistryClient} (id→schema lookups, disk-cached) and {@link #schemaTypeOf} - stay on
+ * the singleton, while {@link #newEncoder()} / {@link #newDecoder()} mint <b>owner-confined</b> serde sets. A
+ * producer keeps one {@link Encoder} per worker instance (an instance is single-flight); a consumer keeps one
+ * {@link Decoder} for its single poll thread. So a given Confluent serializer/deserializer is only ever
+ * touched by one thread at a time. JSON, Avro, and Protobuf are wired.</p>
  */
 public class SchemaCodec {
     private static final Logger log = LoggerFactory.getLogger(SchemaCodec.class);
@@ -66,11 +69,11 @@ public class SchemaCodec {
     private static final byte MAGIC_BYTE = 0x0;
 
     private final SchemaRegistryClient client;
-    private final Map<SchemaType, SchemaSerde> serdes;
+    private final String registryUrl;
 
-    SchemaCodec(SchemaRegistryClient client, Map<SchemaType, SchemaSerde> serdes) {
+    SchemaCodec(SchemaRegistryClient client, String registryUrl) {
         this.client = client;
-        this.serdes = serdes;
+        this.registryUrl = registryUrl;
     }
 
     /**
@@ -99,13 +102,28 @@ public class SchemaCodec {
                 IDENTITY_MAP_CAPACITY,
                 List.of(new JsonSchemaProvider(), new AvroSchemaProvider(), new ProtobufSchemaProvider()),
                 srConfig, cacheDir, ttlMillis);
+        log.info("Schema codec ready (registry={}, cache={}, ttlMs={}, types={})",
+                registryUrl, cacheDir, ttlMillis, List.of(SchemaType.values()));
+        return new SchemaCodec(client, registryUrl);
+    }
+
+    /** A fresh, owner-confined serde set (one {@link SchemaSerde} per type) over the shared registry client. */
+    private Map<SchemaType, SchemaSerde> newSerdes() {
         Map<SchemaType, SchemaSerde> serdes = new EnumMap<>(SchemaType.class);
         serdes.put(SchemaType.JSON, new JsonSchemaSerde(client, registryUrl));
         serdes.put(SchemaType.AVRO, new AvroSchemaSerde(client, registryUrl));
         serdes.put(SchemaType.PROTOBUF, new ProtobufSchemaSerde(client, registryUrl));
-        log.info("Schema codec ready (registry={}, cache={}, ttlMs={}, types={})",
-                registryUrl, cacheDir, ttlMillis, serdes.keySet());
-        return new SchemaCodec(client, serdes);
+        return serdes;
+    }
+
+    /** Mint an {@link Encoder} for one producer owner (e.g. one {@code simple.kafka.notification} instance). */
+    public Encoder newEncoder() {
+        return new Encoder(newSerdes());
+    }
+
+    /** Mint a {@link Decoder} for one consumer owner (one {@link org.platformlambda.mini.kafka.KafkaFlowConsumer}). */
+    public Decoder newDecoder() {
+        return new Decoder(this, newSerdes());
     }
 
     /** True if the bytes are Confluent-framed (magic byte + 4-byte id + payload). */
@@ -118,36 +136,8 @@ public class SchemaCodec {
         return ByteBuffer.wrap(data, 1, 4).getInt();
     }
 
-    /**
-     * Serialize a value into the Confluent wire format for a known global schema id, dispatching to the
-     * serde for {@code type}. The schema is fetched from the registry by id and NOT registered
-     * (auto-register off), so no subject/strategy is involved.
-     */
-    public byte[] serialize(String topic, SchemaType type, int schemaId, Object value) {
-        return serde(type).serialize(topic, schemaId, value);
-    }
-
-    /**
-     * Decode Confluent-framed bytes: read the embedded id, look up the registered {@code schemaType}, and
-     * dispatch to the matching serde, returning a {@code Map}. Throws for unframed bytes or a schema type
-     * not yet supported.
-     */
-    public Object decode(String topic, byte[] data) {
-        if (!isFramed(data)) {
-            throw new IllegalArgumentException("payload is not Confluent schema-framed (missing magic byte)");
-        }
-        return serde(schemaTypeOf(schemaId(data))).decode(topic, data);
-    }
-
-    private SchemaSerde serde(SchemaType type) {
-        SchemaSerde serde = serdes.get(type);
-        if (serde == null) {
-            throw new UnsupportedOperationException("schema-type " + type + " is not yet supported");
-        }
-        return serde;
-    }
-
-    private SchemaType schemaTypeOf(int id) {
+    /** Look up the registered {@code schemaType} for a global id (shared, thread-safe, disk-cached). */
+    SchemaType schemaTypeOf(int id) {
         try {
             ParsedSchema schema = client.getSchemaById(id);
             return SchemaType.from(schema.schemaType());
@@ -156,8 +146,61 @@ public class SchemaCodec {
         }
     }
 
+    private static SchemaSerde serde(Map<SchemaType, SchemaSerde> serdes, SchemaType type) {
+        SchemaSerde serde = serdes.get(type);
+        if (serde == null) {
+            throw new UnsupportedOperationException("schema-type " + type + " is not yet supported");
+        }
+        return serde;
+    }
+
     /** Visible for tests: the shared registry client (file-cached). */
     public SchemaRegistryClient client() {
         return client;
+    }
+
+    /**
+     * Owner-confined producer codec: serialize a value into the Confluent wire format for a known global
+     * schema id. Not thread-safe by itself - hold one per single-flight owner (see {@link SchemaCodec}).
+     */
+    public static final class Encoder {
+        private final Map<SchemaType, SchemaSerde> serdes;
+
+        Encoder(Map<SchemaType, SchemaSerde> serdes) {
+            this.serdes = serdes;
+        }
+
+        /**
+         * Serialize using the serde for {@code type}. The schema is fetched by id and NOT registered
+         * (auto-register off), so no subject/strategy is involved.
+         */
+        public byte[] serialize(String topic, SchemaType type, int schemaId, Object value) {
+            return serde(serdes, type).serialize(topic, schemaId, value);
+        }
+    }
+
+    /**
+     * Owner-confined consumer codec: decode Confluent-framed bytes by their embedded id. Not thread-safe by
+     * itself - hold one per single-threaded owner (see {@link SchemaCodec}).
+     */
+    public static final class Decoder {
+        private final SchemaCodec codec;
+        private final Map<SchemaType, SchemaSerde> serdes;
+
+        Decoder(SchemaCodec codec, Map<SchemaType, SchemaSerde> serdes) {
+            this.codec = codec;
+            this.serdes = serdes;
+        }
+
+        /**
+         * Read the embedded id, look up the registered {@code schemaType}, and dispatch to the matching serde,
+         * returning a {@code Map}. Throws for unframed bytes or a schema type not yet supported.
+         */
+        public Object decode(String topic, byte[] data) {
+            if (!isFramed(data)) {
+                throw new IllegalArgumentException("payload is not Confluent schema-framed (missing magic byte)");
+            }
+            return serde(serdes, codec.schemaTypeOf(schemaId(data))).decode(topic, data);
+        }
     }
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaSerde.java
@@ -30,12 +30,21 @@ interface SchemaSerde {
     /**
      * Serialize {@code value} (typically a {@code Map}) into the Confluent wire format for a pre-registered
      * global {@code schemaId}, using this type's Confluent serializer ({@code use.schema.id}, no auto-register).
+     *
+     * @param topic    the destination topic (a serde may derive its subject from it)
+     * @param schemaId the pre-registered global schema id to frame with
+     * @param value    the value to serialize
+     * @return the Confluent-framed bytes
      */
     byte[] serialize(String topic, int schemaId, Object value);
 
     /**
      * Decode Confluent-framed bytes (the embedded id selected this serde) back into a plain {@code Map} for
      * the flow dataset body.
+     *
+     * @param topic the source topic
+     * @param data  the Confluent-framed bytes
+     * @return the decoded value (a {@code Map})
      */
     Object decode(String topic, byte[] data);
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaType.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaType.java
@@ -29,7 +29,13 @@ public enum SchemaType {
     AVRO,
     PROTOBUF;
 
-    /** Parse a type name case-insensitively; {@code null}/blank defaults to {@link #JSON}. */
+    /**
+     * Parse a type name case-insensitively.
+     *
+     * @param value the type name (e.g. {@code "AVRO"}); {@code null}/blank defaults to {@link #JSON}
+     * @return the matching {@link SchemaType}
+     * @throws IllegalArgumentException if {@code value} is non-blank but not a known type
+     */
     public static SchemaType from(String value) {
         if (value == null || value.isBlank()) {
             return JSON;

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedKafka.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedKafka.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
-import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,13 +37,16 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Embedded single-node KRaft Kafka broker for integration tests. Allocates dynamic broker/controller
- * ports and a private temp log directory ({@code /tmp/mini-kafka}), formatted with the official KRaft
- * {@link Formatter} (the legacy meta.properties format is invalid on Kafka 4.x). Cleaned up on close.
+ * Embedded single-node KRaft Kafka broker for integration tests. Uses <b>fixed</b> broker/controller ports
+ * (predictable: if a port is already in use the test fails fast rather than picking a surprise port) and a
+ * private temp log directory ({@code /tmp/mini-kafka}), formatted with the official KRaft {@link Formatter}
+ * (the legacy meta.properties format is invalid on Kafka 4.x). Cleaned up on close.
  */
 final class EmbeddedKafka implements AutoCloseable {
 
     private static final int NODE_ID = 1;
+    private static final int BROKER_PORT = 19092;
+    private static final int CONTROLLER_PORT = 19093;
     private static final String CONTROLLER_LISTENER = "CONTROLLER";
     private static final String LOG_DIR = "/tmp/mini-kafka";
 
@@ -54,13 +56,11 @@ final class EmbeddedKafka implements AutoCloseable {
 
     EmbeddedKafka() {
         try {
-            int brokerPort = freePort();
-            int controllerPort = freePort();
-            this.bootstrapServers = "127.0.0.1:" + brokerPort;
+            this.bootstrapServers = "127.0.0.1:" + BROKER_PORT;
             this.logDir = prepareLogDir();
             formatStorage(logDir);
             this.server = new KafkaRaftServer(
-                    new KafkaConfig(brokerConfig(brokerPort, controllerPort, logDir)), Time.SYSTEM);
+                    new KafkaConfig(brokerConfig(BROKER_PORT, CONTROLLER_PORT, logDir)), Time.SYSTEM);
             this.server.startup();
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to start embedded Kafka", e);
@@ -111,12 +111,6 @@ final class EmbeddedKafka implements AutoCloseable {
                     .run();
         } catch (Exception e) {
             throw new IllegalStateException("Unable to format embedded Kafka storage", e);
-        }
-    }
-
-    private static int freePort() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
         }
     }
 

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
@@ -85,6 +85,9 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
      *   <li>{@code GET /schemas/ids/{id}} - {@link #getById}</li>
      * </ul>
      * Anything else is logged + answered 404.
+     *
+     * @param exchange the HTTP exchange to route and respond to
+     * @throws IOException if writing the response fails
      */
     private void handle(com.sun.net.httpserver.HttpExchange exchange) throws IOException {
         try {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
@@ -53,6 +53,8 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
     private static final String SCHEMA = "schema";
     private static final String SCHEMA_TYPE = "schemaType";
     private static final String AVRO = "AVRO";
+    // fixed port (predictable: if it is in use the test fails fast rather than picking a surprise port)
+    private static final int PORT = 18081;
 
     private final HttpServer server;
     private final AtomicInteger idGenerator = new AtomicInteger(1);
@@ -60,7 +62,7 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
     private final ConcurrentMap<Integer, Map<String, Object>> idToSchema = new ConcurrentHashMap<>();
 
     public EmbeddedSchemaRegistry() throws IOException {
-        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", PORT), 0);
         server.createContext("/", this::handle);
         server.start();
         log.info("Embedded schema registry on {}", baseUrl());
@@ -75,18 +77,24 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
         server.stop(0);
     }
 
+    /**
+     * Route by method + path to the matching Confluent endpoint handler:
+     * <ul>
+     *   <li>{@code POST /subjects/{subject}/versions} - {@link #register}</li>
+     *   <li>{@code POST /subjects/{subject}} - {@link #lookup} (lookup a schema under a subject)</li>
+     *   <li>{@code GET /schemas/ids/{id}} - {@link #getById}</li>
+     * </ul>
+     * Anything else is logged + answered 404.
+     */
     private void handle(com.sun.net.httpserver.HttpExchange exchange) throws IOException {
         try {
             String method = exchange.getRequestMethod();
             String path = exchange.getRequestURI().getPath();
             String[] p = path.split("/");
-            // /subjects/{subject}/versions  (register)
             if ("POST".equals(method) && p.length == 4 && "subjects".equals(p[1]) && "versions".equals(p[3])) {
                 register(exchange);
-            // /subjects/{subject}  (lookup a schema under a subject)
             } else if ("POST".equals(method) && p.length == 3 && "subjects".equals(p[1])) {
                 lookup(exchange, decode(p[2]));
-            // /schemas/ids/{id}
             } else if ("GET".equals(method) && p.length == 4 && "schemas".equals(p[1]) && "ids".equals(p[2])) {
                 getById(exchange, Utility.getInstance().str2int(p[3]));
             } else {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
@@ -44,7 +44,7 @@ class KafkaFlowAdapterConfigTest {
         return reader;
     }
 
-    /** S2095: the constructor throws during config validation, so no adapter escapes to be closed (and if one ever did, the assertThrows would fail). */
+    // S2095: the constructor throws during config validation, so no adapter escapes to be closed (and if one ever did, the assertThrows would fail).
     @SuppressWarnings("java:S2095")
     private static void build(ConfigReader config) {
         // consumer props are unused: every case here fails validation before any consumer is built

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
@@ -44,6 +44,9 @@ class KafkaFlowAdapterConfigTest {
         return reader;
     }
 
+    // S2095: the constructor is expected to throw during config validation, so no adapter instance escapes to
+    // be closed; if it ever returned one (a bug), the test's assertThrows would fail anyway.
+    @SuppressWarnings("java:S2095")
     private static void build(ConfigReader config) {
         // consumer props are unused: every case here fails validation before any consumer is built
         new KafkaFlowAdapter(new Properties(), config, 1000, POLICY, null);
@@ -58,28 +61,32 @@ class KafkaFlowAdapterConfigTest {
 
     @Test
     void rejectsEmptyConsumerList() {
-        assertThrows(IllegalArgumentException.class, () -> build(config(List.of())));
+        ConfigReader config = config(List.of());
+        assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
     @Test
     void rejectsNonMapEntry() {
-        assertThrows(IllegalArgumentException.class, () -> build(config(List.of("just-a-string"))));
+        ConfigReader config = config(List.of("just-a-string"));
+        assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
     @Test
     void rejectsEntryMissingTopic() {
-        assertThrows(IllegalArgumentException.class, () -> build(config(List.of(Map.of("flow", "f")))));
+        ConfigReader config = config(List.of(Map.of("flow", "f")));
+        assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
     @Test
     void rejectsEntryMissingFlow() {
-        assertThrows(IllegalArgumentException.class, () -> build(config(List.of(Map.of("topic", "t")))));
+        ConfigReader config = config(List.of(Map.of("topic", "t")));
+        assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
     @Test
     void rejectsBlankTopic() {
-        assertThrows(IllegalArgumentException.class,
-                () -> build(config(List.of(Map.of("topic", "  ", "flow", "f")))));
+        ConfigReader config = config(List.of(Map.of("topic", "  ", "flow", "f")));
+        assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
@@ -44,8 +44,7 @@ class KafkaFlowAdapterConfigTest {
         return reader;
     }
 
-    // S2095: the constructor is expected to throw during config validation, so no adapter instance escapes to
-    // be closed; if it ever returned one (a bug), the test's assertThrows would fail anyway.
+    /** S2095: the constructor throws during config validation, so no adapter escapes to be closed (and if one ever did, the assertThrows would fail). */
     @SuppressWarnings("java:S2095")
     private static void build(ConfigReader config) {
         // consumer props are unused: every case here fails validation before any consumer is built

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaTestSupport.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaTestSupport.java
@@ -21,16 +21,6 @@ package org.platformlambda.mini.kafka;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.List;
 import java.util.Properties;
@@ -39,32 +29,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Shared Kafka client factory helpers for the integration tests. The wire contract matches the
- * building blocks: {@code key=String}, {@code value=byte[]}.
+ * Shared Kafka admin helper for the integration tests (the producer/consumer go through the library's own
+ * publisher + flow adapter, so the wire contract - {@code key=String}, {@code value=byte[]} - is exercised
+ * there, not here).
  */
 final class KafkaTestSupport {
 
     private KafkaTestSupport() {}
-
-    static Producer<String, byte[]> newProducer(String bootstrapServers) {
-        Properties p = new Properties();
-        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-        p.put(ProducerConfig.ACKS_CONFIG, "all");
-        return new KafkaProducer<>(p);
-    }
-
-    static Consumer<String, byte[]> newConsumer(String bootstrapServers, String groupId) {
-        Properties p = new Properties();
-        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        p.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        p.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        return new KafkaConsumer<>(p);
-    }
 
     static void createTopic(String bootstrapServers, String topic)
             throws InterruptedException, ExecutionException, TimeoutException {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
@@ -43,6 +43,8 @@ import org.platformlambda.mini.kafka.schema.SchemaCodec;
 import org.platformlambda.mini.kafka.schema.SchemaType;
 
 import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +52,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -207,5 +210,24 @@ class SchemaCodecTest {
     void disabledWhenNoRegistryUrl() {
         assertNull(SchemaCodec.fromConfig(AppConfigReader.getInstance(), "  "),
                 "blank registry url ⇒ schema features off");
+    }
+
+    @Test
+    void serializeDecodeRestoreThreadContextClassLoader() throws Exception {
+        // Guards the @KernelThreadRunner classloader fix: serde build/use pins the Confluent serde classloader
+        // as the thread context classloader, then must restore the caller's - never leak SERDE_CLASSLOADER.
+        int id = codec.client().register(TOPIC + "-tccl-value", new JsonSchema(JSON_SCHEMA));
+        Thread thread = Thread.currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        ClassLoader sentinel = new URLClassLoader(new URL[0], original);
+        try {
+            thread.setContextClassLoader(sentinel);
+            byte[] framed = encoder.serialize(TOPIC, SchemaType.JSON, id, Map.of("hello", "tccl"));
+            assertEquals("tccl", ((Map<?, ?>) decoder.decode(TOPIC, framed)).get("hello"));
+            assertSame(sentinel, thread.getContextClassLoader(),
+                    "serialize/decode restore the caller's thread context classloader");
+        } finally {
+            thread.setContextClassLoader(original);
+        }
     }
 }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
@@ -18,6 +18,8 @@
 
 package org.platformlambda.mini.kafka;
 
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
@@ -29,8 +31,6 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.Message;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -47,13 +47,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Validates the {@link SchemaCodec} against the real Confluent JSON Schema serdes and a self-contained,
+ * Validates the {@link SchemaCodec} (and its owner-confined {@link SchemaCodec.Encoder}/
+ * {@link SchemaCodec.Decoder}) against the real Confluent JSON/Avro/Protobuf serdes and a self-contained,
  * in-JVM {@link EmbeddedSchemaRegistry} (no Kafka broker, no AutoStart, no network beyond loopback):
  * id-driven serialize, magic-id dispatch + decode to a Map, on-disk schema cache, and - critically -
- * decoding messages produced by a stock {@code KafkaJsonSchemaSerializer} (interop with client projects).
+ * decoding messages produced by stock Confluent serializers (interop with client projects).
  */
 class SchemaCodecTest {
 
@@ -68,6 +73,8 @@ class SchemaCodecTest {
 
     private static EmbeddedSchemaRegistry registry;
     private static SchemaCodec codec;
+    private static SchemaCodec.Encoder encoder;
+    private static SchemaCodec.Decoder decoder;
     private static File cacheDir;
 
     @BeforeAll
@@ -77,6 +84,8 @@ class SchemaCodecTest {
         cacheDir = new File(config.getProperty("schema.registry.cache.dir", "/tmp/schema-registry-cache-test"));
         Utility.getInstance().cleanupDir(cacheDir);   // transient /tmp cache: start clean
         codec = SchemaCodec.fromConfig(config, registry.baseUrl());
+        encoder = codec.newEncoder();
+        decoder = codec.newDecoder();
     }
 
     @AfterAll
@@ -91,11 +100,11 @@ class SchemaCodecTest {
     void serializeByIdThenDecodeRoundTrips() throws Exception {
         int id = codec.client().register(TOPIC + "-value", new JsonSchema(JSON_SCHEMA));
 
-        byte[] framed = codec.serialize(TOPIC, SchemaType.JSON, id, Map.of("hello", "world"));
+        byte[] framed = encoder.serialize(TOPIC, SchemaType.JSON, id, Map.of("hello", "world"));
         assertTrue(SchemaCodec.isFramed(framed), "output is Confluent-framed (magic byte + id)");
         assertEquals(id, SchemaCodec.schemaId(framed), "the framed id matches the pre-registered schema");
 
-        Object decoded = codec.decode(TOPIC, framed);
+        Object decoded = decoder.decode(TOPIC, framed);
         assertInstanceOf(Map.class, decoded);
         assertEquals("world", ((Map<?, ?>) decoded).get("hello"));
 
@@ -103,7 +112,7 @@ class SchemaCodecTest {
     }
 
     @Test
-    void decodesMessageFromStockConfluentSerializer() throws Exception {
+    void decodesMessageFromStockConfluentSerializer() {
         // External-client stand-in: a stock KafkaJsonSchemaSerializer that auto-registers from the value.
         CachedSchemaRegistryClient srClient = new CachedSchemaRegistryClient(List.of(registry.baseUrl()),
                 100, List.of(new JsonSchemaProvider()), Map.of());
@@ -112,7 +121,7 @@ class SchemaCodecTest {
         cfg.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true);
         try (KafkaJsonSchemaSerializer<Object> serializer = new KafkaJsonSchemaSerializer<>(srClient, cfg)) {
             byte[] framed = serializer.serialize(TOPIC, Map.of("hello", "external"));
-            Object decoded = codec.decode(TOPIC, framed);
+            Object decoded = decoder.decode(TOPIC, framed);
             assertInstanceOf(Map.class, decoded);
             assertEquals("external", ((Map<?, ?>) decoded).get("hello"),
                     "minimalist-kafka decodes messages produced by a stock Confluent serializer");
@@ -123,11 +132,11 @@ class SchemaCodecTest {
     void serializeAvroByIdThenDecodeRoundTrips() throws Exception {
         int id = codec.client().register(TOPIC + "-avro-value", new AvroSchema(AVRO_SCHEMA));
 
-        byte[] framed = codec.serialize(TOPIC, SchemaType.AVRO, id, Map.of("hello", "avro"));
+        byte[] framed = encoder.serialize(TOPIC, SchemaType.AVRO, id, Map.of("hello", "avro"));
         assertTrue(SchemaCodec.isFramed(framed), "output is Confluent-framed (magic byte + id)");
         assertEquals(id, SchemaCodec.schemaId(framed), "the framed id matches the pre-registered schema");
 
-        Object decoded = codec.decode(TOPIC, framed);
+        Object decoded = decoder.decode(TOPIC, framed);
         assertInstanceOf(Map.class, decoded);
         assertEquals("avro", ((Map<?, ?>) decoded).get("hello"));
 
@@ -135,18 +144,18 @@ class SchemaCodecTest {
     }
 
     @Test
-    void decodesMessageFromStockConfluentAvroSerializer() throws Exception {
+    void decodesMessageFromStockConfluentAvroSerializer() {
         // External-client stand-in: a stock KafkaAvroSerializer that auto-registers from the GenericRecord.
         CachedSchemaRegistryClient srClient = new CachedSchemaRegistryClient(List.of(registry.baseUrl()),
                 100, List.of(new AvroSchemaProvider()), Map.of());
         Map<String, Object> cfg = new HashMap<>();
         cfg.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registry.baseUrl());
         cfg.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true);
-        GenericRecord record = new GenericData.Record(new Schema.Parser().parse(AVRO_SCHEMA));
-        record.put("hello", "external-avro");
+        GenericRecord greeting = new GenericData.Record(new Schema.Parser().parse(AVRO_SCHEMA));
+        greeting.put("hello", "external-avro");
         try (KafkaAvroSerializer serializer = new KafkaAvroSerializer(srClient, cfg)) {
-            byte[] framed = serializer.serialize(TOPIC, record);
-            Object decoded = codec.decode(TOPIC, framed);
+            byte[] framed = serializer.serialize(TOPIC, greeting);
+            Object decoded = decoder.decode(TOPIC, framed);
             assertInstanceOf(Map.class, decoded);
             assertEquals("external-avro", ((Map<?, ?>) decoded).get("hello"),
                     "minimalist-kafka decodes Avro messages produced by a stock Confluent serializer");
@@ -157,11 +166,11 @@ class SchemaCodecTest {
     void serializeProtobufByIdThenDecodeRoundTrips() throws Exception {
         int id = codec.client().register(TOPIC + "-proto-value", new ProtobufSchema(PROTO_SCHEMA));
 
-        byte[] framed = codec.serialize(TOPIC, SchemaType.PROTOBUF, id, Map.of("hello", "protobuf"));
+        byte[] framed = encoder.serialize(TOPIC, SchemaType.PROTOBUF, id, Map.of("hello", "protobuf"));
         assertTrue(SchemaCodec.isFramed(framed), "output is Confluent-framed (magic byte + id)");
         assertEquals(id, SchemaCodec.schemaId(framed), "the framed id matches the pre-registered schema");
 
-        Object decoded = codec.decode(TOPIC, framed);
+        Object decoded = decoder.decode(TOPIC, framed);
         assertInstanceOf(Map.class, decoded);
         assertEquals("protobuf", ((Map<?, ?>) decoded).get("hello"));
 
@@ -169,7 +178,7 @@ class SchemaCodecTest {
     }
 
     @Test
-    void decodesMessageFromStockConfluentProtobufSerializer() throws Exception {
+    void decodesMessageFromStockConfluentProtobufSerializer() {
         // External-client stand-in: a stock KafkaProtobufSerializer that auto-registers from the message.
         CachedSchemaRegistryClient srClient = new CachedSchemaRegistryClient(List.of(registry.baseUrl()),
                 100, List.of(new ProtobufSchemaProvider()), Map.of());
@@ -181,7 +190,7 @@ class SchemaCodecTest {
                 .setField(schema.toDescriptor().findFieldByName("hello"), "external-proto").build();
         try (KafkaProtobufSerializer<Message> serializer = new KafkaProtobufSerializer<>(srClient, cfg)) {
             byte[] framed = serializer.serialize(TOPIC, message);
-            Object decoded = codec.decode(TOPIC, framed);
+            Object decoded = decoder.decode(TOPIC, framed);
             assertInstanceOf(Map.class, decoded);
             assertEquals("external-proto", ((Map<?, ?>) decoded).get("hello"),
                     "minimalist-kafka decodes Protobuf messages produced by a stock Confluent serializer");
@@ -190,7 +199,8 @@ class SchemaCodecTest {
 
     @Test
     void rejectsUnframedPayload() {
-        assertThrows(IllegalArgumentException.class, () -> codec.decode(TOPIC, "{\"hello\":\"x\"}".getBytes()));
+        byte[] unframed = "{\"hello\":\"x\"}".getBytes();
+        assertThrows(IllegalArgumentException.class, () -> decoder.decode(TOPIC, unframed));
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecDispatchTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecDispatchTest.java
@@ -26,17 +26,18 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Covers the {@link SchemaCodec} dispatch guard: a {@link SchemaType} with no registered {@link SchemaSerde}
- * fails clearly rather than silently mis-encoding. Uses the package-private constructor with an empty serde
- * map so no registry is needed. (All three types are wired in production via {@code fromConfig}; this guards
- * the path should a future type be requested before its serde lands.)
+ * Covers the {@link SchemaCodec.Encoder} dispatch guard: a {@link SchemaType} with no registered
+ * {@link SchemaSerde} fails clearly rather than silently mis-encoding. Uses the package-private constructor
+ * with an empty serde map so no registry is needed. (All three types are wired in production via
+ * {@code newEncoder()}; this guards the path should a future type be requested before its serde lands.)
  */
 class SchemaCodecDispatchTest {
 
     @Test
-    void serializeWithNoSerdeForTypeThrows() {
-        SchemaCodec codec = new SchemaCodec(null, new EnumMap<>(SchemaType.class));
+    void encodeWithNoSerdeForTypeThrows() {
+        SchemaCodec.Encoder encoder = new SchemaCodec.Encoder(new EnumMap<>(SchemaType.class));
+        Map<String, Object> value = Map.of("a", "b");
         assertThrows(UnsupportedOperationException.class,
-                () -> codec.serialize("topic", SchemaType.JSON, 1, Map.of("a", "b")));
+                () -> encoder.serialize("topic", SchemaType.JSON, 1, value));
     }
 }


### PR DESCRIPTION
## What

Resolves the SonarQube/IDE review findings on the freshly-merged Schema Registry code, across three modules.

**minimalist-kafka — thread-safety (the substantive change).** The Confluent serializers/deserializers are
not thread-safe, but the codec shared them: one serializer per schema-id across all 10 producer
virtual-thread workers, and one `volatile` deserializer across all consumer threads. `SchemaCodec` is now a
**factory** — the shared, thread-safe parts (cached registry client + `schemaTypeOf`) stay on the singleton,
while `newEncoder()`/`newDecoder()` mint **owner-confined** serde sets: one `Encoder` per producer worker
instance (single-flight), one `Decoder` per consumer poll thread. `simple.kafka.notification` is now
`@KernelThreadRunner`, and each serde holds eager-`final` deserializers (one per serde) + a lazy per-id
serializer map.

**Mechanical Sonar/IDE fixes.** Flow success `==200` → `<400` (2xx/3xx) + Javadoc; enhanced `switch` + merged
`BYTES`/`FIXED` cases + `instanceof` pattern variables + renamed `record` locals (Avro/Protobuf conversions);
consecutive-`//` blocks → Javadoc/`/* */`, with complete `@param`/`@return`/`@throws` on the documented
methods; removed unused `KafkaTestSupport.newProducer/newConsumer`; single-invocation `assertThrows` lambdas;
dropped the serde `@SuppressWarnings(java:S2095)` (after the eager-final refactor those are owned fields).

**schema-registry-standalone.** Access-log-style INFO/WARN activity logs (schema-id + status, accepted +
rejected) in `GetSchemaFunction`/`RegisterSchemaFunction`; removed unused `JSON_TYPE` + `clear()`; split
`loadFromDisk` to drop cognitive complexity 21 → ≤15.

**sync-over-async.** Moved an orphaned Javadoc onto the `awaitResponse` overload it documents (clears the
dangling-Javadoc flag).

**Tests.** Fixed (predictable) ports for the embedded servers — Kafka `19092/19093` & `19192/19193` (high, to
avoid a dev's local `9092`), Schema Registry `18081`, Redis `16379`.

Classloader fix (@KernelThreadRunner): Confluent serde config validation resolves classes via the thread context classloader, which isn't the app classloader on the kernel-thread pool; SchemaCodec now pins the serde classloader around build + serialize/decode (withSerdeClassLoader) and restores it. Manifests only on the fat jar; a regression test asserts the TCCL is restored.

## Why

Eric's review flagged a genuine concurrency hazard, not just style: under load, two threads hitting the same
shared Confluent serde race (those classes use internal `synchronized` and aren't safe to share). Owner
confinement + `@KernelThreadRunner` make every serde single-threaded by construction and keep the blocking
serde work off the virtual-thread event loop. The remaining items pay down the SonarQube/IDE debt on the new
schema code so the quality gate stays clean for the rigid client CI/CD pipelines. All three modules build
green (minimalist-kafka 49 tests + 85% coverage gate; schema-registry-standalone 7; sync-over-async 32 +
gate); the demo compiles against the new `Encoder`/`Decoder` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)