### PR TITLE
chore(release): version 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.7.1, 7/9/2026
+
+Field-driven update for the minimalist-kafka module: OAuth 2.0 authentication for the Schema Registry
+protocol and automatic allow-listing of OAuth token endpoint URLs, closing the loose ends found during
+the 4.6.3 field deployment. Also resolves the final four SonarQube code smells from the field scan.
+No breaking changes.
+
+### Added
+
+1. **Schema Registry OAuth 2.0 (client credentials).** A new `schema-registry.properties` template
+   carries the Confluent Schema Registry client configuration, making the Kafka configuration set
+   consistent: `kafka-producer.properties` / `kafka-consumer.properties` / `schema-registry.properties`
+   (file-then-classpath fallback, `${ENV_VAR:default}` substitution), while `schema.registry.url` stays
+   in `application.properties` as the feature switch. Template entries pass verbatim to the Confluent
+   client, so bearer auth (`bearer.auth.credentials.source=OAUTHBEARER` with issuer endpoint, client id,
+   client secret and scope), optional installation-specific parameters (`bearer.auth.logical.cluster`,
+   `bearer.auth.identity.pool.id`), `SASL_OAUTHBEARER_INHERIT`, `STATIC_TOKEN`, basic auth and SSL
+   settings work without library changes. The bearer token is cached and refreshed before expiry.
+2. **OAuth token URL allow-list automation.** Token endpoint URLs found in any of the three templates
+   (`sasl.oauthbearer.token.endpoint.url`, `bearer.auth.issuer.endpoint.url`) are registered on the JVM
+   allow-list system property `org.apache.kafka.sasl.oauthbearer.allowed.urls` before client
+   construction - merged and deduplicated, never clobbering an operator-set value - removing the manual
+   `System.setProperty` workaround previously needed by field applications.
+
+### Changed
+
+1. **Final field-scan code smells resolved.** JUnit 5 lifecycle method visibility, `EtagFile` field
+   encapsulation, an intentional-singleton suppression, and IDE-flagged touch ups (`ReentrantLock`
+   instead of `synchronized` for virtual-thread friendliness, conditional log arguments, an unused
+   constructor, an unnecessary null check).
+
+---
 ## Version 4.7.0, 7/8/2026
 
 Feature release: the MiniGraph engine gains the `graph.task` skill, so a graph node can invoke any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.1) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.1) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.7.0";
