### PR TITLE
test+docs: trace/correlation-id propagation regression guard and observability guide refresh

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -88,7 +88,7 @@ standard `traceparent` header:
 
 The `X-Trace-Id` header carries the trace ID for callers not yet on W3C Trace Context. The framework does not
 echo the trace ID back to the HTTP client. (The correlation-id — a separate concern — is documented in
-[Reserved Names & Headers](reserved-names-and-headers.md#correlation-id-propagation).)
+[Reserved Names & Headers](reserved-names-and-headers.md#reserved-http-header-names).)
 
 > **Let the framework manage trace headers — don't set them yourself.** Inside a traced flow or function the
 > platform injects `X-Trace-Id` and `traceparent` on every outbound HTTP call from the current trace context,
@@ -97,6 +97,72 @@ echo the trace ID back to the HTTP client. (The correlation-id — a separate co
 > endpoint with `tracing: false`, or a call made outside a trace): there a trace header you set passes through
 > untouched — the intended escape hatch for handing a trace context to a third-party system, or for
 > unit-testing an external endpoint with full control over its request headers.
+
+## Header impedance matching (trace-id and correlation-id) {#impedance-matching}
+
+Not every caller names its headers the way this framework does. An enterprise gateway may have standardized on
+its own trace header long before W3C Trace Context; a legacy Kafka producer may stamp `X-Correlation-ID`; and
+two systems bridged by one application rarely agree with each other. Rather than forcing every party to rename,
+the platform **matches the impedance at the edge**: the header *names* are configuration, while everything
+downstream keeps working with the same two ids —
+
+- the **trace id** (with its W3C `traceparent` context) drives the distributed tracing on this page;
+- the **business correlation-id** is a separate concern — captured at the edge, preserved as the flow's
+  `model.cid`, and exposed to every function via `PostOffice.getMyCorrelationId()`
+  (see [Reserved Names & Headers](reserved-names-and-headers.md#reserved-http-header-names)).
+
+### The configurable names {#impedance-config}
+
+Global defaults in `application.properties`:
+
+| Key | Default | Where it applies |
+|:----|:--------|:-----------------|
+| `http.trace.id.header` | `X-Trace-Id` | REST automation inbound (when no `traceparent` is present) and the async HTTP client outbound |
+| `http.correlation.id.header` | `X-Correlation-Id` | HTTP edge capture inbound; async HTTP client outbound |
+| `kafka.trace.id.header` | *(unset)* | Kafka Flow Adapter inbound fallback; `simple.kafka.notification` outbound, stamped alongside `traceparent` |
+| `kafka.correlation.id.header` | `cid` | Kafka Flow Adapter inbound; `simple.kafka.notification` outbound |
+
+Per-entry overrides, for a single application that faces callers with different conventions:
+
+- a **rest.yaml** endpoint entry accepts `trace.id.header` / `correlation.id.header`;
+- a **kafka-flow-adapter.yaml** consumer binding accepts the same two keys
+  ([Kafka Flow Adapter](kafka-flow-adapter.md#adapter-yaml));
+- [twin-kafka](twin-kafka.md) adds `secondary.kafka.trace.id.header` / `secondary.kafka.correlation.id.header`
+  globals when the second Kafka cluster follows its own convention.
+
+**Precedence:** per-entry override > `application.properties` global > built-in default. A well-formed W3C
+`traceparent` **always** takes precedence for the trace id, whatever the header naming — so adopting these
+overrides never breaks OpenTelemetry-compliant callers. The full key reference lives in the
+[Configuration Reference](configuration-reference.md#observability).
+
+```yaml
+# rest.yaml - one endpoint serves a legacy caller that sends its own header names
+  - service: "legacy.orders"
+    methods: ['POST']
+    url: "/api/legacy/orders"
+    timeout: 15s
+    tracing: true
+    trace.id.header: "X-Legacy-Trace"
+    correlation.id.header: "X-Legacy-Cid"
+```
+
+### Bridging two conventions {#impedance-bridge}
+
+When one application connects two systems that each own a correlation-id convention (for example a
+dual-cluster Kafka bridge), keep each system's header name strictly on its own side:
+
+1. the **inbound** adapter binding declares that system's `correlation.id.header`, so the id lands in
+   `model.cid`;
+2. the **flow** maps it back out under the *next* system's name — `'model.cid -> header.X-Their-Header'` —
+   on the outbound data mapping;
+3. neither system ever sees the other's header name: the id *value* is what crosses the bridge, and the trace
+   context (`traceparent`) rides alongside automatically, keeping one continuous distributed trace end to end.
+
+The [twin-kafka guide](twin-kafka.md) covers this pattern across two Kafka clusters, and the
+[`twin-kafka-demo`](https://github.com/Accenture/mercury-composable/tree/main/examples/twin-kafka-demo) worked
+example runs it end to end: an on-prem system's `X-Correlation-Id` and a cloud system's
+`X-Cloud-Correlation-Id` carry the same id through one bridged transaction, with each header name confined to
+its own cluster.
 
 ## Exporting telemetry {#export}
 

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -188,6 +188,37 @@ class RestEndpointTest extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void traceContinuesAcrossApplicationToApplicationHttpCall() throws InterruptedException, ExecutionException {
+        // The application-to-application case reported from the field: application A receives a traced
+        // HTTP request and its function calls application B's endpoint through "async.http.request".
+        // AsyncHttpClient stamps the current trace context on the outgoing request (X-Trace-Id plus W3C
+        // "traceparent") and app B's REST automation ("tracing: true" on the endpoint) continues the
+        // SAME trace instead of starting a fresh one. Here /api/chain/probe (downstream.caller) is
+        // app A and /api/legacy/probe (header.probe) is app B - one JVM, but both hops go through the
+        // real HTTP stack, exactly like two separate applications.
+        String w3cTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        String traceparent = "00-" + w3cTraceId + "-00f067aa0ba902b7-01";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setHeader("accept", "application/json").setHeader("traceparent", traceparent);
+        req.setUrl("/api/chain/probe").setQueryParameter("port", String.valueOf(port));
+        req.setTargetHost("http://127.0.0.1:" + port);
+        EventEnvelope response = po.asyncRequest(new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST)
+                .setBody(req), RPC_TIMEOUT).toCompletionStage().toCompletableFuture().get();
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        // hop 1: application A adopted the upstream W3C trace context at its HTTP ingress
+        assertEquals(w3cTraceId, map.getElement("caller_trace_id"));
+        // hop 2: application B continued the SAME trace across the app-to-app HTTP call
+        // (its endpoint captures a different legacy trace-id header name, so this also proves the
+        // W3C traceparent stamped by AsyncHttpClient takes precedence regardless of header naming)
+        assertEquals(w3cTraceId, map.getElement("probe_traceId"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void asyncHttpClientForwardsDeveloperSuppliedTraceparent() throws InterruptedException {
         // When this call is not being traced, an explicitly developer-set W3C "traceparent" is an intentional
         // act (e.g. handing a trace context to a 3rd-party system, or forwarding an upstream trace). The

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -184,6 +184,9 @@ class RestEndpointTest extends TestBase {
         MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
         // AsyncHttpClient forwarded the business correlation-id downstream; the service echoes it back
         assertEquals(correlationId, map.getElement("headers.x-correlation-id"));
+        // ... and stamped the trace id under the default X-Trace-Id header - even for a non-W3C trace id
+        // ("201" is not 32-hex, so no traceparent can be formed and X-Trace-Id is the only carrier)
+        assertEquals("201", map.getElement("headers.x-trace-id"));
     }
 
     @SuppressWarnings("unchecked")

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/DownstreamCaller.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/DownstreamCaller.java
@@ -1,0 +1,56 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simulates "application A" in an application-to-application HTTP call: a traced function that
+ * invokes another REST endpoint through the "async.http.request" HTTP client. The downstream
+ * endpoint ("/api/legacy/probe") echoes the trace id it continued under, so a test can assert
+ * end-to-end distributed-trace continuity across the HTTP boundary.
+ */
+@PreLoad(route = "downstream.caller", instances = 10)
+public class DownstreamCaller implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+    private static final long RPC_TIMEOUT = 10000;
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) throws Exception {
+        var po = new PostOffice(headers, instance);
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setHeader("accept", "application/json");
+        req.setUrl("/api/legacy/probe").setTargetHost("http://127.0.0.1:" + input.getQueryParameter("port"));
+        EventEnvelope res = po.eRequest(new EventEnvelope().setTo("async.http.request").setBody(req),
+                                        RPC_TIMEOUT).get();
+        Map<String, Object> result = new HashMap<>();
+        if (res.getBody() instanceof Map<?, ?> probe) {
+            probe.forEach((k, v) -> result.put("probe_" + k, v));
+        }
+        // this function's own trace context, adopted at this app's HTTP ingress
+        result.put("caller_trace_id", po.getTraceId());
+        return result;
+    }
+}

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -58,6 +58,15 @@ rest:
     trace.id.header: "X-Legacy-Trace"
     correlation.id.header: "X-Legacy-Cid"
 
+  # Simulates application A in an application-to-application HTTP call: this traced endpoint's
+  # function calls /api/legacy/probe ("application B") through async.http.request, so tests can
+  # assert that one distributed trace continues across the HTTP hop between the two.
+  - service: "downstream.caller"
+    methods: ['GET']
+    url: "/api/chain/probe"
+    timeout: 15s
+    tracing: true
+
   - service: "hello.mock"
     methods: ['POST']
     url: "/api/upload/demo"


### PR DESCRIPTION
## What

Adds regression coverage for the distributed-tracing propagation contract and refreshes the
Observability guide:

- **New test** `traceContinuesAcrossApplicationToApplicationHttpCall` — a traced application A
  calls application B through `async.http.request`, both hops over the real HTTP stack; asserts
  one continuous trace under the caller's W3C `traceparent`. New `DownstreamCaller` test fixture
  and `/api/chain/probe` test endpoint; using the legacy-header-override endpoint as the
  downstream also proves the stamped `traceparent` takes precedence regardless of per-endpoint
  header naming.
- **New assertion** on the existing downstream test: outbound `X-Trace-Id` stamping by the async
  HTTP client — the carrier for non-W3C trace ids, where no `traceparent` can be formed —
  verified via the downstream header echo.
- **Observability guide**: new "Header impedance matching (trace-id and correlation-id)" section
  documenting the 4.8.x configurable header names — the four `application.properties` globals,
  per-entry overrides (rest.yaml endpoint entries, kafka-flow-adapter.yaml consumer bindings),
  twin-kafka's `secondary.*` globals, the precedence rule (per-entry > global > built-in
  default; W3C `traceparent` always wins for the trace id), and the two-convention bridging
  recipe via `model.cid`. Also repairs a broken anchor to the Reserved Names & Headers page.

## Why

A field team on 4.6.3 reported the traceId no longer propagating between application endpoints —
behavior that changed deliberately in 4.5.0 when the legacy `X-Correlation-Id`-as-trace-id
conflation was retired. Investigation confirmed the framework propagates correctly (validated
live with sync-over-async-demo: one continuous trace across two JVMs and two Kafka hops,
chaining onto a caller-supplied `traceparent`), but exposed two gaps worth closing: the traced
application-to-application HTTP hop had no unit-level regression guard, and the
impedance-matching configuration existed only in the reference tables — not in the Observability
guide's narrative, where someone diagnosing this exact symptom would look.

Verified: RestEndpointTest 36/36; full platform-core suite 394 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>