### PR TITLE
fix(observability): make my_correlation_id read-only; document trace-header ownership

### DIFF
--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -173,6 +173,14 @@ EventEnvelope res = po.request(request, 5000).get();
 // the response is a Java Future and the result is an EventEnvelope
 ```
 
+> **Trace headers are managed for you.** Do not set `X-Trace-Id` or `traceparent` on the `AsyncHttpRequest`
+> inside a traced flow or function — the HTTP client injects them automatically from the current trace context
+> (overwriting any value you provide), so distributed traces stay connected across the HTTP boundary and the
+> upstream trace is propagated for you. If the call is **not** traced (e.g. an endpoint with `tracing: false`,
+> or a standalone / unit-test call), a trace header you set is forwarded as-is — which is what lets you
+> propagate a trace to a third-party system, or test an external endpoint with full control over its request
+> headers.
+
 By default, your user function is running in a virtual thread.
 While the RPC call looks like synchronous, the po.request API will run in non-blocking mode in the same fashion
 as the "async/await" pattern.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -90,6 +90,14 @@ The `X-Trace-Id` header carries the trace ID for callers not yet on W3C Trace Co
 echo the trace ID back to the HTTP client. (The correlation-id — a separate concern — is documented in
 [Reserved Names & Headers](reserved-names-and-headers.md#correlation-id-propagation).)
 
+> **Let the framework manage trace headers — don't set them yourself.** Inside a traced flow or function the
+> platform injects `X-Trace-Id` and `traceparent` on every outbound HTTP call from the current trace context,
+> overwriting any value you set on the request — so the trace stays correct and connected end-to-end, and the
+> upstream trace is propagated automatically. The one exception is a call that is **not** being traced (an
+> endpoint with `tracing: false`, or a call made outside a trace): there a trace header you set passes through
+> untouched — the intended escape hatch for handing a trace context to a third-party system, or for
+> unit-testing an external endpoint with full control over its request headers.
+
 ## Exporting telemetry {#export}
 
 ### The forwarder extension point {#forwarder}

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -157,6 +157,13 @@ The framework does **not** echo the trace ID (or the correlation-id) back to the
 > been retired. Use `X-Trace-Id` / `traceparent` for the trace ID, and `X-Correlation-Id` for the
 > correlation-id (below) - the two concerns are now separate.
 
+> **Don't set `X-Trace-Id` / `traceparent` yourself in application code — let the framework handle it.** When a
+> call is traced, the platform stamps both headers from the current trace context on every outbound HTTP request
+> and overwrites anything you set, so the trace lineage stays correct and the upstream trace propagates
+> automatically. Only when a call is **not** traced (`tracing: false`, or a call made outside a trace) does a
+> value you set pass through unchanged — the intended escape hatch for propagating a trace to a third-party
+> system or for unit tests.
+
 ### Correlation ID propagation
 
 The correlation-id ties a transaction together across business domains, from upstream through the mid-tier

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -111,7 +111,9 @@
   (strip `my_route`/`my_trace_id`/`my_trace_path`) assessed + deferred: `WorkerHandler` L207-214 already makes
   `my_route` authoritative and overwrites `my_trace_id`/`my_trace_path` whenever traced (inert-only when spoofable).
   Full suites green: platform-core 372, event-script-engine 132. Refines [[tracing-correlation-cleanup]]; see
-  [[thread-traceid-correlation-propagation]]. **Status: finding-1 fix + tests done, uncommitted — pending Eric.**
+  [[thread-traceid-correlation-propagation]]. **Status: shipped as PR [#134](https://github.com/Accenture/mercury-composable/pull/134)**
+  (branch `fix/correlation-id-readonly-and-trace-header-docs`; 2 commits — `3065f804` source+tests+docs,
+  `707056e5` memory) — pending review/merge.
   <!-- id: traceid-cid-propagation-edgecase-fixes | created: 2026-07-04 | last_used: 2026-07-04 | uses: 1 | tier: working | origin: 2026-07-04-223237 -->
 
 - **Design principle — a developer-set outbound trace header (`X-Trace-Id` / W3C `traceparent`) is an
@@ -472,8 +474,10 @@
   (incl. event-over-HTTP) + `AsyncHttpClient` downstream + `simple.kafka.notification`. Full reactor (28) +
   pg-example (6) green. **Next: Eric's code review, then commit + PR** (same flow as #128/#129).
   **Update (2026-07-04):** the feature shipped as PR #132 (`1ab78077` on `main`); an external assessment then
-  surfaced two edge-case gaps in it, both now fixed + tested (uncommitted) — see
-  [[traceid-cid-propagation-edgecase-fixes]].
+  reviewed it — one real fix (`my_correlation_id` read-only) + trace-header docs shipped as
+  PR [#134](https://github.com/Accenture/mercury-composable/pull/134) (the "traceparent leak" finding was
+  rejected by design) — see [[traceid-cid-propagation-edgecase-fixes]] and
+  [[developer-set-trace-headers-are-intentional]].
   <!-- id: thread-traceid-correlation-propagation | created: 2026-07-03 | last_used: 2026-07-03 | uses: 1 | tier: working | origin: 2026-07-03-014759 -->
 
 - [x] (completed — Eric, 2026-07-01) **Remove Protobuf support from minimalist-kafka's Schema Registry

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-04 | agent: Claude Code (2026-07-04-181333)
+- **last_session:** 2026-07-04 | agent: Claude Code (2026-07-04-224922)
 - **last_review:** 2026-07-02 | through 2026-07-02-161433.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -91,6 +91,52 @@
   Plan: `~/.claude/plans/glowing-tinkering-glacier.md`. See [[flow-cid-vs-business-correlation-decoupled]] and
   [[thread-traceid-correlation-propagation]]. **Status: implemented + feature-complete, all tests green, uncommitted — pending Eric.**
   <!-- id: tracing-correlation-cleanup | created: 2026-07-03 | last_used: 2026-07-03 | uses: 1 | tier: working | origin: 2026-07-03-014759 -->
+
+- **External assessment of the shipped trace/cid feature (PR #132): one real fix kept, one "finding" rejected
+  by design (2026-07-04, uncommitted).** GitHub Copilot's report
+  (`/tmp/traceid-business-correlationid-propagation-assessment.md`) reviewed `main` and raised two
+  "high-confidence" gaps; verified both against source. **(1) KEPT — `my_correlation_id` was overridable despite
+  being documented read-only:** `TaskExecutor` stamped the reserved header *before* applying `md.optionalHeaders`,
+  so a flow relaying inbound HTTP headers (`input.header -> header`) let a caller spoof the value a task reads via
+  `getMyCorrelationId()` → fix: stamp `my_correlation_id` **last**, after optional headers, so the framework value
+  wins. Regression test proven to fail pre-fix (`FlowTests#correlationIdPropagationTest` extended + `Greetings`
+  echoes `getMyCorrelationId()`). **(2) REJECTED — "AsyncHttpClient leaks caller-supplied `traceparent`":** first
+  fixed (added `traceparent` to `HEADERS_TO_IGNORE`) then **reverted on Eric's guidance** — see the design
+  principle [[developer-set-trace-headers-are-intentional]]. In production the "hijack" cannot occur (a traced
+  request always stamps a fresh W3C traceparent that overwrites; Mercury ids are always W3C-compatible), and when
+  untraced, forwarding a developer-set `traceparent`/`X-Trace-Id` is the *intended* behavior (propagating a trace
+  to a 3rd party / forwarding upstream). The report's leak only reproduces with non-W3C ids (a test artifact).
+  AsyncHttpClient net change = a documenting comment only; replaced the negative test with a positive guard
+  `RestEndpointTest#asyncHttpClientForwardsDeveloperSuppliedTraceparent`. Finding-1 defense-in-depth
+  (strip `my_route`/`my_trace_id`/`my_trace_path`) assessed + deferred: `WorkerHandler` L207-214 already makes
+  `my_route` authoritative and overwrites `my_trace_id`/`my_trace_path` whenever traced (inert-only when spoofable).
+  Full suites green: platform-core 372, event-script-engine 132. Refines [[tracing-correlation-cleanup]]; see
+  [[thread-traceid-correlation-propagation]]. **Status: finding-1 fix + tests done, uncommitted — pending Eric.**
+  <!-- id: traceid-cid-propagation-edgecase-fixes | created: 2026-07-04 | last_used: 2026-07-04 | uses: 1 | tier: working | origin: 2026-07-04-223237 -->
+
+- **Design principle — a developer-set outbound trace header (`X-Trace-Id` / W3C `traceparent`) is an
+  intentional act the framework must honor, not strip (Eric, 2026-07-04).** `AsyncHttpClient` deliberately does
+  **not** filter caller-supplied trace headers. Two legitimate uses: (a) when the call is **untraced**
+  (`tracing: false`, no current context), an app may explicitly set `traceparent`/`X-Trace-Id` to hand a trace
+  context to a downstream/3rd-party system — this passes through unchanged; (b) when the call **is traced**, the
+  framework's own current trace context takes precedence (stamps `X-Trace-Id` = current traceId and `traceparent`
+  = current traceId+spanId at `AsyncHttpClient.updateHttpHeaders`), so the downstream span chains to *this*
+  caller's span — and because a traced request's context is itself adopted from the upstream `X-Trace-Id`/
+  `traceparent` at ingress (`HttpRouter.getTraceId` + `W3cTrace.parse`, L485-495), the upstream trace still
+  propagates automatically. Net: framework overwrites only when it has an active trace of its own; otherwise the
+  developer's explicit header wins. This is *why* the assessment's "traceparent leak" finding was rejected (the
+  only leak case needs non-W3C ids, a test artifact). Contrast: `my_correlation_id` is a reserved *internal*
+  header (surfaced via `getMyCorrelationId()`, not a wire header) and **is** protected as read-only
+  ([[traceid-cid-propagation-edgecase-fixes]] finding 1); the business cid goes downstream as the configurable
+  `http.correlation.id.header` (e.g. `X-Correlation-Id`), which AsyncHttpClient also honors-if-caller-set.
+  **Testability corollary (Eric):** because an *untraced* invocation (the default in a plain unit test — no
+  trace context set) passes every non-hop-by-hop header through verbatim, a unit test can exercise an external
+  /downstream REST endpoint with full control over the request headers (incl. trace headers), no framework
+  interference — guarded by `RestEndpointTest#asyncHttpClientForwardsDeveloperSuppliedTraceparent`.
+  **Documented (2026-07-04):** "let the framework manage trace headers; don't set `X-Trace-Id`/`traceparent`
+  yourself (with the untraced escape hatch)" callouts added to `docs/guides/observability.md` (§W3C),
+  `reserved-names-and-headers.md` (§Trace ID), and `actuators-and-http-client.md` (§AsyncHttpClient).
+  <!-- id: developer-set-trace-headers-are-intentional | created: 2026-07-04 | last_used: 2026-07-04 | uses: 1 | tier: working | origin: 2026-07-04-224922 -->
 
 - **A flow's reply cid and its business correlation-id are distinct and must stay decoupled (2026-07-03).**
   `FlowInstance.cid` is the **reply-routing** key: REST automation awaits an HTTP response whose correlationId
