### PR TITLE
chore(platform-core): drop Jackson 2 test dependency; migrate custom-serializer test to Jackson 3

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-04 | agent: Claude Code (2026-07-04-232341)
+- **last_session:** 2026-07-05 | agent: Claude Code (2026-07-05-011131)
 - **last_review:** 2026-07-02 | through 2026-07-02-161433.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -283,9 +283,26 @@
   Maven Central's latest is still 2.22.0 — the fixing 2.22.1 is unreleased ("Patched version: None"; only 3.x
   shipped its fix, 3.1.4 on 2026-06-04). Recommended to Eric: dismiss alert #28 as "vulnerable code is not in
   use"; bump when 2.22.1 lands — Dependabot re-flags on release (that's the reminder), and the version is
-  centralized (`jackson-2-bom.version` in ~30 poms + 3 explicit `jackson-databind` pins: platform-core,
-  rest-spring-3, kafka-standalone). Do not re-investigate this alert while the pinned version is 2.22.0 and
-  those two grep checks stay empty.
+  centralized (`jackson-2-bom.version` in ~30 poms + explicit `jackson-databind` pins: rest-spring-3,
+  kafka-standalone — platform-core's test-scope pin was removed 2026-07-05, see below). Do not re-investigate
+  this alert while the pinned version is 2.22.0 and those two grep checks stay empty.
+  **Jackson 3 investigation + field-exemption decision (2026-07-05, Eric).** Asked whether moving to Jackson 3
+  (Spring Boot 4's default) could eliminate the Jackson 2 CVE. Findings: **Spring Boot 4.1.0 already put the
+  core/Spring stack on Jackson 3** — platform-core/event-script-engine/rest-spring-4 resolve
+  `tools.jackson:jackson-databind:3.1.4` at compile; Mercury's own code is Gson-based (one direct Jackson import,
+  `JsonSchemaSerde`). Jackson 2 and 3 coexist by design (different group/package). **platform-core is now free of
+  Jackson 2 databind/core** — it already excludes Vert.x's `com.fasterxml jackson-core` (Vert.x runs on Jackson 3),
+  and PR (branch `chore/platform-core-drop-jackson2-test-dep`) migrated the test `JacksonSerializer` to Jackson 3
+  + dropped the test-scope `jackson-databind`; only `jackson-annotations:2.22` remains, which **Jackson 3.1.4
+  itself requires** (annotation model still on the `com.fasterxml.jackson.core` coordinate) and which has no CVE.
+  **The real shipped Jackson 2 databind/core is load-bearing in `minimalist-kafka` and NOT removable:** `databind`
+  ← Confluent JSON-schema serdes (compiled against Jackson 2; `JsonSchemaSerde` calls that API directly) + their
+  `jackson-datatype-*` modules; `core` ← Apache Avro (`kafka-avro-serializer`). Unlike platform-core's Vert.x case,
+  there is no Jackson-3 substitution (Confluent 8.3.0 + Avro 1.12.1 reference `com.fasterxml.*` classes). Also
+  present in `rest-spring-3` (the Spring Boot 3.x line, by design). **Snyk flags by presence, not reachability** —
+  so a field app pulling `minimalist-kafka` will see `jackson-databind:2.22.0` in a scan even though #28 is
+  unreachable. **Decision (Eric): best-effort done; report to the field for a Snyk exemption** citing the
+  not-applicable assessment, and bump to 2.22.1 when Confluent's transitive fix / the release lands.
   <!-- id: jackson-databind-alert28-not-applicable | created: 2026-07-02 | last_used: 2026-07-02 | uses: 1 | tier: working | origin: 2026-07-02-055423 -->
 
 - **minimalist-kafka Schema Registry support — Confluent serdes as a library (2026-06-29; producer became

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -292,7 +292,8 @@
   `tools.jackson:jackson-databind:3.1.4` at compile; Mercury's own code is Gson-based (one direct Jackson import,
   `JsonSchemaSerde`). Jackson 2 and 3 coexist by design (different group/package). **platform-core is now free of
   Jackson 2 databind/core** — it already excludes Vert.x's `com.fasterxml jackson-core` (Vert.x runs on Jackson 3),
-  and PR (branch `chore/platform-core-drop-jackson2-test-dep`) migrated the test `JacksonSerializer` to Jackson 3
+  and PR [#136](https://github.com/Accenture/mercury-composable/pull/136) (branch
+  `chore/platform-core-drop-jackson2-test-dep`) migrated the test `JacksonSerializer` to Jackson 3
   + dropped the test-scope `jackson-databind`; only `jackson-annotations:2.22` remains, which **Jackson 3.1.4
   itself requires** (annotation model still on the `com.fasterxml.jackson.core` coordinate) and which has no CVE.
   **The real shipped Jackson 2 databind/core is load-bearing in `minimalist-kafka` and NOT removable:** `databind`

--- a/memory/sessions/2026-07-05-011131.md
+++ b/memory/sessions/2026-07-05-011131.md
@@ -38,7 +38,8 @@ Best-effort avoidance is done. The Confluent-driven Jackson 2 in minimalist-kafk
 unpublished; Confluent/Avro on Jackson 2) → **report to the field for a Snyk exemption**, citing the
 not-applicable (unreachable) assessment; bump when 2.22.1 / a Confluent update lands.
 
