### PR TITLE
chore(release): version 4.8.3 for field pipeline test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.8.3, 7/13/2026
+
+Security patch: remediates the three transitive OSS vulnerabilities the field security gate
+flagged against v4.8.2, and hardens distributed-tracing regression coverage.
+
+### Security
+
+1. **Apache HttpComponents `httpcore5`/`httpcore5-h2` 5.4.2 → 5.4.3** (HIGH, CWE-770 - resource
+   allocation without throttling). Arrives transitively via the Confluent Schema Registry client's
+   `httpclient5`; Spring Boot's `dependencyManagement` pins the vulnerable version and managed
+   versions beat Maven's nearest-wins resolution, so the fix overrides Spring Boot's
+   `httpcore5.version` property in each of the six modules that resolve the chain
+   (minimalist-kafka, twin-kafka, sync-over-async, kafka-demo, twin-kafka-demo,
+   sync-over-async-demo). The override self-retires when Spring Boot's managed version catches up.
+2. **`log4j-api` 2.25.4 → 2.26.1** (MEDIUM, CWE-116 - improper output encoding). Four poms
+   (minimalist-kafka, twin-kafka, sync-over-async, opentelemetry-forwarder) never declared the
+   `log4j2.version` property, so Spring Boot's default applied; the property is now declared
+   everywhere log4j is resolved.
+3. **`reactor-netty-http` 1.3.5 → 1.3.6** (MEDIUM, CWE-319 - cleartext transmission).
+   `reactor-bom` 2025.0.5 → 2025.0.6 across all 28 poms importing it, including the non-reactor
+   api-playground and pg-example subprojects.
+
+### Added
+
+1. **Trace-continuity regression tests.** A new platform-core test drives the
+   application-to-application HTTP case end-to-end over the real HTTP stack - a traced app A
+   calling app B through `async.http.request` - asserting one continuous W3C trace across both
+   hops; outbound `X-Trace-Id` stamping (the carrier for non-W3C trace ids) is now directly
+   asserted as well.
+2. **Observability guide - header impedance matching.** New section documenting the configurable
+   trace-id / correlation-id header names: the four `application.properties` globals, per-entry
+   overrides (rest.yaml and kafka-flow-adapter.yaml), twin-kafka's `secondary.*` globals, the
+   precedence rule (per-entry > global > built-in default; W3C `traceparent` always wins for the
+   trace id), and the two-convention bridging recipe via `model.cid`.
+
+### Fixed
+
+1. **ScheduleAdminTest CI flake (scheduler-example).** The test treated state-file existence as
+   readiness, but the sample resolver's write is truncate-then-write, so the file exists while
+   still empty. The test now polls the schedule-admin endpoint for a readable record instead of
+   polling the filesystem.
+
+---
 ## Version 4.8.2, 7/12/2026
 
 Patch release: the twin-kafka-demo now faithfully demonstrates cross-cluster correlation-id

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.2) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.3) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.2) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.3) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.8.2";
+    private static final String VERSION = "4.8.3";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.8.2-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.8.2-exec.jar"]
+COPY target/kafka-standalone-4.8.3-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.8.3-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.8.2</version>
+    <version>4.8.3</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.2</version>
+            <version>4.8.3</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version bump 4.8.2 → 4.8.3 across 32 poms, CLAUDE.md/GEMINI.md, `OtelForwarderContext.VERSION`,
the kafka-standalone Dockerfile, and a new CHANGELOG entry (Security / Added / Fixed).

## Why

Security patch release for field pipeline testing. It carries the remediation of the three
transitive OSS vulnerabilities the field Snyk gate flagged against v4.8.2 (#168 — httpcore5
5.4.3 via Spring Boot property override, log4j-api 2.26.1, reactor-netty-http 1.3.6 via
reactor-bom 2025.0.6), the trace-continuity regression tests and observability
impedance-matching documentation (#169), and the ScheduleAdminTest CI race fix (#170).

The release tag is deliberately deferred: main syncs to the field for the pipeline test first,
and v4.8.3 is tagged only after the field publishes to the artifact repository — leaving room
for further fixes before the official release.

Verified: full reactor green with all tests at 4.8.3; pg-example 7/7 standalone.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>