### PR TITLE
feat: twin-kafka-demo worked example + SimpleRandomPartitioner default

### DIFF
--- a/connectors/adapters/kafka/kafka-connector/src/test/java/org/platformlambda/kafka/KafkaAdminEdgeTest.java
+++ b/connectors/adapters/kafka/kafka-connector/src/test/java/org/platformlambda/kafka/KafkaAdminEdgeTest.java
@@ -27,6 +27,7 @@ import org.platformlambda.core.system.AutoStart;
 import org.platformlambda.core.system.EventEmitter;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.PubSub;
+import org.platformlambda.core.util.Utility;
 
 import java.util.List;
 import java.util.Map;
@@ -113,13 +114,13 @@ class KafkaAdminEdgeTest {
         ps.createTopic(topic, 1);
         final BlockingQueue<Object> inbox = new ArrayBlockingQueue<>(10);
         LambdaFunction listener = (headers, input, instance) -> {
-            inbox.offer(input);
+            inbox.add(input);
             return true;
         };
         // subscribe from the latest position (no explicit offset), then publish
         ps.subscribe(topic, 0, listener, "edge-client-1", "edge-group-1");
         // allow the consumer to join the group before publishing
-        Thread.sleep(3000);
+        Utility.getInstance().sleep(3000);
         ps.publish(topic, 0, Map.of("k", "v"), "live message");
         Object delivered = inbox.poll(60, TimeUnit.SECONDS);
         assertEquals("live message", delivered);
@@ -127,7 +128,7 @@ class KafkaAdminEdgeTest {
         // re-subscribe with an explicit numeric offset to replay from the beginning
         final BlockingQueue<Object> replay = new ArrayBlockingQueue<>(10);
         LambdaFunction replayListener = (headers, input, instance) -> {
-            replay.offer(input);
+            replay.add(input);
             return true;
         };
         ps.subscribe(topic, 0, replayListener, "edge-client-2", "edge-group-2", "0");
@@ -148,7 +149,7 @@ class KafkaAdminEdgeTest {
         assertTrue(ps.createTopic(topic, 1));
         final BlockingQueue<Object> inbox = new ArrayBlockingQueue<>(10);
         LambdaFunction listener = (headers, input, instance) -> {
-            inbox.offer(input);
+            inbox.add(input);
             return true;
         };
         ps.subscribe(topic, 0, listener, "edge-client-3", "edge-group-3", "0");

--- a/connectors/adapters/kafka/kafka-connector/src/test/java/org/platformlambda/kafka/KafkaAdminEdgeTest.java
+++ b/connectors/adapters/kafka/kafka-connector/src/test/java/org/platformlambda/kafka/KafkaAdminEdgeTest.java
@@ -1,0 +1,172 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.kafka;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.cloud.services.ServiceRegistry;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.PubSub;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the topic manager's administrative event API (the CLOUD_MANAGER service behind
+ * PubSub) and the consumer's live-subscription paths that the round-trip test does not reach:
+ * subscription while messages arrive (no seek), non-zero start offset, and re-subscription.
+ */
+class KafkaAdminEdgeTest {
+
+    private static final String SYSTEM = "system";
+    private static final String CLOUD_CONNECTOR_HEALTH = "cloud.connector.health";
+    private static final long TIMEOUT = 10000;
+
+    @BeforeAll
+    static void setup() throws InterruptedException {
+        AutoStart.main(new String[0]);
+        final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
+        Platform.getInstance().waitForProvider(CLOUD_CONNECTOR_HEALTH, 90).onSuccess(bench::add);
+        assertEquals(Boolean.TRUE, bench.poll(90, TimeUnit.SECONDS));
+    }
+
+    private EventEnvelope admin(EventEnvelope event) throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter.getInstance().asyncRequest(event.setTo(ServiceRegistry.CLOUD_MANAGER), TIMEOUT)
+                .onSuccess(bench::add);
+        return bench.poll(TIMEOUT + 5000, TimeUnit.MILLISECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void topicManagerAdminApi() throws InterruptedException {
+        String topic = "admin.edge.demo";
+        // create with explicit partition count
+        EventEnvelope created = admin(new EventEnvelope()
+                .setHeader("type", "create").setHeader("topic", topic).setHeader("partitions", "2"));
+        assertNotNull(created);
+        assertEquals(true, created.getBody());
+        // exists
+        EventEnvelope exists = admin(new EventEnvelope()
+                .setHeader("type", "exists").setHeader("topic", topic));
+        assertNotNull(exists);
+        assertEquals(true, exists.getBody());
+        // partition count
+        EventEnvelope partitions = admin(new EventEnvelope()
+                .setHeader("type", "partitions").setHeader("topic", topic));
+        assertNotNull(partitions);
+        assertEquals(2, partitions.getBody());
+        // list contains it
+        EventEnvelope list = admin(new EventEnvelope().setHeader("type", "list"));
+        assertNotNull(list);
+        assertTrue(((List<String>) list.getBody()).contains(topic));
+        // delete
+        EventEnvelope deleted = admin(new EventEnvelope()
+                .setHeader("type", "delete").setHeader("topic", topic));
+        assertNotNull(deleted);
+        assertEquals(true, deleted.getBody());
+        // exists is now false
+        EventEnvelope gone = admin(new EventEnvelope()
+                .setHeader("type", "exists").setHeader("topic", topic));
+        assertNotNull(gone);
+        assertEquals(false, gone.getBody());
+        // an unrecognized request type falls through and returns false
+        EventEnvelope invalid = admin(new EventEnvelope().setHeader("type", "nonsense"));
+        assertNotNull(invalid);
+        assertEquals(false, invalid.getBody());
+        // delete of a non-existent topic is idempotent
+        EventEnvelope idempotent = admin(new EventEnvelope()
+                .setHeader("type", "delete").setHeader("topic", topic));
+        assertNotNull(idempotent);
+        assertEquals(true, idempotent.getBody());
+    }
+
+    @Test
+    void liveSubscriptionAndResubscription() throws Exception {
+        PubSub ps = PubSub.getInstance(SYSTEM);
+        String topic = "live.subscription.demo";
+        ps.createTopic(topic, 1);
+        final BlockingQueue<Object> inbox = new ArrayBlockingQueue<>(10);
+        LambdaFunction listener = (headers, input, instance) -> {
+            inbox.offer(input);
+            return true;
+        };
+        // subscribe from the latest position (no explicit offset), then publish
+        ps.subscribe(topic, 0, listener, "edge-client-1", "edge-group-1");
+        // allow the consumer to join the group before publishing
+        Thread.sleep(3000);
+        ps.publish(topic, 0, Map.of("k", "v"), "live message");
+        Object delivered = inbox.poll(60, TimeUnit.SECONDS);
+        assertEquals("live message", delivered);
+        ps.unsubscribe(topic, 0);
+        // re-subscribe with an explicit numeric offset to replay from the beginning
+        final BlockingQueue<Object> replay = new ArrayBlockingQueue<>(10);
+        LambdaFunction replayListener = (headers, input, instance) -> {
+            replay.offer(input);
+            return true;
+        };
+        ps.subscribe(topic, 0, replayListener, "edge-client-2", "edge-group-2", "0");
+        assertEquals("live message", replay.poll(60, TimeUnit.SECONDS));
+        ps.unsubscribe(topic, 0);
+        ps.deleteTopic(topic);
+        // invalid topic name is rejected by the admin path
+        assertThrows(IllegalArgumentException.class, () -> ps.createTopic("nodotname"));
+    }
+
+    @Test
+    void consumerDispatchEdgeCases() throws Exception {
+        Platform platform = Platform.getInstance();
+        PubSub ps = PubSub.getInstance(SYSTEM);
+        String topic = "dispatch.edge.demo";
+        // creating the same topic twice is idempotent
+        ps.createTopic(topic, 1);
+        assertTrue(ps.createTopic(topic, 1));
+        final BlockingQueue<Object> inbox = new ArrayBlockingQueue<>(10);
+        LambdaFunction listener = (headers, input, instance) -> {
+            inbox.offer(input);
+            return true;
+        };
+        ps.subscribe(topic, 0, listener, "edge-client-3", "edge-group-3", "0");
+        // an embedded event addressed to ANOTHER origin is quietly dropped by the consumer
+        EventEnvelope stranger = new EventEnvelope().setTo("no.where").setBody("not for me");
+        Map<String, String> misdirected = Map.of(
+                org.platformlambda.cloud.EventProducer.EMBED_EVENT, "1",
+                org.platformlambda.cloud.EventProducer.RECIPIENT, "some-other-origin");
+        ps.publish(topic, 0, misdirected, stranger.toBytes());
+        // a corrupted embedded event exercises the consumer's exception path
+        Map<String, String> embedded = Map.of(
+                org.platformlambda.cloud.EventProducer.EMBED_EVENT, "1",
+                org.platformlambda.cloud.EventProducer.RECIPIENT, platform.getOrigin());
+        ps.publish(topic, 0, embedded, "not-a-packed-event".getBytes());
+        // a normal raw message still arrives after the two rejected ones
+        ps.publish(topic, 0, null, "survivor");
+        assertEquals("survivor", inbox.poll(60, TimeUnit.SECONDS));
+        ps.unsubscribe(topic, 0);
+        ps.deleteTopic(topic);
+    }
+}

--- a/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/EventProducerTest.java
+++ b/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/EventProducerTest.java
@@ -1,0 +1,152 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.cloud;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.cloud.services.ServiceRegistry;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.Kv;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.ServiceDiscovery;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.core.websocket.common.MultipartPayload;
+import org.platformlambda.mock.TestBase;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drives the outbound event producer (EventEmitter.CLOUD_CONNECTOR) through its destination
+ * resolution paths: round-robin by route, broadcast fan-out, segmented (multipart) sticky
+ * destinations, fully-qualified targets and unknown destinations.
+ */
+class EventProducerTest extends TestBase {
+
+    private static final String TO = MultipartPayload.TO;
+    private static final String BROADCAST = MultipartPayload.BROADCAST;
+    private static final String ID = MultipartPayload.ID;
+    private static final String COUNT = MultipartPayload.COUNT;
+    private static final String TOTAL = MultipartPayload.TOTAL;
+    private static final String PEER_1 = "ep-peer-1";
+    private static final String PEER_2 = "ep-peer-2";
+    private static final String ROUTE = "ep.load.balanced";
+    // the mock pub/sub decodes the published payload as a packed EventEnvelope
+    private static final byte[] PAYLOAD = new EventEnvelope()
+            .setTo("hello.world").setBody("test-payload").toBytes();
+
+    @BeforeAll
+    static void peers() throws InterruptedException {
+        EventEmitter po = EventEmitter.getInstance();
+        Platform platform = Platform.getInstance();
+        // the mock cloud registers the service registry asynchronously after boot
+        final BlockingQueue<Boolean> ready = new ArrayBlockingQueue<>(1);
+        platform.waitForProvider("cloud.connector.health", 20).onSuccess(ready::add);
+        assertEquals(Boolean.TRUE, ready.poll(20, TimeUnit.SECONDS));
+        long registryDeadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < registryDeadline
+                && !platform.hasRoute(ServiceDiscovery.SERVICE_REGISTRY)) {
+            Utility.getInstance().sleep(200);
+        }
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv("type", "join"),
+                new Kv("origin", platform.getOrigin()), new Kv("topic", "multiplex.0001-000"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv("type", "join"),
+                new Kv("origin", PEER_1), new Kv("topic", "multiplex.0001-007"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv("type", "join"),
+                new Kv("origin", PEER_2), new Kv("topic", "multiplex.0001-008"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv("type", "add"),
+                new Kv("origin", PEER_1), new Kv("route", ROUTE), new Kv("personality", "APP"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv("type", "add"),
+                new Kv("origin", PEER_2), new Kv("route", ROUTE), new Kv("personality", "APP"));
+        long deadline = System.currentTimeMillis() + 8000;
+        while (System.currentTimeMillis() < deadline
+                && ServiceRegistry.getInstances(ROUTE).size() < 2) {
+            Utility.getInstance().sleep(200);
+        }
+        assertEquals(2, ServiceRegistry.getInstances(ROUTE).size());
+    }
+
+    private EventEnvelope produce(EventEnvelope event) throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter.getInstance().asyncRequest(event, 5000).onSuccess(bench::add);
+        return bench.poll(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void roundRobinAcrossInstances() throws InterruptedException {
+        // two sends exercise the load-balancer rotation over the two peers
+        for (int i = 0; i < 2; i++) {
+            EventEnvelope event = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                    .setHeader(TO, ROUTE).setBody(PAYLOAD);
+            EventEnvelope response = produce(event);
+            assertNotNull(response);
+            assertEquals(true, response.getBody());
+        }
+    }
+
+    @Test
+    void broadcastReachesAllInstances() throws InterruptedException {
+        EventEnvelope event = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, ROUTE).setHeader(BROADCAST, "1").setBody(PAYLOAD);
+        EventEnvelope response = produce(event);
+        assertNotNull(response);
+        assertEquals(true, response.getBody());
+    }
+
+    @Test
+    void segmentedMessageSticksToOneDestination() throws InterruptedException {
+        String id = "segment-demo-1";
+        // first block resolves by route and caches the destination
+        EventEnvelope first = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, ROUTE).setHeader(ID, id)
+                .setHeader(COUNT, "1").setHeader(TOTAL, "2").setBody(PAYLOAD);
+        assertNotNull(produce(first));
+        // the final block reuses the cached destination and clears it
+        EventEnvelope last = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, ROUTE).setHeader(ID, id)
+                .setHeader(COUNT, "2").setHeader(TOTAL, "2").setBody(PAYLOAD);
+        assertNotNull(produce(last));
+    }
+
+    @Test
+    void fullyQualifiedAndUnknownTargets() throws InterruptedException {
+        // known origin: direct delivery
+        EventEnvelope direct = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, "some.route@" + PEER_1).setBody(PAYLOAD);
+        EventEnvelope response = produce(direct);
+        assertNotNull(response);
+        assertEquals(true, response.getBody());
+        // unknown origin: quietly dropped
+        EventEnvelope unknown = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, "some.route@no-such-origin").setBody(PAYLOAD);
+        assertNotNull(produce(unknown));
+        // unknown route: no destinations
+        EventEnvelope noRoute = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, "no.such.route").setBody(PAYLOAD);
+        assertNotNull(produce(noRoute));
+        // local route resolves to this instance
+        EventEnvelope local = new EventEnvelope().setTo(EventEmitter.CLOUD_CONNECTOR)
+                .setHeader(TO, ServiceDiscovery.SERVICE_QUERY).setBody(PAYLOAD);
+        assertNotNull(produce(local));
+    }
+}

--- a/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
+++ b/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
@@ -29,6 +29,7 @@ import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.system.EventEmitter;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.ServiceDiscovery;
+import org.platformlambda.core.util.Utility;
 import org.platformlambda.mock.TestBase;
 
 import java.util.HashMap;
@@ -66,7 +67,7 @@ class ServiceRegistryEdgeTest extends TestBase {
         long deadline = System.currentTimeMillis() + 10000;
         while (System.currentTimeMillis() < deadline
                 && !platform.hasRoute(ServiceDiscovery.SERVICE_REGISTRY)) {
-            org.platformlambda.core.util.Utility.getInstance().sleep(200);
+            Utility.getInstance().sleep(200);
         }
     }
 
@@ -74,7 +75,7 @@ class ServiceRegistryEdgeTest extends TestBase {
         Platform platform = Platform.getInstance();
         if (!platform.hasRoute(WATCHER)) {
             LambdaFunction f = (headers, input, instance) -> {
-                events.offer(new HashMap<>(headers));
+                events.add(new HashMap<>(headers));
                 return true;
             };
             platform.registerPrivate(WATCHER, f, 1);
@@ -93,8 +94,8 @@ class ServiceRegistryEdgeTest extends TestBase {
         po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "subscribe_life_cycle"));
     }
 
-    private Map<String, String> waitForEvent(String type, long timeoutMs) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + timeoutMs;
+    private Map<String, String> waitForEvent(String type) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 8000;
         while (System.currentTimeMillis() < deadline) {
             Map<String, String> event = events.poll(500, TimeUnit.MILLISECONDS);
             if (event != null && type.equals(event.get(TYPE))) {
@@ -118,12 +119,12 @@ class ServiceRegistryEdgeTest extends TestBase {
                 .setHeader(TOPIC, "multiplex.0001-005").setHeader("name", "edge-app")
                 .setHeader("exchange", "true");
         po.send(addList);
-        Map<String, String> joined = waitForEvent("join", 8000);
+        Map<String, String> joined = waitForEvent("join");
         assertNotNull(joined, "life-cycle subscriber should see the peer join");
         assertEquals(peer, joined.get(ORIGIN));
         // the peer leaving notifies subscribers and clears its routes
         po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "leave"), new Kv(ORIGIN, peer));
-        Map<String, String> left = waitForEvent("leave", 8000);
+        Map<String, String> left = waitForEvent("leave");
         assertNotNull(left, "life-cycle subscriber should see the peer leave");
         assertEquals(peer, left.get(ORIGIN));
         assertTrue(ServiceRegistry.getInstances("edge.service.one").isEmpty());
@@ -131,7 +132,7 @@ class ServiceRegistryEdgeTest extends TestBase {
 
     @Order(2)
     @Test
-    void keepAliveRefreshesKnownAndUnknownPeers() throws InterruptedException {
+    void keepAliveRefreshesKnownAndUnknownPeers() {
         EventEmitter po = EventEmitter.getInstance();
         Platform platform = Platform.getInstance();
         String peer = "edge-test-peer-2";
@@ -159,7 +160,7 @@ class ServiceRegistryEdgeTest extends TestBase {
         long deadline = System.currentTimeMillis() + 8000;
         while (System.currentTimeMillis() < deadline
                 && !ServiceRegistry.getAllOrigins().containsKey(peer)) {
-            Thread.sleep(200);
+            Utility.getInstance().sleep(200);
         }
         assertTrue(ServiceRegistry.getAllOrigins().containsKey(peer));
         po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "leave"), new Kv(ORIGIN, peer));

--- a/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
+++ b/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
@@ -1,0 +1,259 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.cloud;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.platformlambda.cloud.services.ServiceRegistry;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.Kv;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.ServiceDiscovery;
+import org.platformlambda.mock.TestBase;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the service registry's member life-cycle and peer-synchronization paths that the
+ * main connectivity test does not reach: life-cycle/presence-monitor subscriptions with their
+ * notification fan-out, keep-alive handling for new and known peers, route-list exchange,
+ * broadcast of local add/unregister, monitor-down handling, and the query variants.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ServiceRegistryEdgeTest extends TestBase {
+
+    private static final String TYPE = "type";
+    private static final String ROUTE = "route";
+    private static final String ORIGIN = "origin";
+    private static final String TOPIC = "topic";
+    private static final String WATCHER = "member.event.watcher";
+    private static final BlockingQueue<Map<String, String>> events = new ArrayBlockingQueue<>(10);
+
+    @org.junit.jupiter.api.BeforeAll
+    static void waitForRegistry() throws InterruptedException {
+        Platform platform = Platform.getInstance();
+        // the mock cloud registers the service registry asynchronously after boot
+        final BlockingQueue<Boolean> ready = new ArrayBlockingQueue<>(1);
+        platform.waitForProvider("cloud.connector.health", 20).onSuccess(ready::add);
+        assertEquals(Boolean.TRUE, ready.poll(20, TimeUnit.SECONDS));
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline
+                && !platform.hasRoute(ServiceDiscovery.SERVICE_REGISTRY)) {
+            org.platformlambda.core.util.Utility.getInstance().sleep(200);
+        }
+    }
+
+    private void subscribeWatcher() {
+        Platform platform = Platform.getInstance();
+        if (!platform.hasRoute(WATCHER)) {
+            LambdaFunction f = (headers, input, instance) -> {
+                events.offer(new HashMap<>(headers));
+                return true;
+            };
+            platform.registerPrivate(WATCHER, f, 1);
+        }
+        EventEmitter po = EventEmitter.getInstance();
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "subscribe_life_cycle"), new Kv(ROUTE, WATCHER));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "subscribe_pm_status"), new Kv(ROUTE, WATCHER));
+        // subscribing twice is idempotent; a fully-qualified route (with @) is rejected quietly
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "subscribe_life_cycle"), new Kv(ROUTE, WATCHER));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "subscribe_life_cycle"), new Kv(ROUTE, "invalid@origin"));
+        // missing route header is a no-op
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "subscribe_life_cycle"));
+    }
+
+    private Map<String, String> waitForEvent(String type, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            Map<String, String> event = events.poll(500, TimeUnit.MILLISECONDS);
+            if (event != null && type.equals(event.get(TYPE))) {
+                return event;
+            }
+        }
+        return null;
+    }
+
+    @Order(1)
+    @Test
+    void memberLifeCycleNotifications() throws InterruptedException {
+        subscribeWatcher();
+        EventEmitter po = EventEmitter.getInstance();
+        String peer = "edge-test-peer-1";
+        // a peer joining with a route list (NAME header) notifies life-cycle subscribers
+        Map<String, Object> routes = new HashMap<>();
+        routes.put("edge.service.one", "APP");
+        EventEnvelope addList = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_REGISTRY)
+                .setBody(routes).setHeader(TYPE, "add").setHeader(ORIGIN, peer)
+                .setHeader(TOPIC, "multiplex.0001-005").setHeader("name", "edge-app")
+                .setHeader("exchange", "true");
+        po.send(addList);
+        Map<String, String> joined = waitForEvent("join", 8000);
+        assertNotNull(joined, "life-cycle subscriber should see the peer join");
+        assertEquals(peer, joined.get(ORIGIN));
+        // the peer leaving notifies subscribers and clears its routes
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "leave"), new Kv(ORIGIN, peer));
+        Map<String, String> left = waitForEvent("leave", 8000);
+        assertNotNull(left, "life-cycle subscriber should see the peer leave");
+        assertEquals(peer, left.get(ORIGIN));
+        assertTrue(ServiceRegistry.getInstances("edge.service.one").isEmpty());
+    }
+
+    @Order(2)
+    @Test
+    void keepAliveRefreshesKnownAndUnknownPeers() throws InterruptedException {
+        EventEmitter po = EventEmitter.getInstance();
+        Platform platform = Platform.getInstance();
+        String peer = "edge-test-peer-2";
+        // keep-alive from an unknown peer triggers a join re-broadcast
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "keep-alive"),
+                new Kv(ORIGIN, peer), new Kv(TOPIC, "multiplex.0001-006"),
+                new Kv("name", "edge-app-2"), new Kv("version", "1.0.0"));
+        // keep-alive from a known peer refreshes the last-seen timestamp
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "keep-alive"),
+                new Kv(ORIGIN, peer), new Kv(TOPIC, "multiplex.0001-006"),
+                new Kv("name", "edge-app-2"), new Kv("version", "1.0.0"));
+        // keep-alive for this node removes stalled peers
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "keep-alive"),
+                new Kv(ORIGIN, platform.getOrigin()), new Kv(TOPIC, "multiplex.0001-000"));
+        // join with a monitor version hits the version-detected branch
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "join"),
+                new Kv(ORIGIN, platform.getOrigin()), new Kv(TOPIC, "multiplex.0001-000"),
+                new Kv("version", "9.9.9"));
+        // incomplete events are no-ops
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "join"), new Kv(ORIGIN, peer));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "keep-alive"), new Kv(ORIGIN, peer));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "leave"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "no-such-type"));
+        // allow the async handlers to drain, then confirm the peer is known
+        long deadline = System.currentTimeMillis() + 8000;
+        while (System.currentTimeMillis() < deadline
+                && !ServiceRegistry.getAllOrigins().containsKey(peer)) {
+            Thread.sleep(200);
+        }
+        assertTrue(ServiceRegistry.getAllOrigins().containsKey(peer));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "leave"), new Kv(ORIGIN, peer));
+    }
+
+    @Order(3)
+    @Test
+    void localAddAndUnregisterBroadcastToPeers() throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter po = EventEmitter.getInstance();
+        Platform platform = Platform.getInstance();
+        String myOrigin = platform.getOrigin();
+        // a locally registered route (origin = me, no 'final' flag) is broadcast to peers
+        EventEnvelope add = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_REGISTRY)
+                .setHeader(TYPE, "add").setHeader(ORIGIN, myOrigin)
+                .setHeader(ROUTE, "edge.local.route").setHeader("personality", "APP");
+        po.asyncRequest(add, 5000).onSuccess(bench::add);
+        assertNotNull(bench.poll(10, TimeUnit.SECONDS));
+        assertTrue(ServiceRegistry.getInstances("edge.local.route").contains(myOrigin));
+        // and unregistering it broadcasts the removal
+        EventEnvelope remove = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_REGISTRY)
+                .setHeader(TYPE, "unregister").setHeader(ORIGIN, myOrigin)
+                .setHeader(ROUTE, "edge.local.route");
+        po.asyncRequest(remove, 5000).onSuccess(bench::add);
+        assertNotNull(bench.poll(10, TimeUnit.SECONDS));
+        assertFalse(ServiceRegistry.getInstances("edge.local.route").contains(myOrigin));
+        // destination checks
+        assertTrue(ServiceRegistry.destinationExists(myOrigin));
+        assertTrue(ServiceRegistry.destinationExists("monitor-1"));
+        assertFalse(ServiceRegistry.destinationExists(null));
+        assertFalse(ServiceRegistry.destinationExists("no-such-origin"));
+        assertTrue(ServiceRegistry.getTopic("monitor-2").endsWith("-2"));
+        assertTrue(ServiceRegistry.getInstances("no.such.route").isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Order(4)
+    @Test
+    void queryVariants() throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter po = EventEmitter.getInstance();
+        // info
+        EventEnvelope info = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "info");
+        po.asyncRequest(info, 5000).onSuccess(bench::add);
+        EventEnvelope infoResult = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(infoResult);
+        assertInstanceOf(Map.class, infoResult.getBody());
+        assertTrue(((Map<String, Object>) infoResult.getBody()).containsKey("origin"));
+        // download
+        EventEnvelope download = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "download");
+        po.asyncRequest(download, 5000).onSuccess(bench::add);
+        EventEnvelope downloadResult = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(downloadResult);
+        Map<String, Object> data = (Map<String, Object>) downloadResult.getBody();
+        assertTrue(data.containsKey("routes"));
+        assertTrue(data.containsKey("nodes"));
+        // find for an unknown route
+        EventEnvelope findMissing = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "find").setHeader(ROUTE, "no.such.route");
+        po.asyncRequest(findMissing, 5000).onSuccess(bench::add);
+        EventEnvelope missing = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(missing);
+        assertEquals(false, missing.getBody());
+        // find "*" without a list body is false
+        EventEnvelope findStar = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "find").setHeader(ROUTE, "*").setBody("not-a-list");
+        po.asyncRequest(findStar, 5000).onSuccess(bench::add);
+        EventEnvelope star = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(star);
+        assertEquals(false, star.getBody());
+        // find "*" where one of the routes does not exist is false
+        EventEnvelope findList = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "find").setHeader(ROUTE, "*")
+                .setBody(List.of("no.such.route"));
+        po.asyncRequest(findList, 5000).onSuccess(bench::add);
+        EventEnvelope listResult = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(listResult);
+        assertEquals(false, listResult.getBody());
+        // invalid usage is rejected
+        EventEnvelope invalid = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_QUERY)
+                .setHeader(TYPE, "nonsense");
+        po.asyncRequest(invalid, 5000).onSuccess(bench::add);
+        EventEnvelope error = bench.poll(10, TimeUnit.SECONDS);
+        assertNotNull(error);
+        assertEquals(400, error.getStatus());
+        // unsubscribe both watcher subscriptions (and verify the no-op branches)
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "unsubscribe_life_cycle"), new Kv(ROUTE, WATCHER));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "unsubscribe_pm_status"), new Kv(ROUTE, WATCHER));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY,
+                new Kv(TYPE, "unsubscribe_life_cycle"), new Kv(ROUTE, "never.subscribed"));
+        po.send(ServiceDiscovery.SERVICE_REGISTRY, new Kv(TYPE, "unsubscribe_pm_status"));
+    }
+}