@@ -425,6 +471,9 @@
   4 new tests green. **Feature-complete:** business cid propagates to any touch point via `PostOffice.touch()`
   (incl. event-over-HTTP) + `AsyncHttpClient` downstream + `simple.kafka.notification`. Full reactor (28) +
   pg-example (6) green. **Next: Eric's code review, then commit + PR** (same flow as #128/#129).
+  **Update (2026-07-04):** the feature shipped as PR #132 (`1ab78077` on `main`); an external assessment then
+  surfaced two edge-case gaps in it, both now fixed + tested (uncommitted) — see
+  [[traceid-cid-propagation-edgecase-fixes]].
   <!-- id: thread-traceid-correlation-propagation | created: 2026-07-03 | last_used: 2026-07-03 | uses: 1 | tier: working | origin: 2026-07-03-014759 -->
 
 - [x] (completed — Eric, 2026-07-01) **Remove Protobuf support from minimalist-kafka's Schema Registry

--- a/memory/sessions/2026-07-04-223237.md
+++ b/memory/sessions/2026-07-04-223237.md
@@ -1,0 +1,72 @@
+# Session (2026-07-04T22:32:37.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Reviewed an external assessment report (GitHub Copilot, `/tmp/traceid-business-correlationid-propagation-assessment.md`)
+of the traceId + businessCorrelationId propagation feature now on `main` (shipped as PR #132,
+`feat(observability): complete OTel trace compliance + end-to-end business correlation-id`, commit `1ab78077` —
+the merged form of the earlier `fix/traceid-correlationid-propagation` work, see [[tracing-correlation-cleanup]]).
+The report's positive findings were verified accurate; its **two high-confidence edge-case gaps were both
+confirmed against source and fixed**, each with a regression test proven to fail before the fix.
+
+### Finding 1 — `my_correlation_id` overridable despite being documented read-only (FIXED)
+
+`TaskExecutor` (function-task branch, `~line 964`) stamped the reserved `my_correlation_id` header from
+`flowInstance.businessCorrelationId` **first**, then applied `md.optionalHeaders.forEach(event::setHeader)`
+**after**. A flow that relays inbound HTTP headers (`input.header -> header`, `setInputDataMappingRhs`
+lines 1135-1138; or `... -> header.my_correlation_id`, lines 1142-1145) copies caller-controlled headers into
+`optionalHeaders`, so a caller-supplied `my_correlation_id` overwrote the authoritative value — contradicting
+`docs/guides/reserved-names-and-headers.md` ("read-only … `my_correlation_id`"). **Fix:** reorder — apply
+optional headers first, then stamp `my_correlation_id` **last** so the framework value always wins.
+(Subflow branch was already safe: optional headers go into the body `dataset`, not the launch event's
+`BUSINESS_CORRELATION_ID` header.)
+
+### Finding 2 — `AsyncHttpClient` leaks stale caller-supplied `traceparent` (FIXED)
+
+`AsyncHttpClient.updateHttpHeaders` copies request headers first (lines 321-325); `HEADERS_TO_IGNORE` did
+**not** include `traceparent`. It then stamps a fresh W3C `traceparent` only if
+`W3cTrace.traceparent(traceId, spanId)` is non-null — which returns null when tracing is off / traceId null /
+IDs not W3C-compatible (`W3cTrace` lines 51-56, 75-81). In that case the copied stale value survived and was
+forwarded. Downstream ingress gives a valid inbound `traceparent` **precedence** over `X-Trace-Id`
+(`HttpRouter` lines 491-495), so a leaked value actively hijacks the downstream trace lineage. **Fix:** add
+`W3cTrace.TRACEPARENT` to `HEADERS_TO_IGNORE` — the caller's traceparent is never copied; a fresh one is
+stamped only when a valid current trace/span exists, else none is emitted. This aligns HTTP egress with the
+already-correct Kafka egress (`SimpleKafkaNotification` filters `traceparent` + the reserved `my_*` headers,
+lines 148-162, and stamps fresh from the current span).
+
+**Scope decision (finding 2):** fixed `traceparent` only, not `X-Trace-Id`. `X-Trace-Id` passthrough is an
+*intentional* propagation channel (exercised by `RestEndpointTest#sendHttpHeadWithTraceId`; read inbound by
+`HttpRouter.getTraceId`), whereas `traceparent` is framework-stamped-only and carries the more acute
+downstream-precedence hijack risk. Matches the report's own recommended outbound behavior exactly.
+
+### Defense-in-depth note (assessed, NOT implemented)
+
+The report's secondary suggestion (strip `my_route`/`my_trace_id`/`my_trace_path`/`my_correlation_id` at
+ingress + adapters) was assessed against `WorkerHandler.executeFunction` (lines 207-214): `my_route` is
+**unconditionally** overwritten with the authoritative value (safe); `my_trace_id`/`my_trace_path` are
+overwritten whenever tracing is on, so they are only spoofable in the untraced edge case where they carry no
+meaning; `my_correlation_id` was the one genuinely broken reserved header — now closed by the finding-1 fix.
+Deferred as low-value + broader-blast-radius; raise if hostile-header hardening becomes a priority.
+
+### Tests (both proven to fail pre-fix, pass post-fix)
+
+- `FlowTests#correlationIdPropagationTest` extended: caller also sends a spoofed `my_correlation_id` header;
+  asserts the task's `getMyCorrelationId()` returns the authoritative business cid, not the spoof. Needed a
+  one-line echo in the shared test function `Greetings` (`result.put("my_cid", new PostOffice(headers,
+  instance).getMyCorrelationId())`). Pre-fix: saw `spoofed-…`.
+- `RestEndpointTest#asyncHttpClientDoesNotLeakStaleTraceparent` (new): untraced caller (non-W3C traceId
+  "201") sends a stale `traceparent`; asserts the downstream `hello.mock` echo (`MockHelloWorld` returns
+  `input.toMap()`) never received it. Pre-fix: leaked the stale value verbatim.
+
+**Verification:** full module suites green — platform-core **372**, event-script-engine **132**. Both fixes
+minimal (TaskExecutor reorder; one entry in `HEADERS_TO_IGNORE`).
+
+**Status: both confirmed findings fixed + tested, both module suites green, uncommitted — pending Eric's
+review + commit.**
+
+## Memory References
+- Referenced: tracing-correlation-cleanup, flow-cid-vs-business-correlation-decoupled,
+  thread-traceid-correlation-propagation, trace-thread-keyed-mono-gotcha
+- Created: traceid-cid-propagation-edgecase-fixes

