### PR TITLE
chore(release): advance version to 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.6.0, 7/5/2026
+
+### Added
+
+1. **File-backed FIFO overflow buffer for ElasticQueue — now the default store.** A new dependency-free,
+   portable, virtual-thread-friendly `FileElasticStore` replaces Berkeley DB as the default per-route reactive
+   back-pressure buffer (`elastic.queue.store=file`). It is a per-route sequence of fixed-size, append-only
+   segment files (`[4-byte length][payload]`) with immediate O(1) reclamation of fully-consumed segments (no
+   compaction, no cleaner thread). Paired with **off-loop dispatch**: when the store is virtual-thread-safe,
+   each route's ServiceQueue state machine + blocking spill I/O run on a per-route virtual thread, so a
+   disk/OS-flush stall parks that carrier instead of stalling the shared Vert.x event loop. Tunables:
+   `elastic.queue.segment.size.bytes` (default 16 MB), `elastic.queue.dispatch.mailbox.size` (default 1024,
+   bounded with back-pressure), and `transient.data.store` (tmpfs recommended for latency-sensitive pods). The
+   buffer remains transient (wiped on restart).
+2. **`benchmark/benchmark-reporter`** — a self-contained, single-JVM end-to-end performance harness that drives
+   an echo service via RPC (closed-loop) and callback (open-loop, the path that exercises the ElasticQueue),
+   plus a mixed-workload latency-isolation probe, and writes a self-contained HTML report (inline SVG latency
+   histogram + percentile plot + environment metadata). It runs anywhere a JRE does — a real deployed
+   environment or a benchmark pipeline — and records the active store so `file` and `bdb` can be A/B'd. A
+   committed file-vs-bdb reference analysis lives under `benchmark/benchmark-reporter/analysis/`.
+
+### Changed
+
+1. **ElasticQueue is now a pluggable store, defaulting to `file` (was Berkeley DB).** `ElasticQueue` became a
+   thin facade over an `ElasticStore` strategy selected by `elastic.queue.store` (`file` default, `bdb`
+   fallback). ServiceQueue derives its dispatch mode from the store — `file` runs off the event loop on a
+   per-route virtual thread, `bdb` runs inline on the loop — so the single knob picks a safe (store, dispatch)
+   pairing and the unsafe virtual-thread + BDB combination is unreachable by construction. Rationale: Berkeley
+   DB's internal synchronized/latches stall the shared event loop during housekeeping and pin virtual-thread
+   carriers under load; the file store removes both, and is portable and dependency-free. **Berkeley DB
+   remains fully supported as a one-flag fallback** (`elastic.queue.store=bdb`) — existing installations can
+   opt back at any time, with no data migration (the buffer is transient). The `elastic.queue.cleanup` task is
+   now annotated `@KernelThreadRunner` so its heavy BDB work runs on a kernel thread and never pins a
+   virtual-thread carrier.
+
+### Fixed
+
+1. **File-store production hardening.** The off-loop dispatch mailbox is bounded and applies back-pressure when
+   full instead of growing the heap without bound; open file descriptors are bounded to O(1) (only the write
+   tail and read head stay open, sealed segments reopen on demand); crash/stale spill directories are handled
+   on startup (RUNNING marker + keepalive, plus conservative removal of stale per-origin stores that still
+   contain segment files); and the peek cache is reset on close/reuse in both the file and BDB stores.
+
+---
 ## Version 4.5.0, 6/25/2026
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.5.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.6.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.5.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.6.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-client/pom.xml
+++ b/benchmark/benchmark-client/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-client</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Benchmark client</name>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/docs/guides/build-test-deploy.md
+++ b/docs/guides/build-test-deploy.md
@@ -433,7 +433,7 @@ Add the dependency and it auto-registers (no code):
 <dependency>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
 </dependency>
 ```
 

--- a/docs/guides/event-driven/write-your-first-function.md
+++ b/docs/guides/event-driven/write-your-first-function.md
@@ -134,7 +134,7 @@ Start the application (adjust the version to match your build):
 
 ```bash
 cd examples/composable-example