--- a/connectors/core/service-monitor/src/test/java/org/platformlambda/cloud/MonitorEdgeTest.java
+++ b/connectors/core/service-monitor/src/test/java/org/platformlambda/cloud/MonitorEdgeTest.java
@@ -1,0 +1,145 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.cloud;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.MainApp;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.Kv;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.mock.TestBase;
+import org.platformlambda.ws.MonitorService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the presence monitor's coordination services beyond the main connectivity test:
+ * the additional-info query, housekeeping of peer monitors, presence-event handling for
+ * unknown members, and the topic controller's guarded request types.
+ */
+class MonitorEdgeTest extends TestBase {
+
+    private static final String TYPE = "type";
+    private static final String ORIGIN = "origin";
+    private static final String ADDITIONAL_INFO = "additional.info";
+    private static final long TIMEOUT = 10000;
+
+    @BeforeAll
+    static void waitForMember() {
+        // the mock member connection is established asynchronously after boot
+        for (int i = 0; i < 40 && MonitorService.getConnections().isEmpty(); i++) {
+            Utility.getInstance().sleep(500);
+        }
+        assertFalse(MonitorService.getConnections().isEmpty(), "expect a mock member connection");
+    }
+
+    private EventEnvelope request(EventEnvelope event) throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter.getInstance().asyncRequest(event, TIMEOUT).onSuccess(bench::add);
+        return bench.poll(TIMEOUT + 5000, TimeUnit.MILLISECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void additionalInfoQuery() throws InterruptedException {
+        EventEnvelope response = request(new EventEnvelope().setTo(ADDITIONAL_INFO)
+                .setHeader(TYPE, "query"));
+        assertNotNull(response);
+        assertInstanceOf(Map.class, response.getBody());
+        Map<String, Object> info = (Map<String, Object>) response.getBody();
+        assertTrue(info.containsKey("connections"));
+        assertTrue(info.containsKey("monitors"));
+        assertTrue(info.containsKey("topics"));
+        assertTrue(info.containsKey("virtual_topics"));
+        assertTrue(info.containsKey("total"));
+        // invalid usage is rejected
+        EventEnvelope invalid = request(new EventEnvelope().setTo(ADDITIONAL_INFO)
+                .setHeader(TYPE, "nonsense"));
+        assertNotNull(invalid);
+        assertEquals(400, invalid.getStatus());
+    }
+
+    @Test
+    void houseKeeperTracksPeerMonitors() throws InterruptedException {
+        EventEmitter po = EventEmitter.getInstance();
+        Platform platform = Platform.getInstance();
+        String peerMonitor = "edge-monitor-1";
+        // init for myself registers this monitor instance
+        po.send(MainApp.PRESENCE_HOUSEKEEPER, new Kv(TYPE, "init"),
+                new Kv(ORIGIN, platform.getOrigin()), new Kv("instance", "monitor-app-1"));
+        // init for a peer triggers an alive broadcast instead
+        po.send(MainApp.PRESENCE_HOUSEKEEPER, new Kv(TYPE, "init"), new Kv(ORIGIN, peerMonitor));
+        // a peer keep-alive with the member list registers the peer and refreshes it
+        List<String> members = new ArrayList<>(MonitorService.getConnections().keySet());
+        EventEnvelope alive = new EventEnvelope().setTo(MainApp.PRESENCE_HOUSEKEEPER)
+                .setBody(members)
+                .setHeader(TYPE, MainApp.MONITOR_ALIVE).setHeader(ORIGIN, peerMonitor);
+        assertNotNull(request(alive));
+        // a second keep-alive exercises the refresh (already-known) branch
+        assertNotNull(request(new EventEnvelope().setTo(MainApp.PRESENCE_HOUSEKEEPER)
+                .setBody(members)
+                .setHeader(TYPE, MainApp.MONITOR_ALIVE).setHeader(ORIGIN, peerMonitor)));
+    }
+
+    @Test
+    void presenceHandlerEdgeCases() {
+        EventEmitter po = EventEmitter.getInstance();
+        // delete an unknown member connection is a quiet no-op
+        po.send(MainApp.PRESENCE_HANDLER, new Kv(TYPE, "del"), new Kv(ORIGIN, "no-such-member"));
+        // keep-alive for an unknown member is ignored
+        po.send(MainApp.PRESENCE_HANDLER, new Kv(TYPE, "keep-alive"),
+                new Kv(ORIGIN, "no-such-member"), new Kv("topic", "multiplex.0001-011"));
+        // download request from a peer monitor
+        po.send(MainApp.PRESENCE_HANDLER, new Kv(TYPE, "download"), new Kv(ORIGIN, "edge-monitor-2"));
+        // allow the async handlers to drain
+        Utility.getInstance().sleep(1000);
+        assertFalse(MonitorService.getConnections().containsKey("no-such-member"));
+    }
+
+    @Test
+    void topicControllerGuardedTypes() throws InterruptedException {
+        EventEmitter po = EventEmitter.getInstance();
+        // no type header returns false
+        EventEnvelope noType = request(new EventEnvelope().setTo(MainApp.TOPIC_CONTROLLER));
+        assertNotNull(noType);
+        assertEquals(false, noType.getBody());
+        // unknown type returns false
+        EventEnvelope unknown = request(new EventEnvelope().setTo(MainApp.TOPIC_CONTROLLER)
+                .setHeader(TYPE, "nonsense"));
+        assertNotNull(unknown);
+        assertEquals(false, unknown.getBody());
+        // keep-alive for the current member refreshes its session
+        String member = MonitorService.getConnections().keySet().iterator().next();
+        po.send(MainApp.TOPIC_CONTROLLER, new Kv(TYPE, "keep-alive"), new Kv(ORIGIN, member));
+        // release topic for an unknown origin is a guarded no-op
+        po.send(MainApp.TOPIC_CONTROLLER, new Kv(TYPE, "release_topic"), new Kv(ORIGIN, "no-such-member"));
+        Utility.getInstance().sleep(500);
+        assertTrue(MonitorService.getConnections().containsKey(member));
+    }
+}

--- a/docs/guides/kafka-flow-adapter.md
+++ b/docs/guides/kafka-flow-adapter.md
@@ -189,11 +189,18 @@ parameters its contract depends on and lets the template own everything else:
 |---------|-----------------------|-------------------|
 | Serialization | key=`String`, value=`byte[]` (de)serializers | — |
 | Delivery semantics (consumer) | `enable.auto.commit` / `max.poll.records` — per-binding overlay (see [delivery mode](#delivery-mode)) | `auto.offset.reset` |
+| Partitioning (producer) | `partitioner.class` **defaulted** (not pinned) to `SimpleRandomPartitioner` | any `partitioner.class` set here wins |
 | Connection / security | — | `bootstrap.servers`, `security.protocol`, `sasl.*`, `ssl.*`, `acks` |
 
 `bootstrap.servers` is template-only via `${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:9092}`. The byte[] wire
 contract keeps the building blocks serializer-free; richer encodings layer on top via the
 [Schema Registry integration](#schema) (JSON Schema / Avro), opt-in per binding.
+
+> **Why a random partitioner?** Kafka's default is a *sticky* partitioner — throughput-friendly, but at
+> low volume it lands everything on one partition, leaving a multi-instance consumer group mostly idle.
+> The library's `SimpleRandomPartitioner` is perfectly stateless and distributes keyless records
+> uniformly. Records with an explicit `partition` header bypass it, and keyed records keep Kafka's
+> murmur2 key-hash mapping. Set `partitioner.class` in `kafka-producer.properties` to override.
 
 > **OAuth token URLs are allow-listed automatically.** The Kafka client refuses to fetch an OAuth 2.0
 > token from a URL that is not on the JVM allow-list (the

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -143,7 +143,7 @@ this, so a bridge application runs locally with zero connection configuration.
 
 For a complete runnable walkthrough — an HTTP edge, a pure-YAML bridge, and a system-of-record
 crossing the two emulated clusters with trace/correlation continuity — see the
-[`twin-kafka-demo`](../../examples/twin-kafka-demo/README.md) worked example.
+[`twin-kafka-demo`](https://github.com/Accenture/mercury-composable/tree/main/examples/twin-kafka-demo) worked example.
 
 ## Configuration keys {#config}
 
@@ -166,7 +166,7 @@ impedance-matching overrides.
 
 ## See also {#see-also}
 
-- [twin-kafka-demo](../../examples/twin-kafka-demo/README.md) - runnable worked example of the bridge pattern.
+- [twin-kafka-demo](https://github.com/Accenture/mercury-composable/tree/main/examples/twin-kafka-demo) - runnable worked example of the bridge pattern.
 - [Kafka Flow Adapter](kafka-flow-adapter.md) - the foundation library this module extends.
 - [Configuration Reference](configuration-reference.md#kafka-flow-adapter) - every key in one place.
 - [Reserved names and headers](reserved-names-and-headers.md) - trace/correlation header conventions.

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -141,6 +141,10 @@ cd helpers/kafka-standalone && java -Ddual.servers=true -jar target/kafka-standa
 The shipped templates' defaults (`127.0.0.1:9092` primary, `127.0.0.1:8092` secondary) line up with
 this, so a bridge application runs locally with zero connection configuration.
 
+For a complete runnable walkthrough — an HTTP edge, a pure-YAML bridge, and a system-of-record
+crossing the two emulated clusters with trace/correlation continuity — see the
+[`twin-kafka-demo`](../../examples/twin-kafka-demo/README.md) worked example.
+
 ## Configuration keys {#config}
 
 | Key | Default | Description |
@@ -162,6 +166,7 @@ impedance-matching overrides.
 
 ## See also {#see-also}
 
+- [twin-kafka-demo](../../examples/twin-kafka-demo/README.md) - runnable worked example of the bridge pattern.
 - [Kafka Flow Adapter](kafka-flow-adapter.md) - the foundation library this module extends.
 - [Configuration Reference](configuration-reference.md#kafka-flow-adapter) - every key in one place.
 - [Reserved names and headers](reserved-names-and-headers.md) - trace/correlation header conventions.

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -164,6 +164,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/DemoProcessorTest.java
+++ b/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/DemoProcessorTest.java
@@ -1,0 +1,68 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.serializers.SimpleMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * demo.processor is self-contained (the flow does the publishing): it wraps the inbound text with
+ * processing metadata. The task derives its trace context from the input headers, so it is directly
+ * testable with the reserved my_route / my_trace_id headers a flow would carry.
+ */
+class DemoProcessorTest {
+
+    private final DemoProcessor processor = new DemoProcessor();
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void wrapsTheInboundTextWithProcessingMetadata() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.processor");
+        headers.put("my_trace_id", "trace-1234");
+        headers.put("my_trace_path", "KAFKA demo.inbound");
+        headers.put("cid", "order-001");
+        byte[] input = "hello kafka".getBytes(StandardCharsets.UTF_8);
+        EventEnvelope result = processor.handleEvent(headers, input, 1);
+        assertEquals("order-001", result.getHeaders().get("cid"));
+        assertInstanceOf(byte[].class, result.getBody());
+        Map<String, Object> response = SimpleMapper.getInstance().getMapper().readValue(
+                new String((byte[]) result.getBody(), StandardCharsets.UTF_8), Map.class);
+        assertEquals("hello kafka", response.get("received"));
+        assertEquals("kafka-demo", response.get("processedBy"));
+        assertEquals("trace-1234", response.get("traceId"));
+        assertNotNull(response.get("processedAt"));
+    }
+
+    @Test
+    void withoutCorrelationIdNoCidHeaderIsStamped() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.processor");
+        EventEnvelope result = processor.handleEvent(
+                headers, "plain".getBytes(StandardCharsets.UTF_8), 1);
+        assertFalse(result.getHeaders().containsKey("cid"));
+    }
+}

--- a/examples/lambda-example/src/test/java/org/platformlambda/demo/ServiceTopUpTest.java
+++ b/examples/lambda-example/src/test/java/org/platformlambda/demo/ServiceTopUpTest.java
@@ -1,0 +1,150 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.demo;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.demo.common.TestBase;
+import org.platformlambda.models.ObjectWithGenericType;
+import org.platformlambda.models.SamplePoJo;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the demo services that the earlier tests did not reach: health probe, generic PoJo
+ * holder, simple request parser, authentication demo and file download streaming.
+ */
+class ServiceTopUpTest extends TestBase {
+
+    private static final long RPC_TIMEOUT = 8000;
+
+    private EventEnvelope call(String route, Object body, Map<String, String> headers)
+            throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", Utility.getInstance().getUuid(), "TEST /" + route);
+        EventEnvelope request = new EventEnvelope().setTo(route).setBody(body);
+        if (headers != null) {
+            headers.forEach(request::setHeader);
+        }
+        return po.request(request, RPC_TIMEOUT).get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void healthProbeAnswersInfoAndHealth() throws InterruptedException, ExecutionException {
+        EventEnvelope info = call("demo.health", "ping", Map.of("type", "info"));
+        assertInstanceOf(Map.class, info.getBody());
+        assertEquals("demo.service", ((Map<String, Object>) info.getBody()).get("service"));
+        EventEnvelope health = call("demo.health", "ping", Map.of("type", "health"));
+        assertEquals("demo.service is running fine", health.getBody());
+        EventEnvelope invalid = call("demo.health", "ping", Map.of("type", "nonsense"));
+        assertTrue(invalid.getStatus() >= 400);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void genericPoJoHolderRoundTrip() throws InterruptedException, ExecutionException {
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setUrl("/api/generic/1");
+        req.setPathParameter("id", "1");
+        EventEnvelope response = call("hello.generic", req.toMap(), null);
+        assertEquals(200, response.getStatus());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("Generic class with parametric type SamplePoJo", map.getElement("content.name"));
+        // any other id hits the not-found path
+        req.setPathParameter("id", "2");
+        EventEnvelope notFound = call("hello.generic", req.toMap(), null);
+        assertEquals(404, notFound.getStatus());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void simpleEndpointParsesPathAndQuery() throws InterruptedException, ExecutionException {
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setUrl("/api/simple/foo/last");
+        req.setPathParameter("task", "foo");
+        req.setQueryParameter("a", "1");
+        req.setQueryParameter("b", "2");
+        EventEnvelope response = call("hello.simple", req.toMap(), null);
+        assertEquals(200, response.getStatus());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("foo", map.getElement("task"));
+        assertEquals("last", map.getElement("last_path_parameter"));
+        assertEquals("1", map.getElement("query.a"));
+        // missing query parameters are rejected
+        AsyncHttpRequest incomplete = new AsyncHttpRequest();
+        incomplete.setMethod("GET");
+        incomplete.setUrl("/api/simple/foo/last");
+        EventEnvelope error = call("hello.simple", incomplete.toMap(), null);
+        assertTrue(error.getStatus() >= 400);
+    }
+
+    @Test
+    void authDemoAcceptsAndTagsTheSession() throws InterruptedException, ExecutionException {
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setUrl("/api/hello/generic/1");
+        EventEnvelope response = call("v1.api.auth", req.toMap(), null);
+        assertEquals(Boolean.TRUE, response.getBody());
+        assertEquals("demo", response.getHeaders().get("user"));
+    }
+
+    @Test
+    void fileDownloadStreamsTheSampleFile() throws InterruptedException, ExecutionException {
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setUrl("/api/download");
+        req.setRemoteIp("127.0.0.1");
+        EventEnvelope response = call("hello.download", req.toMap(), null);
+        assertEquals(200, response.getStatus());
+        assertNotNull(response.getHeaders().get("x-stream-id"));
+        assertTrue(response.getHeaders().get("Content-Disposition").contains("helloworld.txt"));
+    }
+
+    @Test
+    void samplePoJoModelRoundTrip() {
+        Date now = new Date();
+        SamplePoJo pojo = new SamplePoJo(1, "name", "address");
+        pojo.setDate(now);
+        pojo.setInstance(2);
+        pojo.setSeq(3);
+        pojo.setOrigin("origin");
+        assertEquals(1, pojo.getId());
+        assertEquals("name", pojo.getName());
+        assertEquals("address", pojo.getAddress());
+        assertEquals(now, pojo.getDate());
+        assertEquals(2, pojo.getInstance());
+        assertEquals(3, pojo.getSeq());
+        assertEquals("origin", pojo.getOrigin());
+        ObjectWithGenericType<SamplePoJo> holder = new ObjectWithGenericType<>();
+        holder.setContent(pojo);
+        holder.setId(9);
+        assertEquals(9, holder.getId());
+        assertEquals(pojo, holder.getContent());
+    }
+}

--- a/examples/pg-example/src/test/java/com/accenture/postgres/tests/ReactiveDbTest.java
+++ b/examples/pg-example/src/test/java/com/accenture/postgres/tests/ReactiveDbTest.java
@@ -293,6 +293,52 @@ class ReactiveDbTest {
         assertEquals(0, records.size());
     }
 
+    /**
+     * This unit test exercises the example's own /api/demo endpoint (DemoRestEndpoint), which uses
+     * the DemoRepo repository for reads and the reactive DatabaseClient for inserts.
+     *
+     * @throws ExecutionException in case of error
+     * @throws InterruptedException in case of error
+     */
+    @Test
+    void doDemoProfileEndpoint() throws ExecutionException, InterruptedException {
+        var po = new PostOffice("unit.test", "303", "TEST /demo-endpoint");
+        // read the seeded record by id (repository pattern)
+        var byId = new AsyncHttpRequest().setMethod("GET").setTargetHost("http://127.0.0.1:"+getPort())
+                        .setUrl("/api/demo/D1").setHeader("accept", "application/json");
+        var found = po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(byId.toMap()), TIMEOUT).get();
+        assertInstanceOf(List.class, found.getBody());
+        var foundRecords = found.getBodyAsListOfPoJo(com.accenture.postgres.models.DemoProfile.class);
+        assertEquals(1, foundRecords.size());
+        var profile = foundRecords.getFirst();
+        assertEquals("D1", profile.id);
+        assertEquals("Aunt May", profile.name);
+        assertEquals("20 Ingram Street", profile.address);
+        // insert a new record (reactive database client)
+        var data = new com.accenture.postgres.models.DemoProfile()
+                        .create("D2", "Peter Parker", "20 Ingram Street");
+        var insert = new AsyncHttpRequest().setMethod("POST").setTargetHost("http://127.0.0.1:"+getPort())
+                        .setUrl("/api/demo").setBody(data).setHeader("content-type", "application/json");
+        var inserted = po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(insert.toMap()),
+                        TIMEOUT).get();
+        assertEquals(Map.of("row_updated", 1), inserted.getBody());
+        // find-all now returns both records (repository pattern)
+        var all = new AsyncHttpRequest().setMethod("GET").setTargetHost("http://127.0.0.1:"+getPort())
+                        .setUrl("/api/demo").setHeader("accept", "application/json");
+        var listed = po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(all.toMap()), TIMEOUT).get();
+        assertInstanceOf(List.class, listed.getBody());
+        var records = listed.getBodyAsListOfPoJo(com.accenture.postgres.models.DemoProfile.class);
+        assertEquals(2, records.size());
+        log.info("DemoProfile toString - {}", records.getFirst());
+        // an incomplete POST body is rejected
+        var incomplete = new AsyncHttpRequest().setMethod("POST").setTargetHost("http://127.0.0.1:"+getPort())
+                        .setUrl("/api/demo").setBody(Map.of("id", "D3"))
+                        .setHeader("content-type", "application/json");
+        var error = po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(incomplete.toMap()),
+                        TIMEOUT).get();
+        assertTrue(error.getStatus() >= 400);
+    }
+
     private int getPort() {
         AppConfigReader config = AppConfigReader.getInstance();
         return util.str2int(config.getProperty("rest.server.port", "8080"));

--- a/examples/pg-example/src/test/resources/pg-schema.sql
+++ b/examples/pg-example/src/test/resources/pg-schema.sql
@@ -19,3 +19,13 @@ CREATE TABLE IF NOT EXISTS temp_unit_test_table (
 
 INSERT INTO temp_unit_test_table (id, name, address, created) VALUES ('001', 'Mary', '100 World Blvd', '2024-12-22 10:10:30');
 INSERT INTO temp_unit_test_table (id, name, address, created) VALUES ('002', 'Peter', '200 World Blvd', '2025-01-02 10:20:30');
+
+-- the demo_profile table serves the example's own /api/demo endpoint (DemoRestEndpoint + DemoRepo)
+CREATE TABLE IF NOT EXISTS demo_profile (
+        id VARCHAR(40) PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        address VARCHAR(256) NOT NULL,
+        created TIMESTAMP NOT NULL
+    );
+
+INSERT INTO demo_profile (id, name, address, created) VALUES ('D1', 'Aunt May', '20 Ingram Street', '2025-01-02 10:20:30');

--- a/examples/pg-example/src/test/resources/rest.yaml
+++ b/examples/pg-example/src/test/resources/rest.yaml
@@ -4,6 +4,23 @@
 # for the original URL and path parameters
 #
 rest:
+  - service: "v1.demo.endpoint"
+    # the example's own demo endpoint (DemoRestEndpoint + DemoRepo)
+    methods: ['GET', 'POST']
+    url: "/api/demo"
+    timeout: 10s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
+  - service: "v1.demo.endpoint"
+    methods: ['GET']
+    url: "/api/demo/{id}"
+    timeout: 10s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
   - service: "v1.rest.tests"
     # GET all records
     # POST to create a new record

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -74,6 +74,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/examples/rest-spring-3-example/src/test/java/com/accenture/examples/common/TestBase.java
+++ b/examples/rest-spring-3-example/src/test/java/com/accenture/examples/common/TestBase.java
@@ -1,0 +1,43 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.common;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+
+/**
+ * Boots the example application once for the whole test run: AutoStart discovers MainApp
+ * (@MainApplication), starts Spring Boot on server.port and loads the preloaded functions.
+ */
+public abstract class TestBase {
+
+    protected static final String HTTP_REQUEST = "async.http.request";
+    protected static final long RPC_TIMEOUT = 10000;
+
+    protected static int springPort;
+
+    @BeforeAll
+    static void setup() {
+        springPort = Utility.getInstance().str2int(
+                AppConfigReader.getInstance().getProperty("server.port", "8083"));
+        AutoStart.main(new String[0]);
+    }
+}

--- a/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/ModelTest.java
+++ b/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/ModelTest.java
@@ -1,0 +1,64 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.models.ObjectWithGenericType;
+import org.platformlambda.models.SamplePoJo;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelTest {
+
+    @Test
+    void samplePoJoRoundTrip() {
+        Date now = new Date();
+        SamplePoJo pojo = new SamplePoJo(1, "Peter Parker", "20 Ingram Street, Queens");
+        pojo.setDate(now);
+        pojo.setInstance(3);
+        pojo.setSeq(7);
+        pojo.setOrigin("unit-test");
+        assertEquals(1, pojo.getId());
+        assertEquals("Peter Parker", pojo.getName());
+        assertEquals("20 Ingram Street, Queens", pojo.getAddress());
+        assertEquals(now, pojo.getDate());
+        assertEquals(3, pojo.getInstance());
+        assertEquals(7, pojo.getSeq());
+        assertEquals("unit-test", pojo.getOrigin());
+        SamplePoJo empty = new SamplePoJo();
+        empty.setId(2);
+        empty.setName("May Parker");
+        empty.setAddress("same street");
+        assertEquals(2, empty.getId());
+        assertEquals("May Parker", empty.getName());
+        assertEquals("same street", empty.getAddress());
+    }
+
+    @Test
+    void genericHolderRoundTrip() {
+        ObjectWithGenericType<SamplePoJo> holder = new ObjectWithGenericType<>();
+        SamplePoJo pojo = new SamplePoJo(100, "name", "address");
+        holder.setContent(pojo);
+        holder.setId(100);
+        assertEquals(100, holder.getId());
+        assertEquals(pojo, holder.getContent());
+    }
+}

--- a/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
+++ b/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
@@ -1,0 +1,108 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import com.accenture.examples.common.TestBase;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RestEndpointTest extends TestBase {
+
+    private EventEnvelope httpGet(String path, String demoHeader)
+            throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", Utility.getInstance().getUuid(), "GET " + path);
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setHeader("accept", "application/json");
+        if (demoHeader != null) {
+            req.setHeader("x-demo-header", demoHeader);
+        }
+        req.setUrl(path);
+        req.setTargetHost("http://127.0.0.1:" + springPort);
+        EventEnvelope request = new EventEnvelope().setTo(HTTP_REQUEST).setBody(req);
+        return po.request(request, RPC_TIMEOUT).get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void helloWorldEchoesHeadersThroughTheService() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/hello/world", "hello-123");
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        // the endpoint forwards the incoming HTTP headers to hello.world, which echoes them
+        // under its own 'body' key - hence body.body from the endpoint's wrapper
+        assertEquals(200, map.getElement("status"));
+        assertEquals("hello-123", map.getElement("body.body.x-demo-header"));
+        assertNotNull(map.getElement("body.origin"));
+        assertNotNull(map.getElement("execution_time"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void helloConcurrentReturnsAllParallelResults() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/hello/concurrent", "parallel-456");
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        Map<String, Object> results = (Map<String, Object>) response.getBody();
+        // the endpoint fans out 10 parallel events to hello.world and aggregates the futures
+        assertEquals(10, results.size());
+        MultiLevelMap map = new MultiLevelMap(results);
+        for (int i = 1; i <= 10; i++) {
+            assertEquals("parallel-456", map.getElement("result-" + i + ".body.body.x-demo-header"));
+        }
+    }
+
+    @Test
+    void demoServletSaysHello() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/demo", null);
+        assertEquals(200, response.getStatus());
+        assertEquals("hello world from servlet!", response.getBody());
+    }
+
+    @Test
+    void pojoOverHttpFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
+        // the Event-over-HTTP peer (lambda-example) is not running in a unit test,
+        // exercising the endpoint's error path
+        EventEnvelope response = httpGet("/api/pojo/http/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+
+    @Test
+    void pojoOverHttpByConfigFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/pojo2/http/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+
+    @Test
+    void pojoServiceMeshFailsFastWithoutTheRemoteService() throws InterruptedException, ExecutionException {
+        // hello.pojo is deployed in lambda-example, not here - exercising the route-not-found path
+        EventEnvelope response = httpGet("/api/pojo/mesh/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+}

--- a/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
+++ b/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
@@ -20,6 +20,8 @@ package com.accenture.examples.tests;
 
 import com.accenture.examples.common.TestBase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.system.PostOffice;
@@ -85,24 +87,15 @@ class RestEndpointTest extends TestBase {
         assertEquals("hello world from servlet!", response.getBody());
     }
 
-    @Test
-    void pojoOverHttpFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
-        // the Event-over-HTTP peer (lambda-example) is not running in a unit test,
-        // exercising the endpoint's error path
-        EventEnvelope response = httpGet("/api/pojo/http/1", null);
-        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
-    }
-
-    @Test
-    void pojoOverHttpByConfigFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
-        EventEnvelope response = httpGet("/api/pojo2/http/1", null);
-        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
-    }
-
-    @Test
-    void pojoServiceMeshFailsFastWithoutTheRemoteService() throws InterruptedException, ExecutionException {
-        // hello.pojo is deployed in lambda-example, not here - exercising the route-not-found path
-        EventEnvelope response = httpGet("/api/pojo/mesh/1", null);
+    /**
+     * The Event-over-HTTP peer (lambda-example) and the hello.pojo service are not deployed in a
+     * unit test, so all three pojo endpoints exercise their fail-fast error paths.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/pojo/http/1", "/api/pojo2/http/1", "/api/pojo/mesh/1"})
+    void pojoEndpointsFailFastWithoutTheRemotePeer(String path)
+            throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet(path, null);
         assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
     }
 }

--- a/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/WsEchoTest.java
+++ b/examples/rest-spring-3-example/src/test/java/com/accenture/examples/tests/WsEchoTest.java
@@ -1,0 +1,85 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import com.accenture.examples.common.TestBase;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.core.websocket.client.PersistentWsClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the WsEchoDemo websocket service ("hello"): a string message is echoed verbatim and a
+ * byte-array message is acknowledged with its length.
+ */
+class WsEchoTest extends TestBase {
+
+    @Test
+    void echoStringAndAcknowledgeBytes() throws InterruptedException {
+        final Utility util = Utility.getInstance();
+        final AppConfigReader config = AppConfigReader.getInstance();
+        final int wsPort = util.str2int(config.getProperty("websocket.server.port", "8086"));
+        final String message = "hello twin demo";
+        final byte[] blob = "12345".getBytes();
+        final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
+        final EventEmitter po = EventEmitter.getInstance();
+        final List<String> received = new ArrayList<>();
+        LambdaFunction connector = (headers, input, instance) -> {
+            if ("open".equals(headers.get("type"))) {
+                String txPath = headers.get("tx_path");
+                po.send(txPath, message);
+                po.send(txPath, blob);
+            }
+            if ("string".equals(headers.get("type"))) {
+                received.add((String) input);
+                if (received.size() == 2) {
+                    bench.add(true);
+                }
+            }
+            return true;
+        };
+        for (int i = 0; i < 3; i++) {
+            if (util.portReady("127.0.0.1", wsPort, 3000)) {
+                break;
+            }
+            util.sleep(1000);
+        }
+        PersistentWsClient client = new PersistentWsClient(connector,
+                Collections.singletonList("ws://127.0.0.1:" + wsPort + "/ws/hello"));
+        client.start();
+        Boolean done = bench.poll(10, TimeUnit.SECONDS);
+        client.close();
+        assertEquals(Boolean.TRUE, done, "expect both websocket responses within 10s");
+        assertTrue(received.contains(message), "string message is echoed verbatim");
+        assertTrue(received.contains("received " + blob.length + " bytes"),
+                "byte message is acknowledged with its length");
+    }
+}

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -74,6 +74,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/examples/rest-spring-4-example/src/test/java/com/accenture/examples/common/TestBase.java
+++ b/examples/rest-spring-4-example/src/test/java/com/accenture/examples/common/TestBase.java
@@ -1,0 +1,43 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.common;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+
+/**
+ * Boots the example application once for the whole test run: AutoStart discovers MainApp
+ * (@MainApplication), starts Spring Boot on server.port and loads the preloaded functions.
+ */
+public abstract class TestBase {
+
+    protected static final String HTTP_REQUEST = "async.http.request";
+    protected static final long RPC_TIMEOUT = 10000;
+
+    protected static int springPort;
+
+    @BeforeAll
+    static void setup() {
+        springPort = Utility.getInstance().str2int(
+                AppConfigReader.getInstance().getProperty("server.port", "8083"));
+        AutoStart.main(new String[0]);
+    }
+}

--- a/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/ModelTest.java
+++ b/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/ModelTest.java
@@ -1,0 +1,64 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.models.ObjectWithGenericType;
+import org.platformlambda.models.SamplePoJo;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelTest {
+
+    @Test
+    void samplePoJoRoundTrip() {
+        Date now = new Date();
+        SamplePoJo pojo = new SamplePoJo(1, "Peter Parker", "20 Ingram Street, Queens");
+        pojo.setDate(now);
+        pojo.setInstance(3);
+        pojo.setSeq(7);
+        pojo.setOrigin("unit-test");
+        assertEquals(1, pojo.getId());
+        assertEquals("Peter Parker", pojo.getName());
+        assertEquals("20 Ingram Street, Queens", pojo.getAddress());
+        assertEquals(now, pojo.getDate());
+        assertEquals(3, pojo.getInstance());
+        assertEquals(7, pojo.getSeq());
+        assertEquals("unit-test", pojo.getOrigin());
+        SamplePoJo empty = new SamplePoJo();
+        empty.setId(2);
+        empty.setName("May Parker");
+        empty.setAddress("same street");
+        assertEquals(2, empty.getId());
+        assertEquals("May Parker", empty.getName());
+        assertEquals("same street", empty.getAddress());
+    }
+
+    @Test
+    void genericHolderRoundTrip() {
+        ObjectWithGenericType<SamplePoJo> holder = new ObjectWithGenericType<>();
+        SamplePoJo pojo = new SamplePoJo(100, "name", "address");
+        holder.setContent(pojo);
+        holder.setId(100);
+        assertEquals(100, holder.getId());
+        assertEquals(pojo, holder.getContent());
+    }
+}

--- a/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
+++ b/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
@@ -1,0 +1,108 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import com.accenture.examples.common.TestBase;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RestEndpointTest extends TestBase {
+
+    private EventEnvelope httpGet(String path, String demoHeader)
+            throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", Utility.getInstance().getUuid(), "GET " + path);
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setHeader("accept", "application/json");
+        if (demoHeader != null) {
+            req.setHeader("x-demo-header", demoHeader);
+        }
+        req.setUrl(path);
+        req.setTargetHost("http://127.0.0.1:" + springPort);
+        EventEnvelope request = new EventEnvelope().setTo(HTTP_REQUEST).setBody(req);
+        return po.request(request, RPC_TIMEOUT).get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void helloWorldEchoesHeadersThroughTheService() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/hello/world", "hello-123");
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        // the endpoint forwards the incoming HTTP headers to hello.world, which echoes them
+        // under its own 'body' key - hence body.body from the endpoint's wrapper
+        assertEquals(200, map.getElement("status"));
+        assertEquals("hello-123", map.getElement("body.body.x-demo-header"));
+        assertNotNull(map.getElement("body.origin"));
+        assertNotNull(map.getElement("execution_time"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void helloConcurrentReturnsAllParallelResults() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/hello/concurrent", "parallel-456");
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        Map<String, Object> results = (Map<String, Object>) response.getBody();
+        // the endpoint fans out 10 parallel events to hello.world and aggregates the futures
+        assertEquals(10, results.size());
+        MultiLevelMap map = new MultiLevelMap(results);
+        for (int i = 1; i <= 10; i++) {
+            assertEquals("parallel-456", map.getElement("result-" + i + ".body.body.x-demo-header"));
+        }
+    }
+
+    @Test
+    void demoServletSaysHello() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/demo", null);
+        assertEquals(200, response.getStatus());
+        assertEquals("hello world from servlet!", response.getBody());
+    }
+
+    @Test
+    void pojoOverHttpFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
+        // the Event-over-HTTP peer (lambda-example) is not running in a unit test,
+        // exercising the endpoint's error path
+        EventEnvelope response = httpGet("/api/pojo/http/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+
+    @Test
+    void pojoOverHttpByConfigFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet("/api/pojo2/http/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+
+    @Test
+    void pojoServiceMeshFailsFastWithoutTheRemoteService() throws InterruptedException, ExecutionException {
+        // hello.pojo is deployed in lambda-example, not here - exercising the route-not-found path
+        EventEnvelope response = httpGet("/api/pojo/mesh/1", null);
+        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
+    }
+}

--- a/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
+++ b/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/RestEndpointTest.java
@@ -20,6 +20,8 @@ package com.accenture.examples.tests;
 
 import com.accenture.examples.common.TestBase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.system.PostOffice;
@@ -85,24 +87,15 @@ class RestEndpointTest extends TestBase {
         assertEquals("hello world from servlet!", response.getBody());
     }
 
-    @Test
-    void pojoOverHttpFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
-        // the Event-over-HTTP peer (lambda-example) is not running in a unit test,
-        // exercising the endpoint's error path
-        EventEnvelope response = httpGet("/api/pojo/http/1", null);
-        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
-    }
-
-    @Test
-    void pojoOverHttpByConfigFailsFastWhenRemoteIsDown() throws InterruptedException, ExecutionException {
-        EventEnvelope response = httpGet("/api/pojo2/http/1", null);
-        assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
-    }
-
-    @Test
-    void pojoServiceMeshFailsFastWithoutTheRemoteService() throws InterruptedException, ExecutionException {
-        // hello.pojo is deployed in lambda-example, not here - exercising the route-not-found path
-        EventEnvelope response = httpGet("/api/pojo/mesh/1", null);
+    /**
+     * The Event-over-HTTP peer (lambda-example) and the hello.pojo service are not deployed in a
+     * unit test, so all three pojo endpoints exercise their fail-fast error paths.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/api/pojo/http/1", "/api/pojo2/http/1", "/api/pojo/mesh/1"})
+    void pojoEndpointsFailFastWithoutTheRemotePeer(String path)
+            throws InterruptedException, ExecutionException {
+        EventEnvelope response = httpGet(path, null);
         assertTrue(response.getStatus() >= 400, "expect an error status, got " + response.getStatus());
     }
 }

--- a/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/WsEchoTest.java
+++ b/examples/rest-spring-4-example/src/test/java/com/accenture/examples/tests/WsEchoTest.java
@@ -1,0 +1,85 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.examples.tests;
+
+import com.accenture.examples.common.TestBase;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.core.websocket.client.PersistentWsClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the WsEchoDemo websocket service ("hello"): a string message is echoed verbatim and a
+ * byte-array message is acknowledged with its length.
+ */
+class WsEchoTest extends TestBase {
+
+    @Test
+    void echoStringAndAcknowledgeBytes() throws InterruptedException {
+        final Utility util = Utility.getInstance();
+        final AppConfigReader config = AppConfigReader.getInstance();
+        final int wsPort = util.str2int(config.getProperty("websocket.server.port", "8086"));
+        final String message = "hello twin demo";
+        final byte[] blob = "12345".getBytes();
+        final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
+        final EventEmitter po = EventEmitter.getInstance();
+        final List<String> received = new ArrayList<>();
+        LambdaFunction connector = (headers, input, instance) -> {
+            if ("open".equals(headers.get("type"))) {
+                String txPath = headers.get("tx_path");
+                po.send(txPath, message);
+                po.send(txPath, blob);
+            }
+            if ("string".equals(headers.get("type"))) {
+                received.add((String) input);
+                if (received.size() == 2) {
+                    bench.add(true);
+                }
+            }
+            return true;
+        };
+        for (int i = 0; i < 3; i++) {
+            if (util.portReady("127.0.0.1", wsPort, 3000)) {
+                break;
+            }
+            util.sleep(1000);
+        }
+        PersistentWsClient client = new PersistentWsClient(connector,
+                Collections.singletonList("ws://127.0.0.1:" + wsPort + "/ws/hello"));
+        client.start();
+        Boolean done = bench.poll(10, TimeUnit.SECONDS);
+        client.close();
+        assertEquals(Boolean.TRUE, done, "expect both websocket responses within 10s");
+        assertTrue(received.contains(message), "string message is echoed verbatim");
+        assertTrue(received.contains("received " + blob.length + " bytes"),
+                "byte message is acknowledged with its length");
+    }
+}

--- a/examples/rest-spring-4-example/src/test/resources/application.properties
+++ b/examples/rest-spring-4-example/src/test/resources/application.properties
@@ -1,5 +1,5 @@
-spring.application.name=rest-spring-3-example
-info.app.version=3.0.0
+spring.application.name=rest-spring-4-example
+info.app.version=4.0.0
 info.app.description=Spring Boot example
 #
 server.port=8083

--- a/examples/rest-spring-4-example/src/test/resources/application.properties
+++ b/examples/rest-spring-4-example/src/test/resources/application.properties
@@ -1,5 +1,5 @@
-spring.application.name=rest-spring-4-example
-info.app.version=4.0.0
+spring.application.name=rest-spring-3-example
+info.app.version=3.0.0
 info.app.description=Spring Boot example
 #
 server.port=8083

--- a/examples/scheduler-example/src/test/java/org/platformlambda/quartz/common/TestBase.java
+++ b/examples/scheduler-example/src/test/java/org/platformlambda/quartz/common/TestBase.java
@@ -1,0 +1,36 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.quartz.common;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+
+/**
+ * Boots the scheduler example once for the whole test run: AutoStart discovers MainApp,
+ * loads the preloaded functions, the cron.yaml jobs and the demo flow.
+ */
+public abstract class TestBase {
+
+    protected static final long RPC_TIMEOUT = 10000;
+
+    @BeforeAll
+    static void setup() {
+        AutoStart.main(new String[0]);
+    }
+}

--- a/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/ScheduleAdminTest.java
+++ b/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/ScheduleAdminTest.java
@@ -1,0 +1,118 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.quartz.tests;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.quartz.common.TestBase;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drives the v1.schedule.admin function (the handler behind GET/POST /api/schedule endpoints)
+ * as a service call, which is how REST automation invokes it.
+ */
+class ScheduleAdminTest extends TestBase {
+
+    private static final String SCHEDULE_ADMIN = "v1.schedule.admin";
+
+    @AfterAll
+    static void cleanup() {
+        Utility.getInstance().cleanupDir(new File("/tmp/scheduler-states"));
+    }
+
+    private EventEnvelope adminRequest(String method, String jobName, Object body)
+            throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", Utility.getInstance().getUuid(),
+                method + " /api/schedule");
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod(method);
+        req.setUrl("/api/schedule" + (jobName == null ? "" : "/" + jobName));
+        if (jobName != null) {
+            req.setPathParameter("name", jobName);
+        }
+        if (body != null) {
+            req.setBody(body);
+        }
+        EventEnvelope request = new EventEnvelope().setTo(SCHEDULE_ADMIN).setBody(req);
+        return po.request(request, RPC_TIMEOUT).get();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void jobListIsReturnedWithoutAJobName() throws InterruptedException, ExecutionException {
+        EventEnvelope response = adminRequest("GET", null, null);
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertNotNull(map.getElement("jobs"));
+        assertEquals("GET /api/schedule/{name}", map.getElement("message"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void manualJobRunCreatesTheStateRecord() throws InterruptedException, ExecutionException {
+        EventEnvelope response = adminRequest("POST", "demo-task", Map.of("operator", "unit.test"));
+        assertEquals(200, response.getStatus());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("Job started", map.getElement("message"));
+        assertEquals("demo-task", map.getElement("job"));
+        // the job executor runs asynchronously; the resolver's start record appears shortly after
+        File state = new File("/tmp/scheduler-states", "demo-task");
+        for (int i = 0; i < 30 && !state.exists(); i++) {
+            Utility.getInstance().sleep(500);
+        }
+        assertTrue(state.exists(), "job executor should have recorded the start state");
+        // once the state record exists, the job can be read back by name
+        EventEnvelope job = adminRequest("GET", "demo-task", null);
+        assertEquals(200, job.getStatus());
+        MultiLevelMap detail = new MultiLevelMap((Map<String, Object>) job.getBody());
+        assertEquals("demo-task", detail.getElement("name"));
+        assertEquals("hello.world", detail.getElement("service"));
+    }
+
+    @Test
+    void unknownJobNameIsRejected() throws InterruptedException, ExecutionException {
+        EventEnvelope response = adminRequest("GET", "no-such-job", null);
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void runWithoutOperatorIsRejected() throws InterruptedException, ExecutionException {
+        EventEnvelope response = adminRequest("POST", "demo-task", Map.of("something", "else"));
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void jobWithoutStateRecordIsNotFound() throws InterruptedException, ExecutionException {
+        File state = new File("/tmp/scheduler-states", "demo-flow");
+        assertTrue(!state.exists() || state.delete());
+        EventEnvelope response = adminRequest("GET", "demo-flow", null);
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/StateResolverTest.java
+++ b/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/StateResolverTest.java
@@ -1,0 +1,89 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.quartz.tests;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.quartz.services.AnotherTask;
+import org.platformlambda.quartz.services.HelloWorld;
+import org.platformlambda.quartz.services.MyDbTask;
+import org.platformlambda.quartz.services.StateResolver;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The state resolver keeps one file per job under /tmp/scheduler-states - directly testable
+ * without booting the platform. The placeholder tasks are exercised alongside.
+ */
+class StateResolverTest {
+
+    private static final String TEMP_FOLDER = "/tmp/scheduler-states";
+    private static final String JOB = "unit-test-job";
+
+    private final StateResolver resolver = new StateResolver();
+
+    private Map<String, String> headers(String type, String name) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("type", type);
+        if (name != null) {
+            headers.put("name", name);
+            headers.put("service", "hello.world");
+            headers.put("schedule", "0/15 0/1 * 1/1 * ? *");
+        }
+        return headers;
+    }
+
+    @Test
+    void startEndAndExpiryLifecycle() {
+        File state = new File(TEMP_FOLDER, JOB);
+        assertTrue(!state.exists() || state.delete());
+        // a job with no state file is good to go
+        assertTrue(resolver.handleEvent(headers("expires", JOB), null, 1));
+        // start creates the state file
+        assertTrue(resolver.handleEvent(headers("start", JOB), Map.of("hello", "world"), 1));
+        assertTrue(state.exists());
+        // a fresh start is not expired (10s window)
+        assertFalse(resolver.handleEvent(headers("expires", JOB), null, 1));
+        // end stamps the end time and elapsed duration
+        assertTrue(resolver.handleEvent(headers("end", JOB), null, 1));
+        assertTrue(state.delete());
+    }
+
+    @Test
+    void invalidTypeIsRejected() {
+        assertThrows(IllegalArgumentException.class, () ->
+                resolver.handleEvent(headers("nonsense", JOB), null, 1));
+        // start/end without a job name falls through to the same rejection
+        assertThrows(IllegalArgumentException.class, () ->
+                resolver.handleEvent(headers("start", null), null, 1));
+    }
+
+    @Test
+    void placeholderTasks() {
+        Map<String, Object> input = Map.of("hello", "world");
+        Map<String, String> headers = Map.of("job", JOB);
+        assertNull(new HelloWorld().handleEvent(headers, input, 1));
+        assertNull(new AnotherTask().handleEvent(headers, input, 1));
+        // my.db.task echoes its input
+        assertEquals(input, new MyDbTask().handleEvent(headers, input, 1));
+    }
+}

--- a/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/StateResolverTest.java
+++ b/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/StateResolverTest.java
@@ -70,11 +70,11 @@ class StateResolverTest {
 
     @Test
     void invalidTypeIsRejected() {
-        assertThrows(IllegalArgumentException.class, () ->
-                resolver.handleEvent(headers("nonsense", JOB), null, 1));
+        Map<String, String> nonsense = headers("nonsense", JOB);
+        assertThrows(IllegalArgumentException.class, () -> resolver.handleEvent(nonsense, null, 1));
         // start/end without a job name falls through to the same rejection
-        assertThrows(IllegalArgumentException.class, () ->
-                resolver.handleEvent(headers("start", null), null, 1));
+        Map<String, String> noJobName = headers("start", null);
+        assertThrows(IllegalArgumentException.class, () -> resolver.handleEvent(noJobName, null, 1));
     }
 
     @Test

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -164,6 +164,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/examples/sync-over-async-demo/src/test/java/com/accenture/soa/demo/tasks/SoaTaskTest.java
+++ b/examples/sync-over-async-demo/src/test/java/com/accenture/soa/demo/tasks/SoaTaskTest.java
@@ -1,0 +1,107 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.soa.demo.tasks;
+
+import com.accenture.soa.demo.support.SyncErrorHandler;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.serializers.SimpleMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The system-of-record tasks derive their trace context from the input headers and do not publish
+ * (the flows do), so all three variants are directly testable. The SoaReply* tasks hand replies to
+ * the Redis return-route coordinator and are exercised by the full multi-terminal run instead.
+ */
+class SoaTaskTest {
+
+    private Map<String, String> flowHeaders(String cid) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "system.of.record");
+        headers.put("my_trace_id", "trace-9999");
+        headers.put("my_trace_path", "KAFKA soa.request");
+        if (cid != null) {
+            headers.put("cid", cid);
+        }
+        return headers;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void byteArrayVariantEchoesTheRequestWithMetadata() {
+        byte[] request = "{\"action\":\"create\",\"order\":\"A-100\"}".getBytes(StandardCharsets.UTF_8);
+        EventEnvelope result = new SystemOfRecord().handleEvent(flowHeaders("cid-1"), request, 1);
+        assertEquals("cid-1", result.getHeaders().get("cid"));
+        Map<String, Object> response = SimpleMapper.getInstance().getMapper().readValue(
+                new String((byte[]) result.getBody(), StandardCharsets.UTF_8), Map.class);
+        assertEquals("processed", response.get("status"));
+        assertEquals("system-of-record", response.get("processedBy"));
+        assertEquals("trace-9999", response.get("traceId"));
+        assertEquals("create", ((Map<String, Object>) response.get("request")).get("action"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void jsonSchemaVariantSharesTheSameLogic() {
+        Map<String, Object> request = Map.of("action", "update", "order", "B-200");
+        EventEnvelope result = new SystemOfRecordJson().handleEvent(flowHeaders("cid-2"), request, 1);
+        assertEquals("cid-2", result.getHeaders().get("cid"));
+        Map<String, Object> response = SimpleMapper.getInstance().getMapper().readValue(
+                new String((byte[]) result.getBody(), StandardCharsets.UTF_8), Map.class);
+        assertEquals("processed", response.get("status"));
+        assertEquals("update", ((Map<String, Object>) response.get("request")).get("action"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void avroVariantBuildsTheFlatClosedShapeReply() {
+        Map<String, Object> request = Map.of("action", "create");
+        EventEnvelope result = new SystemOfRecordAvro().handleEvent(flowHeaders(null), request, 1);
+        assertFalse(result.getHeaders().containsKey("cid"));
+        Map<String, Object> response = SimpleMapper.getInstance().getMapper().readValue(
+                new String((byte[]) result.getBody(), StandardCharsets.UTF_8), Map.class);
+        // flat reply matching the Avro SyncDemoMessage record exactly
+        assertEquals(Map.of("action", "create", "status", "processed",
+                "processedBy", "system-of-record", "traceId", "trace-9999"), response);
+    }
+
+    @Test
+    void errorHandlerStatusPolicy() {
+        SyncErrorHandler handler = new SyncErrorHandler();
+        // a 408 timeout from sync.await passes through
+        Map<String, Object> timeout = handler.handleEvent(Map.of(),
+                Map.of("status", 408, "message", "Timeout for 5000 ms"), 1);
+        assertEquals(408, timeout.get("status"));
+        assertEquals("Timeout for 5000 ms", timeout.get("message"));
+        assertEquals("error", timeout.get("type"));
+        // any 5xx (backend unreachable) is re-mapped to a retriable 503
+        Map<String, Object> backendDown = handler.handleEvent(Map.of(),
+                Map.of("status", 500, "message", "Kafka publish failed"), 1);
+        assertEquals(503, backendDown.get("status"));
+        // defaults apply when the flow maps nothing
+        Map<String, Object> defaults = handler.handleEvent(Map.of(), new HashMap<>(), 1);
+        assertEquals(503, defaults.get("status"));
+        assertEquals("Internal error", defaults.get("message"));
+    }
+}

--- a/examples/twin-kafka-demo/README.md
+++ b/examples/twin-kafka-demo/README.md
@@ -170,9 +170,10 @@ The immediate HTTP ack uses `originator: HTTP_REQUEST`; the system-of-record's o
 - **Fully asynchronous.** The HTTP request is acknowledged immediately (`execution: response`); the
   outcome is observed on the response topic. No sync-over-async (see the sync-over-async-demo for that
   pattern) and no field encryption (see composable-example).
-- **No ordering assumptions.** The system-of-record runs 5 workers and messages spread across the 10
-  partitions by the producer's default (sticky) partitioner. At demo pace consecutive messages often
-  share a batch and land on the same partition; the spread shows under real load.
+- **No ordering assumptions.** The system-of-record runs 5 workers, and minimalist-kafka's default
+  `SimpleRandomPartitioner` (stateless uniform random - Kafka's sticky default would skew low-volume
+  traffic onto one partition) spreads messages across the 10 partitions - watch the `partition=` value
+  vary in the listener.
 - **The bridge is pure YAML.** Consuming with `schema.enabled: true` hands the flow a decoded Map;
   publishing with a `subject` header re-encodes. The two bridge flows are just topic-to-topic mappings —
   `bridge-request.yml` and `bridge-response.yml`.

--- a/examples/twin-kafka-demo/README.md
+++ b/examples/twin-kafka-demo/README.md
@@ -177,9 +177,9 @@ The immediate HTTP ack uses `originator: HTTP_REQUEST`; the system-of-record's o
 - **The bridge is pure YAML.** Consuming with `schema.enabled: true` hands the flow a decoded Map;
   publishing with a `subject` header re-encodes. The two bridge flows are just topic-to-topic mappings —
   `bridge-request.yml` and `bridge-response.yml`.
-- **Maps become JSON bytes with `:binary`.** The notification functions take `byte[]`, so wherever a flow
-  holds a Map (a schema-decoded consume, or a task result), the type-qualifier mapping
-  `model.x:binary -> *` serializes it to its JSON bytes — still pure YAML, no conversion task.
+- **Maps become JSON bytes with `f:binary()`.** The notification functions take `byte[]`, so wherever a
+  flow holds a Map (a schema-decoded consume, or a task result), the pluggable-function mapping
+  `f:binary(model.x) -> *` serializes it to its JSON bytes — still pure YAML, no conversion task.
 - **The Confluent frame is JSON-friendly.** After the 5-byte frame (magic byte + schema id), a JSON
   Schema value is the plain UTF-8 JSON string — that is why `listen_response.js` can print it directly
   (an Avro value would be Avro binary).

--- a/examples/twin-kafka-demo/README.md
+++ b/examples/twin-kafka-demo/README.md
@@ -1,0 +1,186 @@
+# twin-kafka-demo — profile management bridged across two Kafka clusters
+
+A worked example for the **twin-kafka** module: a hypothetical profile management service whose
+requests enter through HTTP on the **on-prem** side, cross a **dual-cluster bridge**, and are served by a
+system-of-record on the **cloud** side — with the trace id and business correlation id staying continuous
+across two Kafka clusters and three applications.
+
+```
+curl ──> [rest app] ──OP_PROFILE_REQUEST──> [bridge app] ──C_PROFILE_REQUEST──> [sor app]
+          (202 ack)     on-prem, JSON Schema    twin-kafka      cloud, plain JSON      /tmp store
+                                                                                          │
+listener <──OP_PROFILE_RESPONSE── [bridge app] <──C_PROFILE_RESPONSE──────────────────────┘
+ (node)      on-prem, JSON Schema
+```
+
+The two clusters are deliberately **asymmetric** — the on-prem cluster governs messages with a Confluent
+Schema Registry (JSON Schema wire format); the cloud cluster carries plain JSON bytes. This mirrors the
+real-world topologies the twin-kafka module was designed for (on-prem Confluent + cloud open-source Kafka
+or Azure Event Hubs, and every combination in between): the Schema Registry is **per-cluster and
+optional**, and the bridge **decodes and re-encodes** rather than relaying framed bytes, because a schema
+id is only meaningful to the registry that issued it.
+
+## The three roles (one jar)
+
+| Profile | Side | What it does | Kafka footprint |
+|---------|------|--------------|-----------------|
+| `rest`  | on-prem | REST edge: `GET`/`POST`/`DELETE /api/profile` → immediate **202** ack, then publishes the Request to `OP_PROFILE_REQUEST` (subject `op-profile-request`) | minimalist-kafka (producer only, with registry) |
+| `bridge` | both | `OP_PROFILE_REQUEST` → decode → `C_PROFILE_REQUEST` (plain JSON); `C_PROFILE_RESPONSE` → re-encode (subject `op-profile-response`) → `OP_PROFILE_RESPONSE`. **Both flows are pure YAML — no Java.** | twin-kafka (primary + secondary) |
+| `sor`  | cloud | System-of-record: applies READ / UPSERT / DELETE to the temp store `/tmp/twin-kafka-demo` (one JSON file per id; 5 workers) and publishes the outcome to `C_PROFILE_RESPONSE`. Errors travel as data — a READ of a missing id replies `not found`. | minimalist-kafka (its "primary" IS the cloud broker — no registry) |
+
+> **Zero-weight principle.** In a real deployment only the bridge carries the twin-kafka dependency; the
+> rest and sor roles are plain minimalist-kafka apps (the sor's bootstrap simply points at the cloud
+> broker). This demo packages all three roles in ONE jar for convenience — the secondary flow adapter
+> starts only in the bridge profile because only `application-bridge.properties` sets
+> `yaml.secondary.kafka.flow.adapter`.
+
+## Trace and correlation continuity
+
+All roles configure explicit Kafka header names (the 4.8.0 configurable headers):
+
+```properties
+kafka.trace.id.header=X-Trace-Id
+kafka.correlation.id.header=X-Correlation-Id
+```
+
+`simple.kafka.notification` / `secondary.kafka.notification` stamp both automatically on every publish
+(no flow mapping needed), and each flow adapter continues the trace and carries the business
+correlation id (`model.cid`) on consume. The node listener at the end of the chain prints the very ids
+minted at the HTTP edge — send `-H 'X-Correlation-Id: <your id>'` with curl and watch it come back after
+two clusters and three apps.
+
+## Build
+
+```shell
+# from the repository root: install the framework libraries first (skip if already installed)
+mvn -q clean install -DskipTests
+
+cd examples/twin-kafka-demo
+mvn clean package
+cd node && npm install && cd ..
+```
+
+## Run (the multi-terminal method)
+
+All commands from the repository root. `x.y.z` is the current version.
+
+### Terminal A — both Kafka brokers (one JVM)
+
+```shell
+cd helpers/kafka-standalone && java -Ddual.servers=true -jar target/kafka-standalone-x.y.z-exec.jar
+```
+
+The on-prem broker listens on **9092**, the cloud broker on **8092**.
+
+### Terminal B — the on-prem Schema Registry (seeded)
+
+The producer never registers schemas at runtime (schemas are governed artifacts), so seed the registry's
+store with the demo's two subjects before starting it:
+
+```shell
+mkdir -p /tmp/schema-registry
+cp examples/twin-kafka-demo/registry/*.json /tmp/schema-registry/
+cd helpers/schema-registry-standalone && java -jar target/schema-registry-standalone-x.y.z.jar
+```
+
+Subjects `op-profile-request` (seed `11.json`) and `op-profile-response` (seed `12.json`), port **8081**.
+
+### Terminal C — create the topics (both clusters, 10 partitions)
+
+```shell
+cd examples/twin-kafka-demo/node && node create_topic.js
+```
+
+> Run this **before** the apps — otherwise the flow adapter auto-creates the topics at 1 partition.
+
+### Terminals D, E, F — the three apps
+
+```shell
+java -Dspring.profiles.active=sor    -jar examples/twin-kafka-demo/target/twin-kafka-demo-x.y.z.jar
+java -Dspring.profiles.active=bridge -jar examples/twin-kafka-demo/target/twin-kafka-demo-x.y.z.jar
+java -Dspring.profiles.active=rest   -jar examples/twin-kafka-demo/target/twin-kafka-demo-x.y.z.jar
+```
+
+The rest app serves HTTP on **8500**.
+
+### Terminal G — the response listener
+
+```shell
+cd examples/twin-kafka-demo/node && node listen_response.js
+```
+
+### Terminal H — drive it with curl
+
+```shell
+# CREATE/UPDATE (UPSERT)
+curl -sS -X POST http://127.0.0.1:8500/api/profile \
+     -H 'content-type: application/json' -H 'X-Correlation-Id: order-001' \
+     -d '{"id":100,"name":"Peter Parker","address":"20 Ingram Street, Queens","telephone":"212-555-1212"}'
+
+# READ
+curl -sS -H 'X-Correlation-Id: order-002' http://127.0.0.1:8500/api/profile/100
+
+# DELETE
+curl -sS -X DELETE -H 'X-Correlation-Id: order-003' http://127.0.0.1:8500/api/profile/100
+
+# READ again -> the system of record replies "not found" (errors travel as data)
+curl -sS -H 'X-Correlation-Id: order-004' http://127.0.0.1:8500/api/profile/100
+```
+
+Each curl returns the immediate ack (**202**):
+
+```json
+{"command":"UPSERT","id":100,"originator":"HTTP_REQUEST","message":"Request accepted for processing"}
+```
+
+…and a moment later the listener prints the system-of-record's outcome, e.g.:
+
+```
+[2026-07-11T...Z] topic=OP_PROFILE_RESPONSE partition=6 schemaId=12
+  X-Trace-Id=4f0e2a...
+  X-Correlation-Id=order-001
+  {"command":"UPSERT","id":100,"profile":{...},"originator":"SYSTEM_OF_RECORDS","message":"Profile 100 saved"}
+```
+
+Note the `X-Correlation-Id` you sent from curl and the `X-Trace-Id` minted at the HTTP edge — both
+continuous across the on-prem cluster, the bridge, the cloud cluster, the system of record, and back.
+
+## Message shapes
+
+**Request** (subject `op-profile-request`, on-prem; plain JSON on the cloud):
+
+```json
+{ "command": "READ | UPSERT | DELETE", "id": 100, "profile": { "id", "name", "address", "telephone" } }
+```
+
+`profile` is present for UPSERT only.
+
+**Response** (subject `op-profile-response`, on-prem; plain JSON on the cloud):
+
+```json
+{ "command": "...", "id": 100, "profile": { ... }, "originator": "HTTP_REQUEST | SYSTEM_OF_RECORDS",
+  "message": "some relevant status message" }
+```
+
+The immediate HTTP ack uses `originator: HTTP_REQUEST`; the system-of-record's outcome uses
+`originator: SYSTEM_OF_RECORDS`.
+
+## Design notes
+
+- **Fully asynchronous.** The HTTP request is acknowledged immediately (`execution: response`); the
+  outcome is observed on the response topic. No sync-over-async (see the sync-over-async-demo for that
+  pattern) and no field encryption (see composable-example).
+- **No ordering assumptions.** The system-of-record runs 5 workers and messages spread across the 10
+  partitions by the producer's default (sticky) partitioner. At demo pace consecutive messages often
+  share a batch and land on the same partition; the spread shows under real load.
+- **The bridge is pure YAML.** Consuming with `schema.enabled: true` hands the flow a decoded Map;
+  publishing with a `subject` header re-encodes. The two bridge flows are just topic-to-topic mappings —
+  `bridge-request.yml` and `bridge-response.yml`.
+- **Maps become JSON bytes with `:binary`.** The notification functions take `byte[]`, so wherever a flow
+  holds a Map (a schema-decoded consume, or a task result), the type-qualifier mapping
+  `model.x:binary -> *` serializes it to its JSON bytes — still pure YAML, no conversion task.
+- **The Confluent frame is JSON-friendly.** After the 5-byte frame (magic byte + schema id), a JSON
+  Schema value is the plain UTF-8 JSON string — that is why `listen_response.js` can print it directly
+  (an Avro value would be Avro binary).
+- **DLQ stays default-on** but is not demonstrated here; see the twin-kafka guide for the per-cluster
+  dead-letter behavior.

--- a/examples/twin-kafka-demo/node/.gitignore
+++ b/examples/twin-kafka-demo/node/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+npm-debug.log*
+.DS_STORE

--- a/examples/twin-kafka-demo/node/config.js
+++ b/examples/twin-kafka-demo/node/config.js
@@ -1,0 +1,25 @@
+// Shared configuration for the twin-kafka-demo node helpers.
+// Override the broker lists with KAFKA_BOOTSTRAP_SERVERS (on-prem) and
+// CLOUD_KAFKA_BOOTSTRAP_SERVERS (cloud) - matching the Java apps' defaults.
+
+export default {
+  // the kafka-standalone helper with dual.servers=true: on-prem on 9092, cloud on 8092
+  onPremBrokers: (process.env.KAFKA_BOOTSTRAP_SERVERS || '127.0.0.1:9092').split(','),
+  cloudBrokers: (process.env.CLOUD_KAFKA_BOOTSTRAP_SERVERS || '127.0.0.1:8092').split(','),
+
+  onPremTopics: ['OP_PROFILE_REQUEST', 'OP_PROFILE_RESPONSE'],   // JSON Schema wire format
+  cloudTopics: ['C_PROFILE_REQUEST', 'C_PROFILE_RESPONSE'],      // plain JSON bytes
+
+  responseTopic: 'OP_PROFILE_RESPONSE',   // what listen_response.js watches
+
+  // header names configured in the Java apps' application.properties
+  traceHeader: 'X-Trace-Id',
+  correlationHeader: 'X-Correlation-Id',
+
+  // Multiple partitions so the system-of-record consumer group can spread across instances.
+  // (Auto-created topics get only 1 partition - run create_topic.js BEFORE the apps.)
+  partitions: 10,
+
+  // ISO-8601 timestamp for simple, sortable console logging
+  ts: () => new Date().toISOString(),
+};

--- a/examples/twin-kafka-demo/node/create_topic.js
+++ b/examples/twin-kafka-demo/node/create_topic.js
@@ -1,0 +1,40 @@
+// create_topic.js - administratively create the demo topics (10 partitions each) on BOTH clusters.
+// Run once after starting kafka-standalone (dual.servers=true):  node create_topic.js
+//
+// Run this BEFORE the apps - the flow adapter auto-creates missing topics at only 1 partition.
+
+import kafkajs from 'kafkajs';
+import cfg from './config.js';
+
+const { Kafka } = kafkajs;
+
+async function createTopics(label, brokers, topics) {
+  const kafka = new Kafka({ clientId: 'twin-demo-admin', brokers });
+  const admin = kafka.admin();
+  await admin.connect();
+  try {
+    const existing = await admin.listTopics();
+    const toCreate = topics
+      .filter((t) => !existing.includes(t))
+      .map((topic) => ({ topic, numPartitions: cfg.partitions, replicationFactor: 1 }));
+
+    if (toCreate.length === 0) {
+      console.log(`[${cfg.ts()}] ${label}: topics already exist: ${topics.join(', ')}`);
+    } else {
+      await admin.createTopics({ topics: toCreate, waitForLeaders: true });
+      console.log(
+        `[${cfg.ts()}] ${label}: created (${cfg.partitions} partitions each): ${toCreate.map((t) => t.topic).join(', ')}`
+      );
+    }
+  } finally {
+    await admin.disconnect();
+  }
+}
+
+(async () => {
+  await createTopics('on-prem', cfg.onPremBrokers, cfg.onPremTopics);
+  await createTopics('cloud', cfg.cloudBrokers, cfg.cloudTopics);
+})().catch((e) => {
+  console.error(`[${cfg.ts()}] error:`, e.message);
+  process.exit(1);
+});

--- a/examples/twin-kafka-demo/node/listen_response.js
+++ b/examples/twin-kafka-demo/node/listen_response.js
@@ -1,0 +1,50 @@
+// listen_response.js - watch the on-prem response topic and print each profile Response with its Kafka
+// metadata (topic, partition), schema id, trace id and correlation id.
+//
+//   node listen_response.js
+//
+// The on-prem cluster uses the Schema Registry, so each value is in the Confluent wire format:
+// magic byte 0x0 + 4-byte big-endian schema id + the payload. For JSON Schema the payload is the plain
+// UTF-8 JSON string (the serde does not transform it), so after stripping the 5-byte frame the message
+// prints directly. (This trick is JSON-Schema-specific: Avro would leave Avro binary after the frame.)
+
+import kafkajs from 'kafkajs';
+import cfg from './config.js';
+
+const { Kafka, logLevel } = kafkajs;
+
+const header = (message, name) => {
+  const value = message.headers?.[name];
+  return value ? value.toString() : '(none)';
+};
+
+(async () => {
+  const kafka = new Kafka({ clientId: 'twin-demo-listener', brokers: cfg.onPremBrokers, logLevel: logLevel.NOTHING });
+  const consumer = kafka.consumer({ groupId: 'twin-demo-listener-group' });
+  await consumer.connect();
+  await consumer.subscribe({ topic: cfg.responseTopic, fromBeginning: false });
+  console.log(`[${cfg.ts()}] listening on ${cfg.responseTopic} (${cfg.onPremBrokers.join(',')}) ...`);
+
+  await consumer.run({
+    eachMessage: async ({ topic, partition, message }) => {
+      const value = message.value ?? Buffer.alloc(0);
+      let schemaId = '(none)';
+      let json = value.toString('utf8');
+      if (value.length >= 5 && value[0] === 0) {
+        schemaId = value.readUInt32BE(1);
+        json = value.subarray(5).toString('utf8');
+      }
+      console.log(`[${cfg.ts()}] topic=${topic} partition=${partition} schemaId=${schemaId}`);
+      console.log(`  ${cfg.traceHeader}=${header(message, cfg.traceHeader)}`);
+      console.log(`  ${cfg.correlationHeader}=${header(message, cfg.correlationHeader)}`);
+      try {
+        console.log(`  ${JSON.stringify(JSON.parse(json))}`);
+      } catch {
+        console.log(`  (not JSON) ${json}`);
+      }
+    },
+  });
+})().catch((e) => {
+  console.error(`[${cfg.ts()}] error:`, e.message);
+  process.exit(1);
+});

--- a/examples/twin-kafka-demo/node/package.json
+++ b/examples/twin-kafka-demo/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "twin-kafka-demo-node",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Node helpers for the twin-kafka worked example (topic admin + response listener)",
+  "type": "module",
+  "scripts": {
+    "create-topics": "node create_topic.js",
+    "listen": "node listen_response.js"
+  },
+  "dependencies": {
+    "kafkajs": "^2.2.4"
+  }
+}

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.platformlambda</groupId>
+    <artifactId>twin-kafka-demo</artifactId>
+    <packaging>jar</packaging>
+    <version>4.8.0</version>
+    <name>Worked example: profile management bridged across two Kafka clusters</name>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.0</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.24</tomcat.version>
+        <netty.version>4.2.16.Final</netty.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <kafka.version>4.2.0</kafka.version>
+        <gson.version>2.14.0</gson.version>
+        <java.version>21</java.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>2025.0.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Converge Guava to platform-core's version: Confluent's serdes (via twin-kafka ->
+                 minimalist-kafka) otherwise win with an older 32.0.1. The failureaccess companion already
+                 arrives transitively; this keeps the demo on the same Guava as the reactor. -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>33.5.0-jre</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- twin-kafka brings secondary.kafka.notification + the secondary flow adapter, and transitively
+             minimalist-kafka + event-script + platform-core. Only the bridge role actually uses the
+             secondary cluster; the demo packages all three roles in ONE jar for convenience. In a real
+             deployment the REST and system-of-record apps would depend on minimalist-kafka only. -->
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>twin-kafka</artifactId>
+            <version>4.8.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>6.0.3</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <skipTests>false</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- AutoStart will find your Main Application(s) -->
+                <configuration>
+                    <mainClass>org.platformlambda.core.system.AutoStart</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -166,6 +166,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/examples/twin-kafka-demo/registry/11.json
+++ b/examples/twin-kafka-demo/registry/11.json
@@ -1,0 +1,6 @@
+{
+  "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"ProfileRequest\",\"type\":\"object\",\"properties\":{\"command\":{\"type\":\"string\",\"enum\":[\"READ\",\"UPSERT\",\"DELETE\"]},\"id\":{\"type\":\"integer\"},\"profile\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"address\":{\"type\":\"string\"},\"telephone\":{\"type\":\"string\"}},\"additionalProperties\":true}},\"required\":[\"command\",\"id\"],\"additionalProperties\":true}",
+  "schemaType": "JSON",
+  "subject": "op-profile-request",
+  "version": 1
+}

--- a/examples/twin-kafka-demo/registry/12.json
+++ b/examples/twin-kafka-demo/registry/12.json
@@ -1,0 +1,6 @@
+{
+  "schema": "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"ProfileResponse\",\"type\":\"object\",\"properties\":{\"command\":{\"type\":\"string\",\"enum\":[\"READ\",\"UPSERT\",\"DELETE\"]},\"id\":{\"type\":\"integer\"},\"profile\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"},\"address\":{\"type\":\"string\"},\"telephone\":{\"type\":\"string\"}},\"additionalProperties\":true},\"originator\":{\"type\":\"string\",\"enum\":[\"HTTP_REQUEST\",\"SYSTEM_OF_RECORDS\"]},\"message\":{\"type\":\"string\"}},\"required\":[\"command\",\"id\",\"originator\"],\"additionalProperties\":true}",
+  "schemaType": "JSON",
+  "subject": "op-profile-response",
+  "version": 1
+}

--- a/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/MainApp.java
+++ b/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/MainApp.java
@@ -1,0 +1,65 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.twin.demo;
+
+import org.platformlambda.core.annotations.MainApplication;
+import org.platformlambda.core.models.EntryPoint;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Entry point for the twin-kafka worked example. The same jar runs in one of three roles, selected by
+ * the active Spring profile ({@code -Dspring.profiles.active=rest|bridge|sor}):
+ *
+ * <ul>
+ *   <li><b>rest</b> - the HTTP edge on the on-prem side. Accepts READ / UPSERT / DELETE profile requests,
+ *       acknowledges immediately (202), and publishes each request to the on-prem {@code OP_PROFILE_REQUEST}
+ *       topic in the Confluent JSON Schema wire format via {@code simple.kafka.notification}.</li>
+ *   <li><b>bridge</b> - the twin-kafka dual-cluster bridge. Consumes {@code OP_PROFILE_REQUEST} from the
+ *       on-prem cluster (schema-decoded), forwards it to the cloud {@code C_PROFILE_REQUEST} topic as plain
+ *       JSON bytes via {@code secondary.kafka.notification}; and in the reverse direction consumes
+ *       {@code C_PROFILE_RESPONSE} from the cloud and re-encodes it onto the on-prem
+ *       {@code OP_PROFILE_RESPONSE} topic with the response schema. Both flows are pure YAML - no Java.</li>
+ *   <li><b>sor</b> - the system-of-record on the cloud side. A plain single-cluster consumer whose
+ *       "primary" IS the cloud broker: it consumes {@code C_PROFILE_REQUEST}, applies the command to the
+ *       temp store {@code /tmp/twin-kafka-demo} (one JSON file per profile id), and publishes the outcome
+ *       to {@code C_PROFILE_RESPONSE}.</li>
+ * </ul>
+ *
+ * <p>In a real deployment only the bridge would carry the twin-kafka dependency - the rest and sor roles
+ * are plain minimalist-kafka apps. This demo packages all three in one jar for convenience; the secondary
+ * flow adapter starts only in the bridge profile because only application-bridge.properties sets
+ * {@code yaml.secondary.kafka.flow.adapter}.</p>
+ */
+@MainApplication
+public class MainApp implements EntryPoint {
+    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
+
+    public static void main(String[] args) {
+        AutoStart.main(args);
+    }
+
+    @Override
+    public void start(String[] args) {
+        String profiles = AppConfigReader.getInstance().getProperty("spring.profiles.active", "(none)");
+        log.info("twin-kafka-demo started; active profile(s)={}", profiles);
+    }
+}

--- a/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ApiRequest.java
+++ b/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ApiRequest.java
@@ -1,0 +1,90 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.twin.demo.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.util.Utility;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * First task of the three REST flows (rest role). Validates the incoming HTTP request, builds the
+ * profile Request message, and returns both the message and the immediate acknowledgment:
+ *
+ * <ul>
+ *   <li>{@code result.request} - the Request map {@code {command, id, profile?}} that the flow publishes
+ *       to the on-prem {@code OP_PROFILE_REQUEST} topic (subject {@code op-profile-request})</li>
+ *   <li>{@code result.ack} - the 202 body returned to the caller right away ({@code execution: response}),
+ *       with {@code originator: HTTP_REQUEST}</li>
+ * </ul>
+ *
+ * <p>The command arrives as the {@code command} task header (a constant per flow). READ and DELETE carry
+ * the profile id as a path parameter; UPSERT carries the full profile in the request body and takes the
+ * id from {@code profile.id}.</p>
+ */
+@PreLoad(route = "v1.api.request", instances = 10)
+public class ApiRequest implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+
+    private static final String COMMAND = "command";
+    private static final String UPSERT = "UPSERT";
+    private static final String ID = "id";
+    private static final String PROFILE = "profile";
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input,
+                                           int instance) throws AppException {
+        String command = headers.get(COMMAND);
+        if (command == null) {
+            throw new AppException(500, "Missing 'command' task header - check the flow definition");
+        }
+        Map<String, Object> request = new HashMap<>();
+        request.put(COMMAND, command);
+        if (UPSERT.equals(command)) {
+            Object profile = input.get(PROFILE);
+            if (!(profile instanceof Map) || ((Map<?, ?>) profile).isEmpty()) {
+                throw new AppException(400, "Missing profile in request body");
+            }
+            int id = parseId(((Map<?, ?>) profile).get(ID));
+            request.put(ID, id);
+            request.put(PROFILE, profile);
+        } else {
+            request.put(ID, parseId(input.get(ID)));
+        }
+        Map<String, Object> ack = new HashMap<>();
+        ack.put(COMMAND, command);
+        ack.put(ID, request.get(ID));
+        ack.put("originator", "HTTP_REQUEST");
+        ack.put("message", "Request accepted for processing");
+        Map<String, Object> result = new HashMap<>();
+        result.put("request", request);
+        result.put("ack", ack);
+        return result;
+    }
+
+    private int parseId(Object id) throws AppException {
+        int n = Utility.getInstance().str2int(String.valueOf(id));
+        if (n <= 0) {
+            throw new AppException(400, "Profile id must be a positive integer");
+        }
+        return n;
+    }
+}

--- a/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
+++ b/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
@@ -1,0 +1,103 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.twin.demo.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.serializers.SimpleMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The system-of-record task (sor role), consuming READ / UPSERT / DELETE requests off the cloud
+ * {@code C_PROFILE_REQUEST} topic. The cloud cluster has no Schema Registry, so the payload is the plain
+ * JSON string of the Request as byte[] - parsed here with the platform's JSON mapper.
+ *
+ * <p>The "database" is the temp store {@code /tmp/twin-kafka-demo}: one {@code <id>.json} file per
+ * profile. Every command gets a Response (errors travel as data - a READ or DELETE of a missing id
+ * replies with "not found" rather than failing), which the flow publishes to {@code C_PROFILE_RESPONSE}.</p>
+ *
+ * <p>Runs with multiple workers ({@code instances=5}) - processing is asynchronous end to end and no
+ * message ordering is assumed.</p>
+ */
+@PreLoad(route = "v1.profile.store", instances = 5)
+public class ProfileStore implements TypedLambdaFunction<byte[], Map<String, Object>> {
+
+    private static final Logger log = LoggerFactory.getLogger(ProfileStore.class);
+
+    private static final String STORE_DIR = "/tmp/twin-kafka-demo";
+    private static final String COMMAND = "command";
+    private static final String ID = "id";
+    private static final String PROFILE = "profile";
+    private static final String MESSAGE = "message";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> handleEvent(Map<String, String> headers, byte[] input, int instance)
+            throws IOException {
+        String requestJson = new String(input, StandardCharsets.UTF_8);
+        Map<String, Object> request = SimpleMapper.getInstance().getMapper().readValue(requestJson, Map.class);
+        String command = String.valueOf(request.get(COMMAND));
+        // the platform's JSON mapper parses whole numbers as Long
+        int id = request.get(ID) instanceof Number n ? n.intValue() : -1;
+        Map<String, Object> response = new HashMap<>();
+        response.put(COMMAND, command);
+        response.put(ID, id);
+        response.put("originator", "SYSTEM_OF_RECORDS");
+        File store = new File(STORE_DIR);
+        if (!store.exists() && !store.mkdirs()) {
+            throw new IOException("Unable to create temp store " + STORE_DIR);
+        }
+        File record = new File(store, id + ".json");
+        switch (command) {
+            case "READ" -> {
+                if (record.exists()) {
+                    response.put(PROFILE, SimpleMapper.getInstance().getMapper().readValue(
+                            Files.readString(record.toPath()), Map.class));
+                    response.put(MESSAGE, "Profile " + id + " found");
+                } else {
+                    response.put(MESSAGE, "Profile " + id + " not found");
+                }
+            }
+            case "UPSERT" -> {
+                Files.writeString(record.toPath(), SimpleMapper.getInstance().getMapper()
+                        .writeValueAsString(request.get(PROFILE)));
+                response.put(PROFILE, request.get(PROFILE));
+                response.put(MESSAGE, "Profile " + id + " saved");
+            }
+            case "DELETE" -> {
+                if (Files.deleteIfExists(record.toPath())) {
+                    response.put(MESSAGE, "Profile " + id + " deleted");
+                } else {
+                    response.put(MESSAGE, "Profile " + id + " not found");
+                }
+            }
+            default -> response.put(MESSAGE, "Unknown command " + command);
+        }
+        log.info("worker-{} {} id={} - {}", instance, command, id, response.get(MESSAGE));
+        return response;
+    }
+}

--- a/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
+++ b/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +33,7 @@ import java.util.Map;
 /**
  * The system-of-record task (sor role), consuming READ / UPSERT / DELETE requests off the cloud
  * {@code C_PROFILE_REQUEST} topic. The cloud cluster has no Schema Registry, so the payload is the plain
- * JSON string of the Request as byte[] - parsed here with the platform's JSON mapper.
+ * JSON string of the Request as byte[] - parsed directly by the platform's JSON mapper.
  *
  * <p>The "database" is the temp store {@code /tmp/twin-kafka-demo}: one {@code <id>.json} file per
  * profile. Every command gets a Response (errors travel as data - a READ or DELETE of a missing id
@@ -58,8 +57,7 @@ public class ProfileStore implements TypedLambdaFunction<byte[], Map<String, Obj
     @SuppressWarnings("unchecked")
     public Map<String, Object> handleEvent(Map<String, String> headers, byte[] input, int instance)
             throws IOException {
-        String requestJson = new String(input, StandardCharsets.UTF_8);
-        Map<String, Object> request = SimpleMapper.getInstance().getMapper().readValue(requestJson, Map.class);
+        Map<String, Object> request = SimpleMapper.getInstance().getMapper().readValue(input, Map.class);
         String command = String.valueOf(request.get(COMMAND));
         // the platform's JSON mapper parses whole numbers as Long
         int id = request.get(ID) instanceof Number n ? n.intValue() : -1;
@@ -71,33 +69,37 @@ public class ProfileStore implements TypedLambdaFunction<byte[], Map<String, Obj
         if (!store.exists() && !store.mkdirs()) {
             throw new IOException("Unable to create temp store " + STORE_DIR);
         }
-        File record = new File(store, id + ".json");
+        File dataFile = new File(store, id + ".json");
         switch (command) {
             case "READ" -> {
-                if (record.exists()) {
+                if (dataFile.exists()) {
                     response.put(PROFILE, SimpleMapper.getInstance().getMapper().readValue(
-                            Files.readString(record.toPath()), Map.class));
-                    response.put(MESSAGE, "Profile " + id + " found");
+                            Files.readString(dataFile.toPath()), Map.class));
+                    response.put(MESSAGE, profileMessage(id, "found"));
                 } else {
-                    response.put(MESSAGE, "Profile " + id + " not found");
+                    response.put(MESSAGE, profileMessage(id, "not found"));
                 }
             }
             case "UPSERT" -> {
-                Files.writeString(record.toPath(), SimpleMapper.getInstance().getMapper()
+                Files.writeString(dataFile.toPath(), SimpleMapper.getInstance().getMapper()
                         .writeValueAsString(request.get(PROFILE)));
                 response.put(PROFILE, request.get(PROFILE));
-                response.put(MESSAGE, "Profile " + id + " saved");
+                response.put(MESSAGE, profileMessage(id, "saved"));
             }
             case "DELETE" -> {
-                if (Files.deleteIfExists(record.toPath())) {
-                    response.put(MESSAGE, "Profile " + id + " deleted");
+                if (Files.deleteIfExists(dataFile.toPath())) {
+                    response.put(MESSAGE, profileMessage(id, "deleted"));
                 } else {
-                    response.put(MESSAGE, "Profile " + id + " not found");
+                    response.put(MESSAGE, profileMessage(id, "not found"));
                 }
             }
             default -> response.put(MESSAGE, "Unknown command " + command);
         }
         log.info("worker-{} {} id={} - {}", instance, command, id, response.get(MESSAGE));
         return response;
+    }
+
+    private String profileMessage(int id, String outcome) {
+        return "Profile " + id + " " + outcome;
     }
 }

--- a/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
+++ b/examples/twin-kafka-demo/src/main/java/com/accenture/twin/demo/tasks/ProfileStore.java
@@ -42,6 +42,9 @@ import java.util.Map;
  * <p>Runs with multiple workers ({@code instances=5}) - processing is asynchronous end to end and no
  * message ordering is assumed.</p>
  */
+// S5443 (publicly writable directory): /tmp/twin-kafka-demo IS the demo's simulated database by
+// design - throwaway local data, no confidentiality or integrity requirement
+@SuppressWarnings("java:S5443")
 @PreLoad(route = "v1.profile.store", instances = 5)
 public class ProfileStore implements TypedLambdaFunction<byte[], Map<String, Object>> {
 

--- a/examples/twin-kafka-demo/src/main/resources/application-bridge.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-bridge.properties
@@ -1,0 +1,28 @@
+#
+# bridge role: the twin-kafka dual-cluster bridge. No REST.
+#   java -Dspring.profiles.active=bridge -jar target/twin-kafka-demo-4.8.0.jar
+#
+# PRIMARY  = the on-prem cluster (9092, WITH Schema Registry)  - minimalist-kafka surface
+# SECONDARY = the cloud cluster  (8092, no Schema Registry)    - twin-kafka surface
+#
+rest.automation=false
+
+# the two bridge flows (request-forward and response-forward) - both pure YAML
+yaml.flow.automation=classpath:/flows-bridge.yaml
+
+# primary (on-prem) client config: bundled minimalist-kafka templates, default bootstrap
+# ${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:9092}
+kafka.producer.properties=file:/tmp/config/kafka-producer.properties,classpath:/kafka-producer.properties
+kafka.consumer.properties=file:/tmp/config/kafka-consumer.properties,classpath:/kafka-consumer.properties
+# consume the on-prem request topic (schema-decoded) into the bridge-request flow
+yaml.kafka.flow.adapter=classpath:/kafka-adapter-bridge-primary.yaml
+
+# the on-prem cluster's Schema Registry: decode inbound OP_PROFILE_REQUEST, re-encode outbound
+# OP_PROFILE_RESPONSE
+schema.registry.url=${SCHEMA_REGISTRY_URL:http://127.0.0.1:8081}
+
+# secondary (cloud) client config: bundled twin-kafka templates, default bootstrap
+# ${SECONDARY_KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:8092} - the kafka-standalone helper's second broker.
+# Setting yaml.secondary.kafka.flow.adapter is what starts the secondary consumer - only this role has it.
+# No secondary.schema.registry.url: the cloud cluster carries plain JSON bytes.
+yaml.secondary.kafka.flow.adapter=classpath:/kafka-adapter-bridge-secondary.yaml

--- a/examples/twin-kafka-demo/src/main/resources/application-rest.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-rest.properties
@@ -1,0 +1,20 @@
+#
+# rest role: the HTTP edge on the on-prem side.
+#   java -Dspring.profiles.active=rest -jar target/twin-kafka-demo-4.8.0.jar
+#
+# Publishes profile requests to the on-prem OP_PROFILE_REQUEST topic in the Confluent JSON Schema wire
+# format. It consumes nothing (responses are observed by the node listener), so no flow adapter here.
+#
+rest.automation=true
+rest.server.port=8500
+yaml.rest.automation=classpath:/rest.yaml
+
+# the three REST-triggered flows (READ / UPSERT / DELETE)
+yaml.flow.automation=classpath:/flows-rest.yaml
+
+# on-prem Kafka producer (bundled minimalist-kafka template; default bootstrap
+# ${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:9092} - the kafka-standalone helper's first broker)
+kafka.producer.properties=file:/tmp/config/kafka-producer.properties,classpath:/kafka-producer.properties
+
+# the on-prem cluster governs messages with a Schema Registry (the schema-registry-standalone helper)
+schema.registry.url=${SCHEMA_REGISTRY_URL:http://127.0.0.1:8081}

--- a/examples/twin-kafka-demo/src/main/resources/application-sor.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-sor.properties
@@ -1,0 +1,22 @@
+#
+# sor role: the system-of-record on the cloud side. No REST.
+#   java -Dspring.profiles.active=sor -jar target/twin-kafka-demo-4.8.0.jar
+#
+# A plain single-cluster minimalist-kafka app whose "primary" IS the cloud broker (8092): it consumes
+# C_PROFILE_REQUEST, applies the command to the temp store /tmp/twin-kafka-demo, and publishes the
+# outcome to C_PROFILE_RESPONSE. No schema.registry.url - the cloud cluster carries plain JSON bytes.
+#
+# (In a real deployment this app would depend on minimalist-kafka only; it needs nothing from twin-kafka.)
+#
+rest.automation=false
+
+# the system-of-record flow
+yaml.flow.automation=classpath:/flows-sor.yaml
+
+# cloud Kafka client config: demo-local template variants whose default bootstrap is
+# ${CLOUD_KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:8092}
+kafka.producer.properties=file:/tmp/config/sor-kafka-producer.properties,classpath:/sor-kafka-producer.properties
+kafka.consumer.properties=file:/tmp/config/sor-kafka-consumer.properties,classpath:/sor-kafka-consumer.properties
+
+# consume the cloud request topic into the profile-store flow
+yaml.kafka.flow.adapter=classpath:/kafka-adapter-sor.yaml

--- a/examples/twin-kafka-demo/src/main/resources/application.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application.properties
@@ -1,0 +1,25 @@
+#
+# Common configuration for the twin-kafka worked example.
+#
+# The same jar runs in one of three roles, selected by the active Spring profile:
+#   rest   -> -Dspring.profiles.active=rest    (HTTP edge on the on-prem side; publishes requests)
+#   bridge -> -Dspring.profiles.active=bridge  (twin-kafka dual-cluster bridge; no REST)
+#   sor    -> -Dspring.profiles.active=sor     (system-of-record on the cloud side; no REST)
+# Profile-specific settings live in application-rest/bridge/sor.properties.
+#
+application.name=twin-kafka-demo
+web.component.scan=com.accenture
+cloud.connector=none
+log.format=text
+
+# dead-letter confirm-write timeout; flow processing is bounded by each flow's own ttl
+kafka.dlq.timeout.ms=10000
+
+# Explicit business correlation-id and trace-id header names on the Kafka wire (4.8.0 configurable
+# headers). Every role stamps and reads the same names, so the node listener at the end of the chain
+# prints the very ids minted at the HTTP edge - continuity across two clusters and three apps.
+kafka.correlation.id.header=X-Correlation-Id
+kafka.trace.id.header=X-Trace-Id
+
+# id->schema cache TTL for roles that use the Schema Registry (rest and bridge)
+schema.registry.cache.ttl=30m

--- a/examples/twin-kafka-demo/src/main/resources/flows-bridge.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/flows-bridge.yaml
@@ -1,0 +1,7 @@
+#
+# bridge role flows: forward requests on-prem -> cloud and responses cloud -> on-prem.
+# Both are pure YAML - the bridge has no application Java code.
+#
+flows:
+  - 'bridge-request.yml'
+  - 'bridge-response.yml'

--- a/examples/twin-kafka-demo/src/main/resources/flows-rest.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/flows-rest.yaml
@@ -1,0 +1,7 @@
+#
+# rest role flows: one per REST endpoint (READ / UPSERT / DELETE).
+#
+flows:
+  - 'get-profile.yml'
+  - 'upsert-profile.yml'
+  - 'delete-profile.yml'

--- a/examples/twin-kafka-demo/src/main/resources/flows-sor.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/flows-sor.yaml
@@ -1,0 +1,5 @@
+#
+# sor role flow: the system-of-record.
+#
+flows:
+  - 'profile-store.yml'

--- a/examples/twin-kafka-demo/src/main/resources/flows/bridge-request.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/bridge-request.yml
@@ -3,7 +3,7 @@
 #
 # Reached when the PRIMARY Kafka flow adapter routes a message from OP_PROFILE_REQUEST. Because that
 # binding sets schema.enabled, the adapter has already decoded the Confluent-framed value to a Map.
-# The ':binary' type qualifier serializes that Map to its JSON bytes for secondary.kafka.notification
+# The f:binary() function serializes that Map to its JSON bytes for secondary.kafka.notification
 # (which takes byte[]); no 'subject' header, so the cloud cluster receives the plain JSON string.
 #
 # This is the twin-kafka bridging rule in action: decode-and-re-encode, never relay raw framed bytes -
@@ -20,7 +20,7 @@ tasks:
   - input:
       - 'text(C_PROFILE_REQUEST) -> header.topic'
       - 'input.body -> model.payload'
-      - 'model.payload:binary -> *'
+      - 'f:binary(model.payload) -> *'
     process: 'secondary.kafka.notification'
     output: []
     description: 'Publish the decoded request to the cloud request topic as plain JSON bytes'

--- a/examples/twin-kafka-demo/src/main/resources/flows/bridge-request.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/bridge-request.yml
@@ -1,0 +1,27 @@
+#
+# Bridge request flow (bridge role) - on-prem -> cloud, pure YAML (no Java).
+#
+# Reached when the PRIMARY Kafka flow adapter routes a message from OP_PROFILE_REQUEST. Because that
+# binding sets schema.enabled, the adapter has already decoded the Confluent-framed value to a Map.
+# The ':binary' type qualifier serializes that Map to its JSON bytes for secondary.kafka.notification
+# (which takes byte[]); no 'subject' header, so the cloud cluster receives the plain JSON string.
+#
+# This is the twin-kafka bridging rule in action: decode-and-re-encode, never relay raw framed bytes -
+# a schema id is only meaningful to the registry that issued it.
+#
+flow:
+  id: 'bridge-request'
+  description: 'Forward a profile request from the on-prem cluster to the cloud cluster'
+  ttl: 30s
+
+first.task: 'secondary.kafka.notification'
+
+tasks:
+  - input:
+      - 'text(C_PROFILE_REQUEST) -> header.topic'
+      - 'input.body -> model.payload'
+      - 'model.payload:binary -> *'
+    process: 'secondary.kafka.notification'
+    output: []
+    description: 'Publish the decoded request to the cloud request topic as plain JSON bytes'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/flows/bridge-response.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/bridge-response.yml
@@ -1,0 +1,25 @@
+#
+# Bridge response flow (bridge role) - cloud -> on-prem, pure YAML (no Java).
+#
+# Reached when the SECONDARY Kafka flow adapter routes a message from C_PROFILE_RESPONSE. The cloud
+# cluster has no Schema Registry, so input.body is the raw byte[] of the JSON string. The flow hands it
+# to simple.kafka.notification with subject op-profile-response: the producer parses the JSON payload,
+# resolves the subject to the pre-registered schema id, and publishes to the on-prem response topic in
+# the Confluent JSON Schema wire format.
+#
+flow:
+  id: 'bridge-response'
+  description: 'Forward a profile response from the cloud cluster to the on-prem cluster'
+  ttl: 30s
+
+first.task: 'simple.kafka.notification'
+
+tasks:
+  - input:
+      - 'text(OP_PROFILE_RESPONSE) -> header.topic'
+      - 'text(op-profile-response) -> header.subject'
+      - 'input.body -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the response to the on-prem response topic (JSON Schema encoded)'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
@@ -1,0 +1,35 @@
+#
+# DELETE flow (rest role) - DELETE /api/profile/{id}
+#
+# Same shape as get-profile: acknowledge immediately (202), then publish the Request to the on-prem
+# request topic (JSON Schema encoded).
+#
+flow:
+  id: 'delete-profile'
+  description: 'DELETE a profile: acknowledge immediately, forward the request to the on-prem cluster'
+  ttl: 10s
+
+first.task: 'v1.api.request'
+
+tasks:
+  - input:
+      - 'text(DELETE) -> header.command'
+      - 'input.path_parameter.id -> id'
+    process: 'v1.api.request'
+    output:
+      - 'int(202) -> output.status'
+      - 'result.ack -> output.body'
+      - 'result.request -> model.request'
+    description: 'Validate the request and acknowledge the caller right away'
+    execution: response
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(OP_PROFILE_REQUEST) -> header.topic'
+      - 'text(op-profile-request) -> header.subject'
+      - 'model.request:binary -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the DELETE request to the on-prem request topic (JSON Schema encoded)'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
@@ -28,7 +28,7 @@ tasks:
   - input:
       - 'text(OP_PROFILE_REQUEST) -> header.topic'
       - 'text(op-profile-request) -> header.subject'
-      - 'model.request:binary -> *'
+      - 'f:binary(model.request) -> *'
     process: 'simple.kafka.notification'
     output: []
     description: 'Publish the DELETE request to the on-prem request topic (JSON Schema encoded)'

--- a/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml
@@ -18,6 +18,7 @@ tasks:
     process: 'v1.api.request'
     output:
       - 'int(202) -> output.status'
+      - 'text(application/json) -> output.header.content-type'
       - 'result.ack -> output.body'
       - 'result.request -> model.request'
     description: 'Validate the request and acknowledge the caller right away'

--- a/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
@@ -23,6 +23,7 @@ tasks:
     process: 'v1.api.request'
     output:
       - 'int(202) -> output.status'
+      - 'text(application/json) -> output.header.content-type'
       - 'result.ack -> output.body'
       - 'result.request -> model.request'
     description: 'Validate the request and acknowledge the caller right away'

--- a/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
@@ -33,7 +33,7 @@ tasks:
   - input:
       - 'text(OP_PROFILE_REQUEST) -> header.topic'
       - 'text(op-profile-request) -> header.subject'
-      - 'model.request:binary -> *'
+      - 'f:binary(model.request) -> *'
     process: 'simple.kafka.notification'
     output: []
     description: 'Publish the READ request to the on-prem request topic (JSON Schema encoded)'

--- a/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml
@@ -1,0 +1,40 @@
+#
+# READ flow (rest role) - GET /api/profile/{id}
+#
+#   1. v1.api.request           - validate + build the Request; acknowledge the caller immediately (202)
+#                                 while the flow continues (execution: response).
+#   2. simple.kafka.notification - publish the Request to the on-prem request topic in the Confluent
+#                                 JSON Schema wire format (subject op-profile-request, pre-registered).
+#
+# The trace-id and business correlation-id are stamped on the Kafka message automatically under the
+# configured X-Trace-Id / X-Correlation-Id headers - no explicit mapping needed.
+#
+flow:
+  id: 'get-profile'
+  description: 'READ a profile: acknowledge immediately, forward the request to the on-prem cluster'
+  ttl: 10s
+
+first.task: 'v1.api.request'
+
+tasks:
+  - input:
+      - 'text(READ) -> header.command'
+      - 'input.path_parameter.id -> id'
+    process: 'v1.api.request'
+    output:
+      - 'int(202) -> output.status'
+      - 'result.ack -> output.body'
+      - 'result.request -> model.request'
+    description: 'Validate the request and acknowledge the caller right away'
+    execution: response
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(OP_PROFILE_REQUEST) -> header.topic'
+      - 'text(op-profile-request) -> header.subject'
+      - 'model.request:binary -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the READ request to the on-prem request topic (JSON Schema encoded)'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/flows/profile-store.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/profile-store.yml
@@ -1,0 +1,36 @@
+#
+# System-of-record flow (sor role).
+#
+# Reached when this app's Kafka flow adapter routes a message from the cloud C_PROFILE_REQUEST topic
+# (raw JSON bytes - the cloud cluster has no Schema Registry).
+#
+#   1. v1.profile.store          - apply READ / UPSERT / DELETE to the temp store /tmp/twin-kafka-demo
+#                                  (5 workers; processing is asynchronous, no ordering assumed).
+#   2. simple.kafka.notification - publish the Response to C_PROFILE_RESPONSE as plain JSON bytes
+#                                  (this app's "primary" IS the cloud broker).
+#
+flow:
+  id: 'profile-store'
+  description: 'Apply the profile command to the system of record and publish the outcome'
+  ttl: 30s
+
+first.task: 'v1.profile.store'
+
+tasks:
+  - input:
+      - 'input.body -> *'
+    process: 'v1.profile.store'
+    output:
+      - 'result -> model.response'
+    description: 'Apply the command to the temp store'
+    execution: sequential
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(C_PROFILE_RESPONSE) -> header.topic'
+      - 'model.response:binary -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the outcome to the cloud response topic as plain JSON bytes'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/flows/profile-store.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/profile-store.yml
@@ -29,7 +29,7 @@ tasks:
 
   - input:
       - 'text(C_PROFILE_RESPONSE) -> header.topic'
-      - 'model.response:binary -> *'
+      - 'f:binary(model.response) -> *'
     process: 'simple.kafka.notification'
     output: []
     description: 'Publish the outcome to the cloud response topic as plain JSON bytes'

--- a/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
@@ -28,7 +28,7 @@ tasks:
   - input:
       - 'text(OP_PROFILE_REQUEST) -> header.topic'
       - 'text(op-profile-request) -> header.subject'
-      - 'model.request:binary -> *'
+      - 'f:binary(model.request) -> *'
     process: 'simple.kafka.notification'
     output: []
     description: 'Publish the UPSERT request to the on-prem request topic (JSON Schema encoded)'

--- a/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
@@ -18,6 +18,7 @@ tasks:
     process: 'v1.api.request'
     output:
       - 'int(202) -> output.status'
+      - 'text(application/json) -> output.header.content-type'
       - 'result.ack -> output.body'
       - 'result.request -> model.request'
     description: 'Validate the profile and acknowledge the caller right away'

--- a/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
+++ b/examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml
@@ -1,0 +1,35 @@
+#
+# UPSERT flow (rest role) - POST /api/profile with the profile JSON as the request body
+#
+# Same shape as get-profile: acknowledge immediately (202), then publish the Request to the on-prem
+# request topic (JSON Schema encoded). The profile id comes from profile.id in the body.
+#
+flow:
+  id: 'upsert-profile'
+  description: 'CREATE/UPDATE a profile: acknowledge immediately, forward the request to the on-prem cluster'
+  ttl: 10s
+
+first.task: 'v1.api.request'
+
+tasks:
+  - input:
+      - 'text(UPSERT) -> header.command'
+      - 'input.body -> profile'
+    process: 'v1.api.request'
+    output:
+      - 'int(202) -> output.status'
+      - 'result.ack -> output.body'
+      - 'result.request -> model.request'
+    description: 'Validate the profile and acknowledge the caller right away'
+    execution: response
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(OP_PROFILE_REQUEST) -> header.topic'
+      - 'text(op-profile-request) -> header.subject'
+      - 'model.request:binary -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the UPSERT request to the on-prem request topic (JSON Schema encoded)'
+    execution: end

--- a/examples/twin-kafka-demo/src/main/resources/kafka-adapter-bridge-primary.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/kafka-adapter-bridge-primary.yaml
@@ -1,0 +1,9 @@
+#
+# Kafka Flow Adapter for the bridge role, PRIMARY (on-prem) cluster: bind the on-prem request topic to
+# the bridge-request flow. schema.enabled decodes the Confluent-framed value to a Map before routing.
+#
+consumer:
+  - topic: 'OP_PROFILE_REQUEST'
+    flow: 'bridge-request'
+    group: '${BRIDGE_REQUEST_GROUP:bridge-request-group}'
+    schema.enabled: true

--- a/examples/twin-kafka-demo/src/main/resources/kafka-adapter-bridge-secondary.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/kafka-adapter-bridge-secondary.yaml
@@ -1,0 +1,9 @@
+#
+# Kafka Flow Adapter for the bridge role, SECONDARY (cloud) cluster: bind the cloud response topic to
+# the bridge-response flow. The cloud cluster has no Schema Registry, so the value arrives as the raw
+# byte[] of the JSON string.
+#
+consumer:
+  - topic: 'C_PROFILE_RESPONSE'
+    flow: 'bridge-response'
+    group: '${BRIDGE_RESPONSE_GROUP:bridge-response-group}'

--- a/examples/twin-kafka-demo/src/main/resources/kafka-adapter-sor.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/kafka-adapter-sor.yaml
@@ -1,0 +1,8 @@
+#
+# Kafka Flow Adapter for the sor role: bind the cloud request topic to the profile-store flow.
+# The cloud cluster has no Schema Registry, so the value arrives as the raw byte[] of the JSON string.
+#
+consumer:
+  - topic: 'C_PROFILE_REQUEST'
+    flow: 'profile-store'
+    group: '${SOR_GROUP:system-of-record-group}'

--- a/examples/twin-kafka-demo/src/main/resources/log4j2.xml
+++ b/examples/twin-kafka-demo/src/main/resources/log4j2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger:%line - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${env:LOG_LEVEL:-INFO}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Root>
+
+        <!-- Telemetry prints the end-to-end span path of each flow -->
+        <logger name="org.platformlambda.core.services.Telemetry" level="INFO" />
+
+        <!-- Reduce Kafka client noise -->
+        <logger name="org.apache.kafka.clients.admin.internals.AdminMetadataManager" level="WARN" />
+        <logger name="org.apache.kafka.clients.admin.KafkaAdminClient" level="WARN" />
+        <logger name="org.apache.kafka.common.utils.AppInfoParser" level="WARN" />
+        <logger name="org.apache.kafka.common.config.AbstractConfig" level="WARN" />
+        <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="WARN" />
+    </Loggers>
+</Configuration>

--- a/examples/twin-kafka-demo/src/main/resources/rest.yaml
+++ b/examples/twin-kafka-demo/src/main/resources/rest.yaml
@@ -1,0 +1,29 @@
+#
+# REST automation for the rest role. Each endpoint is backed by an Event Script flow (no controller)
+# via the built-in 'http.flow.adapter' service - the Mercury Composable way.
+#
+# All three flows acknowledge immediately (202) and continue asynchronously: the request travels
+# on-prem Kafka -> bridge -> cloud Kafka -> system-of-record, and the outcome is observed on the
+# on-prem response topic by the node listener.
+#
+rest:
+  - service: "http.flow.adapter"
+    methods: ['GET']
+    url: "/api/profile/{id}"
+    flow: 'get-profile'
+    timeout: 10s
+    tracing: true
+
+  - service: "http.flow.adapter"
+    methods: ['POST']
+    url: "/api/profile"
+    flow: 'upsert-profile'
+    timeout: 10s
+    tracing: true
+
+  - service: "http.flow.adapter"
+    methods: ['DELETE']
+    url: "/api/profile/{id}"
+    flow: 'delete-profile'
+    timeout: 10s
+    tracing: true

--- a/examples/twin-kafka-demo/src/main/resources/sor-kafka-consumer.properties
+++ b/examples/twin-kafka-demo/src/main/resources/sor-kafka-consumer.properties
@@ -1,0 +1,16 @@
+#
+# Kafka CONSUMER configuration for the sor role - identical to minimalist-kafka's bundled template
+# except that the default bootstrap is the CLOUD broker (the kafka-standalone helper's second listener).
+#
+# Values support ${ENV_VAR:default_value} environment-variable substitution. Override at
+# /tmp/config/sor-kafka-consumer.properties or point kafka.consumer.properties elsewhere.
+#
+# The library pins key/value deserializers, enable.auto.commit=false and max.poll.records=1 in code;
+# the consumer group.id comes from each binding's 'group' in kafka-adapter-sor.yaml.
+#
+
+# --- Connection ---
+bootstrap.servers=${CLOUD_KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:8092}
+
+# --- Where a brand-new consumer group starts reading ---
+auto.offset.reset=${KAFKA_AUTO_OFFSET_RESET:earliest}

--- a/examples/twin-kafka-demo/src/main/resources/sor-kafka-producer.properties
+++ b/examples/twin-kafka-demo/src/main/resources/sor-kafka-producer.properties
@@ -1,0 +1,13 @@
+#
+# Kafka PRODUCER configuration for the sor role - identical to minimalist-kafka's bundled template
+# except that the default bootstrap is the CLOUD broker (the kafka-standalone helper's second listener).
+#
+# Values support ${ENV_VAR:default_value} environment-variable substitution. Override at
+# /tmp/config/sor-kafka-producer.properties or point kafka.producer.properties elsewhere.
+#
+
+# --- Connection ---
+bootstrap.servers=${CLOUD_KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:8092}
+
+# --- Durability ---
+acks=all

--- a/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ApiRequestTest.java
+++ b/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ApiRequestTest.java
@@ -1,0 +1,85 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.twin.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.exception.AppException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * v1.api.request is pure request validation and message shaping - directly testable.
+ */
+class ApiRequestTest {
+
+    private final ApiRequest api = new ApiRequest();
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void upsertBuildsRequestAndAck() throws AppException {
+        Map<String, Object> profile = Map.of(
+                "id", 100, "name", "Peter Parker",
+                "address", "20 Ingram Street, Queens", "telephone", "212-555-1212");
+        Map<String, Object> result = api.handleEvent(
+                Map.of("command", "UPSERT"), Map.of("profile", profile), 1);
+        Map<String, Object> request = (Map<String, Object>) result.get("request");
+        assertEquals("UPSERT", request.get("command"));
+        assertEquals(100, request.get("id"));
+        assertEquals(profile, request.get("profile"));
+        Map<String, Object> ack = (Map<String, Object>) result.get("ack");
+        assertEquals("HTTP_REQUEST", ack.get("originator"));
+        assertEquals("Request accepted for processing", ack.get("message"));
+        assertEquals(100, ack.get("id"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void readAndDeleteCarryTheIdOnly() throws AppException {
+        for (String command : new String[]{"READ", "DELETE"}) {
+            Map<String, Object> result = api.handleEvent(
+                    Map.of("command", command), Map.of("id", "100"), 1);
+            Map<String, Object> request = (Map<String, Object>) result.get("request");
+            assertEquals(command, request.get("command"));
+            assertEquals(100, request.get("id"));
+            assertFalse(request.containsKey("profile"));
+        }
+    }
+
+    @Test
+    void invalidRequestsAreRejected() {
+        // missing command header = a broken flow definition
+        AppException noCommand = assertThrows(AppException.class,
+                () -> api.handleEvent(Map.of(), Map.of("id", "1"), 1));
+        assertEquals(500, noCommand.getStatus());
+        // UPSERT without a profile body
+        AppException noProfile = assertThrows(AppException.class,
+                () -> api.handleEvent(Map.of("command", "UPSERT"), new HashMap<>(), 1));
+        assertEquals(400, noProfile.getStatus());
+        // non-positive or non-numeric id
+        AppException badId = assertThrows(AppException.class,
+                () -> api.handleEvent(Map.of("command", "READ"), Map.of("id", "zero"), 1));
+        assertEquals(400, badId.getStatus());
+        AppException negative = assertThrows(AppException.class,
+                () -> api.handleEvent(Map.of("command", "READ"), Map.of("id", "-5"), 1));
+        assertEquals(400, negative.getStatus());
+    }
+}

--- a/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ProfileStoreTest.java
+++ b/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ProfileStoreTest.java
@@ -1,0 +1,78 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.twin.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.serializers.SimpleMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * v1.profile.store parses the plain JSON request bytes (the cloud cluster carries no schema)
+ * and applies the command to the temp store - directly testable without Kafka.
+ */
+class ProfileStoreTest {
+
+    private static final int TEST_ID = 987654;
+
+    private final ProfileStore store = new ProfileStore();
+
+    private Map<String, Object> apply(Map<String, Object> request) throws IOException {
+        byte[] payload = SimpleMapper.getInstance().getMapper().writeValueAsString(request)
+                .getBytes(StandardCharsets.UTF_8);
+        return store.handleEvent(Map.of(), payload, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void fullLifecycle() throws IOException {
+        Map<String, Object> profile = Map.of(
+                "id", TEST_ID, "name", "Mary Jane", "address", "Queens", "telephone", "555-0000");
+        // READ before create - errors travel as data
+        Map<String, Object> missing = apply(Map.of("command", "READ", "id", TEST_ID));
+        assertEquals("SYSTEM_OF_RECORDS", missing.get("originator"));
+        assertEquals("Profile " + TEST_ID + " not found", missing.get("message"));
+        // UPSERT echoes the saved profile
+        Map<String, Object> saved = apply(Map.of("command", "UPSERT", "id", TEST_ID, "profile", profile));
+        assertEquals("Profile " + TEST_ID + " saved", saved.get("message"));
+        assertEquals(profile.get("name"), ((Map<String, Object>) saved.get("profile")).get("name"));
+        // READ returns the stored profile
+        Map<String, Object> found = apply(Map.of("command", "READ", "id", TEST_ID));
+        assertEquals("Profile " + TEST_ID + " found", found.get("message"));
+        assertEquals("Mary Jane", ((Map<String, Object>) found.get("profile")).get("name"));
+        // DELETE removes it; a second DELETE reports not found
+        Map<String, Object> deleted = apply(Map.of("command", "DELETE", "id", TEST_ID));
+        assertEquals("Profile " + TEST_ID + " deleted", deleted.get("message"));
+        Map<String, Object> gone = apply(Map.of("command", "DELETE", "id", TEST_ID));
+        assertEquals("Profile " + TEST_ID + " not found", gone.get("message"));
+    }
+
+    @Test
+    void unknownCommandAndBadIdTravelAsData() throws IOException {
+        Map<String, Object> unknown = apply(Map.of("command", "PURGE", "id", TEST_ID));
+        assertEquals("Unknown command PURGE", unknown.get("message"));
+        // a non-numeric id degrades to -1 rather than failing the flow
+        Map<String, Object> badId = apply(Map.of("command", "READ", "id", "not-a-number"));
+        assertEquals(-1, badId.get("id"));
+    }
+}

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -133,7 +133,9 @@
   **UPDATE 2026-07-07: v4.6.3 shipped the same day** (tag on merge commit `4c709484`; PRs #143 cleanup +
   #144 bump) — maintenance on top of 4.6.2: final smell suppressions, model encapsulation,
   playground `random` → SecureRandom. All caveats above still apply. Field Sonar dashboard: gate PASSED,
-  0 vuln / 0 bugs / smells rating A; only the CryptoApi DSA hotspot awaits "Safe" review in the Sonar UI.
+  0 vuln / 0 bugs / smells rating A; the CryptoApi DSA hotspot was RESOLVED 2026-07-11 by retiring DSA
+  from CryptoApi entirely (historical, unused in production; commit `56f7e4da` on feature/twin-kafka-demo)
+  — no Sonar UI disposition needed.
   <!-- id: release-4-6-2-shipped | created: 2026-07-07 | last_used: 2026-07-08 | uses: 4 | tier: archive-candidate | origin: 2026-07-07-163607 -->
 
 - **Release 4.6.1 — security + maintenance patch on top of 4.6.0 (2026-07-06, branch `chore/release-4.6.1`,

--- a/memory/sessions/2026-07-11-184804.md
+++ b/memory/sessions/2026-07-11-184804.md
@@ -24,6 +24,19 @@ all 5 sor workers exercised; bridge ran 10 flow executions.
 
 Push output no longer shows the dependabot banner — alert 28 auto-closed after PR #159.
 
+## SimpleRandomPartitioner — commit `68e2233a` (same branch)
+The demo's all-on-one-partition observation was a real loose end, not just cosmetic:
+Kafka's sticky default starves multi-instance consumer groups at low volume. Per Eric
+(field-proven pattern), minimalist-kafka now DEFAULTS partitioner.class to a stateless
+SimpleRandomPartitioner via putIfAbsent in KafkaClientConfig.producerProperties —
+template override wins; twin-kafka secondary + DLQ writer inherit through the seam.
+Uses a shared SecureRandom per Eric's review (ThreadLocalRandom avoided — the repo
+avoids ThreadLocal with virtual threads, same family as the ReentrantLock convention).
+Explicit-partition and keyed-record (murmur2) semantics preserved.
+Verified: 831/831 reactor tests; demo rerun spread 10 UPSERTs across 6 distinct
+partitions (was 1). RoundRobinPartitioner rejected: per-topic counters + known
+unevenness (KAFKA-9965 family); random needs no state at all.
+
 Commit `74f552ae` — feat(examples): twin-kafka-demo - profile management bridged across two Kafka clusters
 
 ```

--- a/memory/sessions/2026-07-11-184804.md
+++ b/memory/sessions/2026-07-11-184804.md
@@ -1,0 +1,67 @@
+# Session (2026-07-11T18:48:04.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** twin-kafka-demo worked example, designed with Eric (his draft intent on
+Desktop, reviewed + adjusted) and validated e2e with the multi-terminal method.
+
+One jar, three Spring profiles: rest (HTTP edge, 202 ack via execution: response, publishes
+JSON-Schema requests), bridge (twin-kafka, PURE YAML both directions), sor (plain
+minimalist-kafka whose primary IS the cloud broker — zero-weight principle). Asymmetric
+topology: on-prem 9092 + seeded schema-registry-standalone; cloud 8092 plain JSON.
+
+KEY LESSON (framework contract): the notification functions are byte[]-typed, and the
+engine does NOT auto-serialize a Map body into a byte[] input (WorkerHandler getMapBody →
+Gson readValue(map, byte[].class) throws; flow aborts 400 with a fast 500 task span).
+The pure-YAML fix is the ':binary' type qualifier — TypeConversionUtils.getBinaryValue(Map)
+= writeValueAsBytes — so 'model.x:binary -> *' hands JSON bytes to the notification.
+The twin-kafka test bridges never hit this because they relay raw byte[] both ways.
+
+Also observed: at demo pace the sticky partitioner lands consecutive messages on one
+partition (all 5 responses on partition 4) — README words the partition-spread claim
+honestly. E2E verified: UPSERT/READ/DELETE/READ-missing with curl correlation ids
+order-001..004 and trace ids intact at the node listener; temp store state correct;
+all 5 sor workers exercised; bridge ran 10 flow executions.
+
+Push output no longer shows the dependabot banner — alert 28 auto-closed after PR #159.
+
+Commit `74f552ae` — feat(examples): twin-kafka-demo - profile management bridged across two Kafka clusters
+
+```
+ docs/guides/twin-kafka.md                          |   5 +
+ examples/twin-kafka-demo/README.md                 | 186 +++++++++++++++++++++
+ examples/twin-kafka-demo/node/.gitignore           |   4 +
+ examples/twin-kafka-demo/node/config.js            |  25 +++
+ examples/twin-kafka-demo/node/create_topic.js      |  40 +++++
+ examples/twin-kafka-demo/node/listen_response.js   |  50 ++++++
+ examples/twin-kafka-demo/node/package.json         |  14 ++
+ examples/twin-kafka-demo/pom.xml                   | 172 +++++++++++++++++++
+ examples/twin-kafka-demo/registry/11.json          |   6 +
+ examples/twin-kafka-demo/registry/12.json          |   6 +
+ .../main/java/com/accenture/twin/demo/MainApp.java |  65 +++++++
+ .../com/accenture/twin/demo/tasks/ApiRequest.java  |  90 ++++++++++
+ .../accenture/twin/demo/tasks/ProfileStore.java    | 103 ++++++++++++
+ .../main/resources/application-bridge.properties   |  28 ++++
+ .../src/main/resources/application-rest.properties |  20 +++
+ .../src/main/resources/application-sor.properties  |  22 +++
+ .../src/main/resources/application.properties      |  25 +++
+ .../src/main/resources/flows-bridge.yaml           |   7 +
+ .../src/main/resources/flows-rest.yaml             |   7 +
+ .../src/main/resources/flows-sor.yaml              |   5 +
+ .../src/main/resources/flows/bridge-request.yml    |  27 +++
+ .../src/main/resources/flows/bridge-response.yml   |  25 +++
+ .../src/main/resources/flows/delete-profile.yml    |  35 ++++
+ .../src/main/resources/flows/get-profile.yml       |  40 +++++
+ .../src/main/resources/flows/profile-store.yml     |  36 ++++
+ .../src/main/resources/flows/upsert-profile.yml    |  35 ++++
+ .../resources/kafka-adapter-bridge-primary.yaml    |   9 +
+ .../resources/kafka-adapter-bridge-secondary.yaml  |   9 +
+ .../src/main/resources/kafka-adapter-sor.yaml      |   8 +
+ .../twin-kafka-demo/src/main/resources/log4j2.xml  |  23 +++
+ .../twin-kafka-demo/src/main/resources/rest.yaml   |  29 ++++
+ .../main/resources/sor-kafka-consumer.properties   |  16 ++
+ .../main/resources/sor-kafka-producer.properties   |  13 ++
+ 33 files changed, 1185 insertions(+)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-11-184804.md
+++ b/memory/sessions/2026-07-11-184804.md
@@ -12,8 +12,9 @@ topology: on-prem 9092 + seeded schema-registry-standalone; cloud 8092 plain JSO
 KEY LESSON (framework contract): the notification functions are byte[]-typed, and the
 engine does NOT auto-serialize a Map body into a byte[] input (WorkerHandler getMapBody →
 Gson readValue(map, byte[].class) throws; flow aborts 400 with a fast 500 task span).
-The pure-YAML fix is the ':binary' type qualifier — TypeConversionUtils.getBinaryValue(Map)
-= writeValueAsBytes — so 'model.x:binary -> *' hands JSON bytes to the notification.
+The pure-YAML fix is the f:binary() pluggable function — TypeConversionUtils.getBinaryValue(Map)
+= writeValueAsBytes — so 'f:binary(model.x) -> *' hands JSON bytes to the notification.
+(The ':binary' colon-qualifier shorthand is DEPRECATED; use the f:binary() form.)
 The twin-kafka test bridges never hit this because they relay raw byte[] both ways.
 
 Also observed: at demo pace the sticky partitioner lands consecutive messages on one

--- a/memory/sessions/2026-07-11-220803.md
+++ b/memory/sessions/2026-07-11-220803.md
@@ -1,0 +1,25 @@
+# Session (2026-07-11T22:08:03.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** Eric's post-lunch touch-ups to twin-kafka-demo (PR #160 in flight);
+see 2026-07-11-184804.md for the main demo session.
+
+Two framework-behavior lessons captured as flow-authoring conventions:
+1. The ':binary' colon-qualifier shorthand is DEPRECATED — use the pluggable
+   function form 'f:binary(model.x) -> *' (commit `a172c355`).
+2. Set the content-type explicitly on flow HTTP responses:
+   'text(application/json) -> output.header.content-type' — otherwise
+   platform-core content-negotiates from the request's 'accept' header,
+   which is not deterministic for arbitrary clients (this commit).
+
+Commit `abd6e905` — fix(twin-kafka-demo): explicit content-type on the immediate 202 ack
+
+```
+ examples/twin-kafka-demo/src/main/resources/flows/delete-profile.yml | 1 +
+ examples/twin-kafka-demo/src/main/resources/flows/get-profile.yml    | 1 +
+ examples/twin-kafka-demo/src/main/resources/flows/upsert-profile.yml | 1 +
+ 3 files changed, 3 insertions(+)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-11-220803.md
+++ b/memory/sessions/2026-07-11-220803.md
@@ -10,7 +10,19 @@ Two framework-behavior lessons captured as flow-authoring conventions:
 2. Set the content-type explicitly on flow HTTP responses:
    'text(application/json) -> output.header.content-type' — otherwise
    platform-core content-negotiates from the request's 'accept' header,
-   which is not deterministic for arbitrary clients (this commit).
+   which is not deterministic for arbitrary clients (commit `abd6e905`).
+
+Also: ProfileStore IDE touch-ups (`e0abf51b` readValue(byte[]) direct, 'record'
+restricted identifier, "Profile " literal helper; `adfdb07e` S5443 suppression —
+/tmp store IS the demo's simulated database by design).
+
+## CryptoApi DSA retirement — commit `56f7e4da`
+Closes the long-pending field Sonar hotspot the proper way: DSA was historical and
+unused in production, so generateDsaKey/dsaSign/dsaVerify, the boolean
+getPublic/getPrivate overloads (DSA-selector only), the DSA constants and
+dsaSignatureTest are all REMOVED — no "Safe" UI disposition needed anymore.
+Public-API removal verified safe: repo-wide grep found no production caller;
+full offline reactor 830/830. Continuity fact [[release-4-6-2-shipped]] updated.
 
 Commit `abd6e905` — fix(twin-kafka-demo): explicit content-type on the immediate 202 ack
 

--- a/memory/sessions/2026-07-11-225429.md
+++ b/memory/sessions/2026-07-11-225429.md
@@ -1,0 +1,57 @@
+# Session (2026-07-11T22:54:29.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** example-app coverage sweep for the field Sonar gate (overall 78% < 80%
+because the field scan covers ALL sources incl. non-reactor example subprojects).
+
+Coverage (jacoco, before → after): rest-spring-3/4-example 0→83% each, scheduler-example
+0→98%, twin-kafka-demo 0→92%, kafka-demo 0→85%, sync-over-async-demo 0→73%,
+lambda-example 52→93%, pg-example 8→89%. composable-example 85%, minigraph 100%,
+kotlin-example 78% left as-is. jacoco plugin added to the 3 demo poms that lacked it.
+
+Notable findings while testing:
+- pg-example's 7 existing tests only exercised the reactive-postgres EXTENSION classes;
+  the example's own /api/demo endpoint was untestable because the TEST resources
+  rest.yaml + pg-schema.sql lacked the demo endpoint entries and demo_profile table.
+- rs3/rs4 example sources are byte-identical → tests mirror exactly (same pattern as the
+  rs3/rs4 module suites).
+- Direct service invocation via po.request(route) avoids REST-port ambiguity and is the
+  cleanest way to drive AsyncHttpRequest-typed functions (scheduler admin, lambda demos).
+- Tasks that build PostOffice from input headers (my_route/my_trace_id) are directly
+  testable without booting Kafka - used for kafka-demo + soa system-of-record variants.
+
+NOTE for the field pipeline: Sonar only counts coverage from provided jacoco reports -
+each example must run `mvn test` in its own directory and the scanner must pick up
+target/site/jacoco/jacoco.xml (sonar.coverage.jacoco.xmlReportPaths).
+
+Commit `f7d9e3f5` — test(examples): unit tests + jacoco across example apps for field Sonar coverage
+
+```
+ examples/kafka-demo/pom.xml                        |  19 +++
+ .../kafka/demo/tasks/DemoProcessorTest.java        |  68 ++++++++++
+ .../org/platformlambda/demo/ServiceTopUpTest.java  | 150 +++++++++++++++++++++
+ .../accenture/postgres/tests/ReactiveDbTest.java   |  46 +++++++
+ .../pg-example/src/test/resources/pg-schema.sql    |  10 ++
+ examples/pg-example/src/test/resources/rest.yaml   |  17 +++
+ .../com/accenture/examples/common/TestBase.java    |  43 ++++++
+ .../com/accenture/examples/tests/ModelTest.java    |  64 +++++++++
+ .../accenture/examples/tests/RestEndpointTest.java | 108 +++++++++++++++
+ .../com/accenture/examples/tests/WsEchoTest.java   |  85 ++++++++++++
+ .../com/accenture/examples/common/TestBase.java    |  43 ++++++
+ .../com/accenture/examples/tests/ModelTest.java    |  64 +++++++++
+ .../accenture/examples/tests/RestEndpointTest.java | 108 +++++++++++++++
+ .../com/accenture/examples/tests/WsEchoTest.java   |  85 ++++++++++++
+ .../src/test/resources/application.properties      |   4 +-
+ .../org/platformlambda/quartz/common/TestBase.java |  36 +++++
+ .../quartz/tests/ScheduleAdminTest.java            | 118 ++++++++++++++++
+ .../quartz/tests/StateResolverTest.java            |  89 ++++++++++++
+ examples/sync-over-async-demo/pom.xml              |  19 +++
+ .../com/accenture/soa/demo/tasks/SoaTaskTest.java  | 107 +++++++++++++++
+ examples/twin-kafka-demo/pom.xml                   |  19 +++
+ .../accenture/twin/demo/tasks/ApiRequestTest.java  |  85 ++++++++++++
+ .../twin/demo/tasks/ProfileStoreTest.java          |  78 +++++++++++
+ 23 files changed, 1463 insertions(+), 2 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-11-225429.md
+++ b/memory/sessions/2026-07-11-225429.md
@@ -24,6 +24,13 @@ NOTE for the field pipeline: Sonar only counts coverage from provided jacoco rep
 each example must run `mvn test` in its own directory and the scanner must pick up
 target/site/jacoco/jacoco.xml (sonar.coverage.jacoco.xmlReportPaths).
 
+## Eric's manual multi-terminal test drive - PASSED (2026-07-11 16:2x)
+UPSERT/READ/DELETE/READ-missing via curl: all 202 acks; listener showed all four
+responses with order-001..004 correlation ids and trace ids intact, schemaId=12.
+SimpleRandomPartitioner confirmed in the field workflow: responses landed on
+partitions 4, 0, 6, 3 (four messages, four partitions - was all-on-one before).
+PR #160 validated by hand; ready for merge at Eric's discretion.
+
 Commit `f7d9e3f5` — test(examples): unit tests + jacoco across example apps for field Sonar coverage
 
 ```

--- a/memory/sessions/2026-07-11-233750.md
+++ b/memory/sessions/2026-07-11-233750.md
@@ -1,0 +1,19 @@
+# Session (2026-07-11T23:37:50.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** example apps rejoin the maven reactor (Eric's decision after the
+coverage sweep gave them tests). Nine modules uncommented in the root pom; pg-example
+deliberately stays standalone (tests download an embedded Postgres binary) and
+benchmark-reporter stays off. CI now runs the example suites on every PR; the field
+Sonar scan collects all example jacoco reports from one root build.
+Verified: full reactor offline WITH tests = 903 tests, 0 failures (830 core + examples).
+
+Commit `374cc418` — build: example apps rejoin the maven reactor
+
+```
+ pom.xml | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/memory/sessions/2026-07-12-002326.md
+++ b/memory/sessions/2026-07-12-002326.md
@@ -1,0 +1,31 @@
+# Session (2026-07-12T00:23:26.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** branch-coverage top-up for cloud-connector / kafka-connector /
+service-monitor (the three largest branch-miss pools dragging the field Sonar
+combined metric to ~79%). Coverage (line/combined): cloud-connector 70/62→84/79,
+kafka-connector 69/64→71/67, service-monitor 76/69→80/74.
+Repo-wide aggregate: line 85.8%, sonar-style combined EXACTLY 80.0% (from 79.1).
+Reactor 918/918.
+
+Techniques worth remembering: drive registry/producer/monitor services via events
+to their platform routes with crafted type headers (the mock harnesses already
+boot everything); a real subscriber function captures notification fan-out; the
+mock pub/sub decodes published payloads as packed EventEnvelopes (raw bytes fail
+with 'Packed input should be Map or List'). kafka-connector's remaining gap is
+topic-substitution mode + one-time boot branches — not reachable in one JVM.
+Standing advice: field Sonar config should exclude benchmark/** (938 untested
+lines outside the reactor) — 80.0% has zero margin.
+
+Commit `3add6e0e` — test(connectors): branch-coverage top-up for the legacy service-mesh stack
+
+```
+ .../platformlambda/kafka/KafkaAdminEdgeTest.java   | 172 ++++++++++++++
+ .../platformlambda/cloud/EventProducerTest.java    | 152 ++++++++++++
+ .../cloud/ServiceRegistryEdgeTest.java             | 259 +++++++++++++++++++++
+ .../org/platformlambda/cloud/MonitorEdgeTest.java  | 145 ++++++++++++
+ 4 files changed, 728 insertions(+)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,9 @@
         <module>helpers/redis-standalone</module>
         <module>helpers/schema-registry-standalone</module>
 
-        <!-- Executables for application examples
+        <!-- Executables for application examples (rejoined the reactor in 4.8.x once they
+             gained unit tests; pg-example stays standalone because its tests download an
+             embedded Postgres binary) -->
         <module>examples/lambda-example</module>
         <module>examples/rest-spring-3-example</module>
         <module>examples/rest-spring-4-example</module>
@@ -50,7 +52,7 @@
         <module>examples/scheduler-example</module>
         <module>examples/minigraph-playground</module>
         <module>examples/kafka-demo</module>
-        <module>examples/sync-over-async-demo</module>-->
+        <module>examples/sync-over-async-demo</module>
 
         <!-- Executable for benchmark tests (benchmark-client retired 4.8.0 — superseded by benchmark-reporter)
         <module>benchmark/benchmark-reporter</module>-->

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaClientConfig.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaClientConfig.java
@@ -83,6 +83,9 @@ public final class KafkaClientConfig {
         Properties p = load(appConfig.getProperty(locationKey, defaultLocations));
         p.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         p.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        // default (not pinned): random distribution instead of Kafka's sticky default, which skews
+        // low-volume traffic onto one partition; a template that sets partitioner.class wins
+        p.putIfAbsent(ProducerConfig.PARTITIONER_CLASS_CONFIG, SimpleRandomPartitioner.class.getName());
         return p;
     }
 

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
@@ -58,7 +58,8 @@ public class KafkaRequestPublisher implements AutoCloseable {
      * failure and can react - the basis for fail-fast on the synchronous request path.
      *
      * @param topic destination topic (required).
-     * @param partition target partition, or {@code null} to let Kafka's default partitioner choose.
+     * @param partition target partition, or {@code null} to let the configured partitioner choose
+     *                  (by default {@link SimpleRandomPartitioner} - uniform random distribution).
      * @param headers Kafka record headers, already byte[]-encoded; may be {@code null}.
      * @param body message body.
      * @return a {@code Mono<Void>} that completes when the broker acknowledges, or errors on failure.

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleRandomPartitioner.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleRandomPartitioner.java
@@ -1,0 +1,79 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Utils;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A perfectly stateless partitioner: each keyless record goes to a uniformly random partition.
+ *
+ * <p>Kafka's built-in default is a <i>sticky</i> partitioner - it keeps writing to one partition until a
+ * batch closes, which is throughput-friendly but skews low-volume traffic badly (an app publishing a few
+ * messages at a time can land everything on a single partition, leaving a multi-instance consumer group
+ * mostly idle). The built-in {@code RoundRobinPartitioner} fixes the skew but keeps per-topic counters and
+ * has known unevenness when batches are recreated. Random distribution needs no state at all and converges
+ * on uniform - the pattern proven in field deployments of this library.</p>
+ *
+ * <p>Semantics preserved from the default partitioner:</p>
+ * <ul>
+ *   <li>a record with an <b>explicit partition</b> (e.g. the {@code partition} header of
+ *       {@code simple.kafka.notification}) never reaches any partitioner - explicit always wins</li>
+ *   <li>a <b>keyed</b> record still maps by murmur2 key hash, so key-based ordering is not broken if a
+ *       caller ever publishes with a record key (the bundled publisher currently does not)</li>
+ * </ul>
+ *
+ * <p>{@link KafkaClientConfig#producerProperties} installs this class as the default
+ * {@code partitioner.class}; a template that sets its own partitioner overrides it.</p>
+ */
+public class SimpleRandomPartitioner implements Partitioner {
+
+    // SecureRandom is thread-safe and keeps no per-thread state - virtual thread friendly design
+    // (ThreadLocalRandom is avoided for the same reason the repo avoids ThreadLocal in general)
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @Override
+    public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes,
+                         Cluster cluster) {
+        List<PartitionInfo> available = cluster.availablePartitionsForTopic(topic);
+        List<PartitionInfo> candidates = available.isEmpty() ? cluster.partitionsForTopic(topic) : available;
+        if (keyBytes != null) {
+            // keyed records keep Kafka's key-hash semantics over ALL partitions (same as the default
+            // partitioner), so a key always maps to the same partition regardless of leader availability
+            return Utils.toPositive(Utils.murmur2(keyBytes)) % cluster.partitionsForTopic(topic).size();
+        }
+        return candidates.get(RANDOM.nextInt(candidates.size())).partition();
+    }
+
+    @Override
+    public void close() {
+        // stateless - nothing to release
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // stateless - nothing to configure
+    }
+}

--- a/system/minimalist-kafka/src/main/resources/kafka-producer.properties
+++ b/system/minimalist-kafka/src/main/resources/kafka-producer.properties
@@ -10,8 +10,10 @@
 #
 # Values support ${ENV_VAR:default_value} environment-variable substitution.
 #
-# The library PINS the serializers in code (key=String, value=byte[] - the wire contract); everything
-# below is yours to configure.
+# The library PINS the serializers in code (key=String, value=byte[] - the wire contract). It also
+# DEFAULTS partitioner.class to the library's SimpleRandomPartitioner (uniform random distribution -
+# Kafka's sticky default skews low-volume traffic onto one partition); set partitioner.class here to
+# override. Everything below is yours to configure.
 #
 
 # --- Connection ---

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaClientConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaClientConfigTest.java
@@ -52,6 +52,21 @@ class KafkaClientConfigTest {
     }
 
     @Test
+    void producerDefaultsToSimpleRandomPartitioner() {
+        Properties p = KafkaClientConfig.producerProperties(EMPTY);
+        assertEquals(SimpleRandomPartitioner.class.getName(), p.getProperty("partitioner.class"),
+                "random distribution is the default when the template does not choose a partitioner");
+    }
+
+    @Test
+    void templatePartitionerOverridesTheRandomDefault() {
+        ConfigBase config = new ConfigReader("classpath:/custom-partitioner-config.properties");
+        Properties p = KafkaClientConfig.producerProperties(config);
+        assertEquals("org.apache.kafka.clients.producer.RoundRobinPartitioner",
+                p.getProperty("partitioner.class"), "a template-selected partitioner wins over the default");
+    }
+
+    @Test
     void consumerLoadsTemplateAndPinsDeserializers() {
         Properties p = KafkaClientConfig.consumerProperties(EMPTY);
         assertEquals(StringDeserializer.class.getName(), p.getProperty("key.deserializer"));

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleRandomPartitionerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleRandomPartitionerTest.java
@@ -1,0 +1,92 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka;
+
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleRandomPartitionerTest {
+
+    private static final String TOPIC = "random-partitioner-test";
+    private static final int PARTITIONS = 10;
+
+    private static Cluster cluster(int partitions, boolean withLeaders) {
+        Node node = new Node(1, "127.0.0.1", 9092);
+        List<PartitionInfo> info = new ArrayList<>();
+        for (int i = 0; i < partitions; i++) {
+            // leader == null marks a partition unavailable for the availablePartitionsForTopic view
+            info.add(new PartitionInfo(TOPIC, i, withLeaders ? node : null, new Node[]{node}, new Node[]{node}));
+        }
+        return new Cluster("test-cluster", List.of(node), info, Set.of(), Set.of());
+    }
+
+    @Test
+    @SuppressWarnings("resource")   // stateless partitioner - close() is a no-op
+    void keylessRecordsSpreadAcrossPartitions() {
+        SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
+        partitioner.configure(Map.of());
+        Cluster cluster = cluster(PARTITIONS, true);
+        Set<Integer> seen = new HashSet<>();
+        for (int i = 0; i < 500; i++) {
+            int p = partitioner.partition(TOPIC, null, null, null, new byte[]{1}, cluster);
+            assertTrue(p >= 0 && p < PARTITIONS, "partition must be in range");
+            seen.add(p);
+        }
+        // 500 uniform draws over 10 partitions miss a given partition with probability (0.9)^500 ~ 1e-23,
+        // so requiring all 10 is deterministic for practical purposes - this is the anti-sticky assertion
+        assertEquals(PARTITIONS, seen.size(), "random distribution must reach every partition");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void keyedRecordsMapDeterministically() {
+        SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
+        Cluster cluster = cluster(PARTITIONS, true);
+        byte[] key = "profile-100".getBytes(StandardCharsets.UTF_8);
+        int first = partitioner.partition(TOPIC, "profile-100", key, null, new byte[]{1}, cluster);
+        for (int i = 0; i < 20; i++) {
+            assertEquals(first, partitioner.partition(TOPIC, "profile-100", key, null, new byte[]{1}, cluster),
+                    "a keyed record must always map to the same partition");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void fallsBackToAllPartitionsWhenNoneAvailable() {
+        SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
+        Cluster cluster = cluster(PARTITIONS, false);
+        for (int i = 0; i < 50; i++) {
+            int p = partitioner.partition(TOPIC, null, null, null, new byte[]{1}, cluster);
+            assertTrue(p >= 0 && p < PARTITIONS, "must fall back to the full partition list");
+        }
+        partitioner.close();
+    }
+}

--- a/system/minimalist-kafka/src/test/resources/custom-partitioner-config.properties
+++ b/system/minimalist-kafka/src/test/resources/custom-partitioner-config.properties
@@ -1,0 +1,3 @@
+# Test fixture: an application config that points the producer template at a custom-partitioner variant,
+# proving that a template-selected partitioner.class wins over the library's random default.
+kafka.producer.properties=classpath:/custom-partitioner-producer.properties

--- a/system/minimalist-kafka/src/test/resources/custom-partitioner-producer.properties
+++ b/system/minimalist-kafka/src/test/resources/custom-partitioner-producer.properties
@@ -1,0 +1,5 @@
+# Test fixture: a producer template that chooses its own partitioner - the library must respect it
+# instead of applying the SimpleRandomPartitioner default.
+bootstrap.servers=127.0.0.1:9092
+acks=all
+partitioner.class=org.apache.kafka.clients.producer.RoundRobinPartitioner

--- a/system/platform-core/src/main/java/org/platformlambda/core/util/CryptoApi.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/util/CryptoApi.java
@@ -41,16 +41,13 @@ public class CryptoApi {
     private static final SecureRandom random = new SecureRandom();
     private static final int BUFFER_SIZE = 1024;
     private static final String RSA = "RSA";
-    private static final String DSA = "DSA";
     private static final String AES = "AES";
     private static final String SHA256 = "SHA-256";
     private static final String SHA512 = "SHA-512";
     private static final String HMAC_SHA256 = "HmacSHA256";
     private static final String HMAC_SHA512 = "HmacSHA512";
     private static final int RSA_2048 = 2048;
-    private static final int DSA_2048 = 2048;
     private static final int[] PUBLIC_KEY_SIZES = {2048, 3072, 4096};
-    private static final String SHA_256_WITH_DSA = "SHA256withDSA";
     private static final String SHA_256_WITH_RSA = "SHA256withRSA";
     private static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
     private static final String RSA_PADDING = "RSA/ECB/OAEPWithSHA1AndMGF1Padding";
@@ -98,7 +95,7 @@ public class CryptoApi {
     /**
      * Get private key bytes
      *
-     * @param keyPair RSA-2048 or DSA-2048 key pair
+     * @param keyPair RSA-2048 key pair
      * @return PKCS-8 encoded byte array
      */
     public byte[] getEncodedPrivateKey(KeyPair keyPair) {
@@ -106,25 +103,17 @@ public class CryptoApi {
     }
 
     public PublicKey getPublic(byte[] publicKey) throws GeneralSecurityException {
-        return getPublic(publicKey, true);
-    }
-
-    public PublicKey getPublic(byte[] publicKey, boolean rsa) throws GeneralSecurityException {
-        return KeyFactory.getInstance(rsa? RSA : DSA).generatePublic(new X509EncodedKeySpec(publicKey));
+        return KeyFactory.getInstance(RSA).generatePublic(new X509EncodedKeySpec(publicKey));
     }
 
     public PrivateKey getPrivate(byte[] privateKey) throws GeneralSecurityException {
-        return getPrivate(privateKey, true);
-    }
-
-    public PrivateKey getPrivate(byte[] privateKey, boolean rsa) throws GeneralSecurityException {
-        return KeyFactory.getInstance(rsa? RSA : DSA).generatePrivate(new PKCS8EncodedKeySpec(privateKey));
+        return KeyFactory.getInstance(RSA).generatePrivate(new PKCS8EncodedKeySpec(privateKey));
     }
 
     /**
      * Get public key bytes
      *
-     * @param keyPair RSA-2048 or DSA-1024 key pair
+     * @param keyPair RSA-2048 key pair
      * @return X509 encoded byte array
      */
     public byte[] getEncodedPublicKey(KeyPair keyPair) {
@@ -132,14 +121,14 @@ public class CryptoApi {
     }
 
     public byte[] rsaEncrypt(byte[] clearText, byte[] publicKey) throws GeneralSecurityException {
-        PublicKey key = getPublic(publicKey, true);
+        PublicKey key = getPublic(publicKey);
         Cipher cipher = Cipher.getInstance(RSA_PADDING);
         cipher.init(Cipher.ENCRYPT_MODE, key);
         return cipher.doFinal(clearText);
     }
 
     public byte[] rsaDecrypt(byte[] cipherText, byte[] privateKey) throws GeneralSecurityException {
-        PrivateKey key = getPrivate(privateKey, true);
+        PrivateKey key = getPrivate(privateKey);
         Cipher cipher = Cipher.getInstance(RSA_PADDING);
         cipher.init(Cipher.DECRYPT_MODE, key);
         return cipher.doFinal(cipherText);
@@ -153,7 +142,7 @@ public class CryptoApi {
      * @throws GeneralSecurityException in case of error
      */
     public byte[] rsaSign(byte[] data, byte[] privateKey) throws GeneralSecurityException {
-        PrivateKey key = getPrivate(privateKey, true);
+        PrivateKey key = getPrivate(privateKey);
         Signature rsa = Signature.getInstance(SHA_256_WITH_RSA);
         rsa.initSign(key);
         rsa.update(data);
@@ -185,65 +174,11 @@ public class CryptoApi {
      * @throws GeneralSecurityException when unable to generate key
      */
     public boolean rsaVerify(byte[] data, byte[] signature, byte[] publicKey) throws GeneralSecurityException {
-        PublicKey key = getPublic(publicKey, true);
+        PublicKey key = getPublic(publicKey);
         Signature rsa = Signature.getInstance(SHA_256_WITH_RSA);
         rsa.initVerify(key);
         rsa.update(data);
         return rsa.verify(signature);
-    }
-
-    public KeyPair generateDsaKey() {
-        return generateDsaKey(DSA_2048);
-    }
-
-    public KeyPair generateDsaKey(int keySize) {
-        if (allowedRsaKeySize(keySize)) {
-            try {
-                KeyPairGenerator kg = KeyPairGenerator.getInstance(DSA);
-                kg.initialize(keySize);
-                return kg.generateKeyPair();
-            } catch (NoSuchAlgorithmException e) {
-                // this does not happen
-                return null;
-            }
-        } else {
-            List<Integer> allowed = new ArrayList<>();
-            for (int size: PUBLIC_KEY_SIZES) {
-                allowed.add(size);
-            }
-            throw new IllegalArgumentException("Key size must be one of "+ allowed);
-        }
-    }
-
-    /**
-     * Create a digital signature using a private key (DSA)
-     * @param data bytes
-     * @param privateKey encoded key
-     * @return signature
-     * @throws GeneralSecurityException in case of error
-     */
-    public byte[] dsaSign(byte[] data, byte[] privateKey) throws GeneralSecurityException {
-        PrivateKey key = getPrivate(privateKey, false);
-        Signature dsa = Signature.getInstance(SHA_256_WITH_DSA);
-        dsa.initSign(key);
-        dsa.update(data);
-        return dsa.sign();
-    }
-
-    /**
-     * Verify a digital signature using a public key (DSA)
-     * @param data bytes
-     * @param signature bytes
-     * @param publicKey encoded public key
-     * @return true if signature is verified
-     * @throws GeneralSecurityException in case of error
-     */
-    public boolean dsaVerify(byte[] data, byte[] signature, byte[] publicKey) throws GeneralSecurityException {
-        PublicKey key = getPublic(publicKey, false);
-        Signature dsa = Signature.getInstance(SHA_256_WITH_DSA);
-        dsa.initVerify(key);
-        dsa.update(data);
-        return dsa.verify(signature);
     }
 
     /**

--- a/system/platform-core/src/test/java/org/platformlambda/core/CryptoTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/CryptoTest.java
@@ -127,17 +127,6 @@ class CryptoTest {
     }
 
     @Test
-    void dsaSignatureTest() throws GeneralSecurityException {
-        KeyPair kp = crypto.generateDsaKey();
-        byte[] pub = kp.getPublic().getEncoded();
-        byte[] pri = kp.getPrivate().getEncoded();
-        byte[] data = "hello world".getBytes();
-        byte[] signature = crypto.dsaSign(data, pri);
-        boolean result = crypto.dsaVerify(data, signature, pub);
-        assertTrue(result);
-    }
-
-    @Test
     void rsaSignatureTest() throws GeneralSecurityException {
         KeyPair kp = crypto.generateRsaKey();
         byte[] pub = kp.getPublic().getEncoded();

--- a/system/twin-kafka/src/main/resources/secondary-kafka-producer.properties
+++ b/system/twin-kafka/src/main/resources/secondary-kafka-producer.properties
@@ -6,8 +6,10 @@
 # or point secondary.kafka.producer.properties (in application.properties) at another location.
 # Values support ${ENV_VAR:default_value} environment-variable substitution.
 #
-# The library PINS the serializers in code (key=String, value=byte[] - the wire contract); everything
-# below is yours to configure. The default port 8092 matches the kafka-standalone helper's SECOND
+# The library PINS the serializers in code (key=String, value=byte[] - the wire contract). It also
+# DEFAULTS partitioner.class to the library's SimpleRandomPartitioner (uniform random distribution -
+# Kafka's sticky default skews low-volume traffic onto one partition); set partitioner.class here to
+# override. Everything below is yours to configure. The default port 8092 matches the kafka-standalone helper's SECOND
 # broker (start it with dual.servers=true for local dual-cluster development).
 #
 


### PR DESCRIPTION
## Summary
Two related changes - the demo, and the loose end it exposed:

1. **twin-kafka-demo** - a runnable worked example for the twin-kafka module:
   profile management whose requests enter through HTTP on the on-prem side,
   cross a dual-cluster bridge, and are served by a system-of-record on the
   cloud side, with trace and business correlation ids continuous across two
   Kafka clusters and three apps.
2. **SimpleRandomPartitioner** - the demo showed Kafka's sticky default
   partitioner landing all low-volume traffic on a single partition, which
   starves multi-instance consumer groups. minimalist-kafka now defaults to a
   stateless random partitioner (the field-proven pattern).

## twin-kafka-demo
One jar, three roles selected by Spring profile (sync-over-async-demo pattern):

- **rest** - HTTP edge (GET/POST/DELETE /api/profile): immediate 202 ack
  (execution: response), then publishes the Request to OP_PROFILE_REQUEST in
  the Confluent JSON Schema wire format (subject op-profile-request)
- **bridge** - twin-kafka dual-cluster bridge, PURE YAML (no Java):
  schema-decodes on-prem requests and forwards plain JSON bytes to the cloud;
  re-encodes cloud responses onto OP_PROFILE_RESPONSE with the response schema
- **sor** - system-of-record on the cloud side: a plain minimalist-kafka app
  whose "primary" IS the cloud broker (zero-weight principle) - applies
  READ/UPSERT/DELETE to /tmp/twin-kafka-demo with 5 workers; errors travel as
  data (READ of a missing id replies "not found")

Deliberately asymmetric topology - on-prem with Schema Registry, cloud with
plain JSON bytes - demonstrating the per-cluster-optional registry and the
decode-and-re-encode bridging rule. Node helpers create the topics (10
partitions, both clusters) and print each response with topic/partition/
schemaId/X-Trace-Id/X-Correlation-Id. Cross-linked from the twin-kafka guide.

## SimpleRandomPartitioner
- Perfectly stateless: uniform random over available partitions using a shared
  SecureRandom (thread-safe, no per-thread state - virtual thread friendly;
  ThreadLocalRandom deliberately avoided)
- Semantics preserved: explicit-partition records bypass partitioners (the
  'partition' header still wins); keyed records keep Kafka's murmur2 key-hash
  mapping
- KafkaClientConfig DEFAULTS partitioner.class via putIfAbsent - a template
  that sets its own partitioner wins; the twin-kafka secondary producer and
  the DLQ writer inherit the default through the shared seam
- Producer templates and the kafka-flow-adapter guide document the default
  and the override

## Verification
- Full reactor offline WITH tests: 831 tests, 0 failures, 0 errors
  (includes new SimpleRandomPartitionerTest + KafkaClientConfig
  default/override cases); JaCoCo gates green
- Demo e2e with the multi-terminal method (dual-broker kafka-standalone,
  seeded schema-registry-standalone, 3 apps, node listener):
  UPSERT/READ/DELETE/READ-missing delivered with curl-supplied correlation
  ids and edge-minted trace ids intact; temp store state confirmed;
  all 5 sor workers exercised
- Partitioner proven live: 10 UPSERTs spread across 6 distinct partitions
  on OP_PROFILE_RESPONSE (before the change: all on one partition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)