### PR TITLE
fix(security): remediate Snyk gate findings against v4.8.2

### DIFF
--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -22,6 +22,11 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
+             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
+             Confluent chain must override the property itself - see minimalist-kafka's pom. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
@@ -39,7 +44,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -22,6 +22,11 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
+             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
+             Confluent chain must override the property itself - see minimalist-kafka's pom. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
@@ -39,7 +44,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -22,6 +22,11 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
+             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
+             Confluent chain must override the property itself - see minimalist-kafka's pom. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <kafka.version>4.2.0</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
@@ -39,7 +44,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -24,6 +24,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <otel.version>1.63.0</otel.version>
     </properties>
 

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -26,6 +26,12 @@
         <java.version>21</java.version>
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
+             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
+             Confluent chain must override the property itself - see minimalist-kafka's pom. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Embedded broker (kafka_2.13) version for tests. Matches the kafka-clients version pinned by
              minimalist-kafka so there is no client/broker protocol skew. -->
         <kafka.version>4.2.0</kafka.version>
@@ -36,7 +42,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -26,6 +26,14 @@
         <java.version>21</java.version>
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override: the Confluent registry client pulls httpclient5, whose paired
+             httpcore5/httpcore5-h2 carries a Snyk HIGH (CWE-770, resource allocation without
+             throttling) at Spring Boot's managed 5.4.2. Spring Boot's dependencyManagement pins
+             the version (management beats nearest-wins, so a direct pin here would not reach
+             consumers) - override its property instead. Every module that resolves the Confluent
+             chain needs this same override. Remove when Spring Boot's managed version reaches 5.4.3. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Pin the Kafka client to the same version as the embedded broker used in tests
              (kafka_2.13) to avoid client/broker protocol skew. -->
         <kafka.version>4.2.0</kafka.version>
@@ -44,7 +52,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.5</version>
+                <version>2025.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -29,6 +29,12 @@
         <java.version>21</java.version>
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
+             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
+             Confluent chain must override the property itself - see minimalist-kafka's pom. -->
+        <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Same pinning rationale as minimalist-kafka: match the embedded test broker. -->
         <kafka.version>4.2.0</kafka.version>
     </properties>


### PR DESCRIPTION
## What

Remediates the three transitive vulnerabilities the field Snyk scan flagged against v4.8.2
(six HIGH findings reducing to one vulnerability resolved by six modules, plus two MEDIUMs),
across 30 pom files:

| Finding | Fixed version | Mechanism |
|---|---|---|
| `httpcore5`/`httpcore5-h2` 5.4.2 — HIGH, CWE-770 (resource allocation without throttling) | 5.4.3 | `<httpcore5.version>` property override in the six modules resolving the Confluent registry chain (minimalist-kafka, twin-kafka, sync-over-async, kafka-demo, twin-kafka-demo, sync-over-async-demo) |
| `log4j-api` 2.25.4 — MEDIUM, CWE-116 (improper output encoding) | 2.26.1 | Added the `<log4j2.version>` property to the four poms that never declared it (minimalist-kafka, twin-kafka, sync-over-async, opentelemetry-forwarder) |
| `reactor-netty-http` 1.3.5 — MEDIUM, CWE-319 (cleartext transmission) | 1.3.6 | reactor-bom 2025.0.5 → 2025.0.6 across all 28 poms importing it, including the non-reactor api-playground and pg-example |

## Why

Snyk reported "no supported fix" because these arrive transitively — and for httpcore5 the real
root cause is Spring Boot 4.1.0's `dependencyManagement`, which pins the vulnerable 5.4.2.
Managed versions beat Maven's nearest-wins resolution, so a direct dependency pin cannot
propagate to consumers (proven empirically); overriding Spring Boot's version property in each
affected module is the correct idiom — the same one already used for `log4j2.version`,
`tomcat.version`, and `netty.version` — and self-retires when Spring Boot's managed version
catches up. The log4j finding survived the 4.8.1 dependency refresh because that sweep only
updated poms that already had the property, leaving four modules on Spring Boot's default.

Verified: reactor-wide `dependency:tree` audit shows zero occurrences of the vulnerable versions
(non-reactor subprojects checked as well); full reactor build green with all tests; pg-example
7/7 standalone. Ships in v4.8.3.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>