### PR TITLE
fix(cloud-connector): settle a loopback race in ServiceRegistryEdgeTest

### DIFF
--- a/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
+++ b/connectors/core/cloud-connector/src/test/java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java
@@ -180,12 +180,20 @@ class ServiceRegistryEdgeTest extends TestBase {
         po.asyncRequest(add, 5000).onSuccess(bench::add);
         assertNotNull(bench.poll(10, TimeUnit.SECONDS));
         assertTrue(ServiceRegistry.getInstances("edge.local.route").contains(myOrigin));
-        // and unregistering it broadcasts the removal
+        // and unregistering it broadcasts the removal. The earlier add was broadcast through the
+        // mock cloud, which loops it back as an add (final) event - on a slow runner that loopback
+        // can land AFTER this unregister and momentarily re-add the route, so poll until the
+        // trailing unregister (final) loopback settles the registry to the removed state.
         EventEnvelope remove = new EventEnvelope().setTo(ServiceDiscovery.SERVICE_REGISTRY)
                 .setHeader(TYPE, "unregister").setHeader(ORIGIN, myOrigin)
                 .setHeader(ROUTE, "edge.local.route");
         po.asyncRequest(remove, 5000).onSuccess(bench::add);
         assertNotNull(bench.poll(10, TimeUnit.SECONDS));
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline
+                && ServiceRegistry.getInstances("edge.local.route").contains(myOrigin)) {
+            Utility.getInstance().sleep(200);
+        }
         assertFalse(ServiceRegistry.getInstances("edge.local.route").contains(myOrigin));
         // destination checks
         assertTrue(ServiceRegistry.destinationExists(myOrigin));

--- a/memory/sessions/2026-07-12-033231.md
+++ b/memory/sessions/2026-07-12-033231.md
@@ -1,0 +1,21 @@
+# Session (2026-07-12T03:32:31.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** CI flake root-caused and fixed — ServiceRegistryEdgeTest
+localAddAndUnregisterBroadcastToPeers raced the mock-cloud LOOPBACK: a local add is
+broadcast to peers and loops back as add(final); on a slow CI runner the loopback lands
+AFTER the unregister and momentarily re-adds the route at assert time. Fix: poll (10s)
+for the settled removed state (the trailing unregister(final) loopback wins by FIFO).
+LESSON for mock-cloud tests: any assertion on registry state that a broadcast loopback
+can rewrite must poll for the settled state, never read immediately after the RPC returns.
+Verified 14/14 across three consecutive local runs.
+
+Commit `c5ea092a` — fix(cloud-connector): settle a loopback race in ServiceRegistryEdgeTest
+
+```
+ .../java/org/platformlambda/cloud/ServiceRegistryEdgeTest.java | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per AGENTS.md "After Every Session", or leave as a lite log)


### PR DESCRIPTION
## Summary
CI failed intermittently on ServiceRegistryEdgeTest.localAddAndUnregisterBroadcastToPeers
(expected: <false> but was: <true>) while local builds passed.

## Root cause
The test's local add is broadcast to peers and the mock cloud loops it back as an
add (final) event on its own thread. On a slow runner the loopback lands AFTER the
unregister has been processed, momentarily re-adding the route exactly when the
test asserts it is gone. The trailing unregister (final) loopback settles the
registry to the removed state (FIFO through the mock queue).

## Fix
Poll (up to 10s) for the settled removed state instead of asserting immediately
after the RPC returns. The other edge tests were re-checked for the same shape -
only this assertion observes state a broadcast loopback can rewrite, so no other
change is needed.

## Verification
cloud-connector suite 14/14 across three consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)