### PR TITLE
feat(platform-core): application log context for structured logging

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -5,7 +5,8 @@ summary: How Mercury's built-in distributed tracing produces an end-to-end span 
 layer: operate
 audience: [developer, ai-agent]
 keywords: [observability, distributed tracing, opentelemetry, otlp, telemetry, w3c trace context,
-  spans, dynatrace, splunk, jaeger, tempo]
+  spans, dynatrace, splunk, jaeger, tempo, log context, structured logging, json logger, mdc,
+  correlation id, updateContext]
 ---
 
 # Observability
@@ -19,6 +20,8 @@ keywords: [observability, distributed tracing, opentelemetry, otlp, telemetry, w
 > - **Built-in** — distributed tracing is part of the platform; you turn it on per endpoint/flow and the
 >   spans propagate without code.
 > - **For** developers and operators wiring Mercury to Dynatrace, Splunk, Jaeger, Tempo, or an OpenTelemetry Collector.
+> - **Logs too** — an opt-in [application log context](#log-context) stamps the same correlation/trace ids (plus your
+>   own key-values) into structured log lines, so logs and spans join up in your backend.
 
 In an event-driven, composable system a single request fans out across **decoupled** functions, flows, and graph
 nodes that never call each other directly. Observability is therefore not optional — it is the only way to see the
@@ -56,7 +59,8 @@ annotations={ <your key>=<value>, ... }
 ```
 
 `span_id` and `parent_span_id` are the OpenTelemetry-compatible IDs (see [W3C trace context](#w3c)); you can attach
-business context with `PostOffice.annotateTrace(key, value)`.
+business context to the span with `PostOffice.annotateTrace(key, value)`. To attach context to **application logs**
+instead, see [Application log context](#log-context).
 
 ### Spans across the three layers {#layers}
 
@@ -140,6 +144,107 @@ values as span attributes, with `service.name` on the resource. See the full key
 To target a system without an OTLP path, implement your own function at `distributed.trace.forwarder` and consume
 the dataset described in [What a trace records](#metrics) — for example, write it to a metrics database or a
 proprietary APM API.
+
+## Application log context {#log-context}
+
+Spans tell you the causal path; **application logs** tell you what happened inside each step. The log-context
+feature closes the gap between them: it injects a `context` block — correlation id, trace/span ids, service name,
+and any business key-values you add — into every structured log line a traced function emits. With the same
+`traceId`/`spanId` on both the span and the log line, you can pivot from a Dynatrace/Splunk trace straight to the
+exact log entries that belong to it.
+
+It deliberately **avoids the ThreadLocal / Log4j MDC** pattern (heavy for a virtual-thread runtime). The context
+rides the same per-request mechanism as the trace itself, keyed to the worker thread and torn down when the
+function returns.
+
+### Turning it on {#log-context-enable}
+
+The feature is **opt-in** and activates only when an optional `app-log-context.yaml` is on the classpath
+(`src/main/resources/`). It applies to the two **structured JSON appenders** — select one via the log4j2
+configuration (`log4j2-json.xml` for pretty output, `log4j2-compact.xml` for single-line); the plain `Console`
+appender is unaffected.
+
+```yaml
+# src/main/resources/app-log-context.yaml
+context:
+  cid: $cid
+  traceId: $traceId
+  tracePath: $tracePath
+  spanId: $spanId
+  parentSpanId: $parentSpanId
+  service: $service
+  timestamp: $utc
+  environment: '${ENV_NAME:dev}'
+  hello: world
+```
+
+The **left side** is the output key (your choice). The **right side** is one of three forms:
+
+| Form | Example | Resolved |
+|:-----|:--------|:---------|
+| Reserved **`$token`** | `service: $service` | live, per log line, from the request's trace context |
+| **`${ENV:default}`** substitution | `environment: '${ENV_NAME:dev}'` | once at startup, from the environment |
+| **Hardcoded literal** | `hello: world` | emitted verbatim on every line |
+
+The reserved tokens are `$cid`, `$traceId`, `$tracePath`, `$spanId`, `$parentSpanId`, `$service` (the current
+function's route), and `$utc` (the log line's UTC timestamp). A token (or env value) that resolves to nothing is
+**omitted** from the block rather than printed as `null` — so a root span simply has no `parentSpanId` key.
+
+### Adding your own key-values {#log-context-custom}
+
+Inside a function, add business context with `PostOffice.updateContext(key, value)`:
+
+```java
+var po = new PostOffice(headers, instance);
+po.updateContext("user", "demo");   // appears in the context block of every subsequent log line
+log.info("processing request");
+```
+
+The reserved keys (`cid`, `traceId`, `tracePath`, `spanId`, `parentSpanId`, `service`, `utc`) are protected —
+passing one to `updateContext` throws `IllegalArgumentException`. On a non-traced request, or when the feature is
+off, the call is a silent no-op.
+
+> **`updateContext` vs `annotateTrace`** — two distinct sinks. `annotateTrace(...)` attaches business data to the
+> **distributed-trace dataset** that flows to your APM backend ([What a trace records](#metrics));
+> `updateContext(...)` attaches it to the **application log** stream only. Neither leaks into the other.
+
+### What it looks like {#log-context-output}
+
+A log line from a traced function then carries the resolved `context` (from the worked example above, with
+`po.updateContext("user", "demo")` added in the function):
+
+```json
+{
+  "level": "INFO",
+  "context": {
+    "cid": "20260630c6ee70d866cb4fae9ab3c44d926ce21a",
+    "traceId": "fbb60df209084531b2b00f6b36a3e651",
+    "tracePath": "GET /api/profile/100",
+    "spanId": "bf8d4b2b6a923d67",
+    "parentSpanId": "98f8e26ae7d9a422",
+    "service": "v1.hello.exception",
+    "environment": "dev",
+    "hello": "world",
+    "user": "demo",
+    "timestamp": "2026-06-30T21:17:03Z"
+  },
+  "time": "2026-06-30 14:17:03.575",
+  "source": "com.accenture.demo.tasks.HelloException.handleEvent(HelloException.java:51)",
+  "thread": 297,
+  "message": "User defined exception handler - status=404 error=Profile 100 not found"
+}
+```
+
+The `traceId` and `spanId` here match the `v1.hello.exception` span the tracer emitted for the same request, so the
+log line and the span join up in your backend. (Key order within `context` is not significant — log viewers reorder
+keys on display.)
+
+### Scope and boundaries {#log-context-scope}
+
+- The `context` block appears **only** when a request is traced and a `traceId` is present. Framework boot logs and
+  logs emitted from a `Mono`/`Flux` completion that runs **after** the worker returns (on a different thread) carry
+  no context — the same boundary distributed tracing has.
+- Feature **off** (no `app-log-context.yaml`) costs one boolean check per log line and nothing else.
 
 ## See also {#see-also}
 

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/HelloException.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/HelloException.java
@@ -20,6 +20,7 @@ package com.accenture.demo.tasks;
 
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,9 @@ public class HelloException implements TypedLambdaFunction<Map<String, Object>, 
 
     @Override
     public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        var po = new PostOffice(headers, instance);
+        // demonstrate adding a user provided key-value into the log context
+        po.updateContext("user", "demo");
         if (input.containsKey(STACK)) {
             // set stack trace as a map. It will be printed as pretty JSON when log.format=json
             var map = Utility.getInstance().stackTraceToMap(String.valueOf(input.get(STACK)));

--- a/examples/composable-example/src/main/resources/app-log-context.yaml
+++ b/examples/composable-example/src/main/resources/app-log-context.yaml
@@ -1,0 +1,19 @@
+#
+# Sample application log context configuration (used by LogContextConfigTest).
+# to demonstrate application context logging
+#
+# Left side  = output key name (your choice)
+# Right side = a reserved $token (resolved per log line) or a ${ENV:default} substitution.
+#
+# Reserved tokens: $cid $traceId $tracePath $spanId $parentSpanId $service $utc
+#
+context:
+  cid: $cid
+  traceId: $traceId
+  tracePath: $tracePath
+  spanId: $spanId
+  parentSpanId: $parentSpanId
+  service: $service
+  timestamp: $utc
+  environment: '${ENV_NAME:dev}'
+  hello: 'world'

--- a/examples/composable-example/src/main/resources/application.properties
+++ b/examples/composable-example/src/main/resources/application.properties
@@ -27,7 +27,7 @@ server.port=8085
 # text and json are for human readers
 # compact is json without pretty print. It is for log analytics consumption.
 #
-log.format=text
+log.format=json
 #
 # Where to load the static files:
 # For embedded resources --> classpath:/public

--- a/system/platform-core/src/main/java/org/platformlambda/core/logging/JsonLogger.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/logging/JsonLogger.java
@@ -53,6 +53,15 @@ public abstract class JsonLogger extends AbstractAppender {
         if (ex != null) {
             data.putAll(util.stackTraceToMap(util.getStackTrace(ex)));
         }
+        // Add the application log context (cid, trace ids, service, custom key-values) when the
+        // optional app-log-context.yaml is present and this log line runs inside a traced worker.
+        // The appender runs on the worker thread, so the context is found by the current thread id.
+        if (LogContextConfig.getInstance().isEnabled()) {
+            LogContext context = LogContextManager.get(Thread.currentThread().threadId());
+            if (context != null) {
+                data.put("context", LogContextConfig.getInstance().render(context, event.getTimeMillis()));
+            }
+        }
         return data;
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContext.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContext.java
@@ -1,0 +1,101 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.platformlambda.core.models.TraceInfo;
+import org.platformlambda.core.util.Utility;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Per-request holder for application log context.
+ * <p>
+ * It carries a reference to the live {@link TraceInfo} (created on the worker thread), the
+ * correlation-id captured from the incoming event, and a map of developer-supplied custom
+ * key-values. It is created and destroyed in lockstep with the worker's trace bracket and
+ * is registered in {@link LogContextManager} keyed by the worker thread id.
+ * <p>
+ * This deliberately avoids the ThreadLocal / Log4j MDC pattern, which is an anti-pattern for
+ * a virtual-thread runtime.
+ */
+public class LogContext {
+    /**
+     * Reserved keys (the logical names) that a developer cannot override via
+     * {@code PostOffice.updateContext}. The output key name in app-log-context.yaml is the
+     * operator's choice; this set governs the developer API only.
+     */
+    public static final Set<String> RESERVED_KEYS =
+            Set.of("cid", "traceId", "tracePath", "spanId", "parentSpanId", "service", "utc");
+
+    private final TraceInfo trace;
+    private final String cid;
+    // key order is not preserved; log aggregators (Dynatrace, Splunk, ...) reorder keys on display anyway
+    private final ConcurrentMap<String, Object> customKeys = new ConcurrentHashMap<>();
+
+    public LogContext(TraceInfo trace, String cid) {
+        this.trace = trace;
+        this.cid = cid;
+    }
+
+    public static boolean isReservedKey(String key) {
+        return RESERVED_KEYS.contains(key);
+    }
+
+    /**
+     * Add (or remove, when value is null) a developer-supplied context key-value.
+     *
+     * @param key custom key (must not be a reserved key)
+     * @param value associated value; null removes the key
+     */
+    public void put(String key, Object value) {
+        if (value == null) {
+            customKeys.remove(key);
+        } else {
+            customKeys.put(key, value);
+        }
+    }
+
+    public Map<String, Object> getCustomKeys() {
+        return customKeys;
+    }
+
+    /**
+     * Resolve a reserved token to its live value.
+     *
+     * @param token one of the reserved tokens (cid, traceId, tracePath, spanId, parentSpanId, service, utc)
+     * @param logTimeMillis the log event time, used for the per-line utc timestamp
+     * @return resolved value, or null if absent (caller omits null keys from the output)
+     */
+    public Object token(String token, long logTimeMillis) {
+        return switch (token) {
+            case "cid" -> cid;
+            case "traceId" -> trace.id;
+            case "tracePath" -> trace.path;
+            case "spanId" -> trace.spanId;
+            case "parentSpanId" -> trace.parentSpanId;
+            case "service" -> trace.route;
+            case "utc" -> Utility.getInstance().date2str(new Date(logTimeMillis), true);
+            default -> null;
+        };
+    }
+}

--- a/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContextConfig.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContextConfig.java
@@ -1,0 +1,165 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.ConfigReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Loads the optional {@code app-log-context.yaml} and resolves the log-context template.
+ * <p>
+ * If the file is present on the classpath, the application log-context feature is enabled and the
+ * JSON appenders ({@code JsonAppender}, {@code CompactAppender}) will add a {@code context} block to
+ * each structured log line. If the file is absent, the feature stays off and the appenders behave
+ * exactly as before.
+ * <p>
+ * The template maps an output key to either:
+ * <ul>
+ *   <li>a reserved {@code $token} (cid, traceId, tracePath, spanId, parentSpanId, service, utc),
+ *       resolved live per log line from the current {@link LogContext}; or</li>
+ *   <li>a constant (a literal, or a {@code ${ENV:default}} substitution resolved once here at load).</li>
+ * </ul>
+ * Loading is via the standard {@link ConfigReader}, so environment-variable substitution and YAML
+ * parsing behave like every other config file. Key order is not preserved and does not matter —
+ * log aggregators reorder keys on display.
+ * <p>
+ * Initialization is lazy and thread-safe (initialization-on-demand holder), independent of platform
+ * boot order. Touching {@link AppConfigReader} first guarantees the base config is registered so
+ * {@code ${ENV:default}} resolves even when an appender initializes early.
+ */
+public class LogContextConfig {
+    private static final Logger log = LoggerFactory.getLogger(LogContextConfig.class);
+    private static final String CONFIG_FILE = "classpath:/app-log-context.yaml";
+    private static final String CONTEXT = "context";
+    private static final String TOKEN_PREFIX = "$";
+    private static final String ENV_PREFIX = "${";
+
+    // Eager singleton (same pattern as Utility) - thread-safe via class initialization, which the JVM
+    // defers until the class is first referenced (the first log line through a JSON appender).
+    private static LogContextConfig instance = new LogContextConfig(loadConfigFile());
+
+    public static LogContextConfig getInstance() {
+        return instance;
+    }
+
+    /**
+     * Replace the singleton instance. Reserved for unit tests that need to exercise the
+     * enabled/disabled feature paths deterministically.
+     *
+     * @param override config instance, or null to reset by reloading the config file
+     */
+    static void setInstanceForTest(LogContextConfig override) {
+        instance = override != null ? override : new LogContextConfig(loadConfigFile());
+    }
+
+    private final boolean enabled;
+    // output key -> reserved token name (without the leading '$'), resolved live per log line
+    private final Map<String, String> tokens = new HashMap<>();
+    // output key -> constant value (env-resolved or literal), fixed at load
+    private final Map<String, Object> constants = new HashMap<>();
+
+    /**
+     * Build a config from a loaded reader (or null when the optional file is absent).
+     * Package-private so tests can construct a config directly from an in-memory ConfigReader.
+     *
+     * @param reader a ConfigReader over app-log-context.yaml, or null to leave the feature disabled
+     */
+    LogContextConfig(ConfigReader reader) {
+        boolean on = false;
+        if (reader != null) {
+            Object section = reader.getMap().get(CONTEXT);
+            if (section instanceof Map<?, ?> raw) {
+                for (Object k : raw.keySet()) {
+                    parseEntry(reader, String.valueOf(k));
+                }
+                on = !tokens.isEmpty() || !constants.isEmpty();
+            } else {
+                log.warn("Log context config has no '{}' section - feature disabled", CONTEXT);
+            }
+        }
+        this.enabled = on;
+        if (on) {
+            log.info("Application log context enabled with {} context key-value(s)", tokens.size() + constants.size());
+        }
+    }
+
+    private static ConfigReader loadConfigFile() {
+        try {
+            // ensure the base config is registered so ${ENV:default} substitution works regardless of timing
+            AppConfigReader.getInstance();
+            return new ConfigReader(CONFIG_FILE);
+        } catch (IllegalArgumentException notFound) {
+            // optional config file absent - feature stays off
+            log.debug("Optional {} not found - log context feature disabled", CONFIG_FILE);
+            return null;
+        }
+    }
+
+    private void parseEntry(ConfigReader reader, String outputKey) {
+        // ConfigReader resolves ${ENV:default} on the leaf value
+        Object resolved = reader.get(CONTEXT + "." + outputKey);
+        String value = resolved == null ? null : String.valueOf(resolved);
+        if (value != null && value.startsWith(TOKEN_PREFIX) && !value.startsWith(ENV_PREFIX)) {
+            String tokenName = value.substring(TOKEN_PREFIX.length());
+            if (!LogContext.RESERVED_KEYS.contains(tokenName)) {
+                throw new IllegalArgumentException(
+                        "Invalid log context token '" + value + "' for key '" + outputKey
+                                + "' - allowed tokens: " + LogContext.RESERVED_KEYS);
+            }
+            tokens.put(outputKey, tokenName);
+        } else if (value != null) {
+            // constant - env-resolved value or literal; an unset ${VAR} with no default resolves to null and is dropped
+            constants.put(outputKey, value);
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Build the context map for one log line. Keys whose value resolves to null are omitted
+     * (never emitted as "null").
+     *
+     * @param context the current request's log context
+     * @param logTimeMillis the log event time (for the per-line utc timestamp)
+     * @return context key-values to embed under the log "context" field
+     */
+    public Map<String, Object> render(LogContext context, long logTimeMillis) {
+        Map<String, Object> out = new HashMap<>();
+        tokens.forEach((outputKey, tokenName) -> {
+            Object value = context.token(tokenName, logTimeMillis);
+            if (value != null) {
+                out.put(outputKey, value);
+            }
+        });
+        out.putAll(constants);
+        context.getCustomKeys().forEach((key, value) -> {
+            if (value != null) {
+                out.put(key, value);
+            }
+        });
+        return out;
+    }
+}

--- a/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContextManager.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/logging/LogContextManager.java
@@ -1,0 +1,49 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Holds the per-request {@link LogContext} keyed by the worker thread id.
+ * <p>
+ * This is the sibling of the trace registry in EventEmitter (which is keyed by
+ * {@code Thread.currentThread().threadId()}): the WorkerHandler registers a context right after
+ * starting tracing and removes it right after stopping tracing, so the entry exists for exactly
+ * the worker's run window. The JSON appenders (which run synchronously on the same worker thread)
+ * look the context up by the current thread id at log time.
+ */
+public class LogContextManager {
+    private static final ConcurrentMap<Long, LogContext> contexts = new ConcurrentHashMap<>();
+
+    private LogContextManager() { }
+
+    public static void register(long threadId, LogContext context) {
+        contexts.put(threadId, context);
+    }
+
+    public static LogContext get(long threadId) {
+        return contexts.get(threadId);
+    }
+
+    public static void remove(long threadId) {
+        contexts.remove(threadId);
+    }
+}

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
@@ -19,6 +19,8 @@
 package org.platformlambda.core.system;
 
 import io.vertx.core.Future;
+import org.platformlambda.core.logging.LogContext;
+import org.platformlambda.core.logging.LogContextManager;
 import org.platformlambda.core.models.CustomSerializer;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.Kv;
@@ -260,6 +262,35 @@ public class PostOffice {
         if (trace != null) {
             trace.annotate(key, value);
         }
+    }
+
+    /**
+     * User application may add a custom key-value to the application log context using this method.
+     * The key-value is rendered into the "context" block of structured log output (JsonAppender /
+     * CompactAppender) when the optional app-log-context.yaml is configured.
+     * <p>
+     * Unlike annotateTrace (which feeds the distributed-trace telemetry), this is a logging-only
+     * sink. The reserved keys (cid, traceId, tracePath, spanId, parentSpanId, service, utc) cannot
+     * be overridden and will throw IllegalArgumentException.
+     * <p>
+     * This is available inside a user function that implements LambdaFunction or TypedLambdaFunction.
+     * It is a no-op when the request is not traced or the log-context feature is not enabled.
+     *
+     * @param key of the log context entry (must not be a reserved key)
+     * @param value associated value; null removes the key
+     * @return this PostOffice instance
+     * @throws IllegalArgumentException if key is one of the reserved keys
+     */
+    public PostOffice updateContext(String key, Object value) {
+        if (LogContext.isReservedKey(key)) {
+            throw new IllegalArgumentException("Cannot override reserved log context key '" + key
+                    + "' - reserved keys are " + LogContext.RESERVED_KEYS);
+        }
+        LogContext context = LogContextManager.get(Thread.currentThread().threadId());
+        if (context != null) {
+            context.put(key, value);
+        }
+        return this;
     }
 
     /**

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -19,6 +19,9 @@
 package org.platformlambda.core.system;
 
 import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.logging.LogContext;
+import org.platformlambda.core.logging.LogContextConfig;
+import org.platformlambda.core.logging.LogContextManager;
 import org.platformlambda.core.models.*;
 import org.platformlambda.core.serializers.SimpleMapper;
 import org.platformlambda.core.serializers.SimpleObjectMapper;
@@ -101,8 +104,23 @@ public class WorkerHandler {
         String rpc = event.getTag(EventEmitter.RPC);
         EventEmitter po = EventEmitter.getInstance();
         String ref = tracing? po.startTracing(parentRoute, event.getTraceId(), event.getTracePath(), event.getSpanId(), instance) : "?";
+        // Register the application log context for this worker thread, in lockstep with the trace
+        // bracket. The JSON appenders look it up by thread id at log time. Gated on a real trace
+        // having been created and on the log-context feature being enabled.
+        long threadId = Thread.currentThread().threadId();
+        if (tracing && LogContextConfig.getInstance().isEnabled()) {
+            // tracing defaults on for every function, but a context only makes sense once a real
+            // traceId is available (trace.id != null), per the log-context contract.
+            TraceInfo logTrace = po.getTrace(parentRoute, instance);
+            if (logTrace != null && logTrace.id != null) {
+                LogContextManager.register(threadId, new LogContext(logTrace, event.getCorrelationId()));
+            }
+        }
         ProcessStatus ps = processEvent(event, rpc);
         TraceInfo trace = po.stopTracing(ref);
+        // processEvent never throws (it has a catch-all), so this always runs - no leak. Cheap no-op
+        // when nothing was registered. A Mono/Flux completion after this point has no context (see docs).
+        LogContextManager.remove(threadId);
         if (tracing && trace != null && trace.id != null && trace.path != null) {
             sendTracingInfo(event.getFrom(), rpc, ps, trace);
         } else if (ps.isNotDelivered()) {
@@ -193,21 +211,7 @@ public class WorkerHandler {
             if (event.getTracePath() != null) {
                 parameters.put(MY_TRACE_PATH, event.getTracePath());
             }
-            Object result;
-            try {
-                result = f.handleEvent(parameters, body, instance);
-            } catch (ClassCastException ce) {
-                // special case when the TypedLambdaFunction is defined in-line instead of a class
-                if (ce.getMessage().contains(CASTING_ERROR)) {
-                    var holder = new EventEnvelope().setBody(body);
-                    if (event.getType() != null) {
-                        holder.setType(event.getType());
-                    }
-                    result = f.handleEvent(parameters, holder, instance);
-                } else {
-                    throw ce;
-                }
-            }
+            Object result = invokeFunction(f, parameters, body, event);
             md.diff = getExecTime(begin);
             String replyTo = event.getReplyTo();
             if (replyTo != null) {
@@ -219,6 +223,26 @@ public class WorkerHandler {
             return ps.setExecutionTime(md.diff).setInputOutput(md.inputOutput);
         } catch (NoClassDefFoundError | AssertionError | Exception e) {
             return getErrorProcessStatus(f, e, ps, md, event, begin);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Object invokeFunction(TypedLambdaFunction f, Map<String, String> parameters, Object body,
+                                  EventEnvelope event) throws Exception {
+        try {
+            return f.handleEvent(parameters, body, instance);
+        } catch (ClassCastException ce) {
+            // special case when the TypedLambdaFunction is defined in-line instead of a class
+            String message = ce.getMessage();
+            if (message != null && message.contains(CASTING_ERROR)) {
+                var holder = new EventEnvelope().setBody(body);
+                if (event.getType() != null) {
+                    holder.setType(event.getType());
+                }
+                return f.handleEvent(parameters, holder, instance);
+            } else {
+                throw ce;
+            }
         }
     }
 
@@ -500,32 +524,45 @@ public class WorkerHandler {
     private boolean updateResponse(EventEnvelope response, Object result) {
         CustomSerializer serializer = def.getCustomSerializer();
         if (result instanceof EventEnvelope resultEvent) {
-            Map<String, String> headers = resultEvent.getHeaders();
-            if (headers.isEmpty() && resultEvent.getStatus() == 408 && resultEvent.getRawBody() == null) {
-                // simulate a READ timeout for ObjectStreamService
-                return true;
-            } else {
-                /*
-                 * When EventEnvelope is used as a return type, the system will transport
-                 * 1. payload
-                 * 2. key-values (as headers)
-                 */
-                if (resultEvent.getType() != null) {
-                    response.setType(resultEvent.getType());
-                }
-                renderOutputBody(resultEvent.getOriginalBody(), serializer, response);
-                for (Map.Entry<String, String> kv: headers.entrySet()) {
-                    String k = kv.getKey();
-                    if (!MY_ROUTE.equals(k) && !MY_TRACE_ID.equals(k) && !MY_TRACE_PATH.equals(k)) {
-                        response.setHeader(k, kv.getValue());
-                    }
-                }
-                response.setStatus(resultEvent.getStatus());
-            }
+            return applyEnvelopeResult(resultEvent, response, serializer);
         } else {
             renderOutputBody(result, serializer, response);
+            return false;
         }
+    }
+
+    /**
+     * Apply an EventEnvelope result onto the response.
+     *
+     * @return true to simulate a READ timeout for ObjectStreamService, false otherwise
+     */
+    private boolean applyEnvelopeResult(EventEnvelope resultEvent, EventEnvelope response, CustomSerializer serializer) {
+        Map<String, String> headers = resultEvent.getHeaders();
+        if (headers.isEmpty() && resultEvent.getStatus() == 408 && resultEvent.getRawBody() == null) {
+            // simulate a READ timeout for ObjectStreamService
+            return true;
+        }
+        /*
+         * When EventEnvelope is used as a return type, the system will transport
+         * 1. payload
+         * 2. key-values (as headers)
+         */
+        if (resultEvent.getType() != null) {
+            response.setType(resultEvent.getType());
+        }
+        renderOutputBody(resultEvent.getOriginalBody(), serializer, response);
+        copyResponseHeaders(headers, response);
+        response.setStatus(resultEvent.getStatus());
         return false;
+    }
+
+    private void copyResponseHeaders(Map<String, String> headers, EventEnvelope response) {
+        for (Map.Entry<String, String> kv: headers.entrySet()) {
+            String k = kv.getKey();
+            if (!MY_ROUTE.equals(k) && !MY_TRACE_ID.equals(k) && !MY_TRACE_PATH.equals(k)) {
+                response.setHeader(k, kv.getValue());
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/system/platform-core/src/test/java/org/platformlambda/core/logging/JsonLoggerContextTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/logging/JsonLoggerContextTest.java
@@ -1,0 +1,103 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.models.TraceInfo;
+import org.platformlambda.core.util.ConfigReader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonLoggerContextTest extends TestBase {
+
+    private final long threadId = Thread.currentThread().threadId();
+
+    // a concrete JsonLogger so we can exercise the shared getJson() used by JsonAppender/CompactAppender
+    private static final JsonLogger LOGGER = new JsonLogger("test", null, null, true, null) {
+        @Override
+        public void append(LogEvent event) {
+            // not needed - we test getJson() directly
+        }
+    };
+
+    @AfterEach
+    void cleanup() {
+        LogContextManager.remove(threadId);
+        LogContextConfig.setInstanceForTest(null);   // next getInstance() reloads (feature absent -> disabled)
+    }
+
+    private void enableFeature() {
+        Map<String, Object> section = new HashMap<>();
+        section.put("service", "$service");
+        section.put("traceId", "$traceId");
+        Map<String, Object> root = new HashMap<>();
+        root.put("context", section);
+        LogContextConfig.setInstanceForTest(new LogContextConfig(new ConfigReader().load(root)));
+    }
+
+    private LogEvent infoEvent() {
+        return Log4jLogEvent.newBuilder()
+                .setLevel(Level.INFO)
+                .setMessage(new SimpleMessage("hello"))
+                .setTimeMillis(1_751_252_588_000L)
+                .build();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addsContextWhenEnabledAndContextPresent() {
+        enableFeature();
+        LogContextManager.register(threadId, new LogContext(new TraceInfo("my.func", "t-77", "GET /x", null), "c-1"));
+
+        Map<String, Object> json = LOGGER.getJson(infoEvent());
+
+        assertTrue(json.containsKey("context"));
+        Map<String, Object> context = (Map<String, Object>) json.get("context");
+        assertEquals("my.func", context.get("service"));
+        assertEquals("t-77", context.get("traceId"));
+        // base fields still present
+        assertEquals("hello", json.get("message"));
+        assertNotNull(json.get("time"));
+    }
+
+    @Test
+    void omitsContextWhenNoContextForThread() {
+        enableFeature();
+        // no LogContext registered for this thread (e.g. framework boot log or async tail)
+        Map<String, Object> json = LOGGER.getJson(infoEvent());
+        assertFalse(json.containsKey("context"));
+    }
+
+    @Test
+    void omitsContextWhenFeatureDisabled() {
+        LogContextConfig.setInstanceForTest(new LogContextConfig(null));   // disabled
+        LogContextManager.register(threadId, new LogContext(new TraceInfo("my.func", "t-1", "GET /x", null), "c"));
+        Map<String, Object> json = LOGGER.getJson(infoEvent());
+        assertFalse(json.containsKey("context"));
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/logging/LogContextConfigTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/logging/LogContextConfigTest.java
@@ -1,0 +1,121 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.models.TraceInfo;
+import org.platformlambda.core.util.ConfigReader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogContextConfigTest extends TestBase {
+
+    private LogContextConfig configFrom(Map<String, Object> contextSection) {
+        Map<String, Object> root = new HashMap<>();
+        root.put("context", contextSection);
+        return new LogContextConfig(new ConfigReader().load(root));
+    }
+
+    @Test
+    void disabledWhenReaderIsNull() {
+        LogContextConfig config = new LogContextConfig(null);
+        assertFalse(config.isEnabled());
+    }
+
+    @Test
+    void disabledWhenNoContextSection() {
+        LogContextConfig config = new LogContextConfig(new ConfigReader().load(Map.of("other", "value")));
+        assertFalse(config.isEnabled());
+    }
+
+    @Test
+    void loadsTemplateFromYamlFile() {
+        // exercises the real YAML parse + ${ENV:default} substitution from a classpath file
+        LogContextConfig config = new LogContextConfig(new ConfigReader("classpath:/test-log-context.yaml"));
+        assertTrue(config.isEnabled());
+
+        TraceInfo trace = new TraceInfo("my.interesting.function", "trace-abc", "GET /api/order", null);
+        LogContext ctx = new LogContext(trace, "cid-123");
+        ctx.put("orderId", "123-45678");
+        Map<String, Object> out = config.render(ctx, 1_751_252_588_000L);
+
+        assertEquals("cid-123", out.get("cid"));
+        assertEquals("trace-abc", out.get("traceId"));
+        assertEquals("GET /api/order", out.get("tracePath"));
+        assertEquals("my.interesting.function", out.get("service"));
+        assertEquals(trace.spanId, out.get("spanId"));
+        assertNotNull(out.get("timestamp"));            // $utc resolves to a UTC ISO-8601 string
+        assertEquals("dev", out.get("environment"));    // ${ENV_NAME:dev} with ENV_NAME unset -> default
+        assertEquals("123-45678", out.get("orderId"));  // developer custom key
+        // root span -> no parentSpanId -> key omitted (never "null")
+        assertFalse(out.containsKey("parentSpanId"));
+    }
+
+    @Test
+    void omitsNullValuedKeys() {
+        Map<String, Object> section = new HashMap<>();
+        section.put("cid", "$cid");
+        section.put("traceId", "$traceId");
+        section.put("parentSpanId", "$parentSpanId");
+        section.put("service", "$service");
+        LogContextConfig config = configFrom(section);
+
+        // no cid, root span (null parentSpanId)
+        TraceInfo trace = new TraceInfo("my.func", "t-1", "GET /x", null);
+        LogContext ctx = new LogContext(trace, null);
+        Map<String, Object> out = config.render(ctx, System.currentTimeMillis());
+
+        assertFalse(out.containsKey("cid"));          // null cid omitted
+        assertFalse(out.containsKey("parentSpanId")); // null parentSpanId omitted
+        assertEquals("t-1", out.get("traceId"));
+        assertEquals("my.func", out.get("service"));
+    }
+
+    @Test
+    void resolvesParentSpanIdWhenPresent() {
+        LogContextConfig config = configFrom(Map.of("parentSpanId", "$parentSpanId"));
+        TraceInfo child = new TraceInfo("child.func", "t-1", "GET /x", "parent-span-99");
+        Map<String, Object> out = config.render(new LogContext(child, "c"), System.currentTimeMillis());
+        assertEquals("parent-span-99", out.get("parentSpanId"));
+    }
+
+    @Test
+    void rejectsUnknownToken() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> configFrom(Map.of("bad", "$notAValidToken")));
+        assertTrue(ex.getMessage().contains("notAValidToken"));
+    }
+
+    @Test
+    void treatsLiteralAndEnvValuesAsConstants() {
+        Map<String, Object> section = new HashMap<>();
+        section.put("fixed", "literal-value");
+        section.put("environment", "${ENV_NAME:staging}");
+        LogContextConfig config = configFrom(section);
+
+        Map<String, Object> out = config.render(new LogContext(new TraceInfo("r", "t", "p", null), "c"),
+                System.currentTimeMillis());
+        assertEquals("literal-value", out.get("fixed"));
+        assertEquals("staging", out.get("environment"));
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/logging/LogContextManagerTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/logging/LogContextManagerTest.java
@@ -1,0 +1,77 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.TraceInfo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogContextManagerTest {
+
+    private LogContext newContext() {
+        return new LogContext(new TraceInfo("my.func", "t-1", "GET /x", null), "cid-1");
+    }
+
+    @Test
+    void registerGetRemove() {
+        long threadId = Thread.currentThread().threadId();
+        assertNull(LogContextManager.get(threadId));
+        LogContext ctx = newContext();
+        LogContextManager.register(threadId, ctx);
+        assertSame(ctx, LogContextManager.get(threadId));
+        LogContextManager.remove(threadId);
+        assertNull(LogContextManager.get(threadId));
+    }
+
+    @Test
+    void contextsAreIsolatedByThreadId() {
+        long id1 = 100_001L;
+        long id2 = 100_002L;
+        LogContext c1 = newContext();
+        LogContext c2 = newContext();
+        try {
+            LogContextManager.register(id1, c1);
+            LogContextManager.register(id2, c2);
+            assertSame(c1, LogContextManager.get(id1));
+            assertSame(c2, LogContextManager.get(id2));
+            assertNotSame(LogContextManager.get(id1), LogContextManager.get(id2));
+        } finally {
+            LogContextManager.remove(id1);
+            LogContextManager.remove(id2);
+        }
+    }
+
+    @Test
+    void customKeyPutAndRemoveOnNull() {
+        LogContext ctx = newContext();
+        ctx.put("orderId", "ord-9");
+        assertEquals("ord-9", ctx.getCustomKeys().get("orderId"));
+        ctx.put("orderId", null);
+        assertFalse(ctx.getCustomKeys().containsKey("orderId"));
+    }
+
+    @Test
+    void reservedKeysAreRecognized() {
+        for (String key : LogContext.RESERVED_KEYS) {
+            assertTrue(LogContext.isReservedKey(key), key + " should be reserved");
+        }
+        assertFalse(LogContext.isReservedKey("orderId"));
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/logging/WorkerLogContextTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/logging/WorkerLogContextTest.java
@@ -1,0 +1,119 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.logging;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.ConfigReader;
+import org.platformlambda.core.util.Utility;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end coverage of the WorkerHandler log-context bracket and PostOffice.updateContext during a
+ * real traced worker invocation.
+ */
+class WorkerLogContextTest extends TestBase {
+
+    private static final Utility util = Utility.getInstance();
+
+    private LogContextConfig enabledConfig() {
+        Map<String, Object> section = new HashMap<>();
+        section.put("service", "$service");
+        section.put("traceId", "$traceId");
+        section.put("cid", "$cid");
+        Map<String, Object> root = new HashMap<>();
+        root.put("context", section);
+        return new LogContextConfig(new ConfigReader().load(root));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void workerRegistersContextAndUpdateContextWorks() throws InterruptedException {
+        Platform platform = Platform.getInstance();
+        String route = "log.context.test.function";
+        String traceId = util.getUuid();
+        String cid = "corr-" + util.getUuid();
+        BlockingQueue<Map<String, Object>> bench = new ArrayBlockingQueue<>(1);
+        AtomicLong workerThreadId = new AtomicLong();
+
+        LambdaFunction f = (headers, input, instance) -> {
+            PostOffice po = PostOffice.trackable(headers, instance);
+            // reserved keys cannot be overridden
+            boolean rejected = false;
+            try {
+                po.updateContext("cid", "should-not-apply");
+            } catch (IllegalArgumentException e) {
+                rejected = true;
+            }
+            po.updateContext("rejectedReserved", rejected);
+            po.updateContext("orderId", "ord-1");
+            workerThreadId.set(Thread.currentThread().threadId());
+            LogContext ctx = LogContextManager.get(Thread.currentThread().threadId());
+            bench.add(LogContextConfig.getInstance().render(ctx, System.currentTimeMillis()));
+            return "ok";
+        };
+        platform.registerPrivate(route, f, 1);
+        LogContextConfig.setInstanceForTest(enabledConfig());
+        try {
+            PostOffice po = new PostOffice("unit.test", traceId, "GET /api/log/ctx");
+            po.send(new EventEnvelope().setTo(route).setBody("x").setCorrelationId(cid));
+
+            Map<String, Object> rendered = bench.poll(10, TimeUnit.SECONDS);
+            assertNotNull(rendered, "function should have rendered the log context");
+            assertEquals(route, rendered.get("service"));   // $service = the function's route
+            assertEquals(traceId, rendered.get("traceId"));
+            assertEquals(cid, rendered.get("cid"));
+            assertEquals("ord-1", rendered.get("orderId"));
+            assertEquals(true, rendered.get("rejectedReserved"));
+
+            // the context must be removed once the worker returns
+            long tid = workerThreadId.get();
+            for (int i = 0; i < 40 && LogContextManager.get(tid) != null; i++) {
+                Thread.sleep(50);
+            }
+            assertNull(LogContextManager.get(tid), "log context must be removed after the worker returns");
+        } finally {
+            platform.release(route);
+            LogContextConfig.setInstanceForTest(null);
+        }
+    }
+
+    @Test
+    void updateContextRejectsReservedKeys() {
+        PostOffice po = PostOffice.trackable("unit.test", "t-1", "GET /x");
+        for (String reserved : LogContext.RESERVED_KEYS) {
+            assertThrows(IllegalArgumentException.class, () -> po.updateContext(reserved, "value"),
+                    "expected rejection for reserved key: " + reserved);
+        }
+        // a non-reserved key on a non-traced request is a silent no-op (no context registered)
+        assertDoesNotThrow(() -> po.updateContext("orderId", "ord-1"));
+    }
+}

--- a/system/platform-core/src/test/resources/test-log-context.yaml
+++ b/system/platform-core/src/test/resources/test-log-context.yaml
@@ -1,0 +1,20 @@
+#
+# Sample application log context configuration (used by LogContextConfigTest).
+#
+# The production feature reads "classpath:/app-log-context.yaml". This test-only copy uses a
+# different name so it does NOT enable the feature globally for the platform-core test suite.
+#
+# Left side  = output key name (your choice)
+# Right side = a reserved $token (resolved per log line) or a ${ENV:default} substitution.
+#
+# Reserved tokens: $cid $traceId $tracePath $spanId $parentSpanId $service $utc
+#
+context:
+  cid: $cid
+  traceId: $traceId
+  tracePath: $tracePath
+  spanId: $spanId
+  parentSpanId: $parentSpanId
+  service: $service
+  timestamp: $utc
+  environment: '${ENV_NAME:dev}'


### PR DESCRIPTION
## What

Adds an opt-in **application log context** to platform-core: when an optional `app-log-context.yaml`
is present, every structured log line a traced function emits gains a `context` block carrying the
correlation id, trace/span ids, service name, a per-line UTC timestamp, and any developer-supplied
key-values. Three new classes in `org.platformlambda.core.logging` (`LogContext`, `LogContextManager`,
`LogContextConfig`); the `JsonLogger.getJson` hook feeds both `JsonAppender` and `CompactAppender`;
`WorkerHandler` registers/removes the context in lockstep with the trace bracket; and
`PostOffice.updateContext(key, value)` lets a function add custom keys (reserved keys are rejected).

Config entries take a reserved `$token`, a `${ENV:default}` substitution, or a hardcoded literal;
null-valued keys are omitted rather than printed as `"null"`. The feature is off by default — absent
the YAML it costs one boolean check per log line and writes nothing.

Also folds in two behavior-preserving refactors of **pre-existing** SonarQube findings in
`WorkerHandler` that surfaced while editing the file: extract `invokeFunction` (resolving the nested-try
rule, plus a null-message guard) and split `updateResponse` into `applyEnvelopeResult` +
`copyResponseHeaders` (cognitive complexity 17 → under the limit).

Includes 16 new tests (config parse/render, registry, `getJson` integration, end-to-end worker bracket
+ `updateContext`); the full platform-core suite stays green (367 tests). A new *Application log context*
section is added to the Observability guide, and `composable-example` demonstrates the feature
(`updateContext` + the config) — validated end-to-end with logs and OpenTelemetry spans joining on the
same `traceId`/`spanId`.

## Why

OpenTelemetry tracing already gives an end-to-end span tree, but the **application log stream** had no
correlation: a log line could not be tied back to its trace, and there was no first-class way to carry
business context (e.g. an order id, a user) onto log output. The traditional answer — Log4j MDC on
`ThreadLocal` — is an anti-pattern for a virtual-thread runtime. This closes that observability gap by
reusing the framework's existing per-request `TraceInfo` mechanism (a holder keyed by the worker thread
id, torn down when the function returns) instead of `ThreadLocal`, so logs and spans line up in the
backend (Dynatrace, Splunk, …) with zero cost when the feature is unused.

---
Co-Authored-By: Claude Code