### PR TITLE
fix(flows): reliable business correlation-id - model.cid mappings + compile-time guard

### DIFF
--- a/examples/kafka-demo/src/main/resources/flows/kafka-demo-flow.yml
+++ b/examples/kafka-demo/src/main/resources/flows/kafka-demo-flow.yml
@@ -15,12 +15,11 @@ first.task: 'demo.processor'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.header.traceparent -> header.traceparent'
     process: 'demo.processor'
     output:
       - 'result -> model.payload'
-      - 'header.cid -> model.cid'
     description: 'Process the inbound message'
     execution: sequential
     next:

--- a/examples/sync-over-async-demo/src/main/resources/flows/soa-reply-avro.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/soa-reply-avro.yml
@@ -14,7 +14,7 @@ first.task: 'soa.reply.avro'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
     process: 'soa.reply.avro'
     output:
       - 'result -> output.body'

--- a/examples/sync-over-async-demo/src/main/resources/flows/soa-reply-json.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/soa-reply-json.yml
@@ -14,7 +14,7 @@ first.task: 'soa.reply.json'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
     process: 'soa.reply.json'
     output:
       - 'result -> output.body'

--- a/examples/sync-over-async-demo/src/main/resources/flows/soa-reply.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/soa-reply.yml
@@ -13,7 +13,7 @@ first.task: 'soa.reply'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
     process: 'soa.reply'
     output:
       - 'result -> output.body'

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-avro.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-avro.yml
@@ -21,12 +21,11 @@ first.task: 'system.of.record.avro'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.header.traceparent -> header.traceparent'
     process: 'system.of.record.avro'
     output:
       - 'result -> model.payload'
-      - 'header.cid -> model.cid'
     description: 'Process the decoded request'
     execution: sequential
     next:

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-json.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record-json.yml
@@ -20,12 +20,11 @@ first.task: 'system.of.record.json'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.header.traceparent -> header.traceparent'
     process: 'system.of.record.json'
     output:
       - 'result -> model.payload'
-      - 'header.cid -> model.cid'
     description: 'Process the decoded request'
     execution: sequential
     next:

--- a/examples/sync-over-async-demo/src/main/resources/flows/system-of-record.yml
+++ b/examples/sync-over-async-demo/src/main/resources/flows/system-of-record.yml
@@ -15,12 +15,11 @@ first.task: 'system.of.record'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.header.traceparent -> header.traceparent'
     process: 'system.of.record'
     output:
       - 'result -> model.payload'
-      - 'header.cid -> model.cid'
     description: 'Process the request'
     execution: sequential
     next:

--- a/extensions/sync-over-async/src/test/resources/flows/soa-reply.yml
+++ b/extensions/sync-over-async/src/test/resources/flows/soa-reply.yml
@@ -12,7 +12,7 @@ first.task: 'soa.reply'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
     process: 'soa.reply'
     output:
       - 'result -> output.body'

--- a/extensions/sync-over-async/src/test/resources/flows/system-of-record.yml
+++ b/extensions/sync-over-async/src/test/resources/flows/system-of-record.yml
@@ -17,12 +17,11 @@ first.task: 'system.of.record'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.header.traceparent -> header.traceparent'
     process: 'system.of.record'
     output:
       - 'result -> model.payload'
-      - 'header.cid -> model.cid'
       - 'header.decision -> decision'
     description: 'Echo the request and decide whether to reply'
     execution: decision