--- a/memory/sessions/2026-07-04-224922.md
+++ b/memory/sessions/2026-07-04-224922.md
@@ -58,6 +58,10 @@ for 3rd-party propagation / unit tests" callouts to three guides: `docs/guides/o
 `reserved-names-and-headers.md` (§Trace ID), `actuators-and-http-client.md` (§AsyncHttpClient). Matched the
 existing `> **Bold lead.**` callout convention. `llms.txt` is a link map — no change needed.
 
+**Also (same session):** committed to branch `fix/correlation-id-readonly-and-trace-header-docs` (2 commits —
+`3065f804` source+tests+docs, `707056e5` memory; both `Co-Authored-By: Claude Code`), pushed, and Eric opened
+PR [#134](https://github.com/Accenture/mercury-composable/pull/134).
+
 ## Memory References
 - Referenced: traceid-cid-propagation-edgecase-fixes, tracing-correlation-cleanup,
   flow-cid-vs-business-correlation-decoupled, thread-traceid-correlation-propagation

--- a/memory/sessions/2026-07-04-224922.md
+++ b/memory/sessions/2026-07-04-224922.md
@@ -1,0 +1,65 @@
+# Session (2026-07-04T22:49:22.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Follow-up to `2026-07-04-223237` (assessment-driven propagation fixes). Eric pushed back on **finding 2**
+(the `AsyncHttpClient` "traceparent leak" fix), and after analysis I **agree and reverted it**. Finding 1
+(`my_correlation_id` read-only) stands unchanged.
+
+### Why finding 2 was rejected (design decision, Eric)
+
+A developer-set outbound trace header (`X-Trace-Id` / W3C `traceparent`) is an **intentional act** the
+framework must honor, not strip. My original fix (add `traceparent` to `HEADERS_TO_IGNORE`) broke two
+legitimate uses:
+- **Untraced call** (`tracing: false`, no current context): an app may explicitly set `traceparent` to hand a
+  trace context to a downstream / 3rd-party system. Must pass through.
+- **Traced call**: the framework's own current context takes precedence (stamps `X-Trace-Id`/`traceparent`
+  from the current trace+span), so the downstream chains to *this* caller's span. And since a traced request's
+  context is itself adopted from the upstream `X-Trace-Id`/`traceparent` at ingress (`HttpRouter.getTraceId` +
+  `W3cTrace.parse`, L485-495), the upstream trace propagates **automatically** — the developer doesn't need to
+  hand-forward it.
+
+So the report's "hijack downstream trace lineage" cannot occur in production: when traced, the fresh W3C
+traceparent always overwrites (Mercury trace ids = dashless UUID/32-hex, span = 16-hex, always W3C-compatible);
+when untraced, forwarding is the intended behavior. The only case that leaks is non-W3C ids — a **test
+artifact**, not real operation. New durable fact: [[developer-set-trace-headers-are-intentional]].
+
+Nuance raised to Eric (not acted on): reverting restores "framework wins when it has an active trace of its
+own." If he ever wants an explicit developer header to override an *already-active* local trace, that's a
+separate, deliberate change I cautioned against (disconnects the span graph). Left as-is.
+
+### Changes this session
+
+- **Reverted** `AsyncHttpClient` `HEADERS_TO_IGNORE` (removed `W3cTrace.TRACEPARENT`) — net change is now a
+  **documenting comment only** in `updateHttpHeaders` explaining the honor-developer-intent behavior, so the
+  strip isn't re-introduced.
+- **Replaced** the negative test `RestEndpointTest#asyncHttpClientDoesNotLeakStaleTraceparent` with a positive
+  guard `asyncHttpClientForwardsDeveloperSuppliedTraceparent` (untraced `EventEmitter` GET, explicit
+  `traceparent`, asserts the downstream `hello.mock` echo received it **unchanged**).
+- **Kept** finding 1 (`TaskExecutor` stamps `my_correlation_id` last) + its test, untouched.
+
+**Verification:** platform-core full suite **372** green (RestEndpointTest 34, incl. the new positive test).
+event-script-engine unchanged from prior session (**132**, finding-1 test intact).
+
+**Status: finding 1 fixed + tested, finding 2 rejected-by-design (reverted to a doc comment), uncommitted —
+pending Eric's review + commit.**
+
+**Also (same session, follow-up Q&A):** Eric confirmed the behavior model (off → developer controls trace
+headers; on → framework enforces upstream-sourced propagation, non-overridable) and surfaced a **testability
+corollary** — an untraced unit-test invocation passes all non-hop-by-hop headers through verbatim, so an
+external REST endpoint can be exercised with full header control. Folded into
+[[developer-set-trace-headers-are-intentional]] as durable "why". No code change.
+
+**Also (same session):** Eric asked to document the guidance so developers don't hand-set trace headers. Added
+"let the framework manage `X-Trace-Id`/`traceparent`; don't set them yourself — with the untraced escape hatch
+for 3rd-party propagation / unit tests" callouts to three guides: `docs/guides/observability.md` (§W3C),
+`reserved-names-and-headers.md` (§Trace ID), `actuators-and-http-client.md` (§AsyncHttpClient). Matched the
+existing `> **Bold lead.**` callout convention. `llms.txt` is a link map — no change needed.
+
+## Memory References
+- Referenced: traceid-cid-propagation-edgecase-fixes, tracing-correlation-cleanup,
+  flow-cid-vs-business-correlation-decoupled, thread-traceid-correlation-propagation
+- Created: developer-set-trace-headers-are-intentional
+- Updated (substance): traceid-cid-propagation-edgecase-fixes (finding 2 → rejected/reverted)

