### PR TITLE
build(deps): Jackson 2.22.1 (closes dependabot alert 28) + OSS dependency refresh

### DIFF
--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -20,9 +20,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.2.15.Final</netty.version>
-        <log4j2.version>2.25.4</log4j2.version>
-        <gson.version>2.13.2</gson.version>
+        <netty.version>4.2.16.Final</netty.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -17,12 +17,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -17,12 +17,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>3.9.1</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -18,11 +18,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>3.9.1</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <kotlin.version>2.1.21</kotlin.version>
         <java.version>21</java.version>
     </properties>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -15,12 +15,12 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>10.1.56</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>10.1.56</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>10.1.57</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>    
 

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <otel.version>1.63.0</otel.version>
     </properties>
 

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <otel.version>1.63.0</otel.version>
     </properties>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -17,12 +17,12 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Embedded broker (kafka_2.13) version for tests. Matches the kafka-clients version pinned by
              minimalist-kafka so there is no client/broker protocol skew. -->
         <kafka.version>4.2.0</kafka.version>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Embedded broker (kafka_2.13) version for tests. Matches the kafka-clients version pinned by
              minimalist-kafka so there is no client/broker protocol skew. -->

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>
@@ -96,13 +96,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.21.2</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <gson.version>2.13.2</gson.version>
         <java.version>21</java.version>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -21,11 +21,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