-**Status: platform-core cleanup committed on its branch; PR to open. Memory updated.**
+**Status: platform-core cleanup shipped as PR [#136](https://github.com/Accenture/mercury-composable/pull/136)
+(branch `chore/platform-core-drop-jackson2-test-dep`). Memory updated.**
 
 ## Memory References
 - Referenced: jackson-databind-alert28-not-applicable, snyk-oss-dependency-update-2026-07,

--- a/memory/sessions/2026-07-05-011131.md
+++ b/memory/sessions/2026-07-05-011131.md
@@ -1,0 +1,46 @@
+# Session (2026-07-05T01:11:31.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Investigated Eric's question: can we upgrade to Jackson 3 (Spring Boot 4's default) to avoid the Jackson 2
+`jackson-databind` CVE (Dependabot alert #28 / CWE-915, no 2.22.1 published yet)? Full detail folded into
+[[jackson-databind-alert28-not-applicable]]. Conclusion + one small change shipped.
+
+### Findings (verified via `dependency:tree`, not assumed)
+
+- **Spring Boot 4.1.0 already moved the core/Spring stack to Jackson 3.** platform-core / event-script-engine /
+  rest-spring-4 resolve `tools.jackson:jackson-databind:3.1.4` at compile. Mercury's own serialization is Gson
+  (`SimpleMapper`); the only direct Jackson import in all main sources is `JsonSchemaSerde` (Confluent's Jackson 2
+  API). So there's essentially no Mercury code to "migrate."
+- **Jackson 2 and 3 coexist** (different group/package: `tools.jackson` vs `com.fasterxml`); `jackson-annotations`
+  stays on the old coordinate and Jackson 3.1.4 depends on it (`2.22`) — benign, no CVE.
+- **platform-core is now Jackson-2 databind/core-free.** It already excluded Vert.x's `com.fasterxml jackson-core`
+  (Vert.x runs on Jackson 3); this session migrated the test `JacksonSerializer` (a `CustomSerializer` demo) to
+  Jackson 3 and dropped the test-scope `jackson-databind`. Only `jackson-annotations:2.22` remains (Jackson-3-owned).
+- **minimalist-kafka's Jackson 2 is load-bearing and NOT removable.** `jackson-databind` ← Confluent JSON-schema
+  serdes (+ `jackson-datatype-*`; `JsonSchemaSerde` calls the Jackson 2 API directly); `jackson-core` ← Apache Avro
+  (`kafka-avro-serializer`). No Jackson-3 substitution (Confluent 8.3.0 / Avro 1.12.1 reference `com.fasterxml.*`).
+  Excluding would break JSON-schema + Avro and the build. Also in rest-spring-3 (SB3 line, by design).
+- **Snyk flags by presence, not reachability** — so #28 (unreachable per our code analysis) still shows on any
+  field app pulling minimalist-kafka.
+
+### Change shipped
+
+Commit `fbd040ec` (branch `chore/platform-core-drop-jackson2-test-dep`): `JacksonSerializer` → Jackson 3
+(`tools.jackson`), removed the platform-core test-scope `jackson-databind`. Test-classpath tidy-up (the dep was
+never shipped), not a shipped-CVE fix. platform-core full suite **372 green** (verified with these exact changes).
+
+### Decision (Eric)
+
+Best-effort avoidance is done. The Confluent-driven Jackson 2 in minimalist-kafka is unfixable here (2.22.1
+unpublished; Confluent/Avro on Jackson 2) → **report to the field for a Snyk exemption**, citing the
+not-applicable (unreachable) assessment; bump when 2.22.1 / a Confluent update lands.
+
+**Status: platform-core cleanup committed on its branch; PR to open. Memory updated.**
+
+## Memory References
+- Referenced: jackson-databind-alert28-not-applicable, snyk-oss-dependency-update-2026-07,
+  kafka-csfle-delegation, minimalist-kafka-schema-registry
+- Updated (substance): jackson-databind-alert28-not-applicable (Jackson 3 investigation + field-exemption decision)

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -153,12 +153,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.84</version>

--- a/system/platform-core/src/test/java/org/platformlambda/common/JacksonSerializer.java
+++ b/system/platform-core/src/test/java/org/platformlambda/common/JacksonSerializer.java
@@ -18,21 +18,22 @@
 
 package org.platformlambda.common;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.platformlambda.core.models.CustomSerializer;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Map;
 
+// Test-only CustomSerializer that plugs a Jackson mapper into platform-core's serializer extension point
+// (the default is Gson). Uses Jackson 3 (tools.jackson), which Spring Boot 4 already puts on the compile
+// classpath - so this needs no separate Jackson dependency and keeps Jackson 2 off platform-core entirely.
 public class JacksonSerializer implements CustomSerializer {
 
-    private static final ObjectMapper mapper;
-
-    static {
-        mapper = JsonMapper.builder().build();
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-    }
+    // Jackson 3's builder is the immutable configuration API; FAIL_ON_UNKNOWN_PROPERTIES is off by default
+    // in Jackson 3, but we disable it explicitly so the intent survives any future default change.
+    private static final JsonMapper mapper = JsonMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
 
     @SuppressWarnings("unchecked")
     @Override


### PR DESCRIPTION
## What

Removes platform-core's last Jackson 2 dependency. Its only Jackson 2 usage was a **test-scope** `jackson-databind`, consumed solely by `JacksonSerializer` — a test-only `CustomSerializer` implementation that proves the serializer extension point works with a user-supplied mapper (the default is Gson).

- Migrated `JacksonSerializer` to **Jackson 3** (`tools.jackson`), which Spring Boot 4 already puts on the compile classpath.
- Removed the explicit test-scope `jackson-databind` declaration from `system/platform-core/pom.xml`.

After this, platform-core resolves **no** `com.fasterxml` `jackson-databind`/`jackson-core` at any scope — only `tools.jackson:3.1.4` plus `jackson-annotations:2.22`, which Jackson 3.1.4 itself requires (the `@JsonProperty`/`@JsonIgnore`/`@JsonCreator` annotation model is still published under the `com.fasterxml.jackson.core` coordinate) and which carries no CVE.

## Why

Part of a security-hardening pass on the Jackson 2 footprint (Dependabot alert #28 / CWE-915 in `jackson-databind`, no `2.22.1` published yet). Investigation showed Spring Boot 4.1.0 already moved the core/Spring stack to Jackson 3, so platform-core's only remaining Jackson 2 was this test dependency — cleanly removable by moving the test serializer to Jackson 3.

**Scope note (intentionally not addressed here):** this is a test-classpath tidy-up, not a shipped-CVE fix — the dependency was never shipped. The real, shipped Jackson 2 `databind`/`core` is **load-bearing in `minimalist-kafka`** (Confluent's JSON-schema serdes require `databind`; Apache Avro requires `core`) and cannot be removed or substituted with Jackson 3 (Confluent 8.3.0 / Avro 1.12.1 are compiled against the `com.fasterxml.*` API). That residual — unreachable per prior assessment but flagged by Snyk on presence — is being handled by field exemption until `jackson-databind:2.22.1` (or a Confluent/Avro Jackson 3 uptake) lands.

## Testing

platform-core full suite: **372 tests green** with these exact changes.

Co-Authored-By: Claude Code <noreply@anthropic.com>