--- a/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
@@ -964,10 +964,11 @@ public class TaskExecutor implements TypedLambdaFunction<EventEnvelope, Void> {
             var event = new EventEnvelope().setTo(functionRoute).setReplyTo(TaskExecutor.SERVICE_NAME)
                                             .setCorrelationId(compositeInternalCorrelationId)
                                             .setBody(unwrapBodyIfWildcard(md))
-                                            .setSpanId(parentSpanId)
-                                            // expose the flow's business correlation-id (model.cid) as a read-only header
-                                            .setHeader(MY_CORRELATION_ID, flowInstance.businessCorrelationId);
+                                            .setSpanId(parentSpanId);
             md.optionalHeaders.forEach(event::setHeader);
+            // expose the flow's business correlation-id (model.cid) as a read-only reserved header - stamped
+            // last so a mapped optional header named my_correlation_id cannot override the framework value
+            event.setHeader(MY_CORRELATION_ID, flowInstance.businessCorrelationId);
             // execute task by sending event
             if (deferred > 0) {
                 po.sendLater(event, new Date(System.currentTimeMillis() + deferred));

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -766,6 +766,9 @@ class FlowTests extends TestBase {
         request.setTargetHost(HOST).setMethod("GET").setHeader("accept", "application/json");
         // upstream supplies its own X-Correlation-Id; it must thread through to model.cid
         request.setHeader("X-Correlation-Id", correlationId);
+        // a hostile/accidental attempt to override the read-only reserved header: the greetings flow relays
+        // all inbound HTTP headers via 'input.header -> header', so this rides into the task's optional headers
+        request.setHeader("my_correlation_id", "spoofed-" + Utility.getInstance().getUuid());
         request.setUrl("/api/greetings/12345");
         PostOffice po = new PostOffice("unit.test", "1002", "TEST /correlation");
         EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
@@ -776,6 +779,9 @@ class FlowTests extends TestBase {
         Map<String, Object> result = (Map<String, Object>) res.getBody();
         // the upstream correlation-id is captured at the edge and preserved as the flow's model.cid
         assertEquals(correlationId, result.get("cid"));
+        // the framework-injected my_correlation_id is read-only: the spoofed inbound header does NOT win -
+        // the task observes the authoritative business correlation-id via getMyCorrelationId()
+        assertEquals(correlationId, result.get("my_cid"));
     }
 
     private void greetingAssertions(String user, Map<String, Object> original, Map<String, Object> result) {

--- a/system/event-script-engine/src/test/java/com/accenture/tasks/Greetings.java
+++ b/system/event-script-engine/src/test/java/com/accenture/tasks/Greetings.java
@@ -23,6 +23,7 @@ import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -91,6 +92,9 @@ public class Greetings implements TypedLambdaFunction<EventEnvelope, Object> {
             result.put(MESSAGE, "I got your greeting message - " + greeting);
             result.put(TIME, new Date());
             result.put(ORIGINAL, input);
+            // expose the framework-injected read-only business correlation-id as this task actually sees it,
+            // proving a caller/flow-mapped "my_correlation_id" header cannot override the authoritative value
+            result.put("my_cid", new PostOffice(headers, instance).getMyCorrelationId());
             if (headers.containsKey(DEMO)) {
                 result.put(DEMO + 1, headers.get(DEMO));
             }

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -323,12 +323,16 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                 http.set(kv.getKey(), kv.getValue());
             }
         }
-        // propagate the trace ID as X-Trace-Id alongside the W3C "traceparent" below
+        // Trace headers (X-Trace-Id / W3C "traceparent") copied from the request above are left intact when
+        // this call is not being traced: an explicitly developer-set trace header is an intentional act (e.g.
+        // handing a trace context to a 3rd-party system, or forwarding an upstream trace) and must propagate.
+        // When this call IS traced, the framework's own current trace context takes precedence below so the
+        // downstream span chains to this caller's span - and since a traced request's context is itself adopted
+        // from the upstream X-Trace-Id/traceparent at ingress, the upstream trace still propagates.
         String traceId = po.getTraceId();
         if (traceId != null) {
             http.set(TRACE_ID_HEADER, traceId);
         }
-        // propagate W3C trace context so the downstream server span chains to this caller's span
         String traceparent = W3cTrace.traceparent(traceId, spanId);
         if (traceparent != null) {
             http.set(W3cTrace.TRACEPARENT, traceparent);

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -162,6 +162,29 @@ class RestEndpointTest extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void asyncHttpClientForwardsDeveloperSuppliedTraceparent() throws InterruptedException {
+        // When this call is not being traced, an explicitly developer-set W3C "traceparent" is an intentional
+        // act (e.g. handing a trace context to a 3rd-party system, or forwarding an upstream trace). The
+        // framework must NOT strip it - it only stamps its own traceparent when it has an active trace to
+        // propagate. This guards against re-introducing a blanket ignore of caller-supplied trace headers.
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setHeader("accept", "application/json").setHeader("traceparent", traceparent);
+        req.setUrl("/api/hello/world").setTargetHost("http://127.0.0.1:" + port);
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        // the downstream service received the developer-supplied traceparent unchanged
+        assertEquals(traceparent, map.getElement("headers.traceparent"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void plainRestFunctionReceivesCorrelationId() throws InterruptedException, ExecutionException {
         // "/api/simple/{task}/*" is a pure "service: hello.world" mapping (no flow) — a plain REST endpoint
         // routed directly to a composable function. It must still receive the business correlation-id.


### PR DESCRIPTION
## What

Follow-up to #132 (trace + business-correlation-id propagation), addressing an
external assessment of that feature. Two candidate findings were reviewed against
the source; one was a real bug (fixed), the other is intended behavior (documented).

- **Fix — `my_correlation_id` is now truly read-only.** `TaskExecutor` stamped the
  reserved business-correlation-id header *before* applying a task's mapped optional
  headers, so a flow that relays inbound HTTP headers (`input.header -> header`) let a
  caller spoof the value a task reads via `PostOffice.getMyCorrelationId()`. The
  framework value is now stamped **last**, so it always wins.
- **No behavior change — developer-set trace headers stay honored.** The assessment
  also flagged `AsyncHttpClient` "leaking" a caller-supplied `traceparent`. This is by
  design: when a call is traced the framework overwrites `X-Trace-Id`/`traceparent`
  from its own current context (adopted from upstream at ingress); when untraced, a
  developer-set trace header passes through. Only an explanatory comment was added.
- **Docs.** Added "let the framework manage trace headers — don't set
  `X-Trace-Id`/`traceparent` yourself, with the untraced escape hatch" callouts to
  `observability.md`, `reserved-names-and-headers.md`, and `actuators-and-http-client.md`.

## Why

`my_correlation_id` is documented as a read-only, framework-injected reserved header
(the business correlation-id surfaced to every function). The stamping order broke that
guarantee: any flow using the common wholesale header relay could let an upstream caller
overwrite the authoritative correlation-id, which would then propagate downstream — an
observability/correlation-integrity gap that contradicted the docs.

The `traceparent` "leak" was intentionally left as-is: stripping caller-set trace headers
would break two legitimate uses — propagating a trace context to a third-party system, and
unit-testing an external endpoint with full control over its request headers. The correct
resolution there was to document the ownership model, not change the code.

## Testing

- `FlowTests#correlationIdPropagationTest` — extended with a spoof attempt; asserts the
  task observes the authoritative business cid (proven to fail before the fix).
- `RestEndpointTest#asyncHttpClientForwardsDeveloperSuppliedTraceparent` — new positive
  guard: an untraced call forwards a developer-set `traceparent` unchanged.
- Full module suites green: **platform-core 372**, **event-script-engine 132**.

Co-Authored-By: Claude Code <noreply@anthropic.com>