--- a/memory/sessions/2026-07-11-004024.md
+++ b/memory/sessions/2026-07-11-004024.md
@@ -1,0 +1,41 @@
+# Session (2026-07-11T00:40:24.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** model.cid flow-mapping sweep (field loose end from the 4.7.1
+X-Correlation-ID deployment; Eric-directed after the earlier investigation).
+
+CONVENTION going forward: in Kafka-triggered flows, map the business correlation-id
+from `model.cid` (engine-seeded from the configured `kafka.correlation.id.header`,
+UUID fallback) — NEVER from the raw record header (`input.header.cid`), which breaks
+when the header name is overridden (field uses X-Correlation-ID). Also do NOT
+re-capture the function's header echo (`header.cid -> model.cid` output mapping):
+redundant, and erases model.cid if the function does not echo. Raw
+`input.header.<name>` is only for ADDITIONAL headers (e.g. CloudEvents ce-id).
+13 flows fixed across sync-over-async, minimalist-kafka, kafka-demo,
+sync-over-async-demo; sink-flow guidance comments updated.
+NOTE: examples/* are standalone poms, not reactor modules — build them from their
+own directories (root `-pl examples/...` fails).
+
+Verified: minimalist-kafka 83/83, sync-over-async 32/32, both example apps build.
+
+Commit `615078b1` — fix(flows): map the business correlation-id from model.cid, not the raw Kafka header
+
+```
+ .../src/main/resources/flows/kafka-demo-flow.yml          |  3 +--
+ .../src/main/resources/flows/soa-reply-avro.yml           |  2 +-
+ .../src/main/resources/flows/soa-reply-json.yml           |  2 +-
+ .../src/main/resources/flows/soa-reply.yml                |  2 +-
+ .../src/main/resources/flows/system-of-record-avro.yml    |  3 +--
+ .../src/main/resources/flows/system-of-record-json.yml    |  3 +--
+ .../src/main/resources/flows/system-of-record.yml         |  3 +--
+ .../src/test/resources/flows/soa-reply.yml                |  2 +-
+ .../src/test/resources/flows/system-of-record.yml         |  3 +--
+ .../src/test/resources/flows/avro-sink-flow.yml           | 15 ++++++++-------
+ .../src/test/resources/flows/json-sink-flow.yml           | 15 ++++++++-------
+ .../src/test/resources/flows/kafka-pattern-sink-flow.yml  |  2 +-
+ .../src/test/resources/flows/kafka-sink-flow.yml          | 15 ++++++++-------
+ 13 files changed, 34 insertions(+), 36 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-11-004024.md
+++ b/memory/sessions/2026-07-11-004024.md
@@ -18,6 +18,21 @@ own directories (root `-pl examples/...` fails).
 
 Verified: minimalist-kafka 83/83, sync-over-async 32/32, both example apps build.
 
+## Commit `5853c0c8` — compile-time guard for reserved model keys (Eric-approved follow-up)
+Isolation audit first (Eric's question): framework propagation channels
+(my_correlation_id reserved header TaskExecutor:971 stamped LAST, sub-flow inheritance,
+HTTP response no-auto-echo) all read the IMMUTABLE FlowInstance.businessCorrelationId
+final field — edge isolation confirmed. Residual gap: explicit `model.cid -> ...`
+mappings read the mutable state machine. Hardened: CompileFlows rejects data-mapping
+RHS targeting model.cid/instance/flow/ttl (exact or nested .x/[0]) with a precise
+ERROR; offending TASK is dropped (flow still registers — the established
+invalid-mapping contract, NOT whole-flow rejection). model.parent/root exact writes
+already rejected by DataMappingHelper.validModel; nested parent.x stays valid
+(shared-state mechanism). KEY PLACEMENT FACT: check lives in CompileFlows, NOT the
+shared DataMappingHelper — MiniGraph uses the helper and model.ttl is USER-SETTABLE
+there (graph timeout control). Fixtures parser-test-28/29 + FlowTests assertion.
+event-script-engine 133/133.
+
 Commit `615078b1` — fix(flows): map the business correlation-id from model.cid, not the raw Kafka header
 
 ```

--- a/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
@@ -67,11 +67,11 @@ public class CompileFlows implements EntryPoint {
     private static final String MODEL_NAMESPACE = "model.";
     /**
      * Metadata keys seeded into each flow instance's state machine by the engine
-     * (see FlowInstance) - a data mapping must never overwrite them. A corrupted
+     * (see FlowInstance). A data mapping must never overwrite them - a corrupted
      * model.cid, for example, would propagate to downstream systems through any
-     * later 'model.cid -> ...' mapping. model.parent / model.root are protected
-     * as whole namespaces by DataMappingHelper.validModel; writing beneath them
-     * (model.parent.*) is the legitimate shared-state mechanism and stays allowed.
+     * later 'model.cid -> ...' mapping. The model.parent and model.root keys are
+     * protected as whole namespaces by DataMappingHelper.validModel; writing
+     * beneath them (model.parent.*) is the shared-state mechanism and stays allowed.
      */
     private static final List<String> RESERVED_MODEL_KEYS =
             List.of("model.cid", "model.instance", "model.flow", "model.ttl", "model.parent", "model.root");