-java -jar target/composable-example-4.5.0.jar
+java -jar target/composable-example-4.6.0.jar
 ```
 
 Test with `curl`:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -48,7 +48,7 @@ mvn clean install
 
 ```shell
 cd examples/composable-example
-java -jar target/composable-example-4.5.0.jar
+java -jar target/composable-example-4.6.0.jar
 ```
 
 Look for these lines to confirm it's running:
@@ -103,7 +103,7 @@ built-in tutorial graph:
 
 ```shell
 cd examples/minigraph-playground
-java -jar target/minigraph-playground-4.5.0.jar
+java -jar target/minigraph-playground-4.6.0.jar
 ```
 
 ```bash

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -118,7 +118,7 @@ Tempo, …). Add the dependency and it auto-registers; no code required:
 <dependency>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
 </dependency>
 ```
 

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/README.md
+++ b/examples/kafka-demo/README.md
@@ -39,7 +39,7 @@ Run each step in its own terminal, from the repo root unless noted.
 ```shell
 cd helpers/kafka-standalone
 mvn clean package
-java -jar target/kafka-standalone-4.5.0.jar
+java -jar target/kafka-standalone-4.6.0.jar
 ```
 Wait for it to report the broker is up on `127.0.0.1:9092`.
 
@@ -54,7 +54,7 @@ node create-topics.js
 ```shell
 cd examples/kafka-demo
 mvn clean package
-java -jar target/kafka-demo-4.5.0.jar
+java -jar target/kafka-demo-4.6.0.jar
 ```
 It starts the flow adapter (consuming `demo.inbound`) and the producer.
 

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/README.md
+++ b/examples/sync-over-async-demo/README.md
@@ -41,11 +41,11 @@ business logic) and [`SyncErrorHandler`](src/main/java/com/accenture/soa/demo/su
 
 ### Terminal A — Redis
 ```shell
-cd helpers/redis-standalone && java -jar target/redis-standalone-4.5.0.jar
+cd helpers/redis-standalone && java -jar target/redis-standalone-4.6.0.jar
 ```
 ### Terminal B — Kafka
 ```shell
-cd helpers/kafka-standalone && java -jar target/kafka-standalone-4.5.0.jar
+cd helpers/kafka-standalone && java -jar target/kafka-standalone-4.6.0.jar
 ```
 
 ### Create the topics (10 partitions each) — once
@@ -68,11 +68,11 @@ let the group spread across facades, which is what makes the multi-facade test b
 
 ### Terminal C — backend pod
 ```shell
-java -Dspring.profiles.active=backend -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.5.0.jar
+java -Dspring.profiles.active=backend -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.6.0.jar
 ```
 ### Terminal D — facade pod (REST on :8400)
 ```shell
-java -Dspring.profiles.active=facade -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.5.0.jar
+java -Dspring.profiles.active=facade -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.6.0.jar
 ```
 ### Terminal E — call it synchronously
 ```shell
@@ -94,7 +94,7 @@ The facade and backend logs show the same `traceId` across the Kafka hops.
   originated the request, even when the *other* facade is the one that consumed the reply off `soa.response`
   (watch which facade logs `soa.reply` vs. which one returns the HTTP response):
   ```shell
-  java -Dspring.profiles.active=facade -Drest.server.port=8401 -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.5.0.jar
+  java -Dspring.profiles.active=facade -Drest.server.port=8401 -jar examples/sync-over-async-demo/target/sync-over-async-demo-4.6.0.jar
   curl -sS -X POST http://127.0.0.1:8401/api/sync-to-async -H 'content-type: application/json' -d '{"order":"B-200"}'
   ```
 - **Timeout → HTTP 408.** Stop the backend (Terminal C) and call again with a short budget; with no reply,