+    private static final String VERSION = "4.7.1";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.7.0-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.7.0-exec.jar"]
+COPY target/kafka-standalone-4.7.1-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.7.1-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-07-09-230932.md
+++ b/memory/sessions/2026-07-09-230932.md
@@ -1,0 +1,55 @@
+# Session (2026-07-09T23:09:32.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** release-bump session after the SR OAuth feature merge (PR #150).
+
+Version bump 4.7.0 → 4.7.1 on `chore/release-4.7.1`: 30 poms, OtelForwarderContext,
+kafka-standalone Dockerfile, CLAUDE/GEMINI headers, CHANGELOG 4.7.1 entry (SR OAuth 2.0,
+allow-list automation, final smell cleanup). Bumped off pre-merge main (reactor install
+verified green), then REBASED onto origin/main after #150 merged (clean, commit
+`cc558061` on top of `19c23ca1`); minimalist-kafka suite re-verified at 4.7.1 post-rebase.
+Note: main also picked up #149 (sync-over-async README refresh, Eric's own).
+
+Commit `3f3383a7` (pre-rebase) → `cc558061` — chore(release): bump version to 4.7.1
+
+```
+ CHANGELOG.md                                       | 32 ++++++++++++++++++++++
+ CLAUDE.md                                          |  2 +-
+ GEMINI.md                                          |  2 +-
+ benchmark/benchmark-reporter/pom.xml               |  4 +--
+ connectors/adapters/kafka/kafka-connector/pom.xml  |  6 ++--
+ connectors/adapters/kafka/kafka-presence/pom.xml   |  6 ++--
+ connectors/core/cloud-connector/pom.xml            |  4 +--
+ connectors/core/service-monitor/pom.xml            |  6 ++--
+ examples/composable-example/pom.xml                |  4 +--
+ examples/kafka-demo/pom.xml                        |  4 +--
+ examples/kotlin-example/pom.xml                    |  4 +--
+ examples/lambda-example/pom.xml                    |  6 ++--
+ examples/minigraph-playground/pom.xml              |  4 +--
+ examples/pg-example/pom.xml                        |  6 ++--
+ examples/rest-spring-3-example/pom.xml             |  6 ++--
+ examples/rest-spring-4-example/pom.xml             |  6 ++--
+ examples/scheduler-example/pom.xml                 |  4 +--
+ examples/sync-over-async-demo/pom.xml              |  4 +--
+ extensions/api-playground/pom.xml                  |  4 +--
+ extensions/opentelemetry-forwarder/pom.xml         |  6 ++--
+ .../support/OtelForwarderContext.java              |  2 +-
+ extensions/reactive-postgres/pom.xml               |  4 +--
+ extensions/sync-over-async/pom.xml                 |  4 +--
+ helpers/kafka-standalone/Dockerfile                |  4 +--
+ helpers/kafka-standalone/pom.xml                   |  4 +--
+ helpers/redis-standalone/pom.xml                   |  4 +--
+ helpers/schema-registry-standalone/pom.xml         |  4 +--
+ pom.xml                                            |  4 +--
+ system/event-script-engine/pom.xml                 |  4 +--
+ system/mini-scheduler/pom.xml                      |  4 +--
+ system/minigraph-playground-engine/pom.xml         |  4 +--
+ system/minimalist-kafka/pom.xml                    |  4 +--
+ system/platform-core/pom.xml                       |  2 +-
+ system/rest-spring-3/pom.xml                       |  4 +--
+ system/rest-spring-4/pom.xml                       |  4 +--
+ 35 files changed, 104 insertions(+), 72 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Parent Mercury</name>
 
     <modules>
@@ -51,7 +51,7 @@
         <module>examples/kafka-demo</module>
         <module>examples/sync-over-async-demo</module>-->
 
-        <!-- Executable for benchmark tests (benchmark-client retired 4.7.0 — superseded by benchmark-reporter)
+        <!-- Executable for benchmark tests (benchmark-client retired 4.7.1 — superseded by benchmark-reporter)
         <module>benchmark/benchmark-reporter</module>-->
     </modules>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.0</version>
+            <version>4.7.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What

Version bump 4.7.0 -> 4.7.1 for deployment to the field. A patch release carrying the
minimalist-kafka Schema Registry OAuth 2.0 feature (PR #150) - the loose ends found
during the 4.6.3 field test of sync-over-async and minimalist-kafka. No breaking changes.

- 30 `pom.xml` files: 4.7.0 -> 4.7.1
- `OtelForwarderContext.VERSION`, kafka-standalone Dockerfile, CLAUDE.md/GEMINI.md headers
- CHANGELOG 4.7.1 entry covering the release content:
  - **Added** — Schema Registry OAuth 2.0 client-credentials via the new
    `schema-registry.properties` template (verbatim pass-through to the Confluent client;
    `schema.registry.url` stays in application.properties as the feature switch);
    automatic registration of OAuth token endpoint URLs on the JVM
    `org.apache.kafka.sasl.oauthbearer.allowed.urls` allow-list (no more manual
    `System.setProperty` in field applications)
  - **Changed** — final four field-scan code smells resolved plus IDE-flagged touch-ups
    (ReentrantLock for virtual-thread friendliness, and related cleanups)

## Verification

- Full offline reactor install passes at 4.7.1
- Branch rebased onto main after PR #150 merged (clean); minimalist-kafka suite re-verified
- No stale 4.7.0 references outside CHANGELOG history and memory logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)