### PR TITLE
feat(minimalist-kafka): resolve schema id from subject + version for simple.kafka.notification

### DIFF
--- a/docs/guides/kafka-flow-adapter.md
+++ b/docs/guides/kafka-flow-adapter.md
@@ -7,7 +7,7 @@ layer: operate
 audience: [developer, ai-agent]
 keywords: [kafka, flow adapter, minimalist-kafka, consumer, producer, dead letter queue, dlq, partition,
   consumer group, kafka-flow-adapter.yaml, simple.kafka.notification, at-least-once, traceparent,
-  schema registry, confluent, avro, protobuf, json schema, schema-id, schema-type, schema.enabled]
+  schema registry, confluent, avro, protobuf, json schema, subject, version, schema.enabled]
 ---
 
 # Kafka Flow Adapter
@@ -161,9 +161,9 @@ po.send(new EventEnvelope().setTo("simple.kafka.notification")
 Publishing is **drop-n-forget** (Kafka's commit log is the durable buffer), but async delivery failures are
 logged rather than silently masked.
 
-Two optional headers opt a publish into the Confluent wire format instead of raw `byte[]`: `schema-id` and
-`schema-type` (see [Schema Registry](#schema)). They are encoding directives — consumed by the function, not
-forwarded as Kafka headers.
+One header opts a publish into the Confluent wire format instead of raw `byte[]`: `subject` (with an optional
+`version`; see [Schema Registry](#schema)). It is an encoding directive — consumed by the function, not
+forwarded as a Kafka header.
 
 ### Trace continuity across Kafka {#tracing}
 
@@ -188,30 +188,37 @@ schema.registry.url=${SCHEMA_REGISTRY_URL:http://127.0.0.1:8081}
 schema.registry.cache.ttl=30m                          # TTL for the in-memory schema cache (by id)
 ```
 
-### Produce: id-driven, no subject or naming strategy {#schema-produce}
+### Produce: subject-driven {#schema-produce}
 
-`simple.kafka.notification` serializes the body into the wire format when you supply two headers:
+`simple.kafka.notification` serializes the body into the wire format when you supply a `subject` header:
 
 | Header | Description |
 |--------|-------------|
-| `schema-id` | The **global** schema id to serialize with. The schema must be **pre-registered**; the producer fetches it by id (`GET /schemas/ids/{id}`) and never registers. |
-| `schema-type` | `JSON`, `AVRO`, or `PROTOBUF`. Selects the serializer. Defaults to `JSON`. |
+| `subject` | The registry **subject** to serialize against. The schema must be **pre-registered**; the producer resolves the subject to a global schema id (and its type — `JSON`, `AVRO`, or `PROTOBUF`) from the registry and never registers. |
+| `version` | Optional. The subject version to resolve: a positive integer to **pin** a specific version, or `latest` to track the current version. Defaults to `latest`. |
 
 ```yaml
 # in a flow task that publishes via simple.kafka.notification
 input:
   - 'text(orders) -> header.topic'
-  - 'text(AVRO) -> header.schema-type'
-  - 'text(42) -> header.schema-id'
+  - 'text(orders-value) -> header.subject'    # version omitted → latest
   - 'model.payload -> *'        # the body: a Map / JSON document
 process: 'simple.kafka.notification'
 ```
 
-The Confluent wire format carries only the global id, never the subject — so being **id-driven** makes the
-producer **subject-naming-strategy agnostic** (TopicName / RecordName / TopicRecordName are all supported by
-construction, and a topic can carry many record types). Whoever registers the schema — CI, a client project,
-an admin tool — owns the strategy. This assumes schemas are **governed artifacts registered out-of-band**, as
-they are in practice; the producer never auto-registers.
+The producer resolves the subject (+ version) to a **global schema id** and its **schema type** from the
+registry, then serializes with Confluent's own serializer. The wire format itself is unchanged — it still
+carries only the global id (`[magic 0x00][4-byte global schema id][payload]`) — and the consumer
+(id-from-wire) is unchanged; only the producer's *input* moved from an explicit id+type to a subject. Whoever
+registers the schema — CI, a client project, an admin tool — owns the subject naming strategy (TopicName /
+RecordName / TopicRecordName are all supported, and a topic can carry many record types). This assumes schemas
+are **governed artifacts registered out-of-band**, as they are in practice; the producer never auto-registers.
+
+> **CSFLE not yet wired.** [Confluent Client-Side Field Level Encryption (CSFLE)](https://docs.confluent.io/cloud/current/security/encrypt/csfle/overview.html)
+> is **not yet supported** by `minimalist-kafka` — the serializer is configured **without** encryption rule
+> executors or a KMS. A schema that carries CSFLE encryption rules would therefore be serialized in
+> **PLAINTEXT** (the rules are silently ignored, not enforced). **Do not use `simple.kafka.notification` to
+> produce to CSFLE-protected topics** until CSFLE support lands (planned).
 
 ### Consume: decode by embedded id {#schema-consume}
 
@@ -233,8 +240,9 @@ immediately via the [DLQ path](#reliability) rather than retried.
 
 ### Notes {#schema-notes}
 
-- **One id-driven path, three formats.** The producer and consumer are type-generic; only the `schema-type`
-  header (and the registered schema) differ. JSON Schema is *open* (`additionalProperties`), while Avro and
+- **One subject-driven path, three formats.** The producer and consumer are type-generic; only the `subject`
+  (and the registered schema behind it) differ — the producer reads the schema type from the registry, so the
+  flow never names it. JSON Schema is *open* (`additionalProperties`), while Avro and
   Protobuf records are *closed-shape* — a message must match the declared fields, and a non-schema field is
   dropped on the wire. Avro applies declared field defaults for absent fields; Protobuf relies on proto3
   implicit defaults. Avro/Protobuf decode to generic records (no generated classes), rendered to a `Map`.
@@ -244,6 +252,12 @@ immediately via the [DLQ path](#reliability) rather than retried.
   schema registered while the app is running becomes visible on the next lookup. The TTL lets schema changes
   be picked up without restarting pods (handy in dev / lower environments); lengthen it in production where
   schemas change rarely. The cache is rebuildable and **cleared at startup**.
+- **Subject→id resolution cache.** The producer also caches the *subject (+ version) → schema id* resolution,
+  and how long depends on the version. A **pinned numeric version** (`subject` + `version: N`) maps to one
+  immutable schema id, so it is cached **long** (effectively forever). `latest` (the default) can change when a
+  new version is registered, so it is cached on a **short TTL** and re-resolved frequently, picking up a new
+  current version without a restart. Pin a version in production paths where the schema must not shift
+  underneath you; use `latest` in dev / lower environments where tracking the newest schema is convenient.
 - **Worked example.** The [sync-over-async demo](sync-over-async.md) runs the same end-to-end flow over all
   three formats (`json-topic-1/2`, `avro-topic-1/2`, `protobuf-topic-1/2`) alongside the raw `byte[]` path.
 

--- a/examples/sync-over-async-demo/README.md
+++ b/examples/sync-over-async-demo/README.md
@@ -113,9 +113,10 @@ compare the two side by side; the byte[] path (`soa.request` / `soa.response`) i
 
 **Seed the registry, then start it.** Schemas are governed artifacts registered out-of-band, so the demo
 ships pre-registered schemas rather than self-registering at runtime. The [`registry/`](registry/) folder
-holds one file per schema id — [`1.json`](registry/1.json) (a permissive JSON Schema covering both JSON legs),
-[`2.json`](registry/2.json) (the [Avro variant](#avro-variant-confluent-wire-format)), and
-[`3.json`](registry/3.json) (the [Protobuf variant](#protobuf-variant-confluent-wire-format)). Copy them into
+holds one file per schema id, each now carrying its `subject` + `version` — [`1.json`](registry/1.json)
+(subject `sync-demo-json`, a permissive JSON Schema covering both JSON legs),
+[`2.json`](registry/2.json) (subject `sync-demo-avro`, the [Avro variant](#avro-variant-confluent-wire-format)), and
+[`3.json`](registry/3.json) (subject `sync-demo-protobuf`, the [Protobuf variant](#protobuf-variant-confluent-wire-format)). Copy them into
 the registry's store (default `/tmp/schema-registry`), then start the registry — one registry serves all
 three variants:
 ```shell
@@ -144,8 +145,8 @@ trace continuity — is identical):
 
 | Aspect | How |
 |--------|-----|
-| **Producer is id-driven** | the flows publish with `schema-id: 1` + `schema-type: JSON` headers; `simple.kafka.notification` serializes the body into the Confluent wire format using that **pre-registered** id. The producer never needs the subject or a naming strategy — see [the Kafka Flow Adapter guide](../../docs/guides/kafka-flow-adapter.md). |
-| **Schema registered out-of-band** | the registry is seeded from `registry/1.json` (id 1); the serializer only does `GET /schemas/ids/1`. Mirrors enterprise reality, where schemas are governed artifacts — no runtime registration in the app. |
+| **Producer is subject-driven** | the flows publish with a `subject: sync-demo-json` header (no explicit `version`, so it defaults to `latest`); `simple.kafka.notification` resolves the global schema id and type from that subject internally, then serializes the body into the Confluent wire format using the **pre-registered** schema. The producer never needs a naming strategy — see [the Kafka Flow Adapter guide](../../docs/guides/kafka-flow-adapter.md). |
+| **Schema registered out-of-band** | the registry is seeded from `registry/1.json` (subject `sync-demo-json`, version 1); the producer resolves the subject to an id and the serializer fetches the schema. Mirrors enterprise reality, where schemas are governed artifacts — no runtime registration in the app. |
 | **Consumer decodes by id** | the `json-topic-1` / `json-topic-2` adapter bindings set `schema.enabled: true`, so the adapter reads the embedded id, fetches the schema, and hands the flow a decoded **Map**. |
 | **Map-input task variants** | because the decoded body is a Map, `system.of.record.json` and `soa.reply.json` take a `Map` (vs the byte[] `system.of.record` / `soa.reply`); they reuse the same logic. |
 
@@ -153,9 +154,10 @@ trace continuity — is identical):
 
 The same end-to-end pattern again, now over **Confluent Avro** on a third pair of topics — `avro-topic-1`
 (request) and `avro-topic-2` (reply). Nothing in the producer/consumer machinery changes from the JSON path:
-the flows publish with `schema-type: AVRO` + `schema-id: 2`, and `simple.kafka.notification` dispatches to
-the Avro serializer purely from those headers. The registry seed already includes **id 2** (copied in the
-step above), so the same Terminal F registry serves both variants.
+the flows publish with a `subject: sync-demo-avro` header, and `simple.kafka.notification` resolves that
+subject to the Avro schema id + type and dispatches to the Avro serializer. The registry seed already
+includes **subject `sync-demo-avro`** (`registry/2.json`, copied in the step above), so the same Terminal F
+registry serves both variants.
 
 Call the Avro endpoint:
 ```shell
@@ -187,15 +189,16 @@ The one instructive difference from JSON Schema — **Avro records are closed-sh
 | **Defaults fill partial input** | the request carries only `action`; the framework's Map→`GenericRecord` conversion applies each field's **schema default** (`""`) for the rest, so a partial input serializes cleanly (Avro's own strict JSON decoder would reject it). |
 | **Generic, no codegen** | decode yields a `GenericRecord` (not a generated class), rendered back to a `Map` — so the flow tasks stay plain `Map`-in/`Map`-out, exactly like the JSON variant. |
 
-Everything else — id-driven produce, out-of-band registration, `schema.enabled` decode-by-id, the Redis
+Everything else — subject-driven produce, out-of-band registration, `schema.enabled` decode-by-id, the Redis
 return route, and trace continuity — is identical to the JSON path.
 
 ## Protobuf variant (Confluent wire format)
 
 The third and final schema type, over `protobuf-topic-1` (request) and `protobuf-topic-2` (reply). Again
-nothing in the producer/consumer machinery changes: the flows publish with `schema-type: PROTOBUF` +
-`schema-id: 3`, and `simple.kafka.notification` dispatches to the Protobuf serializer from those headers.
-The registry seed already includes **id 3** (the same Terminal F registry serves all three variants).
+nothing in the producer/consumer machinery changes: the flows publish with a `subject: sync-demo-protobuf`
+header, and `simple.kafka.notification` resolves that subject to the Protobuf schema id + type and dispatches
+to the Protobuf serializer. The registry seed already includes **subject `sync-demo-protobuf`**
+(`registry/3.json`); the same Terminal F registry serves all three variants.
 
 Call the Protobuf endpoint:
 ```shell
@@ -223,8 +226,8 @@ with two protobuf-specific notes:
 | **Defaults are free (proto3)** | a field absent from the request is simply not set; proto3's implicit default (`""`) applies on read. The framework's Map→`DynamicMessage` conversion just skips unset fields — no explicit defaults needed (unlike Avro). |
 | **DynamicMessage, no codegen** | serialize builds a `DynamicMessage` against the registered schema's descriptor and decode renders the `DynamicMessage` back to a `Map` — no generated `.proto` Java classes. Confluent's Protobuf wire format also carries a message-index after the id; the serde handles that framing transparently. |
 
-That completes the three Confluent wire formats — **JSON Schema, Avro, and Protobuf** — over one id-driven
-produce + `schema.enabled` consume path, differing only by the `schema-type` header.
+That completes the three Confluent wire formats — **JSON Schema, Avro, and Protobuf** — over one
+subject-driven produce + `schema.enabled` consume path, differing only by the `subject` header.
 
 ## How it maps to the pattern
 
@@ -235,8 +238,8 @@ produce + `schema.enabled` consume path, differing only by the `schema-type` hea
 | `soa-reply.yml` (`soa.reply`) | facade | deliver the Kafka reply to the coordinator → wake the awaiting request |
 | `system-of-record.yml` (`system.of.record`) | backend | the application's async processing, on a separate pod |
 | Redis return route | facade | routes the reply back to the originating pod (cross-pod, scalable) |
-| `*-json.yml` flows + `registry/1.json` (id 1) | both | the [JSON Schema variant](#json-schema-variant-confluent-wire-format) over `json-topic-1` / `json-topic-2` |
-| `*-avro.yml` flows + `registry/2.json` (id 2) | both | the [Avro variant](#avro-variant-confluent-wire-format) over `avro-topic-1` / `avro-topic-2` |
+| `*-json.yml` flows + `registry/1.json` (subject `sync-demo-json`, id 1) | both | the [JSON Schema variant](#json-schema-variant-confluent-wire-format) over `json-topic-1` / `json-topic-2` |
+| `*-avro.yml` flows + `registry/2.json` (subject `sync-demo-avro`, id 2) | both | the [Avro variant](#avro-variant-confluent-wire-format) over `avro-topic-1` / `avro-topic-2` |
 
 ## Validated runs (telemetry evidence)
 

--- a/examples/sync-over-async-demo/registry/1.json
+++ b/examples/sync-over-async-demo/registry/1.json
@@ -1,4 +1,6 @@
 {
   "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"SyncDemoMessage\",\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\"},\"status\":{\"type\":\"string\"},\"processedBy\":{\"type\":\"string\"}},\"additionalProperties\":true}",
-  "schemaType": "JSON"
+  "schemaType": "JSON",
+  "subject": "sync-demo-json",
+  "version": 1
 }

--- a/examples/sync-over-async-demo/registry/2.json
+++ b/examples/sync-over-async-demo/registry/2.json
@@ -1,4 +1,6 @@
 {
   "schema": "{\"type\":\"record\",\"name\":\"SyncDemoMessage\",\"namespace\":\"com.accenture.soa.demo\",\"fields\":[{\"name\":\"action\",\"type\":\"string\",\"default\":\"\"},{\"name\":\"status\",\"type\":\"string\",\"default\":\"\"},{\"name\":\"processedBy\",\"type\":\"string\",\"default\":\"\"},{\"name\":\"traceId\",\"type\":\"string\",\"default\":\"\"}]}",
-  "schemaType": "AVRO"
+  "schemaType": "AVRO",
+  "subject": "sync-demo-avro",
+  "version": 1
 }

--- a/examples/sync-over-async-demo/registry/3.json
+++ b/examples/sync-over-async-demo/registry/3.json
@@ -1,4 +1,6 @@
 {
   "schema": "syntax = \"proto3\";\npackage com.accenture.soa.demo;\n\nmessage SyncDemoMessage {\n  string action = 1;\n  string status = 2;\n  string processedBy = 3;\n  string traceId = 4;\n}\n",
-  "schemaType": "PROTOBUF"
+  "schemaType": "PROTOBUF",
+  "subject": "sync-demo-protobuf",
+  "version": 1
 }

--- a/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-avro.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-avro.yml
@@ -3,12 +3,13 @@
 #
 # Identical to the byte[]/JSON flows except it publishes to 'avro-topic-1' as Confluent Avro:
 #   1. sync.prepare              - register the return route and serialize the request payload.
-#   2. simple.kafka.notification - publish to 'avro-topic-1' with schema-id=2 + schema-type=AVRO, so the body
-#                                  is serialized into the Confluent wire format (magic byte + id + payload).
+#   2. simple.kafka.notification - publish to 'avro-topic-1' with subject=sync-demo-avro (version defaults to
+#                                  latest); the producer resolves the schema id from the subject and serializes
+#                                  the body into the Confluent wire format (magic byte + id + payload).
 #   3. sync.await                - block until the backend's reply arrives via 'avro-topic-2' + Redis.
 #
-# schema-id 2 is the demo's Avro SyncDemoMessage schema, pre-registered in the Schema Registry (see
-# registry/2.json). The producer is id-driven: it never needs a subject or naming strategy.
+# subject 'sync-demo-avro' is the demo's Avro SyncDemoMessage schema, pre-registered in the Schema Registry
+# (see registry/2.json, which carries subject + version). The producer resolves the schema id internally.
 #
 flow:
   id: 'sync-to-async-avro'
@@ -32,8 +33,7 @@ tasks:
 
   - input:
       - 'text(avro-topic-1) -> header.topic'
-      - 'text(AVRO) -> header.schema-type'
-      - 'text(2) -> header.schema-id'
+      - 'text(sync-demo-avro) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-json.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-json.yml
@@ -3,12 +3,13 @@
 #
 # Identical to the byte[] flow except it publishes to 'json-topic-1' as Confluent JSON Schema:
 #   1. sync.prepare              - register the return route and serialize the request payload.
-#   2. simple.kafka.notification - publish to 'json-topic-1' with schema-id + schema-type=JSON, so the body
-#                                  is serialized into the Confluent wire format (magic byte + id + payload).
+#   2. simple.kafka.notification - publish to 'json-topic-1' with subject=sync-demo-json (version defaults to
+#                                  latest); the producer resolves the schema id from the subject and serializes
+#                                  the body into the Confluent wire format (magic byte + id + payload).
 #   3. sync.await                - block until the backend's reply arrives via 'json-topic-2' + Redis.
 #
-# schema-id 1 is the demo's SyncDemoMessage schema, pre-registered in the Schema Registry (see
-# registry/1.json). The producer is id-driven: it never needs a subject or naming strategy.
+# subject 'sync-demo-json' is the demo's JSON SyncDemoMessage schema, pre-registered in the Schema Registry
+# (see registry/1.json, which carries subject + version). The producer resolves the schema id internally.
 #
 flow:
   id: 'sync-to-async-json'
@@ -32,8 +33,7 @@ tasks:
 
   - input:
       - 'text(json-topic-1) -> header.topic'
-      - 'text(JSON) -> header.schema-type'
-      - 'text(1) -> header.schema-id'
+      - 'text(sync-demo-json) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-protobuf.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/sync-to-async-protobuf.yml
@@ -3,12 +3,13 @@
 #
 # Identical to the byte[]/JSON/Avro flows except it publishes to 'protobuf-topic-1' as Confluent Protobuf:
 #   1. sync.prepare              - register the return route and serialize the request payload.
-#   2. simple.kafka.notification - publish to 'protobuf-topic-1' with schema-id=3 + schema-type=PROTOBUF, so
-#                                  the body is serialized into the Confluent wire format (magic + id + index + payload).
+#   2. simple.kafka.notification - publish to 'protobuf-topic-1' with subject=sync-demo-protobuf (version
+#                                  defaults to latest); the producer resolves the schema id from the subject and
+#                                  serializes the body into the Confluent wire format (magic + id + index + payload).
 #   3. sync.await                - block until the backend's reply arrives via 'protobuf-topic-2' + Redis.
 #
-# schema-id 3 is the demo's Protobuf SyncDemoMessage schema, pre-registered in the Schema Registry (see
-# registry/3.json). The producer is id-driven: it never needs a subject or naming strategy.
+# subject 'sync-demo-protobuf' is the demo's Protobuf SyncDemoMessage schema, pre-registered in the Schema
+# Registry (see registry/3.json, which carries subject + version). The producer resolves the schema id internally.
 #
 flow:
   id: 'sync-to-async-protobuf'
@@ -32,8 +33,7 @@ tasks:
 
   - input:
       - 'text(protobuf-topic-1) -> header.topic'
-      - 'text(PROTOBUF) -> header.schema-type'
-      - 'text(3) -> header.schema-id'
+      - 'text(sync-demo-protobuf) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-avro.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-avro.yml
@@ -5,9 +5,11 @@
 #
 #   1. system.of.record.avro     - the backend logic on the decoded Map; builds a FLAT reply matching the
 #                                  closed-shape Avro SyncDemoMessage record (action, status, processedBy, traceId).
-#   2. simple.kafka.notification - publish the reply to 'avro-topic-2' as Avro (schema-id=2 + type).
+#   2. simple.kafka.notification - publish the reply to 'avro-topic-2' with subject=sync-demo-avro (version
+#                                  defaults to latest); the producer resolves the schema id from the subject.
 #
-# schema-id 2 is the demo's pre-registered Avro SyncDemoMessage schema (see registry/2.json).
+# subject 'sync-demo-avro' is the demo's pre-registered Avro SyncDemoMessage schema (see registry/2.json,
+# which carries subject + version).
 #
 flow:
   id: 'system-of-record-avro'
@@ -32,8 +34,7 @@ tasks:
 
   - input:
       - 'text(avro-topic-2) -> header.topic'
-      - 'text(AVRO) -> header.schema-type'
-      - 'text(2) -> header.schema-id'
+      - 'text(sync-demo-avro) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-json.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-json.yml
@@ -4,9 +4,11 @@
 # already decoded the Confluent-framed value to a Map, which 'system.of.record.json' receives.
 #
 #   1. system.of.record.json     - the backend logic (echo + metadata) on the decoded Map.
-#   2. simple.kafka.notification - publish the reply to 'json-topic-2' as JSON Schema (schema-id + type).
+#   2. simple.kafka.notification - publish the reply to 'json-topic-2' with subject=sync-demo-json (version
+#                                  defaults to latest); the producer resolves the schema id from the subject.
 #
-# schema-id 1 is the demo's pre-registered SyncDemoMessage schema (see registry/1.json).
+# subject 'sync-demo-json' is the demo's pre-registered JSON SyncDemoMessage schema (see registry/1.json,
+# which carries subject + version).
 #
 flow:
   id: 'system-of-record-json'
@@ -31,8 +33,7 @@ tasks:
 
   - input:
       - 'text(json-topic-2) -> header.topic'
-      - 'text(JSON) -> header.schema-type'
-      - 'text(1) -> header.schema-id'
+      - 'text(sync-demo-json) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-protobuf.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-protobuf.yml
@@ -5,9 +5,11 @@
 #
 #   1. system.of.record.protobuf - the backend logic on the decoded Map; builds a FLAT reply matching the
 #                                  closed-shape protobuf SyncDemoMessage (action, status, processedBy, traceId).
-#   2. simple.kafka.notification - publish the reply to 'protobuf-topic-2' as Protobuf (schema-id=3 + type).
+#   2. simple.kafka.notification - publish the reply to 'protobuf-topic-2' with subject=sync-demo-protobuf
+#                                  (version defaults to latest); the producer resolves the schema id from the subject.
 #
-# schema-id 3 is the demo's pre-registered Protobuf SyncDemoMessage schema (see registry/3.json).
+# subject 'sync-demo-protobuf' is the demo's pre-registered Protobuf SyncDemoMessage schema (see
+# registry/3.json, which carries subject + version).
 #
 flow:
   id: 'system-of-record-protobuf'
@@ -32,8 +34,7 @@ tasks:
 
   - input:
       - 'text(protobuf-topic-2) -> header.topic'
-      - 'text(PROTOBUF) -> header.schema-type'
-      - 'text(3) -> header.schema-id'
+      - 'text(sync-demo-protobuf) -> header.subject'
       - 'model.cid -> header.cid'
       - 'model.payload -> *'
     process: 'simple.kafka.notification'

--- a/helpers/schema-registry-standalone/README.md
+++ b/helpers/schema-registry-standalone/README.md
@@ -1,0 +1,138 @@
+# Standalone Schema Registry server
+
+A convenient application to run a **Confluent-compatible Schema Registry for local development and testing** —
+with **no Docker image required**. It implements the subset of the Confluent Schema Registry REST API that the
+Confluent serializers/deserializers actually call, for **Avro, JSON Schema, and Protobuf**, on the built-in
+platform-core reactive HTTP server (no `rest-spring`).
+
+> For development and testing only — **not** for production use.
+
+This is a sibling of [`kafka-standalone`](../kafka-standalone) and [`redis-standalone`](../redis-standalone)
+under `helpers/`: together they give you a local Kafka broker, a local Redis server, and a local Schema
+Registry without external infrastructure. It backs the schema features of
+[`minimalist-kafka`](../../system/minimalist-kafka) and the
+[`sync-over-async-demo`](../../examples/sync-over-async-demo). See also the guide:
+[`docs/guides/schema-registry-mock.md`](../../docs/guides/schema-registry-mock.md).
+
+## Build and run
+
+```shell
+cd helpers/schema-registry-standalone
+mvn clean package
+java -jar target/schema-registry-standalone-4.5.0.jar
+```
+
+The server starts on `http://127.0.0.1:8081`. Press `Ctrl-C` to stop.
+
+Point a Confluent client (or `minimalist-kafka`) at it with `schema.registry.url=http://localhost:8081`.
+
+## REST API
+
+All error responses use the Confluent shape `{"error_code": <int>, "message": <string>}`, where `error_code`
+is a registry-specific sub-code (not the HTTP status).
+
+### `GET /` — health check
+
+Returns `200` with an empty object `{}`.
+
+```shell
+curl http://localhost:8081/
+# {}
+```
+
+### `POST /subjects/{subject}/versions` — register a schema
+
+Registers a schema under a subject and returns its **global id**. The id is content-addressed (identical
+content returns the same id, even across subjects); a new **version** is assigned under the subject unless the
+same content is already a version there (idempotent).
+
+Request body:
+
+```json
+{ "schema": "<escaped schema string>", "schemaType": "AVRO | JSON | PROTOBUF" }
+```
+
+`schema` is required (an opaque string — the registry is schema-language-agnostic). `schemaType` is optional
+and defaults to `AVRO`.
+
+```shell
+curl -X POST http://localhost:8081/subjects/orders-value/versions \
+  -H 'content-type: application/vnd.schemaregistry.v1+json' \
+  -d '{"schemaType":"JSON","schema":"{\"type\":\"object\",\"properties\":{\"hello\":{\"type\":\"string\"}}}"}'
+# {"id":1}
+```
+
+| Result | HTTP | error_code |
+|---|---|---|
+| Registered (or already present) | 200 | — (`{"id": N}`) |
+| Missing subject in path | 404 | 40401 |
+| Missing `schema` string, or not well-formed JSON (Avro/JSON only) | 422 | 42201 |
+
+### `GET /schemas/ids/{id}` — fetch a schema by global id
+
+```shell
+curl http://localhost:8081/schemas/ids/1
+# {"schema":"{...}","schemaType":"JSON"}
+```
+
+Returns `{"schema": ...}` plus `schemaType` for non-Avro schemas (Confluent omits `schemaType` for Avro, the
+default). Unknown id → `404` / `40403`.
+
+### `GET /subjects/{subject}/versions/{version}` — resolve a subject/version
+
+`{version}` is a positive integer (to pin a specific version) or the alias `latest`. This is what
+`getSchemaMetadata(subject, version)` / `getLatestSchemaMetadata(subject)` call to resolve a subject/version to
+a global schema id.
+
+```shell
+curl http://localhost:8081/subjects/orders-value/versions/latest
+# {"subject":"orders-value","id":1,"version":1,"schema":"{...}","schemaType":"JSON"}
+
+curl http://localhost:8081/subjects/orders-value/versions/1
+# {"subject":"orders-value","id":1,"version":1,"schema":"{...}","schemaType":"JSON"}
+```
+
+Returns `{subject, id, version, schema}` plus `schemaType` for non-Avro schemas.
+
+| Result | HTTP | error_code |
+|---|---|---|
+| Found | 200 | — |
+| Unknown subject | 404 | 40401 |
+| Unknown version (subject exists) | 404 | 40402 |
+
+## Storage
+
+Schemas are persisted as **one file per global id** — `<id>.json` (e.g. `1.json`) — under the directory set by
+`schema.registry.data.store` (default `/tmp/schema-registry`). Each file holds
+`{"schema", "schemaType", "subject", "version"}`.
+
+- **Stable ids across restarts.** Files are loaded on boot, so ids stay stable — the store is a convenient
+  place to back up or **seed** schemas with known ids (see the demo's `registry/{1,2,3}.json`).
+- **On-demand pickup.** A `<id>.json` dropped into the directory while the server is running is served on the
+  next `GET /schemas/ids/{id}` — no restart needed.
+- **Subjects & versions.** A global id is content-addressed; versions are per-subject, tracked in an in-memory
+  `subject → (version → id)` index rebuilt on boot from the per-id files. A subject-based lookup therefore
+  resolves subjects present at boot (or registered while running); a file dropped in after boot is
+  id-resolvable immediately but subject-resolvable only after a restart. A single `<id>.json` records one
+  subject/version, so the uncommon case of identical content under multiple subjects only round-trips the
+  first across a restart.
+
+Override the store for a durable location:
+
+```shell
+java -Dschema.registry.data.store="$HOME/schema-registry" -jar target/schema-registry-standalone-4.5.0.jar
+```
+
+## Choosing a port
+
+The port defaults to `8081`. Override it with the `rest.server.port` property:
+
+```shell
+java -Drest.server.port=8082 -jar target/schema-registry-standalone-4.5.0.jar
+```
+
+## Prefer Docker / the real registry?
+
+This helper simply removes the external-infrastructure requirement for local work. You can of course run the
+real Confluent Schema Registry (via Docker or Confluent Cloud) and point `schema.registry.url` at it instead —
+the API surface above is a faithful subset, so clients need no changes.

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/ApiError.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/ApiError.java
@@ -29,6 +29,7 @@ import java.util.Map;
  * where {@code error_code} is a registry-specific sub-code (not the HTTP status). The well-known codes:
  * <ul>
  *   <li>40401 - Subject not found (HTTP 404)</li>
+ *   <li>40402 - Version not found (HTTP 404)</li>
  *   <li>40403 - Schema not found (HTTP 404)</li>
  *   <li>42201 - Invalid schema (HTTP 422)</li>
  * </ul>
@@ -36,6 +37,7 @@ import java.util.Map;
 final class ApiError {
 
     static final int SUBJECT_NOT_FOUND = 40401;
+    static final int VERSION_NOT_FOUND = 40402;
     static final int SCHEMA_NOT_FOUND = 40403;
     static final int INVALID_SCHEMA = 42201;
 

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/GetVersionFunction.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/GetVersionFunction.java
@@ -1,0 +1,96 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.helpers.registry.services;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.helpers.registry.store.SchemaStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Faithful mock of Confluent's {@code GET /subjects/{subject}/versions/{version}} (fetch the schema metadata
+ * for a subject at a version). {@code version} is a positive integer or the alias {@code latest}.
+ * <p>
+ * The REST endpoint is wired directly to this function in rest.yaml (no flow), so the input is the raw
+ * {@link AsyncHttpRequest} and {@code subject}/{@code version} come from the path. The response mirrors
+ * Confluent: {@code {"subject", "id", "version", "schema"}} with {@code "schemaType"} included only for
+ * non-AVRO schemas (Confluent omits it for AVRO). Unknown subject ⇒ 404 / 40401; unknown version ⇒ 404 / 40402.
+ * This is what {@code CachedSchemaRegistryClient.getSchemaMetadata(subject, version)} and
+ * {@code getLatestSchemaMetadata(subject)} call to resolve a subject/version to a global schema id.
+ */
+@PreLoad(route = "schema.registry.get.version", instances = 10)
+public class GetVersionFunction implements TypedLambdaFunction<AsyncHttpRequest, EventEnvelope> {
+    private static final Logger log = LoggerFactory.getLogger(GetVersionFunction.class);
+
+    private static final String LATEST = "latest";
+
+    private final SchemaStore store = SchemaStore.getInstance();
+    private final Utility util = Utility.getInstance();
+
+    @Override
+    public EventEnvelope handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+        String subject = input.getPathParameter("subject");
+        String versionParam = input.getPathParameter("version");
+        if (subject == null || subject.isEmpty() || !store.hasSubject(subject)) {
+            log.warn("GET /subjects/{}/versions/{} -> 404 (subject not found)", subject, versionParam);
+            return ApiError.of(404, ApiError.SUBJECT_NOT_FOUND, "Subject '" + subject + "' not found");
+        }
+        Integer version = resolveVersion(subject, versionParam);
+        if (version == null) {
+            log.warn("GET /subjects/{}/versions/{} -> 404 (version not found)", subject, versionParam);
+            return ApiError.of(404, ApiError.VERSION_NOT_FOUND, "Version '" + versionParam + "' not found");
+        }
+        Integer id = store.idForVersion(subject, version);
+        SchemaStore.SchemaEntry entry = id == null ? null : store.get(id);
+        if (entry == null) {
+            log.warn("GET /subjects/{}/versions/{} -> 404 (version not found)", subject, versionParam);
+            return ApiError.of(404, ApiError.VERSION_NOT_FOUND, "Version '" + versionParam + "' not found");
+        }
+        Map<String, Object> response = new HashMap<>();
+        response.put("subject", subject);
+        response.put("id", id);
+        response.put("version", version);
+        response.put("schema", entry.schema());
+        // Confluent omits schemaType for AVRO (the default) and includes it otherwise.
+        if (!SchemaStore.AVRO_TYPE.equals(entry.schemaType())) {
+            response.put("schemaType", entry.schemaType());
+        }
+        log.info("GET /subjects/{}/versions/{} -> 200 (id={}, version={}, schemaType={})",
+                subject, versionParam, id, version, entry.schemaType());
+        return new EventEnvelope().setStatus(200).setBody(response);
+    }
+
+    /** Resolve {@code latest} to the newest version, or parse a positive integer; null if not resolvable. */
+    private Integer resolveVersion(String subject, String versionParam) {
+        if (versionParam == null || versionParam.isEmpty()) {
+            return null;
+        }
+        if (LATEST.equalsIgnoreCase(versionParam)) {
+            return store.latestVersion(subject);
+        }
+        return util.isDigits(versionParam) ? util.str2int(versionParam) : null;
+    }
+}

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/RegisterSchemaFunction.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/services/RegisterSchemaFunction.java
@@ -76,7 +76,7 @@ public class RegisterSchemaFunction implements TypedLambdaFunction<AsyncHttpRequ
             log.warn("POST /subjects/{}/versions (schemaType={}) -> 422 (not well-formed JSON)", subject, schemaType);
             return ApiError.of(422, ApiError.INVALID_SCHEMA, "Invalid schema: not well-formed JSON");
         }
-        int id = store.register(schema, schemaType);
+        int id = store.register(subject, schema, schemaType);
         log.info("POST /subjects/{}/versions (schemaType={}) -> 200 id={}", subject, schemaType, id);
         return new EventEnvelope().setStatus(200).setBody(Map.of("id", id));
     }

--- a/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/store/SchemaStore.java
+++ b/helpers/schema-registry-standalone/src/main/java/org/platformlambda/helpers/registry/store/SchemaStore.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,12 +37,22 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Minimalist in-memory schema store mimicking Confluent Schema Registry, persisted as <b>one file per schema
  * id</b> ({@code <id>.json}, e.g. {@code 1.json}) under the configurable {@code schema.registry.data.store}
- * directory (default {@code /tmp/schema-registry}). Each file holds {@code {"schema": ..., "schemaType": ...}}.
+ * directory (default {@code /tmp/schema-registry}). Each file holds
+ * {@code {"schema": ..., "schemaType": ..., "subject": ..., "version": ...}}.
  *
  * <p>The store is loaded on boot and persists across restarts, so schema ids stay stable - the per-id files
  * are a convenient store you can back up / seed (e.g. a demo with known ids). Because storage is one file per
  * id, a schema <b>dropped into the directory while the server is running</b> (e.g. {@code 10.json}) is picked
  * up <b>on demand</b> by the next {@code GET /schemas/ids/10} - no restart needed (see {@link #get(int)}).</p>
+ *
+ * <p><b>Subjects &amp; versions.</b> A global schema id is content-addressed (identical content = same id, even
+ * across subjects, faithful to Confluent). Versions are per-subject and tracked in an in-memory
+ * {@code subject → (version → id)} index, rebuilt on boot from the per-id files (each records the subject and
+ * version it was first registered under). This backs {@code GET /subjects/{subject}/versions/{version}} and
+ * {@code .../latest}. <b>Mock limitation:</b> a single {@code <id>.json} records one subject/version, so the
+ * uncommon case of the same content registered under multiple subjects only round-trips the first across a
+ * restart (all subjects still resolve within a running session). A file dropped in after boot is id-resolvable
+ * on demand, but subject-resolvable only after a restart (or re-registration).</p>
  *
  * <p>The default lives under {@code /tmp} (cleared by the OS on reboot); override to a durable directory
  * ({@code -Dschema.registry.data.store=$HOME/schema-registry}) to survive reboots.</p>
@@ -57,6 +68,8 @@ public class SchemaStore {
     private static final String SCHEMA = "schema";
     private static final String SCHEMA_TYPE = "schemaType";
     private static final String LEGACY_SCHEMA_TYPE = "schema_type";
+    private static final String SUBJECT = "subject";
+    private static final String VERSION = "version";
 
     private static final SchemaStore instance = new SchemaStore();
 
@@ -65,13 +78,16 @@ public class SchemaStore {
 
     private final ConcurrentMap<Integer, SchemaEntry> idToSchema = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Integer> hashToId = new ConcurrentHashMap<>();
+    // subject -> (version -> global schema id); versions are per-subject, ids are global/content-addressed.
+    private final ConcurrentMap<String, ConcurrentMap<Integer, Integer>> subjectVersions = new ConcurrentHashMap<>();
     private final AtomicInteger idGenerator = new AtomicInteger(1);
 
     private final String storeDir;
     private final Utility util = Utility.getInstance();
     private final CryptoApi crypto = new CryptoApi();
 
-    public record SchemaEntry(String schema, String schemaType) {}
+    /** A stored schema: the opaque schema string, its type, and the subject/version it was registered under. */
+    public record SchemaEntry(String schema, String schemaType, String subject, int version) {}
 
     private SchemaStore() {
         this.storeDir = AppConfigReader.getInstance().getProperty(STORE_DIR_KEY, DEFAULT_STORE_DIR);
@@ -84,19 +100,48 @@ public class SchemaStore {
         return instance;
     }
 
-    public int register(String schema, String schemaType) {
+    /**
+     * Register a schema under a subject. The global id is content-addressed (identical content returns the
+     * same id, even across subjects); a new version is assigned under the subject unless this id is already a
+     * version there (idempotent).
+     *
+     * @param subject    the subject to register under (the per-subject version sequence)
+     * @param schema     the opaque schema string
+     * @param schemaType {@code AVRO} (default when null/empty), {@code JSON}, or {@code PROTOBUF}
+     * @return the global schema id
+     */
+    public int register(String subject, String schema, String schemaType) {
         String type = schemaType == null || schemaType.isEmpty() ? AVRO_TYPE : schemaType;
         String hashKey = getHash(type + ":" + schema);
         Integer existingId = hashToId.get(hashKey);
-        if (existingId != null) {
-            return existingId;
+        int id = existingId != null ? existingId : nextFreeId();
+        int version = assignVersion(subject, id);
+        if (existingId == null) {
+            // First time this content is seen: store + persist with the registering subject/version.
+            SchemaEntry entry = new SchemaEntry(schema, type, subject, version);
+            idToSchema.put(id, entry);
+            hashToId.put(hashKey, id);
+            saveEntry(id, entry);
         }
-        int newId = nextFreeId();
-        SchemaEntry entry = new SchemaEntry(schema, type);
-        idToSchema.put(newId, entry);
-        hashToId.put(hashKey, newId);
-        saveEntry(newId, entry);
-        return newId;
+        return id;
+    }
+
+    /** Assign (or find, if idempotent) the per-subject version for {@code id}. Returns 0 when no subject. */
+    private int assignVersion(String subject, int id) {
+        if (subject == null || subject.isEmpty()) {
+            return 0;
+        }
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.computeIfAbsent(subject, k -> new ConcurrentHashMap<>());
+        synchronized (versions) {
+            for (Map.Entry<Integer, Integer> e : versions.entrySet()) {
+                if (e.getValue().equals(id)) {
+                    return e.getKey();
+                }
+            }
+            int version = versions.isEmpty() ? 1 : Collections.max(versions.keySet()) + 1;
+            versions.put(version, id);
+            return version;
+        }
     }
 
     /**
@@ -110,6 +155,29 @@ public class SchemaStore {
     public SchemaEntry get(int id) {
         SchemaEntry entry = idToSchema.get(id);
         return entry != null ? entry : loadEntry(id);
+    }
+
+    /** @return true if the subject has at least one registered version. */
+    public boolean hasSubject(String subject) {
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.get(subject);
+        return versions != null && !versions.isEmpty();
+    }
+
+    /** @return the newest version number for the subject, or {@code null} if the subject is unknown/empty. */
+    public Integer latestVersion(String subject) {
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.get(subject);
+        if (versions == null || versions.isEmpty()) {
+            return null;
+        }
+        synchronized (versions) {
+            return Collections.max(versions.keySet());
+        }
+    }
+
+    /** @return the global schema id for {@code subject} at {@code version}, or {@code null} if not found. */
+    public Integer idForVersion(String subject, int version) {
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.get(subject);
+        return versions == null ? null : versions.get(version);
     }
 
     private String getHash(String typeAndSchema) {
@@ -145,12 +213,14 @@ public class SchemaStore {
             String name = file.getName();
             loadEntry(util.str2int(name.substring(0, name.length() - JSON_SUFFIX.length())));
         }
-        log.info("Loaded {} schemas from disk. Next ID will be {}", idToSchema.size(), idGenerator.get());
+        log.info("Loaded {} schemas ({} subjects) from disk. Next ID will be {}",
+                idToSchema.size(), subjectVersions.size(), idGenerator.get());
     }
 
     /**
-     * Read {@code <id>.json} from disk into memory and advance the id generator past it (so a later
-     * registration never reuses the id). Returns {@code null} when the file is absent or unreadable.
+     * Read {@code <id>.json} from disk into memory, index its subject/version, and advance the id generator
+     * past it (so a later registration never reuses the id). Returns {@code null} when the file is absent or
+     * unreadable.
      */
     @SuppressWarnings("unchecked")
     private SchemaEntry loadEntry(int id) {
@@ -159,19 +229,24 @@ public class SchemaStore {
             return null;
         }
         try {
-            Map<String, String> map = SimpleMapper.getInstance().getMapper()
+            Map<String, Object> map = SimpleMapper.getInstance().getMapper()
                     .readValue(Files.readString(file.toPath()), Map.class);
-            String schema = map.get(SCHEMA);
-            if (schema == null) {
+            Object schemaValue = map.get(SCHEMA);
+            if (!(schemaValue instanceof String schema) || schema.isEmpty()) {
                 return null;
             }
             // accept either "schemaType" (canonical) or a legacy "schema_type"; default to AVRO.
-            String type = map.containsKey(LEGACY_SCHEMA_TYPE)
-                    ? map.get(LEGACY_SCHEMA_TYPE)
+            Object typeValue = map.containsKey(LEGACY_SCHEMA_TYPE) ? map.get(LEGACY_SCHEMA_TYPE)
                     : map.getOrDefault(SCHEMA_TYPE, AVRO_TYPE);
-            SchemaEntry entry = new SchemaEntry(schema, type);
+            String type = typeValue == null ? AVRO_TYPE : String.valueOf(typeValue);
+            String subject = map.get(SUBJECT) == null ? null : String.valueOf(map.get(SUBJECT));
+            int version = map.get(VERSION) == null ? 0 : util.str2int(String.valueOf(map.get(VERSION)));
+            SchemaEntry entry = new SchemaEntry(schema, type, subject, version);
             idToSchema.put(id, entry);
             hashToId.put(getHash(type + ":" + schema), id);
+            if (subject != null && !subject.isEmpty() && version > 0) {
+                subjectVersions.computeIfAbsent(subject, k -> new ConcurrentHashMap<>()).put(version, id);
+            }
             idGenerator.accumulateAndGet(id + 1, Math::max);
             return entry;
         } catch (IOException | RuntimeException e) {

--- a/helpers/schema-registry-standalone/src/main/resources/rest.yaml
+++ b/helpers/schema-registry-standalone/src/main/resources/rest.yaml
@@ -13,3 +13,8 @@ rest:
     methods:
       - "GET"
     url: "/schemas/ids/{id}"
+
+  - service: "schema.registry.get.version"
+    methods:
+      - "GET"
+    url: "/subjects/{subject}/versions/{version}"

--- a/helpers/schema-registry-standalone/src/test/java/org/platformlambda/helpers/registry/SchemaRegistryTest.java
+++ b/helpers/schema-registry-standalone/src/test/java/org/platformlambda/helpers/registry/SchemaRegistryTest.java
@@ -185,6 +185,42 @@ class SchemaRegistryTest {
         assertEquals(42201, body.get("error_code"));
     }
 
+    @Test
+    void resolveSubjectVersion() throws Exception {
+        String schema = asSchemaString(JSON_SCHEMA);
+        EventEnvelope reg = http("POST", "/subjects/test-version/versions", registerBody(schema, "JSON"));
+        int id = (Integer) ((Map<?, ?>) reg.getBody()).get("id");
+
+        // GET /subjects/{subject}/versions/latest -> Confluent metadata shape {subject,id,version,schema,schemaType}
+        EventEnvelope latest = http("GET", "/subjects/test-version/versions/latest", null);
+        assertEquals(200, latest.getStatus());
+        Map<?, ?> body = (Map<?, ?>) latest.getBody();
+        assertEquals("test-version", body.get("subject"));
+        assertEquals(id, ((Number) body.get("id")).intValue());
+        assertEquals(1, ((Number) body.get("version")).intValue());
+        assertEquals("JSON", body.get("schemaType"));
+        assertEquals(schema, body.get("schema"));
+
+        // .../versions/1 resolves the same id as latest
+        EventEnvelope v1 = http("GET", "/subjects/test-version/versions/1", null);
+        assertEquals(200, v1.getStatus());
+        assertEquals(id, ((Number) ((Map<?, ?>) v1.getBody()).get("id")).intValue());
+    }
+
+    @Test
+    void unknownSubjectAndVersionReturn404() throws Exception {
+        // unknown subject -> Confluent error_code 40401
+        EventEnvelope noSubject = http("GET", "/subjects/no-such-subject/versions/latest", null);
+        assertEquals(404, noSubject.getStatus());
+        assertEquals(40401, ((Map<?, ?>) noSubject.getBody()).get("error_code"));
+
+        // known subject, unknown version -> Confluent error_code 40402
+        http("POST", "/subjects/test-ver-404/versions", registerBody(asSchemaString(Map.of("type", "string")), null));
+        EventEnvelope noVersion = http("GET", "/subjects/test-ver-404/versions/99", null);
+        assertEquals(404, noVersion.getStatus());
+        assertEquals(40402, ((Map<?, ?>) noVersion.getBody()).get("error_code"));
+    }
+
     /** Serialize a schema document to the compact (non-pretty) escaped string the Confluent API carries. */
     private static String asSchemaString(Map<String, Object> schema) {
         return SimpleMapper.getInstance().getCompactGson().toJson(schema);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHeaders.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHeaders.java
@@ -34,17 +34,21 @@ public final class KafkaHeaders {
     public static final String CORRELATION_ID = "cid";
 
     /**
-     * Optional for {@code simple.kafka.notification}: the global schema id (an int) to serialize the body
-     * with, using the Confluent wire format. When present, {@link #SCHEMA_TYPE} selects the serializer.
-     * Absent ⇒ the body is published as raw byte[] (the default minimalist behavior).
+     * Optional for {@code simple.kafka.notification}: the registry <b>subject</b> whose schema serializes the
+     * body into the Confluent wire format. The subject + {@link #VERSION} are resolved to a global schema id
+     * (and type) via the Schema Registry client; the caller never needs to know the id. Absent ⇒ the body is
+     * published as raw byte[] (the default minimalist behavior).
      */
-    public static final String SCHEMA_ID = "schema-id";
+    public static final String SUBJECT = "subject";
 
     /**
-     * Optional companion to {@link #SCHEMA_ID}: the schema type (e.g. {@code JSON}). Defaults to {@code JSON}
-     * when a {@link #SCHEMA_ID} is given without a type.
+     * Optional companion to {@link #SUBJECT}: the subject version to resolve - {@code "latest"} (the default
+     * when omitted) or a positive integer. The schema type is resolved from the registry, not supplied.
      */
-    public static final String SCHEMA_TYPE = "schema-type";
+    public static final String VERSION = "version";
+
+    /** Default {@link #VERSION} when a {@link #SUBJECT} is given without one. */
+    public static final String DEFAULT_VERSION = "latest";
 
     private KafkaHeaders() {}
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
@@ -24,10 +24,9 @@ import org.platformlambda.core.models.TraceInfo;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.serializers.SimpleMapper;
 import org.platformlambda.core.system.PostOffice;
-import org.platformlambda.core.util.Utility;
 import org.platformlambda.core.util.W3cTrace;
+import org.platformlambda.mini.kafka.schema.ResolvedSchema;
 import org.platformlambda.mini.kafka.schema.SchemaCodec;
-import org.platformlambda.mini.kafka.schema.SchemaType;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
@@ -85,11 +84,11 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
         Integer partition = parsePartition(headers.get(KafkaHeaders.PARTITION));
         Map<String, byte[]> kafkaHeaders = new HashMap<>();
         headers.forEach((key, value) -> {
-            // topic/partition/schema-* are routing/encoding directives; the inbound traceparent is replaced below.
+            // topic/partition/subject/version are routing/encoding directives; the inbound traceparent is replaced below.
             if (!KafkaHeaders.TOPIC.equals(key)
                     && !KafkaHeaders.PARTITION.equals(key)
-                    && !KafkaHeaders.SCHEMA_ID.equals(key)
-                    && !KafkaHeaders.SCHEMA_TYPE.equals(key)
+                    && !KafkaHeaders.SUBJECT.equals(key)
+                    && !KafkaHeaders.VERSION.equals(key)
                     && !W3cTrace.TRACEPARENT.equals(key)) {
                 kafkaHeaders.put(key, value.getBytes(StandardCharsets.UTF_8));
             }
@@ -103,29 +102,28 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
     }
 
     /**
-     * When a {@code schema-id} header is present, serialize the body into the Confluent wire format via this
-     * instance's own {@link SchemaCodec.Encoder} (the schema is pre-registered; identified by id). Otherwise
-     * the body is published as raw byte[] - the default minimalist behavior.
+     * When a {@code subject} header is present, serialize the body into the Confluent wire format via this
+     * instance's own {@link SchemaCodec.Encoder}: the {@code subject} + {@code version} (default
+     * {@code latest}) are resolved to a global schema id and type, and the body is framed with that id.
+     * Otherwise the body is published as raw byte[] - the default minimalist behavior.
      */
     private byte[] encode(String topic, Map<String, String> headers, byte[] body, int instance) {
-        String schemaId = headers.get(KafkaHeaders.SCHEMA_ID);
-        if (schemaId == null) {
+        String subject = headers.get(KafkaHeaders.SUBJECT);
+        if (subject == null || subject.isBlank()) {
             return body;
         }
         SchemaCodec codec = KafkaRuntime.schemaCodec();
         if (codec == null) {
-            throw new IllegalStateException("'" + KafkaHeaders.SCHEMA_ID + "' header set but "
+            throw new IllegalStateException("'" + KafkaHeaders.SUBJECT + "' header set but "
                     + "'schema.registry.url' is not configured");
         }
-        if (!Utility.getInstance().isDigits(schemaId.trim())) {
-            throw new IllegalArgumentException("'" + KafkaHeaders.SCHEMA_ID + "' must be an integer, got '"
-                    + schemaId + "'");
-        }
-        SchemaType type = SchemaType.from(headers.get(KafkaHeaders.SCHEMA_TYPE));
+        String version = headers.getOrDefault(KafkaHeaders.VERSION, KafkaHeaders.DEFAULT_VERSION);
+        // Resolve subject+version -> global id + type (cached); throws IllegalState/IllegalArgument on failure.
+        ResolvedSchema resolved = codec.resolve(subject, version);
         // The body is the structured value to encode (for JSON, a JSON document); parse it for the serializer.
         Object value = SimpleMapper.getInstance().getMapper().readValue(body, Object.class);
         SchemaCodec.Encoder encoder = encoders.computeIfAbsent(instance, i -> codec.newEncoder());
-        return encoder.serialize(topic, type, Integer.parseInt(schemaId.trim()), value);
+        return encoder.serialize(topic, resolved.type(), resolved.id(), value);
     }
 
     /** Build a W3C traceparent from this function's current trace context (null if tracing is off). */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ManagedCacheSchemaRegistryClient.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ManagedCacheSchemaRegistryClient.java
@@ -21,8 +21,10 @@ package org.platformlambda.mini.kafka.schema;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.platformlambda.core.util.ManagedCache;
+import org.platformlambda.core.util.Utility;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,13 +48,18 @@ import java.util.Map;
  */
 public class ManagedCacheSchemaRegistryClient extends CachedSchemaRegistryClient {
 
+    /** The reserved version alias that resolves to a subject's current newest version. */
+    public static final String LATEST = "latest";
+
     private final ManagedCache cache;
+    private final ManagedCache versionCache;
 
     public ManagedCacheSchemaRegistryClient(List<String> urls, int identityMapCapacity,
                                             List<SchemaProvider> providers, Map<String, ?> configs,
-                                            ManagedCache cache) {
+                                            ManagedCache cache, ManagedCache versionCache) {
         super(urls, identityMapCapacity, providers, configs);
         this.cache = cache;
+        this.versionCache = versionCache;
     }
 
     /**
@@ -75,5 +82,57 @@ public class ManagedCacheSchemaRegistryClient extends CachedSchemaRegistryClient
         ParsedSchema schema = super.getSchemaById(id);
         cache.put(key, schema);
         return schema;
+    }
+
+    /**
+     * Resolve a {@code (subject, version)} to a global schema id and its type. The id is then used by the
+     * id-based serializer ({@code use.schema.id}) to frame the Confluent wire format - subject/version are a
+     * producer-side convenience and never travel on the wire.
+     *
+     * <p><b>Cache, by mutability.</b> A pinned numeric version is immutable, so its resolution is cached in
+     * {@code versionCache} (long TTL, bounded). A subject's {@code latest} is mutable (a new registration
+     * moves it), so it shares the short-TTL id→schema {@code cache} (under a {@code "latest/"}-namespaced key
+     * that cannot collide with the digit-only id keys) - a short TTL re-resolves a moved {@code latest}.</p>
+     *
+     * <p>The schema type is taken from the parsed schema (via {@link #getSchemaById(int)}), so it is
+     * authoritative - never guessed from a possibly-absent {@code schemaType} - and that lookup also warms the
+     * id→schema cache, so the subsequent serialize needs no extra round-trip.</p>
+     *
+     * @param subject the registered subject name
+     * @param version {@code "latest"} (or null/blank) for the newest version, or a positive integer
+     * @return the resolved global id and schema type
+     * @throws IOException              if a registry round-trip fails
+     * @throws RestClientException      if the registry rejects the lookup (e.g. subject/version not found)
+     * @throws IllegalArgumentException if {@code version} is neither {@code "latest"} nor a positive integer
+     */
+    public ResolvedSchema resolve(String subject, String version) throws IOException, RestClientException {
+        boolean latest = version == null || version.isBlank() || LATEST.equalsIgnoreCase(version.trim());
+        int parsedVersion = latest ? 0 : parseVersion(version);
+        // latest shares the short-TTL id cache (mutable); pinned numeric versions use the long-TTL version
+        // cache (immutable). The "latest/" prefix keeps latest keys out of the id cache's digit-only key space.
+        String key = latest ? LATEST + "/" + subject : subject + "/" + parsedVersion;
+        ManagedCache nameCache = latest ? cache : versionCache;
+        if (nameCache.get(key) instanceof ResolvedSchema cached) {
+            return cached;
+        }
+        SchemaMetadata metadata = latest ? getLatestSchemaMetadata(subject) : getSchemaMetadata(subject, parsedVersion);
+        int id = metadata.getId();
+        // Authoritative type from the parsed schema; also warms the id→schema cache for the serialize step.
+        ResolvedSchema resolved = new ResolvedSchema(id, SchemaType.from(getSchemaById(id).schemaType()));
+        nameCache.put(key, resolved);
+        return resolved;
+    }
+
+    private static int parseVersion(String version) {
+        String v = version.trim();
+        if (!Utility.getInstance().isDigits(v)) {
+            throw new IllegalArgumentException("'version' must be '" + LATEST
+                    + "' or a positive integer, got '" + version + "'");
+        }
+        int parsed = Integer.parseInt(v);
+        if (parsed < 1) {
+            throw new IllegalArgumentException("'version' must be >= 1, got '" + version + "'");
+        }
+        return parsed;
     }
 }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ResolvedSchema.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ResolvedSchema.java
@@ -1,0 +1,29 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka.schema;
+
+/**
+ * The result of resolving a {@code (subject, version)} to a registered schema: the global schema id used to
+ * frame the Confluent wire format, and the schema type that selects the serializer. Both are derived from
+ * the registry (the type authoritatively from the parsed schema, so it is never guessed).
+ *
+ * @param id   the global schema id
+ * @param type the schema type
+ */
+public record ResolvedSchema(int id, SchemaType type) {}

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -65,8 +65,19 @@ public class SchemaCodec {
     private static final String REGISTRY_URL = "schema.registry.url";
     private static final String CACHE_TTL = "schema.registry.cache.ttl";
     private static final String DEFAULT_CACHE_TTL = "30m";
-    /** Name of the platform {@link ManagedCache} that holds id→schema lookups (for monitoring/inspection). */
+    private static final String VERSION_CACHE_TTL = "schema.registry.version.cache.ttl";
+    // A pinned subject+numeric-version is immutable, so it can be cached effectively forever; a long TTL
+    // (plus a bounded item count) keeps it fresh enough while removing any unbounded-growth risk.
+    private static final String DEFAULT_VERSION_CACHE_TTL = "10d";
+    private static final long VERSION_CACHE_MAX_ITEMS = 3000L;
+    /**
+     * Name of the platform {@link ManagedCache} that holds id→schema lookups (for monitoring/inspection).
+     * It also holds {@code subject+latest → (id,type)} resolutions (mutable, so the same short TTL applies),
+     * under {@code "latest/"}-namespaced keys that cannot collide with the digit-only id keys.
+     */
     public static final String CACHE_NAME = "schema.registry";
+    /** ManagedCache holding {@code subject+numeric-version → (id,type)} resolutions (immutable, long TTL, bounded). */
+    public static final String VERSION_CACHE_NAME = "schema.registry.version";
     private static final int IDENTITY_MAP_CAPACITY = 1000;
     private static final byte MAGIC_BYTE = 0x0;
 
@@ -131,6 +142,12 @@ public class SchemaCodec {
          */
         ManagedCache cache = ManagedCache.createCache(CACHE_NAME, ttlMillis);
         cache.clear();
+        // subject+numeric-version → (id,type): immutable, so a long TTL (default 10d), bounded to 3000 items.
+        long versionTtlMillis = 1000L * Utility.getInstance()
+                .getDurationInSeconds(config.getProperty(VERSION_CACHE_TTL, DEFAULT_VERSION_CACHE_TTL));
+        ManagedCache versionCache = ManagedCache.createCache(VERSION_CACHE_NAME, versionTtlMillis, VERSION_CACHE_MAX_ITEMS);
+        versionCache.clear();
+        // (subject+latest resolutions share the short-TTL id cache above; no separate cache needed.)
         Map<String, Object> srConfig = new HashMap<>();
         srConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
         /*
@@ -145,7 +162,7 @@ public class SchemaCodec {
         SchemaRegistryClient client = new ManagedCacheSchemaRegistryClient(List.of(registryUrl),
                 IDENTITY_MAP_CAPACITY,
                 List.of(new JsonSchemaProvider(), new AvroSchemaProvider(), new ProtobufSchemaProvider()),
-                srConfig, cache);
+                srConfig, cache, versionCache);
         log.info("Schema codec ready (registry={}, cache={}, ttlMs={}, types={})",
                 registryUrl, CACHE_NAME, ttlMillis, List.of(SchemaType.values()));
         return new SchemaCodec(client, registryUrl);
@@ -206,6 +223,29 @@ public class SchemaCodec {
             return SchemaType.from(schema.schemaType());
         } catch (IOException | RestClientException e) {
             throw new IllegalStateException("Unable to resolve schema id " + id + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Resolve a {@code (subject, version)} to a global schema id + type (cached two-tier; see
+     * {@link ManagedCacheSchemaRegistryClient#resolve}). This is the producer-side convenience that lets a
+     * caller name a subject instead of knowing the global id.
+     *
+     * @param subject the registered subject name
+     * @param version {@code "latest"} (or null/blank) for the newest version, or a positive integer
+     * @return the resolved global id and schema type
+     * @throws IllegalStateException    if the subject/version cannot be resolved against the registry
+     * @throws IllegalArgumentException if {@code version} is neither {@code "latest"} nor a positive integer
+     */
+    public ResolvedSchema resolve(String subject, String version) {
+        if (!(client instanceof ManagedCacheSchemaRegistryClient resolver)) {
+            throw new IllegalStateException("subject/version resolution requires ManagedCacheSchemaRegistryClient");
+        }
+        try {
+            return resolver.resolve(subject, version);
+        } catch (IOException | RestClientException e) {
+            throw new IllegalStateException("Unable to resolve subject '" + subject + "' version '"
+                    + version + "': " + e.getMessage(), e);
         }
     }
 

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedSchemaRegistry.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +41,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <ul>
  *   <li>{@code POST /subjects/{subject}/versions} - register, returns {@code {"id": N}} (content-based,
- *       global, deduplicated)</li>
+ *       global, deduplicated; also assigns a per-subject version)</li>
+ *   <li>{@code GET /subjects/{subject}/versions/{version}} - subject+version metadata ({@code latest} or an
+ *       integer), used to resolve a subject/version to a global id</li>
  *   <li>{@code GET /schemas/ids/{id}} - returns {@code {"schema": ..., "schemaType": ...}}</li>
  *   <li>{@code POST /subjects/{subject}} - schema lookup, returns the registered entity or 404</li>
  * </ul>
@@ -56,10 +59,14 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
     // fixed port (predictable: if it is in use the test fails fast rather than picking a surprise port)
     private static final int PORT = 18081;
 
+    private static final String LATEST = "latest";
+
     private final HttpServer server;
     private final AtomicInteger idGenerator = new AtomicInteger(1);
     private final ConcurrentMap<String, Integer> contentToId = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, Map<String, Object>> idToSchema = new ConcurrentHashMap<>();
+    // subject -> (version -> global id); versions are per-subject, ids are global/content-addressed.
+    private final ConcurrentMap<String, ConcurrentMap<Integer, Integer>> subjectVersions = new ConcurrentHashMap<>();
 
     public EmbeddedSchemaRegistry() throws IOException {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", PORT), 0);
@@ -95,7 +102,9 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
             String path = exchange.getRequestURI().getPath();
             String[] p = path.split("/");
             if ("POST".equals(method) && p.length == 4 && "subjects".equals(p[1]) && "versions".equals(p[3])) {
-                register(exchange);
+                register(exchange, decode(p[2]));
+            } else if ("GET".equals(method) && p.length == 5 && "subjects".equals(p[1]) && "versions".equals(p[3])) {
+                getVersion(exchange, decode(p[2]), p[4]);
             } else if ("POST".equals(method) && p.length == 3 && "subjects".equals(p[1])) {
                 lookup(exchange, decode(p[2]));
             } else if ("GET".equals(method) && p.length == 4 && "schemas".equals(p[1]) && "ids".equals(p[2])) {
@@ -109,7 +118,7 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
         }
     }
 
-    private void register(com.sun.net.httpserver.HttpExchange exchange) throws IOException {
+    private void register(com.sun.net.httpserver.HttpExchange exchange, String subject) throws IOException {
         Map<String, Object> body = readBody(exchange);
         String schema = String.valueOf(body.get(SCHEMA));
         String type = body.containsKey(SCHEMA_TYPE) ? String.valueOf(body.get(SCHEMA_TYPE)) : AVRO;
@@ -121,7 +130,48 @@ public class EmbeddedSchemaRegistry implements AutoCloseable {
             idToSchema.put(newId, entry);
             return newId;
         });
+        assignVersion(subject, id);
         respond(exchange, 200, Map.of("id", id));
+    }
+
+    /** Assign (or find, if idempotent) the per-subject version for {@code id}. */
+    private void assignVersion(String subject, int id) {
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.computeIfAbsent(subject, k -> new ConcurrentHashMap<>());
+        synchronized (versions) {
+            for (Map.Entry<Integer, Integer> e : versions.entrySet()) {
+                if (e.getValue().equals(id)) {
+                    return;
+                }
+            }
+            versions.put(versions.isEmpty() ? 1 : Collections.max(versions.keySet()) + 1, id);
+        }
+    }
+
+    /** {@code GET /subjects/{subject}/versions/{version}} - metadata used to resolve subject+version to an id. */
+    private void getVersion(com.sun.net.httpserver.HttpExchange exchange, String subject, String versionParam)
+            throws IOException {
+        ConcurrentMap<Integer, Integer> versions = subjectVersions.get(subject);
+        if (versions == null || versions.isEmpty()) {
+            respond(exchange, 404, Map.of("error_code", 40401, "message", "Subject '" + subject + "' not found"));
+            return;
+        }
+        Integer version = LATEST.equalsIgnoreCase(versionParam) ? Collections.max(versions.keySet())
+                : (Utility.getInstance().isDigits(versionParam) ? Utility.getInstance().str2int(versionParam) : null);
+        Integer id = version == null ? null : versions.get(version);
+        if (id == null) {
+            respond(exchange, 404, Map.of("error_code", 40402, "message", "Version '" + versionParam + "' not found"));
+            return;
+        }
+        Map<String, Object> entry = idToSchema.get(id);
+        Map<String, Object> entity = new HashMap<>();
+        entity.put("subject", subject);
+        entity.put("version", version);
+        entity.put("id", id);
+        entity.put(SCHEMA, entry.get(SCHEMA));
+        if (!AVRO.equals(entry.get(SCHEMA_TYPE))) {
+            entity.put(SCHEMA_TYPE, entry.get(SCHEMA_TYPE));
+        }
+        respond(exchange, 200, entity);
     }
 
     private void lookup(com.sun.net.httpserver.HttpExchange exchange, String subject) throws IOException {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
@@ -134,18 +134,19 @@ class KafkaFlowAdapterTest {
     @SuppressWarnings("unchecked")
     void schemaFramedMessageDecodedIntoFlow() throws Exception {
         SchemaSinkTask.RECEIVED.clear();
-        // pre-register the JSON schema (governed artifact); the producer publishes by its global id
-        int schemaId = KafkaRuntime.schemaCodec().client().register(SCHEMA_TOPIC + "-value", new JsonSchema(JSON_SCHEMA));
+        // pre-register the JSON schema (governed artifact) under a subject; the producer names the subject
+        String subject = SCHEMA_TOPIC + "-value";
+        KafkaRuntime.schemaCodec().client().register(subject, new JsonSchema(JSON_SCHEMA));
         String cid = Utility.getInstance().getUuid();
 
-        // publish via simple.kafka.notification with schema-id: the body is serialized into the Confluent
-        // wire format; the schema-enabled adapter binding decodes it back to a Map for the flow.
+        // publish via simple.kafka.notification with subject (version defaults to latest): the producer
+        // resolves the schema id, serializes into the Confluent wire format; the schema-enabled adapter
+        // binding decodes it back to a Map for the flow.
         PostOffice po = PostOffice.trackable("unit.test", TRACE_ID, "TEST /schema");
         po.send(new EventEnvelope().setTo("simple.kafka.notification")
                 .setHeader(KafkaHeaders.TOPIC, SCHEMA_TOPIC)
                 .setHeader(KafkaHeaders.CORRELATION_ID, cid)
-                .setHeader(KafkaHeaders.SCHEMA_ID, String.valueOf(schemaId))
-                .setHeader(KafkaHeaders.SCHEMA_TYPE, "JSON")
+                .setHeader(KafkaHeaders.SUBJECT, subject)
                 .setBody("{\"hello\":\"schema\"}".getBytes(StandardCharsets.UTF_8))
                 .setTraceId(TRACE_ID).setTracePath("TEST /schema"));
 
@@ -162,18 +163,18 @@ class KafkaFlowAdapterTest {
     @SuppressWarnings("unchecked")
     void avroFramedMessageDecodedIntoFlow() throws Exception {
         SchemaSinkTask.RECEIVED.clear();
-        // pre-register the Avro schema (governed artifact); the producer publishes by its global id
-        int schemaId = KafkaRuntime.schemaCodec().client().register(AVRO_TOPIC + "-value", new AvroSchema(AVRO_SCHEMA));
+        // pre-register the Avro schema (governed artifact) under a subject; the producer names the subject
+        String subject = AVRO_TOPIC + "-value";
+        KafkaRuntime.schemaCodec().client().register(subject, new AvroSchema(AVRO_SCHEMA));
         String cid = Utility.getInstance().getUuid();
 
-        // publish via simple.kafka.notification with schema-type=AVRO: the body is serialized into the
-        // Confluent Avro wire format; the schema-enabled adapter binding decodes it back to a Map.
+        // publish via simple.kafka.notification with subject (version defaults to latest): the body is
+        // serialized into the Confluent Avro wire format; the schema-enabled adapter binding decodes it to a Map.
         PostOffice po = PostOffice.trackable("unit.test", TRACE_ID, "TEST /avro");
         po.send(new EventEnvelope().setTo("simple.kafka.notification")
                 .setHeader(KafkaHeaders.TOPIC, AVRO_TOPIC)
                 .setHeader(KafkaHeaders.CORRELATION_ID, cid)
-                .setHeader(KafkaHeaders.SCHEMA_ID, String.valueOf(schemaId))
-                .setHeader(KafkaHeaders.SCHEMA_TYPE, "AVRO")
+                .setHeader(KafkaHeaders.SUBJECT, subject)
                 .setBody("{\"hello\":\"avro\"}".getBytes(StandardCharsets.UTF_8))
                 .setTraceId(TRACE_ID).setTracePath("TEST /avro"));
 
@@ -190,19 +191,18 @@ class KafkaFlowAdapterTest {
     @SuppressWarnings("unchecked")
     void protobufFramedMessageDecodedIntoFlow() throws Exception {
         SchemaSinkTask.RECEIVED.clear();
-        // pre-register the Protobuf schema (governed artifact); the producer publishes by its global id
-        int schemaId = KafkaRuntime.schemaCodec().client()
-                .register(PROTOBUF_TOPIC + "-value", new ProtobufSchema(PROTO_SCHEMA));
+        // pre-register the Protobuf schema (governed artifact) under a subject; the producer names the subject
+        String subject = PROTOBUF_TOPIC + "-value";
+        KafkaRuntime.schemaCodec().client().register(subject, new ProtobufSchema(PROTO_SCHEMA));
         String cid = Utility.getInstance().getUuid();
 
-        // publish via simple.kafka.notification with schema-type=PROTOBUF: the body is serialized into the
-        // Confluent Protobuf wire format; the schema-enabled adapter binding decodes it back to a Map.
+        // publish via simple.kafka.notification with subject (version defaults to latest): the body is
+        // serialized into the Confluent Protobuf wire format; the schema-enabled adapter binding decodes it.
         PostOffice po = PostOffice.trackable("unit.test", TRACE_ID, "TEST /protobuf");
         po.send(new EventEnvelope().setTo("simple.kafka.notification")
                 .setHeader(KafkaHeaders.TOPIC, PROTOBUF_TOPIC)
                 .setHeader(KafkaHeaders.CORRELATION_ID, cid)
-                .setHeader(KafkaHeaders.SCHEMA_ID, String.valueOf(schemaId))
-                .setHeader(KafkaHeaders.SCHEMA_TYPE, "PROTOBUF")
+                .setHeader(KafkaHeaders.SUBJECT, subject)
                 .setBody("{\"hello\":\"protobuf\"}".getBytes(StandardCharsets.UTF_8))
                 .setTraceId(TRACE_ID).setTracePath("TEST /protobuf"));
 

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.ManagedCache;
+import org.platformlambda.mini.kafka.schema.ResolvedSchema;
 import org.platformlambda.mini.kafka.schema.SchemaCodec;
 import org.platformlambda.mini.kafka.schema.SchemaType;
 
@@ -114,6 +115,37 @@ class SchemaCodecTest {
         assertEquals("world", ((Map<?, ?>) decoded).get("hello"));
 
         assertTrue(schemaCached(id), "schema cached in memory by id");
+    }
+
+    @Test
+    void resolveSubjectVersionToId() throws Exception {
+        String subject = "resolve-demo-value";
+        int id = codec.client().register(subject, new JsonSchema(JSON_SCHEMA));
+
+        ResolvedSchema byLatest = codec.resolve(subject, "latest");
+        assertEquals(id, byLatest.id(), "latest resolves to the registered global id");
+        assertEquals(SchemaType.JSON, byLatest.type(), "type derived authoritatively from the parsed schema");
+
+        assertEquals(id, codec.resolve(subject, null).id(), "null/blank version means latest");
+        assertEquals(id, codec.resolve(subject, "1").id(), "pinned version 1 resolves to the same id");
+
+        // resolution is cached: numeric in the (long-TTL) version cache, latest in the (short-TTL) id cache
+        assertTrue(ManagedCache.getInstance(SchemaCodec.VERSION_CACHE_NAME).exists(subject + "/1"),
+                "numeric version resolution cached");
+        assertTrue(ManagedCache.getInstance(SchemaCodec.CACHE_NAME).exists("latest/" + subject),
+                "latest resolution cached in the id cache under a namespaced key");
+    }
+
+    @Test
+    void resolveRejectsBadVersionAndUnknownSubject() throws Exception {
+        String subject = "resolve-errors-value";
+        codec.client().register(subject, new JsonSchema(JSON_SCHEMA));
+        // a non-numeric, non-"latest" version is rejected up front
+        assertThrows(IllegalArgumentException.class, () -> codec.resolve(subject, "v2"),
+                "version must be 'latest' or a positive integer");
+        // an unknown subject cannot be resolved
+        assertThrows(IllegalStateException.class, () -> codec.resolve("no-such-subject", "latest"),
+                "unknown subject fails to resolve");
     }
 
     @Test


### PR DESCRIPTION
## What

`simple.kafka.notification` now serializes by a registry **`subject`** (+ optional **`version`**, default
`latest`) instead of a caller-supplied global schema id. The producer resolves subject/version → global id
+ schema type internally, then serializes through the unchanged id-based (`use.schema.id`) path. Because
4.5.0 of `minimalist-kafka` is unreleased, the previous `schema-id`/`schema-type` headers are removed
outright — this is the single, simpler producer contract, not an added option.

- **`KafkaHeaders`**: `SUBJECT` (`subject`) + `VERSION` (`version`, default `latest`) replace `SCHEMA_ID`/`SCHEMA_TYPE`.
- **`ManagedCacheSchemaRegistryClient.resolve(subject, version)`**: resolves via `getLatest/getSchemaMetadata`;
  the type is derived authoritatively from `getSchemaById(id)` (which also warms the id→schema cache). Two
  caches: pinned **numeric versions** in a dedicated long-TTL (10d), bounded (3000) cache (immutable);
  **`latest`** shares the existing 30m id→schema cache under a `latest/`-namespaced key (mutable → short TTL).
- **Standalone mock**: new `GET /subjects/{subject}/versions/{version}` (`latest` or integer) returning the
  Confluent shape with `40401`/`40402` errors; `SchemaStore` gains an in-memory `subject→version→id` index
  rebuilt on boot from the per-id files. Adds a module **README** documenting every REST endpoint.
- The **wire format and consumer are unchanged** (global id still on the wire; id-from-wire decode).
- **Migration**: demo (registry seeds + 6 flows + README), serde/adapter tests, `EmbeddedSchemaRegistry`, and
  the kafka-flow-adapter guide moved to subject/version. minimalist-kafka + mock suites green; validated
  end-to-end (multi-terminal) with one continuous OTel trace across both Kafka hops for JSON, Avro, and Protobuf.

**CSFLE:** made *ready, not wired*. CSFLE is subject-centric, so this is the right foundation, but encryption
rule executors + KMS are out of scope; the guide carries a safety caveat (do not produce to CSFLE-protected
topics until CSFLE support lands).

## Why

An id-driven producer forced the caller to know a content-addressed **global schema id**, which real callers
don't have — schemas are governed, **subject-centric** artifacts. Naming a subject is how developers actually
think, and it lets the producer stay ignorant of Confluent's three subject naming strategies (the caller states
the subject, so there is nothing to derive — which is precisely the confusion this removes). Keeping the change
to the producer's *input* (subject/version) leaves the wire contract and consumer path untouched, and lays the
subject-centric groundwork CSFLE will need next.

---
Co-Authored-By: Claude Code