### PR TITLE
chore(memory): v4.6.3 release closure

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -81,7 +81,7 @@
   #144 bump) — maintenance on top of 4.6.2: final smell suppressions, model encapsulation,
   playground `random` → SecureRandom. All caveats above still apply. Field Sonar dashboard: gate PASSED,
   0 vuln / 0 bugs / smells rating A; only the CryptoApi DSA hotspot awaits "Safe" review in the Sonar UI.
-  <!-- id: release-4-6-2-shipped | created: 2026-07-07 | last_used: 2026-07-07 | uses: 2 | tier: working | origin: 2026-07-07-163607 -->
+  <!-- id: release-4-6-2-shipped | created: 2026-07-07 | last_used: 2026-07-08 | uses: 3 | tier: active | origin: 2026-07-07-163607 -->
 
 - **Release 4.6.1 — security + maintenance patch on top of 4.6.0 (2026-07-06, branch `chore/release-4.6.1`,
   Claude Code).** 4.6.0 was already GitHub-released (tag `v4.6.0`, immutable); rather than recall/re-tag it,

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -77,7 +77,11 @@
   CHANGELOG; (4) kafka-connector's embedded-broker tests rely on kafka-standalone's `@MainApplication`
   (seq 10) owning the broker — never start a second `EmbeddedKafka` in the same JVM (its formatStorage
   wipes `/tmp/kafka-logs` under the running broker → Kafka fatal Exit(1)).
-  <!-- id: release-4-6-2-shipped | created: 2026-07-07 | last_used: 2026-07-07 | uses: 1 | tier: working | origin: 2026-07-07-163607 -->
+  **UPDATE 2026-07-07: v4.6.3 shipped the same day** (tag on merge commit `4c709484`; PRs #143 cleanup +
+  #144 bump) — maintenance on top of 4.6.2: final smell suppressions, model encapsulation,
+  playground `random` → SecureRandom. All caveats above still apply. Field Sonar dashboard: gate PASSED,
+  0 vuln / 0 bugs / smells rating A; only the CryptoApi DSA hotspot awaits "Safe" review in the Sonar UI.
+  <!-- id: release-4-6-2-shipped | created: 2026-07-07 | last_used: 2026-07-07 | uses: 2 | tier: working | origin: 2026-07-07-163607 -->
 
 - **Release 4.6.1 — security + maintenance patch on top of 4.6.0 (2026-07-06, branch `chore/release-4.6.1`,
   Claude Code).** 4.6.0 was already GitHub-released (tag `v4.6.0`, immutable); rather than recall/re-tag it,

--- a/memory/sessions/2026-07-08-015440.md
+++ b/memory/sessions/2026-07-08-015440.md
@@ -12,10 +12,14 @@ OtelForwarderContext.VERSION, CLAUDE/GEMINI headers, kafka-standalone Dockerfile
 hotspot remediation, no behavior/API changes). Zero docs/README edits needed.
 Verified: full offline reactor `mvn clean test` — 18 modules pass.
 
-## STATUS
-Branch pushed; PR title/description provided. After merge: tag v4.6.3 on the merge
-commit (v4.6.1/v4.6.2 precedent), then Eric publishes the GitHub release + clones to
-the field. Outstanding non-code item: CryptoApi DSA hotspot "Safe" review in Sonar UI.
+## 🚀 v4.6.3 PUBLISHED
+PR #144 merged (merge commit `4c709484`, CI green: Build & Unit Tests 5m14s + memory
+×2, 0 failures). Eric published the GitHub release:
+https://github.com/Accenture/mercury-composable/releases/tag/v4.6.3
+Round-5 arc closed: sonar5 scan showed gate PASSED (0 vuln/0 bugs/79 smells rating A);
+Eric's 41-file manual cleanup reviewed-all-correct + 2 loose ends fixed (S5778,
+SecureRandom). Outstanding non-code item: CryptoApi DSA hotspot "Safe" review in the
+SonarQube UI (pending IT exemption rights).
 
 ## Memory References
 - Referenced: [[release-4-6-2-shipped]]


### PR DESCRIPTION
Memory-layer-only change (no code): records the v4.6.3 publication
(https://github.com/Accenture/mercury-composable/releases/tag/v4.6.3) in the session log
and appends the 4.6.3 shipment to the release Key Decision fact (all 4.6.2 caveats still
apply; only the CryptoApi DSA hotspot awaits its "Safe" review in the SonarQube UI).
memory-lint: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)