### PR TITLE
v4.8.0 - Twin Kafka: dual-cluster bridging, plus trace/correlation header flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.8.0, 7/10/2026
+
+Feature release: the new twin-kafka module for dual Kafka cluster bridging, configurable trace-id
+headers with per-entry overrides for legacy impedance matching, and a hardened business
+correlation-id path (model.cid mappings plus a compile-time guard for reserved metadata model keys).
+No breaking changes; single-cluster applications and existing configurations work unchanged.
+
+### Added
+
+1. **twin-kafka - dual Kafka cluster support for bridge applications.** A new `system/twin-kafka`
+   module on top of minimalist-kafka connects an application to a SECOND Kafka cluster (e.g. on-prem
+   Apache Kafka bridging to cloud Confluent Kafka): `secondary.kafka.notification` (full feature
+   parity with `simple.kafka.notification`), an optional secondary flow adapter
+   (`yaml.secondary.kafka.flow.adapter`), and an optional per-cluster Schema Registry
+   (`secondary.schema.registry.url`) - the registry is independent per cluster, so asymmetric
+   topologies (one side with a registry, one without) and Kafka-protocol-compatible services such as
+   Azure Event Hubs are supported. A bridge is plain flow YAML - consume from one cluster's adapter,
+   publish through the other cluster's notification function - with trace and correlation-id
+   continuity across both hops. Dead letters from secondary bindings land on the secondary cluster.
+   Template defaults align with kafka-standalone's `dual.servers=true` second broker for local
+   dual-cluster development. minimalist-kafka gains behavior-preserving reuse seams (template
+   location overloads, notification extension accessors, key-prefix schema codec with per-registry
+   caches) and remains unchanged for single-cluster use.
+2. **Configurable trace-id headers with per-entry overrides.** New globals `http.trace.id.header`
+   (default `X-Trace-Id`, previously hard-coded) and `kafka.trace.id.header` (unset by default;
+   inbound fallback when no W3C `traceparent` is present, outbound stamped alongside `traceparent`
+   for legacy consumers). A rest.yaml endpoint entry or kafka-flow-adapter.yaml consumer binding may
+   override the header names with the optional `trace.id.header` / `correlation.id.header` keys -
+   impedance matching for pre-existing and third-party systems, with precedence
+   per-entry > global > built-in default. The W3C `traceparent` standard always takes precedence for
+   the trace-id.
+
+### Changed
+
+1. **Reliable business correlation-id in flows.** Shipped flows map the correlation-id from
+   `model.cid` (engine-seeded from the configured header) instead of the raw Kafka record header, so
+   an overridden header name (e.g. `X-Correlation-ID`) propagates correctly; the redundant
+   header-echo re-capture was removed. `CompileFlows` now rejects any data mapping that would
+   overwrite reserved state-machine metadata (`model.cid`, `model.instance`, `model.flow`,
+   `model.ttl`) with a precise startup error.
+2. Final SonarQube code smells resolved, including IDE-flagged touch-ups across the new modules.
+
+---
 ## Version 4.7.1, 7/9/2026
 
 Field-driven update for the minimalist-kafka module: OAuth 2.0 authentication for the Schema Registry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.1) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.7.1) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.7.1";
+    private static final String VERSION = "4.8.0";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.7.1-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.7.1-exec.jar"]
+COPY target/kafka-standalone-4.8.0-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.8.0-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-07-11-034954.md
+++ b/memory/sessions/2026-07-11-034954.md
@@ -11,6 +11,12 @@ AvroConversionsTest assertNotNull; class-level 'resource' suppressions on
 SchemaCodecTest + TwinKafkaBridgeTest; Stream.of over List.of().stream().
 English/typos ignored per Eric. Verified minimalist 86/86, twin 4/4.
 
+## Release bump 4.7.1 → 4.8.0 — commit `973c77f8` on chore/release-4.8.0
+PR #156 merged (`9b13379f`). MINOR bump (twin-kafka + trace-header config + model.cid
+hardening = features). 31 poms now in the sweep (twin-kafka joined) + the usual surface.
+CHANGELOG 4.8.0 covers #153/#154/#155/#156. Verified: offline reactor install (now incl.
+twin-kafka module) + twin suite 4/4 at 4.8.0. Awaiting release PR + merge + tag.
+
 Commit `4d85a42e` — refactor: resolve IDE-flagged smells from the twin-kafka review
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Parent Mercury</name>
 
     <modules>
@@ -52,7 +52,7 @@
         <module>examples/kafka-demo</module>
         <module>examples/sync-over-async-demo</module>-->
 
-        <!-- Executable for benchmark tests (benchmark-client retired 4.7.1 — superseded by benchmark-reporter)
+        <!-- Executable for benchmark tests (benchmark-client retired 4.8.0 — superseded by benchmark-reporter)
         <module>benchmark/benchmark-reporter</module>-->
     </modules>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.7.1</version>
+            <version>4.8.0</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What's new

### twin-kafka - dual Kafka cluster support

A new opt-in module that connects an application to a SECOND Kafka cluster on top of
minimalist-kafka, for the dual-cluster bridge use case (e.g. on-prem Apache Kafka
bridging to cloud Confluent Kafka):

- `secondary.kafka.notification` - full feature parity with `simple.kafka.notification`
  (routing, header propagation, W3C traceparent stamping, subject-driven Confluent
  serialization) against the second cluster
- Optional secondary flow adapter (`yaml.secondary.kafka.flow.adapter`) with the same
  per-binding options as the primary; dead letters land on the cluster where the failed
  message originated
- **Per-cluster, optional Schema Registry** - an on-prem Apache Kafka without a registry
  bridges cleanly to a cloud Confluent cluster with one; registries and their schema-id
  caches are fully independent
- Deployment topologies are configuration-only: Apache + Confluent, Confluent + Confluent
  (two registries), and Apache + Azure Event Hubs (Kafka protocol) - see the new
  Twin Kafka guide
- A bridge is plain flow YAML - consume from one cluster's adapter, publish through the
  other cluster's notification function - with trace and business correlation-id
  continuity across both hops
- Local dev: `kafka-standalone` emulates both clusters in one process with
  `dual.servers=true` (broker 1 on 9092, broker 2 on 8092)

Single-cluster applications keep using the lightweight minimalist-kafka alone - this
module is the opt-in for the special dual-cluster case.

### Configurable trace-id headers with per-entry overrides

- `http.trace.id.header` (default `X-Trace-Id`, previously hard-coded) and
  `kafka.trace.id.header` (optional) name the trace-id headers; W3C `traceparent`
  always takes precedence
- A rest.yaml endpoint or kafka-flow-adapter.yaml binding may override
  `trace.id.header` / `correlation.id.header` per entry - impedance matching for
  pre-existing and third-party systems, with precedence per-entry > global > default

### Hardened business correlation-id path

- Shipped flows map the correlation-id from `model.cid` (engine-seeded from the
  configured header), so overridden header names propagate correctly end-to-end
- The flow compiler now rejects any data mapping that would overwrite reserved
  state-machine metadata (`model.cid`, `model.instance`, `model.flow`, `model.ttl`)
  with a precise startup error

No breaking changes - existing configurations work unchanged.