### PR TITLE
refactor(twin-kafka): hardening from the external assessment report

### DIFF
--- a/examples/twin-kafka-demo/README.md
+++ b/examples/twin-kafka-demo/README.md
@@ -36,7 +36,7 @@ id is only meaningful to the registry that issued it.
 
 ## Trace and correlation continuity
 
-All roles configure explicit Kafka header names (the 4.8.0 configurable headers):
+All roles configure explicit Kafka header names (the configurable Kafka header names):
 
 ```properties
 kafka.trace.id.header=X-Trace-Id
@@ -183,5 +183,6 @@ The immediate HTTP ack uses `originator: HTTP_REQUEST`; the system-of-record's o
 - **The Confluent frame is JSON-friendly.** After the 5-byte frame (magic byte + schema id), a JSON
   Schema value is the plain UTF-8 JSON string — that is why `listen_response.js` can print it directly
   (an Avro value would be Avro binary).
-- **DLQ stays default-on** but is not demonstrated here; see the twin-kafka guide for the per-cluster
-  dead-letter behavior.
+- **Retry is default-on; a dead-letter topic is opt-in per binding** (`dlq-topic`) and not configured
+  here - without one, exhausted failures are logged and dropped to avoid a redelivery storm. See the
+  twin-kafka guide for the per-cluster dead-letter behavior.

--- a/examples/twin-kafka-demo/src/main/resources/application-bridge.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-bridge.properties
@@ -1,6 +1,6 @@
 #
 # bridge role: the twin-kafka dual-cluster bridge. No REST.
-#   java -Dspring.profiles.active=bridge -jar target/twin-kafka-demo-4.8.0.jar
+#   java -Dspring.profiles.active=bridge -jar target/twin-kafka-demo-x.y.z.jar
 #
 # PRIMARY  = the on-prem cluster (9092, WITH Schema Registry)  - minimalist-kafka surface
 # SECONDARY = the cloud cluster  (8092, no Schema Registry)    - twin-kafka surface

--- a/examples/twin-kafka-demo/src/main/resources/application-rest.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-rest.properties
@@ -1,6 +1,6 @@
 #
 # rest role: the HTTP edge on the on-prem side.
-#   java -Dspring.profiles.active=rest -jar target/twin-kafka-demo-4.8.0.jar
+#   java -Dspring.profiles.active=rest -jar target/twin-kafka-demo-x.y.z.jar
 #
 # Publishes profile requests to the on-prem OP_PROFILE_REQUEST topic in the Confluent JSON Schema wire
 # format. It consumes nothing (responses are observed by the node listener), so no flow adapter here.

--- a/examples/twin-kafka-demo/src/main/resources/application-sor.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application-sor.properties
@@ -1,6 +1,6 @@
 #
 # sor role: the system-of-record on the cloud side. No REST.
-#   java -Dspring.profiles.active=sor -jar target/twin-kafka-demo-4.8.0.jar
+#   java -Dspring.profiles.active=sor -jar target/twin-kafka-demo-x.y.z.jar
 #
 # A plain single-cluster minimalist-kafka app whose "primary" IS the cloud broker (8092): it consumes
 # C_PROFILE_REQUEST, applies the command to the temp store /tmp/twin-kafka-demo, and publishes the

--- a/examples/twin-kafka-demo/src/main/resources/application.properties
+++ b/examples/twin-kafka-demo/src/main/resources/application.properties
@@ -15,9 +15,9 @@ log.format=text
 # dead-letter confirm-write timeout; flow processing is bounded by each flow's own ttl
 kafka.dlq.timeout.ms=10000
 
-# Explicit business correlation-id and trace-id header names on the Kafka wire (4.8.0 configurable
-# headers). Every role stamps and reads the same names, so the node listener at the end of the chain
-# prints the very ids minted at the HTTP edge - continuity across two clusters and three apps.
+# Explicit business correlation-id and trace-id header names on the Kafka wire (the configurable
+# header names). Every role stamps and reads the same names, so the node listener at the end of the
+# chain prints the very ids minted at the HTTP edge - continuity across two clusters and three apps.
 kafka.correlation.id.header=X-Correlation-Id
 kafka.trace.id.header=X-Trace-Id
 

--- a/memory/sessions/2026-07-12-030038.md
+++ b/memory/sessions/2026-07-12-030038.md
@@ -1,0 +1,41 @@
+# Session (2026-07-12T03:00:38.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** twin-kafka hardening from the Copilot assessment report
+(/tmp/twin-kafka-assessment-report.md — reviewed first, all 4 findings VERIFIED against
+code before applying; cross-vendor review loop working as designed).
+
+1. KafkaFlowAdapter registry-url diagnostic-key overload (completes the notification-side
+   registryUrlKey() seam symmetry); SecondaryKafkaAutoStart passes its secondary key.
+2. Two secondary regression tests (TwinKafkaBridgeTest 4→6): header-name overrides proven
+   with a raw wire-level KafkaConsumer; poison-flow DLQ lands on the SECONDARY cluster.
+3. Demo README DLQ wording fixed — retry default-on, DLQ opt-in per binding (my error).
+4. Four stale 4.8.0 refs in demo resources → x.y.z / version-free (one more than the
+   report found; they escaped the release sweep — reinforces the no-version-in-comments
+   lesson AND that the sweep only covers poms + 4 known files).
+
+GOTCHA (test build): -pl module `mvn test` compiles against the INSTALLED dependency jar —
+after changing minimalist-kafka's API, `install` it before testing twin-kafka.
+Verified: minimalist 91/91, twin 6/6, reactor 920/920.
+
+Commit `145d017f` — refactor(twin-kafka): hardening from the Copilot assessment report
+
+```
+ examples/twin-kafka-demo/README.md                 |  7 +-
+ .../main/resources/application-bridge.properties   |  2 +-
+ .../src/main/resources/application-rest.properties |  2 +-
+ .../src/main/resources/application-sor.properties  |  2 +-
+ .../src/main/resources/application.properties      |  6 +-
+ .../mini/kafka/KafkaFlowAdapter.java               | 11 ++-
+ .../twin/kafka/SecondaryKafkaAutoStart.java        |  2 +-
+ .../org/platformlambda/twin/kafka/PoisonTask.java  | 36 ++++++++++
+ .../twin/kafka/TwinKafkaBridgeTest.java            | 83 +++++++++++++++++++++-
+ .../src/test/resources/application.properties      |  5 ++
+ system/twin-kafka/src/test/resources/flows.yaml    |  1 +
+ .../src/test/resources/flows/poison-flow.yml       | 18 +++++
+ .../resources/secondary-kafka-flow-adapter.yaml    |  6 ++
+ 13 files changed, 169 insertions(+), 12 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
@@ -121,10 +121,19 @@ public class KafkaFlowAdapter implements AutoCloseable {
 
     private final List<KafkaFlowConsumer> consumers = new ArrayList<>();
     private final Properties consumerProps;
+    // the registry-url application property named in error messages (for accurate diagnostics) -
+    // twin-kafka passes its secondary key so operators are pointed at the right setting
+    private final String registryUrlKey;
 
     public KafkaFlowAdapter(Properties consumerProps, ConfigReader config, long dlqTimeout,
                             RetryPolicy retryPolicy, SchemaCodec schemaCodec) {
+        this(consumerProps, config, dlqTimeout, retryPolicy, schemaCodec, "schema.registry.url");
+    }
+
+    public KafkaFlowAdapter(Properties consumerProps, ConfigReader config, long dlqTimeout,
+                            RetryPolicy retryPolicy, SchemaCodec schemaCodec, String registryUrlKey) {
         this.consumerProps = consumerProps;
+        this.registryUrlKey = registryUrlKey;
         Object entries = config.get(CONSUMER);
         if (!(entries instanceof List<?> list) || list.isEmpty()) {
             throw new IllegalArgumentException("kafka-flow-adapter config must contain a non-empty 'consumer' list");
@@ -169,7 +178,7 @@ public class KafkaFlowAdapter implements AutoCloseable {
         }
         if (schemaEnabled && schemaCodec == null) {
             throw new IllegalArgumentException("consumer[" + i + "] (" + label + ") sets "
-                    + "schema.enabled but 'schema.registry.url' is not configured");
+                    + "schema.enabled but '" + registryUrlKey + "' is not configured");
         }
         KafkaConsumerBinding.Builder builder = KafkaConsumerBinding.builder()
                 .flowId(flowId).groupId(groupId).partition(partition).schemaEnabled(schemaEnabled)

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaAutoStart.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaAutoStart.java
@@ -90,7 +90,7 @@ public class SecondaryKafkaAutoStart implements EntryPoint {
             RetryPolicy retryPolicy = new RetryPolicy(maxRetries, retryBackoffMs, publisher);
             Properties consumerProps = KafkaClientConfig.consumerProperties(config, CONSUMER_LOCATION, DEFAULT_CONSUMER);
             KafkaFlowAdapter adapter = new KafkaFlowAdapter(consumerProps, new ConfigReader(adapterConfig),
-                    dlqTimeout, retryPolicy, schemaCodec);
+                    dlqTimeout, retryPolicy, schemaCodec, REGISTRY_URL);
             adapter.start();
             SecondaryKafkaRuntime.setAdapter(adapter);
             log.info("Secondary Kafka flow adapter started from {}", adapterConfig);

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/PoisonTask.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/PoisonTask.java
@@ -1,0 +1,36 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.twin.kafka;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * Always fails - the task of the poison-flow used by the secondary dead-letter regression test.
+ */
+@PreLoad(route = "poison.task", instances = 1)
+public class PoisonTask implements TypedLambdaFunction<byte[], Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, byte[] input, int instance) {
+        throw new IllegalStateException("poison - always fails");
+    }
+}

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
@@ -21,6 +21,9 @@ package org.platformlambda.twin.kafka;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,8 @@ import org.platformlambda.mini.kafka.KafkaHeaders;
 import org.platformlambda.mini.kafka.KafkaRuntime;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +81,8 @@ class TwinKafkaBridgeTest {
         clusterA = new EmbeddedKafka(19092, 19093, "/tmp/twin-kafka-a");
         clusterB = new EmbeddedKafka(18092, 18093, "/tmp/twin-kafka-b");
         createTopics(clusterA.bootstrapServers(), "bridge.source", "reverse.mirror");
-        createTopics(clusterB.bootstrapServers(), "bridge.mirror", "reverse.source", "schema.mirror");
+        createTopics(clusterB.bootstrapServers(), "bridge.mirror", "reverse.source", "schema.mirror",
+                "header.probe", "poison.source", "poison.dlq");
         // registry on the SECONDARY side only (asymmetric topology)
         registryB = new EmbeddedSchemaRegistry();
         System.setProperty("SECONDARY_SCHEMA_REGISTRY_URL", registryB.baseUrl());
@@ -210,5 +216,80 @@ class TwinKafkaBridgeTest {
         assertNotNull(response);
         assertTrue(String.valueOf(response.getError()).contains("schema.registry.url"),
                 "the failure names the primary registry key, got: " + response.getError());
+    }
+
+    /**
+     * The secondary notification must stamp the SECONDARY header-name overrides
+     * (secondary.kafka.correlation.id.header / secondary.kafka.trace.id.header from the test
+     * application.properties) on cluster-B records - observed with a raw consumer on the wire.
+     */
+    @Test
+    void secondaryOutboundHeaderOverrides() throws Exception {
+        String cid = "override-" + Utility.getInstance().getUuid();
+        PostOffice po = PostOffice.trackable("unit.test", TRACE_B, "TEST /secondary/headers");
+        po.send(new EventEnvelope().setTo("secondary.kafka.notification")
+                .setHeader(KafkaHeaders.TOPIC, "header.probe")
+                .setHeader("X-Secondary-Cid", cid)
+                .setBody("{\"hello\":\"header probe\"}".getBytes(StandardCharsets.UTF_8))
+                .setTraceId(TRACE_B).setTracePath("TEST /secondary/headers"));
+        ConsumerRecord<String, byte[]> record = pollOne(clusterB.bootstrapServers(),
+                "header.probe", "header-probe-group");
+        assertNotNull(record, "the probe record should arrive on cluster B");
+        assertEquals(cid, headerValue(record, "X-Secondary-Cid"),
+                "business correlation-id stamped under the SECONDARY override name");
+        assertEquals(TRACE_B, headerValue(record, "X-Secondary-Trace"),
+                "trace-id stamped under the SECONDARY override name");
+        assertTrue(String.valueOf(headerValue(record, "traceparent")).contains(TRACE_B),
+                "W3C traceparent is stamped alongside the legacy trace-id header");
+        assertNull(headerValue(record, "cid"),
+                "the global default name is not used when the secondary override is set");
+    }
+
+    /**
+     * Dead letters from a SECONDARY binding must land on the SECONDARY cluster: the poison flow
+     * always fails, and after exhausted retries the record appears on the binding's dlq-topic on
+     * cluster B (RetryPolicy carries the secondary publisher).
+     */
+    @Test
+    void secondaryDeadLettersLandOnSecondaryCluster() throws Exception {
+        PostOffice po = PostOffice.trackable("unit.test", TRACE_B, "TEST /secondary/dlq");
+        po.send(new EventEnvelope().setTo("secondary.kafka.notification")
+                .setHeader(KafkaHeaders.TOPIC, "poison.source")
+                .setBody("{\"hello\":\"boom\"}".getBytes(StandardCharsets.UTF_8))
+                .setTraceId(TRACE_B).setTracePath("TEST /secondary/dlq"));
+        // 3 retries at 500ms backoff, then the dead-letter write to the secondary cluster
+        ConsumerRecord<String, byte[]> record = pollOne(clusterB.bootstrapServers(),
+                "poison.dlq", "dlq-probe-group");
+        assertNotNull(record, "the exhausted record should land on the secondary cluster's DLQ topic");
+        assertEquals("{\"hello\":\"boom\"}", new String(record.value(), StandardCharsets.UTF_8),
+                "the dead letter carries the original payload");
+    }
+
+    /** Raw wire-level consumer: poll one record from a topic (up to 60s). */
+    private static ConsumerRecord<String, byte[]> pollOne(String bootstrapServers, String topic,
+                                                          String groupId) {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", bootstrapServers);
+        props.put("group.id", groupId);
+        props.put("auto.offset.reset", "earliest");
+        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(props)) {
+            consumer.subscribe(List.of(topic));
+            long deadline = System.currentTimeMillis() + 60000;
+            while (System.currentTimeMillis() < deadline) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofSeconds(2));
+                for (ConsumerRecord<String, byte[]> r : records) {
+                    return r;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Read a record header as UTF-8 text (null when absent). */
+    private static String headerValue(ConsumerRecord<String, byte[]> record, String name) {
+        var header = record.headers().lastHeader(name);
+        return header == null ? null : new String(header.value(), StandardCharsets.UTF_8);
     }
 }

--- a/system/twin-kafka/src/test/resources/application.properties
+++ b/system/twin-kafka/src/test/resources/application.properties
@@ -25,3 +25,8 @@ schema.registry.url=${SCHEMA_REGISTRY_URL:}
 # secondary registry injected by the test
 secondary.schema.registry.url=${SECONDARY_SCHEMA_REGISTRY_URL:}
 secondary.schema.registry.cache.ttl=1h
+
+# secondary outbound header-name overrides (exercised by SecondaryHeaderAndDlqTest): the secondary
+# notification stamps these names on cluster B records instead of the global kafka.* defaults
+secondary.kafka.correlation.id.header=X-Secondary-Cid
+secondary.kafka.trace.id.header=X-Secondary-Trace

--- a/system/twin-kafka/src/test/resources/flows.yaml
+++ b/system/twin-kafka/src/test/resources/flows.yaml
@@ -7,3 +7,4 @@ flows:
   - 'sink-a-flow.yml'
   - 'sink-b-flow.yml'
   - 'schema-sink-flow.yml'
+  - 'poison-flow.yml'

--- a/system/twin-kafka/src/test/resources/flows/poison-flow.yml
+++ b/system/twin-kafka/src/test/resources/flows/poison-flow.yml
@@ -1,0 +1,18 @@
+#
+# Dead-letter regression flow: its single task always fails, so the secondary adapter's retry
+# policy exhausts and writes the record to the binding's dlq-topic ON THE SECONDARY CLUSTER.
+#
+flow:
+  id: 'poison-flow'
+  description: 'Always fails - drives the secondary dead-letter path'
+  ttl: 10s
+
+first.task: 'poison.task'
+
+tasks:
+  - input:
+      - 'input.body -> *'
+    process: 'poison.task'
+    output: []
+    description: 'Throw on every delivery'
+    execution: end

--- a/system/twin-kafka/src/test/resources/secondary-kafka-flow-adapter.yaml
+++ b/system/twin-kafka/src/test/resources/secondary-kafka-flow-adapter.yaml
@@ -14,3 +14,9 @@ consumer:
     flow: 'schema-sink-flow'
     group: 'schema-b-group'
     schema.enabled: true
+  # dead-letter regression: the poison flow always fails, so exhausted retries must land on the
+  # SECONDARY cluster's DLQ topic (RetryPolicy carries the secondary publisher)
+  - topic: 'poison.source'
+    flow: 'poison-flow'
+    group: 'poison-b-group'
+    dlq-topic: 'poison.dlq'


### PR DESCRIPTION
## Summary
Implements the four findings of the external (Copilot) twin-kafka assessment.
Each finding was verified against the code before applying - all four were
genuine.

## Changes
1. **Accurate secondary diagnostics** - KafkaFlowAdapter gains a registry-url
   diagnostic-key parameter (default `schema.registry.url`);
   SecondaryKafkaAutoStart passes `secondary.schema.registry.url`, so a
   secondary `schema.enabled` binding without a secondary registry now fails
   fast naming the right setting. This completes the seam symmetry with the
   notification side's existing `registryUrlKey()`.
2. **Two secondary-specific regression tests** (TwinKafkaBridgeTest 4 -> 6):
   - `secondaryOutboundHeaderOverrides` - a raw wire-level consumer proves
     cluster-B records carry the `secondary.kafka.*.header` override names
     (X-Secondary-Cid / X-Secondary-Trace) plus the W3C traceparent, and not
     the global default name
   - `secondaryDeadLettersLandOnSecondaryCluster` - a poison flow exhausts
     retries and the record lands on the binding's `dlq-topic` ON the
     secondary cluster, proving RetryPolicy carries the secondary publisher
3. **Demo README DLQ wording corrected** - retry is default-on; a dead-letter
   topic is opt-in per binding (`dlq-topic`); without one, exhausted failures
   are logged and dropped (matches KafkaFlowConsumer behavior)
4. **Stale 4.8.0 references in demo resources** replaced with the `x.y.z`
   placeholder / version-free phrasing - four occurrences, one more than the
   report found; they had escaped the release sweep, reinforcing the
   no-version-strings-in-comments convention

## Verification
- minimalist-kafka 91/91 (adapter overload is additive)
- twin-kafka 6/6 (both new regressions green against the dual embedded brokers)
- Full reactor offline WITH tests: 920 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)