@@ -243,34 +243,38 @@ public class CompileFlows implements EntryPoint {
     private boolean validInputMapping(String name, List<String> inputList, Task task, FlowConfigMetadata md) {
         List<String> filteredInputMapping = filterDataMapping(inputList);
         for (String raw : filteredInputMapping) {
-            // convert deprecated "simple type matching" syntax to "simple plugin" syntax
-            String line = converter.convert(raw);
-            if (!line.equals(raw)) {
-                log.warn("Deprecated input syntax in task {} of {} - '{}' converted to '{}'",
-                        md.uniqueTaskName, name, raw, line);
-            }
-            if (helper.validInput(line)) {
-                int sep = line.lastIndexOf(MAP_TO);
-                String rhs = line.substring(sep + 2).trim();
-                if (rhs.startsWith(INPUT_NAMESPACE) || rhs.equals(INPUT)) {
-                    log.warn("Task {} in {} uses input namespace in right-hand-side - {}",
-                            md.uniqueTaskName, name, line);
-                }
-                String reserved = reservedModelKeyViolation(rhs);
-                if (reserved != null) {
-                    log.error("Skip invalid task {} in {} that overwrites the reserved metadata '{}' - {}",
-                            md.uniqueTaskName, name, reserved, line);
-                    return false;
-                }
-                task.input.add(line);
-                if (line.contains(MODEL_PARENT) || line.contains(MODEL_ROOT)) {
-                    task.enableInputParentRef();
-                }
-            } else {
-                log.error("Skip invalid task {} in {} that has invalid input mapping - {}",
-                        md.uniqueTaskName, name, line);
+            if (!addValidatedInputEntry(name, raw, task, md)) {
                 return false;
             }
+        }
+        return true;
+    }
+
+    /** Validate one input data mapping entry and add it to the task (false = the task must be skipped). */
+    private boolean addValidatedInputEntry(String name, String raw, Task task, FlowConfigMetadata md) {
+        // convert deprecated "simple type matching" syntax to "simple plugin" syntax
+        String line = converter.convert(raw);
+        if (!line.equals(raw)) {
+            log.warn("Deprecated input syntax in task {} of {} - '{}' converted to '{}'",
+                    md.uniqueTaskName, name, raw, line);
+        }
+        if (!helper.validInput(line)) {
+            log.error("Skip invalid task {} in {} that has invalid input mapping - {}",
+                    md.uniqueTaskName, name, line);
+            return false;
+        }
+        int sep = line.lastIndexOf(MAP_TO);
+        String rhs = line.substring(sep + 2).trim();
+        if (rhs.startsWith(INPUT_NAMESPACE) || rhs.equals(INPUT)) {
+            log.warn("Task {} in {} uses input namespace in right-hand-side - {}",
+                    md.uniqueTaskName, name, line);
+        }
+        if (rejectedReservedTarget(INPUT, rhs, name, md, line)) {
+            return false;
+        }
+        task.input.add(line);
+        if (line.contains(MODEL_PARENT) || line.contains(MODEL_ROOT)) {
+            task.enableInputParentRef();
         }
         return true;
     }
@@ -287,10 +291,7 @@ public class CompileFlows implements EntryPoint {
             }
             if (helper.validOutput(line, isDecisionTask)) {
                 String rhs = line.substring(line.lastIndexOf(MAP_TO) + 2).trim();
-                String reserved = reservedModelKeyViolation(rhs);
-                if (reserved != null) {
-                    log.error("Skip invalid task {} in {} that overwrites the reserved metadata '{}' - {}",
-                            md.uniqueTaskName, name, reserved, line);
+                if (rejectedReservedTarget(OUTPUT, rhs, name, md, line)) {
                     return false;
                 }
                 task.output.add(line);
@@ -308,6 +309,18 @@ public class CompileFlows implements EntryPoint {
             return false;
         }
         return true;
+    }
+
+    /** Log and reject a data mapping entry whose target overwrites reserved state-machine metadata. */
+    private boolean rejectedReservedTarget(String direction, String rhs, String name,
+                                           FlowConfigMetadata md, String line) {
+        String reserved = reservedModelKeyViolation(rhs);
+        if (reserved != null) {
+            log.error("Skip invalid task ({}) {} in {} that overwrites the reserved metadata '{}' - {}",
+                    direction, md.uniqueTaskName, name, reserved, line);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
@@ -65,6 +65,16 @@ public class CompileFlows implements EntryPoint {
     private static final String MODEL_PARENT = "model.parent.";
     private static final String MODEL_ROOT = "model.root.";
     private static final String MODEL_NAMESPACE = "model.";
+    /**
+     * Metadata keys seeded into each flow instance's state machine by the engine
+     * (see FlowInstance) - a data mapping must never overwrite them. A corrupted
+     * model.cid, for example, would propagate to downstream systems through any
+     * later 'model.cid -> ...' mapping. model.parent / model.root are protected
+     * as whole namespaces by DataMappingHelper.validModel; writing beneath them
+     * (model.parent.*) is the legitimate shared-state mechanism and stays allowed.
+     */
+    private static final List<String> RESERVED_MODEL_KEYS =
+            List.of("model.cid", "model.instance", "model.flow", "model.ttl", "model.parent", "model.root");
     private static final String NEGATE_MODEL = "!model.";
     private static final String EXT_NAMESPACE = "ext:";
     private static final String TEXT_TYPE = "text(";
@@ -246,6 +256,12 @@ public class CompileFlows implements EntryPoint {
                     log.warn("Task {} in {} uses input namespace in right-hand-side - {}",
                             md.uniqueTaskName, name, line);
                 }
+                String reserved = reservedModelKeyViolation(rhs);
+                if (reserved != null) {
+                    log.error("Skip invalid task {} in {} that overwrites the reserved metadata '{}' - {}",
+                            md.uniqueTaskName, name, reserved, line);
+                    return false;
+                }
                 task.input.add(line);
                 if (line.contains(MODEL_PARENT) || line.contains(MODEL_ROOT)) {
                     task.enableInputParentRef();
@@ -270,6 +286,13 @@ public class CompileFlows implements EntryPoint {
                         md.uniqueTaskName, name, raw, line);
             }
             if (helper.validOutput(line, isDecisionTask)) {
+                String rhs = line.substring(line.lastIndexOf(MAP_TO) + 2).trim();
+                String reserved = reservedModelKeyViolation(rhs);
+                if (reserved != null) {
+                    log.error("Skip invalid task {} in {} that overwrites the reserved metadata '{}' - {}",
+                            md.uniqueTaskName, name, reserved, line);
+                    return false;
+                }
                 task.output.add(line);
                 if (line.contains(MODEL_PARENT) || line.contains(MODEL_ROOT)) {
                     task.enableOutputParentRef();
@@ -285,6 +308,29 @@ public class CompileFlows implements EntryPoint {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Detect a data mapping target (RHS) that would overwrite a reserved metadata key of the
+     * flow instance's state machine. Exact matches are rejected for all reserved keys; nested
+     * writes (e.g. {@code model.cid.x} or {@code model.cid[0]}) are also rejected for the scalar
+     * metadata keys because they would replace the scalar with a map or list. Nested writes under
+     * {@code model.parent} / {@code model.root} remain valid - that is the shared-state mechanism.
+     *
+     * @param rhs the right-hand-side of a data mapping
+     * @return the reserved key that would be overwritten, or null if the target is acceptable
+     */
+    private String reservedModelKeyViolation(String rhs) {
+        for (String reserved : RESERVED_MODEL_KEYS) {
+            if (rhs.equals(reserved)) {
+                return reserved;
+            }
+            boolean sharedNamespace = reserved.equals("model.parent") || reserved.equals("model.root");
+            if (!sharedNamespace && (rhs.startsWith(reserved + ".") || rhs.startsWith(reserved + "["))) {
+                return reserved;
+            }
+        }
+        return null;
     }
 
     private void finalizeEntry(Flow entry) {

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -55,6 +55,27 @@ class FlowTests extends TestBase {
     private static final String HTTP_CLIENT = "async.http.request";
 
     @Test
+    void reservedModelKeysAreProtectedAtCompileTime() {
+        // A data mapping that overwrites reserved metadata (model.cid, model.instance, model.flow,
+        // model.ttl, model.parent, model.root) is rejected by CompileFlows. Consistent with all
+        // other invalid mappings, the offending task is dropped at compile time (with an ERROR log),
+        // so the flow cannot execute it: parser-test-28 writes 'result.user -> model.cid' (output),
+        // parser-test-29 writes 'text(hacked) -> model.instance' (input).
+        var outputViolation = com.accenture.models.Flows.getFlow("parser-test-28");
+        assertNotNull(outputViolation);
+        assertFalse(outputViolation.tasks.containsKey("greeting.test"),
+                "task with an output mapping overwriting model.cid must be dropped");
+        var inputViolation = com.accenture.models.Flows.getFlow("parser-test-29");
+        assertNotNull(inputViolation);
+        assertFalse(inputViolation.tasks.containsKey("greeting.test"),
+                "task with an input mapping overwriting model.instance must be dropped");
+        // positive control: the same task name loads fine in a fixture without reserved-key writes
+        var control = com.accenture.models.Flows.getFlow("greetings");
+        assertNotNull(control, "valid flows still load");
+        assertFalse(control.tasks.isEmpty());
+    }
+
+    @Test
     void inputValidationTest1() throws InterruptedException {
         inputValidationCase(1, "12345", "hello world", false);
     }

--- a/system/event-script-engine/src/test/resources/more-flows.yaml
+++ b/system/event-script-engine/src/test/resources/more-flows.yaml
@@ -29,6 +29,8 @@ flows:
   - 'parser-test-25.yml'
   - 'parser-test-26.yml'
   - 'parser-test-27.yml'
+  - 'parser-test-28.yml'
+  - 'parser-test-29.yml'
   # duplicated filename is intentional for unit test
   - 'parser-test-17.yml'
 

--- a/system/event-script-engine/src/test/resources/parser-flows/parser-test-28.yml
+++ b/system/event-script-engine/src/test/resources/parser-flows/parser-test-28.yml
@@ -1,0 +1,18 @@
+flow:
+  id: 'parser-test-28'
+  description: 'test invalid OUTPUT data mapping that overwrites a reserved metadata model key'
+  ttl: 10s
+
+first.task: 'greeting.test'
+
+tasks:
+  - input:
+      - 'input.path_parameter.user -> header.user'
+    process: 'greeting.test'
+    output:
+      - 'result -> output.body'
+      # invalid: model.cid is seeded by the engine from the upstream business correlation-id
+      # and must not be overwritten by a data mapping
+      - 'result.user -> model.cid'
+    description: 'Hello World'
+    execution: end

--- a/system/event-script-engine/src/test/resources/parser-flows/parser-test-29.yml
+++ b/system/event-script-engine/src/test/resources/parser-flows/parser-test-29.yml
@@ -1,0 +1,18 @@
+flow:
+  id: 'parser-test-29'
+  description: 'test invalid INPUT data mapping that overwrites a reserved metadata model key'
+  ttl: 10s
+
+first.task: 'greeting.test'
+
+tasks:
+  - input:
+      - 'input.path_parameter.user -> header.user'
+      # invalid: model.instance is reserved engine metadata (also covers nested writes
+      # such as model.ttl.x or model.flow[0] that would replace the scalar)
+      - 'text(hacked) -> model.instance'
+    process: 'greeting.test'
+    output:
+      - 'result -> output.body'
+    description: 'Hello World'
+    execution: end

--- a/system/minimalist-kafka/src/test/resources/flows/avro-sink-flow.yml
+++ b/system/minimalist-kafka/src/test/resources/flows/avro-sink-flow.yml
@@ -9,10 +9,11 @@
 # reads, so 'model.cid' carries it here - and every task sees it via PostOffice.getMyCorrelationId() - just
 # like an HTTP-triggered flow. (It is set alongside the envelope correlation-id, which
 # KafkaFlowConsumer.invokeFlow's blocking PostOffice.request(...) rewrites for RPC reply-matching; setting
-# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow reads
-# the raw inbound header ('input.header.cid') instead - equivalent for the default header, and the way to
-# read a proprietary upstream header name (e.g. a CloudEvents 'ce-id', or a custom 'x-correlation-id'):
-#   'input.header.x-correlation-id -> header.cid'
+# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow maps
+# 'model.cid' - reliable regardless of the actual Kafka header name, which is configurable via
+# 'kafka.correlation.id.header' (e.g. X-Correlation-ID). Reading a raw inbound header directly
+# ('input.header.<name>') remains the way to pick up an additional header that is not the configured
+# correlation-id header (e.g. a CloudEvents 'ce-id').
 #
 flow:
   id: 'avro-sink-flow'
@@ -24,9 +25,9 @@ first.task: 'avro.test.sink'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
-      # To use a proprietary upstream header instead, replace the mapping above with, for example:
-      #   'input.header.x-correlation-id -> header.cid'
+      - 'model.cid -> header.cid'
+      # model.cid is seeded by the adapter from the configured 'kafka.correlation.id.header';
+      # to read an additional raw header, add e.g. 'input.header.ce-id -> header.ce-id'
     process: 'avro.test.sink'
     output:
       - 'result -> output.body'

--- a/system/minimalist-kafka/src/test/resources/flows/json-sink-flow.yml
+++ b/system/minimalist-kafka/src/test/resources/flows/json-sink-flow.yml
@@ -9,10 +9,11 @@
 # reads, so 'model.cid' carries it here - and every task sees it via PostOffice.getMyCorrelationId() - just
 # like an HTTP-triggered flow. (It is set alongside the envelope correlation-id, which
 # KafkaFlowConsumer.invokeFlow's blocking PostOffice.request(...) rewrites for RPC reply-matching; setting
-# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow reads
-# the raw inbound header ('input.header.cid') instead - equivalent for the default header, and the way to
-# read a proprietary upstream header name (e.g. a CloudEvents 'ce-id', or a custom 'x-correlation-id'):
-#   'input.header.x-correlation-id -> header.cid'
+# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow maps
+# 'model.cid' - reliable regardless of the actual Kafka header name, which is configurable via
+# 'kafka.correlation.id.header' (e.g. X-Correlation-ID). Reading a raw inbound header directly
+# ('input.header.<name>') remains the way to pick up an additional header that is not the configured
+# correlation-id header (e.g. a CloudEvents 'ce-id').
 #
 flow:
   id: 'json-sink-flow'
@@ -24,9 +25,9 @@ first.task: 'json.test.sink'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
-      # To use a proprietary upstream header instead, replace the mapping above with, for example:
-      #   'input.header.x-correlation-id -> header.cid'
+      - 'model.cid -> header.cid'
+      # model.cid is seeded by the adapter from the configured 'kafka.correlation.id.header';
+      # to read an additional raw header, add e.g. 'input.header.ce-id -> header.ce-id'
     process: 'json.test.sink'
     output:
       - 'result -> output.body'

--- a/system/minimalist-kafka/src/test/resources/flows/kafka-pattern-sink-flow.yml
+++ b/system/minimalist-kafka/src/test/resources/flows/kafka-pattern-sink-flow.yml
@@ -13,7 +13,7 @@ first.task: 'kafka.pattern.test.sink'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
+      - 'model.cid -> header.cid'
       - 'input.metadata.topic -> header.topic'
       - 'input.metadata.partition -> header.partition'
       - 'input.metadata.offset -> header.offset'

--- a/system/minimalist-kafka/src/test/resources/flows/kafka-sink-flow.yml
+++ b/system/minimalist-kafka/src/test/resources/flows/kafka-sink-flow.yml
@@ -7,10 +7,11 @@
 # reads, so 'model.cid' carries it here - and every task sees it via PostOffice.getMyCorrelationId() - just
 # like an HTTP-triggered flow. (It is set alongside the envelope correlation-id, which
 # KafkaFlowConsumer.invokeFlow's blocking PostOffice.request(...) rewrites for RPC reply-matching; setting
-# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow reads
-# the raw inbound header ('input.header.cid') instead - equivalent for the default header, and the way to
-# read a proprietary upstream header name (e.g. a CloudEvents 'ce-id', or a custom 'x-correlation-id'):
-#   'input.header.x-correlation-id -> header.cid'
+# the header too is what keeps model.cid correct - see KafkaFlowConsumer.toFlowRequest.) This flow maps
+# 'model.cid' - reliable regardless of the actual Kafka header name, which is configurable via
+# 'kafka.correlation.id.header' (e.g. X-Correlation-ID). Reading a raw inbound header directly
+# ('input.header.<name>') remains the way to pick up an additional header that is not the configured
+# correlation-id header (e.g. a CloudEvents 'ce-id').
 #
 flow:
   id: 'kafka-sink-flow'
@@ -22,9 +23,9 @@ first.task: 'kafka.test.sink'
 tasks:
   - input:
       - 'input.body -> *'
-      - 'input.header.cid -> header.cid'
-      # To use a proprietary upstream header instead, replace the mapping above with, for example:
-      #   'input.header.x-correlation-id -> header.cid'
+      - 'model.cid -> header.cid'
+      # model.cid is seeded by the adapter from the configured 'kafka.correlation.id.header';
+      # to read an additional raw header, add e.g. 'input.header.ce-id -> header.ce-id'
     process: 'kafka.test.sink'
     output:
       - 'result -> output.body'


### PR DESCRIPTION
## What

Two related hardenings of business correlation-id handling in Event Script flows,
following the 4.7.1 field deployment that overrides `kafka.correlation.id.header`
with `X-Correlation-ID`.

### 1. Flows map the correlation-id from model.cid, not the raw Kafka header

The engine seeds `model.cid` from the configured `kafka.correlation.id.header`
(default `cid`, UUID fallback). Flows that retrieved the raw record header by literal
name (`input.header.cid`) silently lose the upstream correlation-id when the header
name is overridden. 13 flows across sync-over-async, minimalist-kafka, kafka-demo and
sync-over-async-demo now map `'model.cid -> header.cid'`. The redundant
`'header.cid -> model.cid'` output re-capture is removed (it round-tripped the same
engine-seeded value through the function's header echo - and would erase model.cid if
a function stopped echoing). Sink-flow guidance comments updated accordingly.

### 2. Compile-time guard for reserved metadata model keys

An audit confirmed the framework's own propagation channels (the read-only
`my_correlation_id` header, sub-flow inheritance) read the immutable
`FlowInstance.businessCorrelationId` field - but an accidental `-> model.cid` write
would corrupt any later explicit `model.cid -> ...` mapping to downstream systems.
`CompileFlows` now rejects any data mapping whose RHS overwrites engine-seeded
metadata (`model.cid`, `model.instance`, `model.flow`, `model.ttl` - exact or nested
writes) with a precise startup error; the offending task is dropped, consistent with
all other invalid mappings. `model.parent`/`model.root` whole-namespace writes were
already rejected; nested writes under them remain valid (the sub-flow shared-state
mechanism). The check is deliberately in `CompileFlows` rather than the shared
`DataMappingHelper` because MiniGraph legitimately lets users set `model.ttl`.

## Testing

- New fixtures `parser-test-28` (output violation) / `parser-test-29` (input
  violation) + a `FlowTests` case asserting the offending tasks are dropped
- event-script-engine 133/133, minimalist-kafka 83/83, sync-over-async 32/32
  (sink and round-trip flows exercise the changed mappings against the embedded broker)
- kafka-demo and sync-over-async-demo build clean; repo-wide sweep confirmed no
  legitimate flow writes to a reserved key

🤖 Generated with [Claude Code](https://claude.com/claude-code)