### PR TITLE
chore(release): version 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.7.0, 7/8/2026
+
+Feature release: the MiniGraph engine gains the `graph.task` skill, so a graph node can invoke any
+composable function through its route name. This makes composable functions usable as custom skills
+and completes the extension model - built-in skills for zero-code work, `graph.task` for a small
+piece of custom business logic, and `graph.extension` for sub-graph/flow orchestration. No breaking
+changes; all existing graph models and APIs are unchanged.
+
+### Added
+
+1. **MiniGraph `graph.task` skill.** A Task node with `task=<route>` invokes a composable function
+   (a `TypedLambdaFunction` registered with `@PreLoad`) using Event Script style `input[]`/`output[]`
+   data mapping. Input mapping supports `*` (merge the mapped value into the request body, applied in
+   declaration order), `header.{name}` (set a request header) and composite body keys; the request
+   body auto-converts when the function declares a PoJo input. Response body, status and headers land
+   at `{node}.result`, `{node}.status` and `{node}.header`. Optional `for_each[]` with `concurrency`
+   (1-30, default 3) provides iterative fork-join execution and `exception=<node>` routes failures to
+   a handler node; calls are bounded by `model.ttl` (default 30s).
+2. **Tutorial 13.** A deployed graph model (`tutorial-13`) and help topics (`help tutorial 13`,
+   `describe skill graph.task`) demonstrate the new skill end-to-end with the dev-mode demo function
+   `v1.hello.task`.
+
+### Changed
+
+1. **Knowledge-graph documentation and grammar catalog updated for `graph.task`.** The machine-readable
+   `minigraph-commands.json` catalog, the skills reference, the command reference and the guide index
+   now describe the eight built-in skills; the CI anti-drift gate verifies the catalog stays in sync
+   with the shipped help pages.
+2. **MiniGraph playground UI bundle refreshed** from the webapp source.
+
+---
 ## Version 4.6.3, 7/7/2026
 
 Maintenance release: final SonarQube smell cleanup and security-hotspot remediation following the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.6.3) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.6.3) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.6.3";
+    private static final String VERSION = "4.7.0";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.6.3-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.6.3-exec.jar"]
+COPY target/kafka-standalone-4.7.0-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.7.0-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-07-09-001942.md
+++ b/memory/sessions/2026-07-09-001942.md
@@ -1,0 +1,56 @@
+# Session (2026-07-09T00:19:43.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** release-bump session following the graph.task feature merge (PR #146).
+
+Version bump 4.6.3 → 4.7.0 (MINOR: new graph.task skill is a feature) on branch
+`chore/release-4.7.0`: 30 poms, OtelForwarderContext.VERSION, kafka-standalone
+Dockerfile, CLAUDE/GEMINI headers, CHANGELOG 4.7.0 entry (graph.task, tutorial 13,
+grammar catalog + docs sync, UI bundle refresh). Verified: offline reactor install
+clean; minigraph suite 62/62 at 4.7.0.
+
+STATUS: awaiting Eric's release PR + merge; tag v4.7.0 goes on the squash-merge commit.
+
+Commit `38db9b95` — chore(release): bump version to 4.7.0
+
+```
+ CHANGELOG.md                                       | 31 ++++++++++++++++++++++
+ CLAUDE.md                                          |  2 +-
+ GEMINI.md                                          |  2 +-
+ benchmark/benchmark-reporter/pom.xml               |  4 +--
+ connectors/adapters/kafka/kafka-connector/pom.xml  |  6 ++---
+ connectors/adapters/kafka/kafka-presence/pom.xml   |  6 ++---
+ connectors/core/cloud-connector/pom.xml            |  4 +--
+ connectors/core/service-monitor/pom.xml            |  6 ++---
+ examples/composable-example/pom.xml                |  4 +--
+ examples/kafka-demo/pom.xml                        |  4 +--
+ examples/kotlin-example/pom.xml                    |  4 +--
+ examples/lambda-example/pom.xml                    |  6 ++---
+ examples/minigraph-playground/pom.xml              |  4 +--
+ examples/pg-example/pom.xml                        |  6 ++---
+ examples/rest-spring-3-example/pom.xml             |  6 ++---
+ examples/rest-spring-4-example/pom.xml             |  6 ++---
+ examples/scheduler-example/pom.xml                 |  4 +--
+ examples/sync-over-async-demo/pom.xml              |  4 +--
+ extensions/api-playground/pom.xml                  |  4 +--
+ extensions/opentelemetry-forwarder/pom.xml         |  6 ++---
+ .../support/OtelForwarderContext.java              |  2 +-
+ extensions/reactive-postgres/pom.xml               |  4 +--
+ extensions/sync-over-async/pom.xml                 |  4 +--
+ helpers/kafka-standalone/Dockerfile                |  4 +--
+ helpers/kafka-standalone/pom.xml                   |  4 +--
+ helpers/redis-standalone/pom.xml                   |  4 +--
+ helpers/schema-registry-standalone/pom.xml         |  4 +--
+ pom.xml                                            |  4 +--
+ system/event-script-engine/pom.xml                 |  4 +--
+ system/mini-scheduler/pom.xml                      |  4 +--
+ system/minigraph-playground-engine/pom.xml         |  4 +--
+ system/minimalist-kafka/pom.xml                    |  4 +--
+ system/platform-core/pom.xml                       |  2 +-
+ system/rest-spring-3/pom.xml                       |  4 +--
+ system/rest-spring-4/pom.xml                       |  4 +--
+ 35 files changed, 103 insertions(+), 72 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Parent Mercury</name>
 
     <modules>
@@ -51,7 +51,7 @@
         <module>examples/kafka-demo</module>
         <module>examples/sync-over-async-demo</module>-->
 
-        <!-- Executable for benchmark tests (benchmark-client retired 4.6.3 — superseded by benchmark-reporter)
+        <!-- Executable for benchmark tests (benchmark-client retired 4.7.0 — superseded by benchmark-reporter)
         <module>benchmark/benchmark-reporter</module>-->
     </modules>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.6.3</version>
+    <version>4.7.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.6.3</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What

Version bump 4.6.3 -> 4.7.0 for release to the field. A **minor** version bump: 4.7.0
introduces the new MiniGraph `graph.task` skill (PR #146) with no breaking changes.

- 30 `pom.xml` files: 4.6.3 -> 4.7.0
- `OtelForwarderContext.VERSION`, kafka-standalone Dockerfile, CLAUDE.md/GEMINI.md headers
- CHANGELOG 4.7.0 entry covering the release content:
  - **Added** — `graph.task` skill (invoke a composable function by route name with Event
    Script style data mapping, `for_each` fork-join, exception routing); Tutorial 13 with
    the deployed demo graph and help topics
  - **Changed** — knowledge-graph docs and the machine-readable grammar catalog now
    describe the eight built-in skills (CI anti-drift gate enforced); playground UI
    bundle refreshed

## Verification

- Full offline reactor install passes at 4.7.0
- minigraph-playground-engine suite 62/62
- No stale 4.6.3 references outside CHANGELOG history and memory logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)