@@ -122,7 +122,7 @@ variants:
 # Terminal F — seed + start the local Confluent-compatible Schema Registry (port 8081)
 mkdir -p /tmp/schema-registry
 cp examples/sync-over-async-demo/registry/*.json /tmp/schema-registry/
-cd helpers/schema-registry-standalone && java -jar target/schema-registry-standalone-4.5.0.jar
+cd helpers/schema-registry-standalone && java -jar target/schema-registry-standalone-4.6.0.jar
 ```
 The store keeps one `<id>.json` per schema, so you can also drop a new file (e.g. `4.json`) into
 `/tmp/schema-registry` while the registry is running — it is picked up on the next request, no restart needed.

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/README.md
+++ b/extensions/opentelemetry-forwarder/README.md
@@ -17,7 +17,7 @@ Add the dependency to your application:
 <dependency>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
 </dependency>
 ```
 

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with robust Pub/Sub + auto-reconnect.

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/README.md
+++ b/helpers/redis-standalone/README.md
@@ -16,7 +16,7 @@ Kafka broker and a local Redis server without external infrastructure, which is 
 ```shell
 cd helpers/redis-standalone
 mvn clean package
-java -jar target/redis-standalone-4.5.0.jar
+java -jar target/redis-standalone-4.6.0.jar
 ```
 
 The server starts on `127.0.0.1:6379`. Press `Ctrl-C` to stop (it shuts the `redis-server` subprocess down
@@ -27,7 +27,7 @@ cleanly).
 The port defaults to `6379`. Override it with the `redis.port` property:
 
 ```shell
-java -Dredis.port=6380 -jar target/redis-standalone-4.5.0.jar
+java -Dredis.port=6380 -jar target/redis-standalone-4.6.0.jar
 ```
 
 ## Prefer Docker?

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/README.md
+++ b/helpers/schema-registry-standalone/README.md
@@ -21,7 +21,7 @@ for why. See also the guide: [`docs/guides/schema-registry-mock.md`](../../docs/
 ```shell
 cd helpers/schema-registry-standalone
 mvn clean package
-java -jar target/schema-registry-standalone-4.5.0.jar
+java -jar target/schema-registry-standalone-4.6.0.jar
 ```
 
 The server starts on `http://127.0.0.1:8081`. Press `Ctrl-C` to stop.
@@ -122,7 +122,7 @@ Schemas are persisted as **one file per global id** — `<id>.json` (e.g. `1.jso
 Override the store for a durable location:
 
 ```shell
-java -Dschema.registry.data.store="$HOME/schema-registry" -jar target/schema-registry-standalone-4.5.0.jar
+java -Dschema.registry.data.store="$HOME/schema-registry" -jar target/schema-registry-standalone-4.6.0.jar
 ```
 
 ## Choosing a port
@@ -130,7 +130,7 @@ java -Dschema.registry.data.store="$HOME/schema-registry" -jar target/schema-reg
 The port defaults to `8081`. Override it with the `rest.server.port` property:
 
 ```shell
-java -Drest.server.port=8082 -jar target/schema-registry-standalone-4.5.0.jar
+java -Drest.server.port=8082 -jar target/schema-registry-standalone-4.6.0.jar
 ```
 
 ## Prefer Docker / the real registry?

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -11,7 +11,7 @@ RPC perform on par with reactive code. Also available for Node.js (separate repo
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.5.0`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.6.0`)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-06-004133.md
+++ b/memory/sessions/2026-07-06-004133.md
@@ -1,0 +1,26 @@
+# Session (2026-07-06T00:41:33.000Z)
+
+**Agent:** Claude Code
+
+## Release: version bump 4.5.0 → 4.6.0
+
+PR #137 (file-FIFO ElasticQueue default + off-loop dispatch + benchmark-reporter) was merged to `main` by
+Eric; local switched to `main` + pulled. Eric asked to advance the version to 4.6.0.
+
+- Bumped **all 31 module poms** `<version>4.5.0</version>` → `4.6.0` (verified: every `4.5.0` in the poms was
+  a Mercury artifact — `org.platformlambda` / `com.accenture` — no third-party coincidence). Reactor
+  `mvn validate` = BUILD SUCCESS ("Parent Mercury 4.6.0").
+- Added the **4.6.0 CHANGELOG entry** (Added: file store + default flip, benchmark-reporter; Changed:
+  pluggable ElasticStore; Fixed: file-store production hardening).
+- Committed on branch **`chore/release-4.6.0`** (main is protected → PR flow); pushed. PR title/description
+  handed to Eric to create.
+- Updated the memory layer's current-version refs to 4.6.0 ([[instructions.md]], vision.md).
+
+**Flagged to Eric (out of the requested poms+CHANGELOG scope, still at 4.5.0):** doc version examples
+(`docs/guides/build-test-deploy.md`, `observability.md`, `getting-started.md`,
+`event-driven/write-your-first-function.md`, `extensions/opentelemetry-forwarder/README.md`) and the project
+descriptions in `CLAUDE.md` / `GEMINI.md`. Offered to bump these in the same release PR for doc accuracy.
+Historical `memory/sessions/*` + `archive/` left untouched (immutable records).
+
+## Memory References
+- Referenced: (release chore; no fact links)

--- a/memory/sessions/2026-07-06-004133.md
+++ b/memory/sessions/2026-07-06-004133.md
@@ -16,11 +16,12 @@ Eric; local switched to `main` + pulled. Eric asked to advance the version to 4.
   handed to Eric to create.
 - Updated the memory layer's current-version refs to 4.6.0 ([[instructions.md]], vision.md).
 
-**Flagged to Eric (out of the requested poms+CHANGELOG scope, still at 4.5.0):** doc version examples
-(`docs/guides/build-test-deploy.md`, `observability.md`, `getting-started.md`,
-`event-driven/write-your-first-function.md`, `extensions/opentelemetry-forwarder/README.md`) and the project
-descriptions in `CLAUDE.md` / `GEMINI.md`. Offered to bump these in the same release PR for doc accuracy.
-Historical `memory/sessions/*` + `archive/` left untouched (immutable records).
+**Then (Eric approved) also bumped the embedded version refs in docs/READMEs + CLAUDE/GEMINI** (`17f7d5f9`,
+12 files): doc pom-snippet examples + runnable jar filenames across `docs/guides/*` and module READMEs
+(mini-scheduler, opentelemetry-forwarder, kafka-demo, sync-over-async-demo, schema-registry-standalone,
+redis-standalone), plus the `com.accenture.mercury vX` project-description line in `CLAUDE.md`/`GEMINI.md`.
+Only the historical `CHANGELOG` 4.5.0 entry + immutable `memory/sessions|archive` records remain at 4.5.0
+(correctly). All on branch `chore/release-4.6.0`.
 
 ## Memory References
 - Referenced: (release chore; no fact links)

--- a/memory/vision.md
+++ b/memory/vision.md
@@ -35,7 +35,7 @@ the one below:
   LLM backend is integrated in-repo yet; today the "AI" is an external session following a
   documented prompt.
 
-**Type:** Multi-module Java 21 framework / SDK (Maven reactor, `com.accenture.mercury` v4.5.0).
+**Type:** Multi-module Java 21 framework / SDK (Maven reactor, `com.accenture.mercury` v4.6.0).
 
 ## What it should become  *(TARGET)*
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/README.md
+++ b/system/mini-scheduler/README.md
@@ -73,7 +73,7 @@ the service "hello.world" and the flow "hello-flow" every 10 seconds.
 <dependency>
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
 </dependency>
 ```
 

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <!-- Kafka client (key=String, value=byte[]). -->

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.5.0</version>
+    <version>4.6.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Advance the Maven reactor from 4.5.0 to 4.6.0 to mark the file-backed FIFO ElasticQueue milestone (PR #137:
file store as the new default overflow buffer, off-loop virtual-thread dispatch, and the benchmark-reporter
module).

- All 31 module poms bumped 4.5.0 → 4.6.0 (module versions + inter-module dependency refs).
- CHANGELOG.md 4.6.0 entry added (Added / Changed / Fixed).
- Embedded version references updated in documentation: docs/guides pom-snippet examples and runnable jar
  filenames, module READMEs, and the CLAUDE.md / GEMINI.md project description.
- `mvn validate` on the full reactor: BUILD SUCCESS.
- Berkeley DB remains a one-flag fallback (`elastic.queue.store=bdb`); no data migration (transient buffer).

The historical CHANGELOG 4.5.0 entry is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)