### PR TITLE
fix(scheduler-example): settle a state-file race in ScheduleAdminTest

### DIFF
--- a/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/ScheduleAdminTest.java
+++ b/examples/scheduler-example/src/test/java/org/platformlambda/quartz/tests/ScheduleAdminTest.java
@@ -82,16 +82,22 @@ class ScheduleAdminTest extends TestBase {
         MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
         assertEquals("Job started", map.getElement("message"));
         assertEquals("demo-task", map.getElement("job"));
-        // the job executor runs asynchronously; the resolver's start record appears shortly after
-        File state = new File("/tmp/scheduler-states", "demo-task");
-        for (int i = 0; i < 30 && !state.exists(); i++) {
+        // The job executor runs asynchronously and the sample state resolver's file write is
+        // truncate-then-write (not atomic), so the state file can EXIST while still empty - both
+        // when the start record is created and again when the end record rewrites it. File
+        // existence is therefore not readiness. Poll the admin endpoint itself until it returns
+        // a readable record (an empty/partial file surfaces as a 200 with no map content).
+        MultiLevelMap detail = null;
+        long deadline = System.currentTimeMillis() + 15000;
+        while (System.currentTimeMillis() < deadline) {
+            EventEnvelope job = adminRequest("GET", "demo-task", null);
+            if (job.getStatus() == 200 && job.getBody() instanceof Map<?, ?> m && m.get("name") != null) {
+                detail = new MultiLevelMap((Map<String, Object>) m);
+                break;
+            }
             Utility.getInstance().sleep(500);
         }
-        assertTrue(state.exists(), "job executor should have recorded the start state");
-        // once the state record exists, the job can be read back by name
-        EventEnvelope job = adminRequest("GET", "demo-task", null);
-        assertEquals(200, job.getStatus());
-        MultiLevelMap detail = new MultiLevelMap((Map<String, Object>) job.getBody());
+        assertNotNull(detail, "job state record should become readable after the manual run");
         assertEquals("demo-task", detail.getElement("name"));
         assertEquals("hello.world", detail.getElement("service"));
     }


### PR DESCRIPTION
## What

Fixes the CI flake in `ScheduleAdminTest.manualJobRunCreatesTheStateRecord` (seen on PR #168's
CI run). The test now polls the schedule-admin endpoint for a *readable* state record (200 plus
map content, 15s deadline) instead of polling the filesystem for the state file's existence.

## Why

The sample state resolver writes with truncate-then-write (`Utility.bytes2file` →
`FileOutputStream`), so the state file EXISTS while still empty — once when the start record is
created, and again when the end record rewrites it after the fast demo job completes. On a slow
CI runner the follow-up GET landed inside that window: the admin function read an empty file,
Gson mapped the empty string to null, and the 200-with-null-body crashed the test with an NPE in
`MultiLevelMap`. File existence is not readiness; polling the consuming API for settled state is
the same pattern applied in the ServiceRegistryEdgeTest fix (#164).

Verified: scheduler-example suite 8/8; the affected test repeated 3x green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>