### PR TITLE
docs(minimalist-kafka): clarify CSFLE KMS-driver packaging + KEK ownership; add Avro CSFLE test

### DIFF
--- a/docs/guides/kafka-flow-adapter.md
+++ b/docs/guides/kafka-flow-adapter.md
@@ -333,13 +333,22 @@ encryption executor + a KMS driver are on the classpath and (b) their configurat
 else — resolving keys, encrypting tagged fields on write, decrypting on read — is Confluent's serializer/
 deserializer doing exactly what it would do in any Confluent-based application.
 
-**1. Dependencies.** `system/minimalist-kafka/pom.xml` already declares:
+**1. Dependencies.** `system/minimalist-kafka/pom.xml` declares:
 
 - `io.confluent:kafka-schema-registry-client-encryption` — the field-encryption rule executor (auto-discovered
-  via `ServiceLoader`; no explicit `rule.executors` config needed).
-- **Exactly one** cloud KMS driver: `io.confluent:kafka-schema-registry-client-encryption-aws` is uncommented
-  by default; if your installation uses Azure Key Vault or GCP KMS instead, comment out the AWS dependency and
-  uncomment the matching one. A field installation configures one KMS vendor, not several.
+  via `ServiceLoader`; no explicit `rule.executors` config needed). This is a normal compile dependency, so an
+  app that depends on `minimalist-kafka` **inherits the executor transitively** — nothing to add.
+- **Exactly one** cloud KMS driver — **which your application must supply itself.** In this module's own POM the
+  AWS driver (`io.confluent:kafka-schema-registry-client-encryption-aws`) is uncommented as the default/template
+  (Azure and GCP are present alongside it, commented out). But that dependency is marked Maven `<optional>true</optional>`,
+  so it is **not inherited transitively** by a downstream consumer of the published artifact. Your app must
+  therefore declare exactly one KMS driver appropriate to its environment — AWS, Azure, GCP, or (for tests) the
+  local Tink driver — on its own classpath. A field installation configures one KMS vendor, not several.
+
+> Why optional rather than a default AWS dependency for everyone? Forcing the AWS SDK onto every consumer would
+> be wrong for Azure/GCP and non-CSFLE users. So `minimalist-kafka` ships the vendor-neutral executor and lets
+> the application pick its one KMS driver. A common symptom of skipping this: a subject configured with a CSFLE
+> rule fails at runtime because no KMS driver is on the app's classpath.
 
 **2. The `ENCRYPT` rule — and its KEK/KMS identity — is per-subject, set on the schema, not in this app's
 config.** When a subject is registered with an `ENCRYPT` rule tagging a field (e.g. `confluent:tags: ["PII"]`

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-04 | agent: Claude Code (2026-07-04-181333)
+- **last_session:** 2026-07-04 | agent: Claude Code (2026-07-04-232341)
 - **last_review:** 2026-07-02 | through 2026-07-02-161433.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -180,7 +180,19 @@
   **Wire/consumer unchanged** — only the tagged field *values* become ciphertext. Guide docs:
   `docs/guides/kafka-flow-adapter.md` §"CSFLE". Design spec (v3.0, gitignored):
   `draft-design-specs/kafka_csfle_field_encryption_design.md` — §10/§11 record exactly what shipped.
-  **Status: implemented, all tests green, uncommitted — pending Eric's review.** See [[thread-csfle-field-encryption]].
+  **Status: shipped as PR #131 (commit `49d4eeca` on `main`).** See [[thread-csfle-field-encryption]].
+  **Assessment follow-up (2026-07-04, branch `fix/csfle-docs-and-avro-test`, uncommitted):** an external
+  GitHub Copilot report confirmed the delegation model is correct and found three non-blocking gaps, all
+  addressed — (1) the AWS KMS driver is Maven `optional` so it is NOT inherited transitively; docs + POM comment
+  now state the executor IS inherited but the app must supply exactly one KMS driver itself
+  (`docs/guides/kafka-flow-adapter.md` §"CSFLE" step 1, `pom.xml` comment); (2) the `SchemaCodec` Javadoc + the
+  `SchemaCodecCsfleConfigTest#extractSerdeConfigStripsPrefixAndIgnoresOtherKeys` example listed the rule-owned
+  `encrypt.kek.name` as a `schema.registry.serde.*` pass-through key — corrected to genuine driver keys
+  (`access.key.id`/`secret`); this completes the earlier partial correction (the guide + the *other* test method
+  were fixed 2026-07-02, but the Javadoc + this test example were missed); (3) added
+  `SchemaCodecCsfleConfigTest#avroCsfleConfigReachesEncoderAndDecoder` — the first direct Avro CSFLE round-trip
+  through `SchemaCodec.Encoder`/`Decoder` (Avro was only symmetrically wired, JSON-only tested). Full module
+  green (79 tests, coverage gate met).
   <!-- id: kafka-csfle-delegation | created: 2026-07-02 | last_used: 2026-07-02 | uses: 1 | tier: working | origin: 2026-07-02-020429 -->
 
 - **Repo-wide OSS dependency security update (2026-07-01, committed on `feature/deprecate-simple-type-matching`).**

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -181,9 +181,9 @@
   `docs/guides/kafka-flow-adapter.md` §"CSFLE". Design spec (v3.0, gitignored):
   `draft-design-specs/kafka_csfle_field_encryption_design.md` — §10/§11 record exactly what shipped.
   **Status: shipped as PR #131 (commit `49d4eeca` on `main`).** See [[thread-csfle-field-encryption]].
-  **Assessment follow-up (2026-07-04, branch `fix/csfle-docs-and-avro-test`, uncommitted):** an external
-  GitHub Copilot report confirmed the delegation model is correct and found three non-blocking gaps, all
-  addressed — (1) the AWS KMS driver is Maven `optional` so it is NOT inherited transitively; docs + POM comment
+  **Assessment follow-up — PR [#135](https://github.com/Accenture/mercury-composable/pull/135) (2026-07-04,
+  branch `fix/csfle-docs-and-avro-test`):** an external GitHub Copilot report confirmed the delegation model is
+  correct and found three non-blocking gaps, all addressed — (1) the AWS KMS driver is Maven `optional` so it is NOT inherited transitively; docs + POM comment
   now state the executor IS inherited but the app must supply exactly one KMS driver itself
   (`docs/guides/kafka-flow-adapter.md` §"CSFLE" step 1, `pom.xml` comment); (2) the `SchemaCodec` Javadoc + the
   `SchemaCodecCsfleConfigTest#extractSerdeConfigStripsPrefixAndIgnoresOtherKeys` example listed the rule-owned

--- a/memory/sessions/2026-07-04-232341.md
+++ b/memory/sessions/2026-07-04-232341.md
@@ -46,8 +46,8 @@ mechanics (GenericRecord conversion) actually encrypt/decrypt, not just "wired s
 ("All coverage checks have been met") — the new Avro test adds coverage rather than tripping the narrow-selector
 gate.
 
-**Status: all three gaps addressed, module green, uncommitted on `fix/csfle-docs-and-avro-test` — pending Eric's
-review + commit/PR.**
+**Status: all three gaps addressed, module green. Committed to `fix/csfle-docs-and-avro-test` (`388dc937`
+code/docs, `bb073739` memory), pushed; Eric opened PR [#135](https://github.com/Accenture/mercury-composable/pull/135).**
 
 ## Memory References
 - Referenced: kafka-csfle-delegation, thread-csfle-field-encryption, minimalist-kafka-schema-registry

--- a/memory/sessions/2026-07-04-232341.md
+++ b/memory/sessions/2026-07-04-232341.md
@@ -1,0 +1,54 @@
+# Session (2026-07-04T23:23:41.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Reviewed a second external assessment report (GitHub Copilot,
+`/tmp/csfle-compatibility-assessment.md`) — this one on the CSFLE compatibility feature
+([[kafka-csfle-delegation]], shipped as PR #131, commit `49d4eeca` on `main`). The report confirmed the
+delegation model is correct and raised **three non-blocking gaps**; all three verified true against source
+and addressed. Unlike the propagation report, none was rejected — all were legitimate.
+
+Work is on a **fresh branch `fix/csfle-docs-and-avro-test` off `main`** (separate from PR #134). The pending
+PR-#134 memory note was **stashed** first (`stash@{0}: pr134-memory-note`) to keep that decision open and keep
+this branch clean off main.
+
+### Finding 1 — AWS KMS driver is Maven `optional` → not transitive to consumers (docs gap)
+
+`kafka-schema-registry-client-encryption-aws` is `<optional>true</optional>` in `system/minimalist-kafka/pom.xml`,
+so a downstream app depending on the published artifact does NOT inherit a KMS driver — but the docs said AWS is
+"uncommented by default," implying it's present. Kept optional (per the report — forcing an AWS SDK on every
+consumer is wrong for Azure/GCP/non-CSFLE). Clarified `docs/guides/kafka-flow-adapter.md` §CSFLE step 1 + the
+`pom.xml` comment: the field-encryption **executor** is a normal compile dep (inherited transitively), but the
+**KMS driver** is optional (not transitive) and the app must declare exactly one itself.
+
+### Finding 2 — Javadoc + a test example misstate where KEK/KMS identity lives
+
+`SchemaCodec` Javadoc and `SchemaCodecCsfleConfigTest#extractSerdeConfigStripsPrefixAndIgnoresOtherKeys` listed
+the rule-owned `encrypt.kek.name` as a `schema.registry.serde.*` pass-through key — contradicting the guide, the
+Confluent behavior (`RuleContext.getParameter` resolves it from the schema rule), and the *correct* comment in
+the same test file's other method. **This completes the partial correction noted in [[kafka-csfle-delegation]]:**
+the guide + the `csfleConfigReachesEncoderAndDecoder` test were fixed 2026-07-02, but the Javadoc and this
+extraction example were missed. Now both use genuine driver keys (`access.key.id`/`secret`) and the Javadoc
+explains KEK/KMS identity is per-subject rule-owned, never serde config.
+
+### Finding 3 — Avro CSFLE wired but only JSON tested
+
+`AvroSchemaSerde` applies `extraSerdeConfig` symmetrically (both serde maps), but both CSFLE tests were
+JSON-only. Added `SchemaCodecCsfleConfigTest#avroCsfleConfigReachesEncoderAndDecoder`: registers an Avro schema
+with an inline `confluent:tags` field + `ENCRYPT` rule, round-trips through the real
+`SchemaCodec.Encoder`/`Decoder` (Map→GenericRecord path), asserts the tagged field is ciphertext on the wire and
+decrypts back. Uses the same mock:// + local-Tink-KMS `secret` pattern as the JSON test. Proves Avro's different
+mechanics (GenericRecord conversion) actually encrypt/decrypt, not just "wired symmetrically."
+
+**Verification:** full `minimalist-kafka` module green — **79 tests**, and the jacoco coverage gate passed
+("All coverage checks have been met") — the new Avro test adds coverage rather than tripping the narrow-selector
+gate.
+
+**Status: all three gaps addressed, module green, uncommitted on `fix/csfle-docs-and-avro-test` — pending Eric's
+review + commit/PR.**
+
+## Memory References
+- Referenced: kafka-csfle-delegation, thread-csfle-field-encryption, minimalist-kafka-schema-registry
+- Updated (substance): kafka-csfle-delegation (assessment follow-up — 3 gaps addressed; status → shipped as #131)

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -140,10 +140,14 @@
 
         <!-- Cloud KMS driver. A field installation configures exactly ONE KMS vendor - each registers its
              KmsDriver via ServiceLoader and pulls that cloud's SDK, and the field-encryption executor above
-             works with whichever single driver is present. AWS is the default here; if your installation
-             uses Azure Key Vault or GCP KMS instead, comment out the AWS dependency below and uncomment the
-             matching one. optional=true so a consumer of this module isn't forced to resolve a cloud SDK it
-             doesn't use. -->
+             works with whichever single driver is present. AWS is enabled here as the default/template; for
+             Azure Key Vault or GCP KMS instead, comment out the AWS dependency below and uncomment the
+             matching one.
+             NOTE: optional=true means this driver is NOT inherited transitively - a downstream app depending
+             on the published minimalist-kafka artifact does NOT receive a KMS driver from here and must
+             declare exactly one itself (this keeps non-CSFLE and other-vendor consumers from being forced to
+             resolve a cloud SDK they don't use). The field-encryption executor above is a normal compile
+             dependency, so consumers DO inherit it - only the vendor KMS driver is the app's own choice. -->
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption-aws</artifactId>

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -74,9 +74,13 @@ public class SchemaCodec {
      * Prefix for CSFLE (and any other Confluent serde) properties to pass through verbatim - each
      * {@code schema.registry.serde.<key>} in application config becomes {@code <key>} in both the
      * serializer and deserializer config maps of every {@link SchemaSerde}. Generic and driver-agnostic:
-     * the encryption executor + AWS/Azure/GCP/Tink KMS driver config keys (e.g. {@code encrypt.kek.name},
-     * {@code encrypt.kms.type}, {@code encrypt.kms.key.id}, cloud credentials) flow through without any
-     * code change here. Absent entries ⇒ the serdes build exactly as before (plaintext).
+     * this is for the KMS <i>driver's</i> own global settings only - e.g. cloud credentials such as
+     * {@code access.key.id}/{@code secret.access.key}/{@code profile} (AWS), or the local Tink driver's
+     * {@code secret} - which flow through without any code change here. It is <b>not</b> where a key is
+     * chosen: the KEK/KMS identity ({@code encrypt.kek.name}/{@code encrypt.kms.type}/
+     * {@code encrypt.kms.key.id}) is per-subject and lives on the registered schema's {@code ENCRYPT} rule,
+     * which Confluent resolves via {@code RuleContext.getParameter} - never from this serde config. Absent
+     * entries ⇒ the serdes build exactly as before (plaintext).
      */
     private static final String SERDE_CONFIG_PREFIX = "schema.registry.serde.";
     private static final String CACHE_TTL = "schema.registry.cache.ttl";

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecCsfleConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecCsfleConfigTest.java
@@ -18,6 +18,9 @@
 
 package org.platformlambda.mini.kafka.schema;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
@@ -80,14 +83,17 @@ class SchemaCodecCsfleConfigTest {
     @Test
     void extractSerdeConfigStripsPrefixAndIgnoresOtherKeys() {
         Map<String, Object> appConfig = new HashMap<>();
-        appConfig.put("schema.registry.serde.encrypt.kek.name", "my-kek");
+        // genuine driver-level keys only: an AWS credential + the local KMS driver's secret. NOT
+        // encrypt.kek.name/kms.type/kms.key.id - those are per-subject rule params resolved from the
+        // registered schema, never from this serde pass-through (see csfleConfigReachesEncoderAndDecoder).
+        appConfig.put("schema.registry.serde.access.key.id", "AKIA-example");
         appConfig.put("schema.registry.serde.secret", "my-secret");
         appConfig.put("schema.registry.cache.ttl", "30m");   // not a serde.* key - must be excluded
         appConfig.put("schema.registry.url", "http://localhost:8081"); // likewise excluded
 
         Map<String, Object> extracted = SchemaCodec.extractSerdeConfig(new MapConfig(appConfig));
 
-        assertEquals(Map.of("encrypt.kek.name", "my-kek", "secret", "my-secret"), extracted);
+        assertEquals(Map.of("access.key.id", "AKIA-example", "secret", "my-secret"), extracted);
     }
 
     @Test
@@ -139,6 +145,50 @@ class SchemaCodecCsfleConfigTest {
         SchemaCodec.Decoder decoder = codec.newDecoder();
         Map<String, Object> decoded = (Map<String, Object>) decoder.decode(TOPIC, framed);
         assertEquals("123-45-6789", decoded.get(TAGGED_FIELD), "SchemaCodec.Decoder decrypts back to the original");
+        assertEquals("world", decoded.get("hello"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void avroCsfleConfigReachesEncoderAndDecoder() throws Exception {
+        // Avro mirror of csfleConfigReachesEncoderAndDecoder: Avro has different mechanics (the input Map is
+        // converted to a GenericRecord against the registered schema before serialize), so CSFLE is proven
+        // end-to-end for Avro too, not just assumed symmetric with JSON. Same delegation model: the ENCRYPT
+        // rule + its KEK/KMS identity live on the registered schema; only the local KMS driver's global
+        // "secret" comes through the schema.registry.serde.* pass-through.
+        String mockUrl = "mock://" + util.getUuid();
+
+        Map<String, Object> extraSerdeConfig = new HashMap<>();
+        extraSerdeConfig.put("secret", "spike-test-passphrase");
+
+        SchemaRegistryClient mockClient = SchemaRegistryClientFactory.newClient(
+                List.of(mockUrl), 100, List.of(new AvroSchemaProvider()), Map.of(), Map.of());
+        SchemaCodec codec = new SchemaCodec(mockClient, mockUrl, extraSerdeConfig);
+
+        // the tagged field carries confluent:tags inline in the Avro schema; the ENCRYPT rule selects by tag
+        String schemaString = "{\"type\":\"record\",\"name\":\"Customer\",\"namespace\":\"test\",\"fields\":["
+                + "{\"name\":\"hello\",\"type\":\"string\"},"
+                + "{\"name\":\"" + TAGGED_FIELD + "\",\"type\":\"string\",\"confluent:tags\":[\"" + PII_TAG + "\"]}"
+                + "]}";
+        Map<String, String> ruleParams = new HashMap<>();
+        ruleParams.put("encrypt.kek.name", "csfle-avro-kek");
+        ruleParams.put("encrypt.kms.type", "local-kms");
+        ruleParams.put("encrypt.kms.key.id", "local-kms://csfle-avro-key");
+        Rule encryptRule = new Rule("encryptPII", null, RuleKind.TRANSFORM, RuleMode.WRITEREAD,
+                "ENCRYPT", Set.of(PII_TAG), ruleParams, null, null, "ERROR", false);
+        ParsedSchema ruledSchema = new AvroSchema(schemaString).copy(null, new RuleSet(List.of(), List.of(encryptRule)));
+        int id = mockClient.register(TOPIC + "-avro-value", ruledSchema);
+
+        SchemaCodec.Encoder encoder = codec.newEncoder();
+        Map<String, Object> value = Map.of("hello", "world", TAGGED_FIELD, "123-45-6789");
+        byte[] framed = encoder.serialize(TOPIC, SchemaType.AVRO, id, value);
+
+        String wireText = new String(framed, StandardCharsets.ISO_8859_1);
+        assertFalse(wireText.contains("123-45-6789"), "tagged Avro field must be encrypted on the wire via SchemaCodec");
+
+        SchemaCodec.Decoder decoder = codec.newDecoder();
+        Map<String, Object> decoded = (Map<String, Object>) decoder.decode(TOPIC, framed);
+        assertEquals("123-45-6789", decoded.get(TAGGED_FIELD), "SchemaCodec.Decoder decrypts the Avro field back");
         assertEquals("world", decoded.get("hello"));
     }
 


### PR DESCRIPTION
## What

Follow-up to #131 (CSFLE compatibility), addressing an external assessment of that
feature. The report confirmed the delegation model is correct and raised three
non-blocking gaps; all three are fixed here. No runtime behavior change — docs, a
Javadoc, a POM comment, and one new test.

- **KMS-driver packaging.** The AWS KMS driver is Maven `optional`, so it is **not**
  inherited transitively by a downstream consumer of the published artifact — yet the
  docs said AWS was "uncommented by default," implying it's present. Kept it optional
  (forcing an AWS SDK on every consumer is wrong for Azure/GCP/non-CSFLE users) and
  clarified the guide + POM comment: the field-encryption **executor** is a normal
  compile dependency (inherited), but the app must supply **exactly one KMS driver**
  itself.
- **KEK/KMS identity ownership.** The `SchemaCodec` Javadoc and the `extractSerdeConfig`
  test example listed the rule-owned `encrypt.kek.name` as a `schema.registry.serde.*`
  pass-through key — contradicting the guide, Confluent behavior (resolved from the
  schema rule via `RuleContext.getParameter`), and the correct comment in the same test
  file. Corrected both to genuine driver keys (`access.key.id` / `secret`).
- **Avro CSFLE coverage.** `AvroSchemaSerde` applies the serde config symmetrically, but
  only JSON CSFLE was directly tested. Added
  `SchemaCodecCsfleConfigTest#avroCsfleConfigReachesEncoderAndDecoder`: an Avro schema
  with an inline `confluent:tags` field + `ENCRYPT` rule, round-tripped through the real
  `SchemaCodec.Encoder`/`Decoder`, asserting the tagged field is ciphertext on the wire
  and decrypts back.

## Why

The CSFLE feature is architecturally sound, but a field team following the docs could hit
a runtime failure: a subject configured with a CSFLE rule fails because no KMS driver is
on the app's classpath — the docs implied `minimalist-kafka` already brought AWS. And the
`encrypt.kek.name` examples could lead a user to set a key selector in app config where it
has no effect (Confluent reads it from the schema rule). Both are accuracy gaps that make
the feature harder to adopt correctly. Avro CSFLE was only "wired symmetrically" with JSON;
for a security feature, an explicit round-trip test is worth more than symmetry-by-inspection,
especially since Avro's Map→GenericRecord path differs from JSON.

## Testing

Full `minimalist-kafka` module green: **79 tests**, jacoco coverage gate met (the new Avro
test adds coverage).

Co-Authored-By: Claude Code <noreply@anthropic.com>