-        <gson.version>2.13.2</gson.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <gson.version>2.13.2</gson.version>
         <java.version>21</java.version>

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -21,11 +21,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
-        <gson.version>2.13.2</gson.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/memory/sessions/2026-07-11-170135.md
+++ b/memory/sessions/2026-07-11-170135.md
@@ -1,0 +1,53 @@
+# Session (2026-07-11T17:01:35.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** Jackson 2.22.1 dependency bump — closes dependabot alert 28
+(previously advisory-only; the fixed version released 2026-07-08).
+
+`jackson-2-bom.version` 2.22.0 → 2.22.1 across all 29 module poms;
+kafka-standalone's explicit jackson-core/databind pins aligned to 2.22.1.
+Note: MvnRepository's "artifact relocated → tools.jackson.core" banner refers to
+the Jackson 3.x line; 2.22.1 stays under com.fasterxml.jackson.core, and
+platform-core's tools.jackson.core 3.1.4 path is unaffected.
+Verified: full reactor build green; minimalist-kafka 86/86 (Confluent JSON/Avro
+serdes exercise databind), rest-spring-3 11/11; dependency tree resolves 2.22.1.
+
+Next up per Eric: twin-kafka-demo — details to be discussed after this merges.
+
+Commit `2eaa1a38` — build(deps): bump Jackson to 2.22.1 to close dependabot alert 28
+
+```
+ connectors/adapters/kafka/kafka-connector/pom.xml | 2 +-
+ connectors/adapters/kafka/kafka-presence/pom.xml  | 2 +-
+ connectors/core/cloud-connector/pom.xml           | 2 +-
+ connectors/core/service-monitor/pom.xml           | 2 +-
+ examples/composable-example/pom.xml               | 2 +-
+ examples/kafka-demo/pom.xml                       | 2 +-
+ examples/kotlin-example/pom.xml                   | 2 +-
+ examples/lambda-example/pom.xml                   | 2 +-
+ examples/minigraph-playground/pom.xml             | 2 +-
+ examples/pg-example/pom.xml                       | 2 +-
+ examples/rest-spring-3-example/pom.xml            | 2 +-
+ examples/rest-spring-4-example/pom.xml            | 2 +-
+ examples/scheduler-example/pom.xml                | 2 +-
+ examples/sync-over-async-demo/pom.xml             | 2 +-
+ extensions/api-playground/pom.xml                 | 2 +-
+ extensions/opentelemetry-forwarder/pom.xml        | 2 +-
+ extensions/reactive-postgres/pom.xml              | 2 +-
+ extensions/sync-over-async/pom.xml                | 2 +-
+ helpers/kafka-standalone/pom.xml                  | 6 +++---
+ helpers/redis-standalone/pom.xml                  | 2 +-
+ helpers/schema-registry-standalone/pom.xml        | 2 +-
+ system/event-script-engine/pom.xml                | 2 +-
+ system/mini-scheduler/pom.xml                     | 2 +-
+ system/minigraph-playground-engine/pom.xml        | 2 +-
+ system/minimalist-kafka/pom.xml                   | 2 +-
+ system/platform-core/pom.xml                      | 2 +-
+ system/rest-spring-3/pom.xml                      | 2 +-
+ system/rest-spring-4/pom.xml                      | 2 +-
+ system/twin-kafka/pom.xml                         | 2 +-
+ 29 files changed, 31 insertions(+), 31 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-11-170135.md
+++ b/memory/sessions/2026-07-11-170135.md
@@ -12,6 +12,16 @@ platform-core's tools.jackson.core 3.1.4 path is unaffected.
 Verified: full reactor build green; minimalist-kafka 86/86 (Confluent JSON/Avro
 serdes exercise databind), rest-spring-3 11/11; dependency tree resolves 2.22.1.
 
+## OSS dependency refresh (same branch, second commit)
+Per Eric's MvnRepository review: log4j2 2.25.4 → 2.26.1, netty 4.2.15.Final →
+4.2.16.Final, gson 2.13.2 → 2.14.0, tomcat 11.0.23 → 11.0.24 (framework modules,
+aligned with spring-boot-starter-parent 4.1.0), tomcat 10.1.56 → 10.1.57
+(rest-spring-3 + rest-spring-3-example ONLY — the Spring Boot 3 line stays on
+Tomcat 10.1.x), vertx-core 5.1.3 → 5.1.4 (single declaration in platform-core).
+Verified: full reactor WITH tests — 826 tests, 0 failures, 0 errors;
+rest-spring-3-example standalone build green; dependency trees confirm all five
+effective versions.
+
 Next up per Eric: twin-kafka-demo — details to be discussed after this merges.
 
 Commit `2eaa1a38` — build(deps): bump Jackson to 2.22.1 to close dependabot alert 28

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Pin the Kafka client to the same version as the embedded broker used in tests
              (kafka_2.13) to avoid client/broker protocol skew. -->
         <kafka.version>4.2.0</kafka.version>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Pin the Kafka client to the same version as the embedded broker used in tests
              (kafka_2.13) to avoid client/broker protocol skew. -->

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -18,12 +18,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>5.1.3</version>
+            <version>5.1.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>10.1.56</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -20,12 +20,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>10.1.56</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>10.1.57</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.23</tomcat.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.25.4</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.13.2</gson.version>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -20,12 +20,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.23</tomcat.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.2.0</kafka.version>
-        <gson.version>2.13.2</gson.version>
+        <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
 

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.15.Final</netty.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Same pinning rationale as minimalist-kafka: match the embedded test broker. -->
         <kafka.version>4.2.0</kafka.version>
     </properties>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <!-- Same pinning rationale as minimalist-kafka: match the embedded test broker. -->
         <kafka.version>4.2.0</kafka.version>


### PR DESCRIPTION
## Summary
Dependency refresh in two commits:

1. **Jackson 2.22.1** — remediates the security vulnerability in dependabot
   alert #28 (https://github.com/Accenture/mercury-composable/security/dependabot/28).
   Previously advisory-only because no fixed version existed; 2.22.1
   (released 2026-07-08) contains the fix.
2. **OSS refresh** — routine updates for the rest of the stack.

## Changes
### Jackson
- `jackson-2-bom.version` 2.22.0 → 2.22.1 in all 29 module poms
- kafka-standalone explicit pins aligned: jackson-core 2.21.2 → 2.22.1,
  jackson-databind 2.22.0 → 2.22.1

### OSS refresh
- log4j2 2.25.4 → 2.26.1
- netty 4.2.15.Final → 4.2.16.Final
- gson 2.13.2 → 2.14.0
- tomcat 11.0.23 → 11.0.24 (framework modules, aligned with
  spring-boot-starter-parent 4.1.0)
- tomcat 10.1.56 → 10.1.57 (rest-spring-3 + rest-spring-3-example only;
  the Spring Boot 3 line stays on Tomcat 10.1.x)
- vertx-core 5.1.3 → 5.1.4 (platform-core)

Note: Jackson 2.22.1 remains under `com.fasterxml.jackson.core` coordinates;
the MvnRepository "relocated to tools.jackson.core" banner applies to the
Jackson 3.x line only, which platform-core already uses (3.1.4) and which is
not affected by the alert.

## Verification
- Full reactor build WITH tests at the new versions: 826 tests,
  0 failures, 0 errors
- rest-spring-3-example standalone build green
- Dependency trees confirm effective versions: jackson-core/databind 2.22.1,
  vertx-core 5.1.4, netty-common 4.2.16.Final, gson 2.14.0, log4j-core 2.26.1,
  tomcat-embed-core 11.0.24 (rest-spring-4) and 10.1.57 (rest-spring-3-example)
- minimalist-kafka 86/86 and rest-spring-3 11/11 were additionally run
  standalone after the Jackson bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)