### PR TITLE
chore(memory): v4.8.2 release closure

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -63,6 +63,30 @@
 
 ## Key Decisions
 
+- **Release 4.8.2 — SHIPPED 2026-07-12 (tag `v4.8.2` on merge commit `6c024311`; PRs #164-#166).**
+  Patch release: twin-kafka-demo correlation-id impedance matching + opt-in template
+  externalization. Cross-vendor loop precedent: GitHub Copilot authored the patch (its session log
+  2026-07-13-001009), crashed mid-task; Claude Code reviewed all edits, completed the crash gap
+  (twin-kafka.md table, configuration-reference rows, sync-over-async properties) and committed with
+  dual attribution (one Co-Authored-By per collaborator per AGENTS.md). **Durable facts:**
+  (1) **Impedance matching is the demo pattern:** each cluster keeps its own business
+  correlation-id header (on-prem X-Correlation-Id, cloud X-Cloud-Correlation-Id); adapters read the
+  cluster header into model.cid, flows map model.cid back out under the NEXT cluster's name — never
+  leak a cluster's header name across the bridge (twin-kafka tests assert this at the wire level).
+  (2) **Template externalization is OPT-IN** (scope: minimalist-kafka/twin-kafka family only):
+  KafkaClientConfig + SecondaryKafkaAutoStart location defaults are classpath-only; devops
+  pipelines set the location key to a rendered file, optionally with a classpath fallback chain —
+  field migration note in the 4.8.2 CHANGELOG (deployments relying on the implicit /tmp/config
+  fallback must set keys explicitly). Legacy connector stack + mini-scheduler keep their own
+  file-first conventions. (3) **SOR response leg publishes via secondary.kafka.notification** —
+  the demo response stays on the cloud cluster until the bridge consumes it; Spring profiles are
+  logical personalities, not security boundaries (README documents that real isolation needs
+  separate deployment/credentials/network policy). (4) **Release-sweep gotcha:** when the outgoing
+  version is a substring of a dependency version (classgraph 4.8.184 contains "4.8.1"), the perl
+  sweep needs a digit lookahead `(?!\d)` — not every bump is naturally safe.
+  See [[release-4-8-1-shipped]] for the prior cycle's facts.
+  <!-- id: release-4-8-2-shipped | created: 2026-07-12 | last_used: 2026-07-12 | uses: 1 | tier: active | origin: 2026-07-13-014037 -->
+
 - **Release 4.8.1 — SHIPPED 2026-07-11 (tag `v4.8.1` on merge commit `3d226c5b`; PRs #159-#161).**
   Maintenance release: dependency security updates (Jackson 2.22.1 closed dependabot/28; log4j2/
   netty/tomcat/gson/vertx refreshed), twin-kafka-demo, SimpleRandomPartitioner, DSA retirement and

--- a/memory/sessions/2026-07-13-014037.md
+++ b/memory/sessions/2026-07-13-014037.md
@@ -36,3 +36,9 @@ IS a substring — the perl sweep needs a digit lookahead `s/4\.8\.1(?!\d)/4.8.2
 (the 4.8.0→4.8.1 sweep was naturally safe; not every bump is). CHANGELOG carries the
 /tmp/config migration note (deployments relying on the implicit fallback must set the
 location keys explicitly). Verified: reactor 920/920 at 4.8.2; pg-example 7/7.
+
+v4.8.2 published: https://github.com/Accenture/mercury-composable/releases/tag/v4.8.2
+Continuity fact [[release-4-8-2-shipped]] records the milestone + durable facts.
+
+## Memory References (addendum)
+- [[release-4-8-2-shipped]] — created (release closure)


### PR DESCRIPTION
## Summary
Memory layer closure for the v4.8.2 release
(https://github.com/Accenture/mercury-composable/releases/tag/v4.8.2).

New continuity fact `release-4-8-2-shipped` recording the milestone and the
cycle's durable facts:

- the impedance-matching demo pattern (per-cluster correlation-id header names,
  translated through model.cid, never leaked across the bridge - wire-asserted)
- template externalization is opt-in for the minimalist-kafka/twin-kafka family
  (classpath-only defaults; the /tmp/config migration note for field
  deployments; legacy connector + mini-scheduler conventions unchanged)
- the SOR response leg via secondary.kafka.notification, and the honest note
  that Spring profiles are logical personalities, not security boundaries
- the release-sweep digit-lookahead gotcha (classgraph 4.8.184 contains
  "4.8.1")
- the cross-vendor precedent: Copilot-authored patch, Claude-reviewed and
  crash-gap-completed, committed with one Co-Authored-By per collaborator

memory-lint: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)