### PR TITLE
refactor(minigraph): reword GraphTask comment flagged as commented-out code

### DIFF
--- a/memory/sessions/2026-07-10-135832.md
+++ b/memory/sessions/2026-07-10-135832.md
@@ -1,0 +1,30 @@
+# Session (2026-07-10T13:58:32.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** field feedback on v4.7.1 + one-line smell fix.
+
+## v4.7.1 field scan (Eric's screenshots, 2026-07-10)
+Sonar gate PASSED at 4.7.1: New Code 85.9% coverage (176 new lines), 1 new issue;
+Overall 0 vulnerabilities / 0 bugs / 1 code smell, ratings A. Security Hotspot 1
+(CryptoApi DSA, rating E) still awaits the "Safe" UI review (Eric's IT exemption).
+
+**Field validation of SR OAuth (partial):** outbound messages delivered from the app to
+Kafka — OAuth 2.0 bearer path CONFIRMED working in production (token obtained, schema
+retrieved for serialization). Inbound/response path untested — no messages received from
+downstream yet (suspected downstream issue, analysis pending when messages arrive).
+
+**Field header convention:** Kafka uses `X-Correlation-ID`, HTTP uses `X-Correlation-Id`.
+Verified: HTTP inbound is case-insensitive (AsyncHttpRequest.caseInsensitiveGet); Kafka
+record headers are exact-match by design → field sets
+`kafka.correlation.id.header=X-Correlation-ID`. CAVEAT: demo soa-reply flow maps raw
+`input.header.cid` — field reply flow should map `model.cid -> header.cid` instead
+(model.cid is seeded from the configured header by KafkaFlowConsumer/EventScriptManager).
+
+## Commit `d529cea1` — the 1 new smell fixed
+GraphTask.stageTaskParameter comment ("// '*' maps ... body;") — S125 parsed the
+trailing semicolon + quoted '*' as commented-out code. Reworded in plain English.
+LESSON: avoid semicolons/code-like fragments in // comments — Sonar S125 false-positives.
+Verified GraphTaskTest 6/6. Branch fix/graph-task-comment-smell pushed; PR pending.
+
+## Memory References
+- Referenced: [[release-4-7-0-shipped]]

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphTask.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphTask.java
@@ -114,9 +114,9 @@ public class GraphTask extends GraphLambdaFunction {
     @SuppressWarnings("unchecked")
     private Object stageTaskParameter(String nodeName, EventEnvelope request, String rhs, Object value, Object body) {
         if (WHOLE_BODY.equals(rhs)) {
-            // '*' maps the LHS value as the whole request body;
-            // a map is deep copied so that later entries can merge into it without
-            // touching the graph's state machine
+            // The whole-body target maps the LHS value as the entire request body.
+            // A map is deep copied so that later entries can merge into it without
+            // touching the graph's state machine.
             return value instanceof Map? util.deepCopy((Map<String, Object>) value) : value;
         }
         if (rhs.startsWith(HEADER_NAMESPACE)) {


### PR DESCRIPTION
Resolves the single new code smell from the 4.7.1 field scan (java:S125). The
whole-body mapping comment in `GraphTask.stageTaskParameter` ended with a semicolon
and quoted the `'*'` operator, which Sonar parsed as a commented-out code fragment.
Reworded in plain English - comment-only change, no behavior impact.

Verified: GraphTaskTest 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)