### PR TITLE
docs(rest-automation): document per-entry trace.id.header and correlation.id.header keys

### DIFF
--- a/docs/guides/rest-automation/ai-agent-guide.md
+++ b/docs/guides/rest-automation/ai-agent-guide.md
@@ -85,6 +85,22 @@ rest:
     timeout: 10s
 ```
 
+A traced endpoint serving a legacy caller that uses its own trace/correlation header names
+(per-endpoint impedance matching — the optional `trace.id.header` / `correlation.id.header`
+keys override the global `http.trace.id.header` / `http.correlation.id.header` names for
+this entry only; a well-formed W3C `traceparent` still takes precedence for the trace-id):
+
+```yaml
+rest:
+  - service: 'legacy.orders'
+    methods: ['POST']
+    url: '/api/legacy/orders'
+    timeout: 15s
+    tracing: true
+    trace.id.header: 'X-Legacy-Trace'
+    correlation.id.header: 'X-Legacy-Cid'
+```
+
 ## See also {#see-also}
 
 - [REST automation grammar](rest-grammar.md) + [`rest-automation.json`](rest-automation.json) — the source of truth.

--- a/docs/guides/rest-automation/index.md
+++ b/docs/guides/rest-automation/index.md
@@ -115,6 +115,8 @@ A REST endpoint may look like this:
 | headers | Reference ID of a HEADERS<br>transformation section | 'header_1' |
 | authentication | *Optional*. Route the HTTP<br>request for authentication<br>is provided. | default is false |
 | tracing | Enable distributed tracing<br>when set to 'true' | default is false |
+| trace.id.header | *Optional*. Per-endpoint override of the<br>trace-id header name for this entry<br>(global default is `http.trace.id.header`,<br>normally `X-Trace-Id`) | 'X-Legacy-Trace' |
+| correlation.id.header | *Optional*. Per-endpoint override of the<br>business correlation-id header name<br>(global default is `http.correlation.id.header`,<br>normally `X-Correlation-Id`) | 'X-Legacy-Cid' |
 
 When more than one service route name is provided, the first one is the primary service and the system will
 deliver its output as HTTP response. The second one is the secondary service for listening to the REST endpoint.
@@ -196,6 +198,32 @@ three lines of log from "distributed trace" showing that the HTTP request is pro
 > *Note*: The "async.http.response" is a built-in function to send the HTTP response to the browser.
           The term "browser" also refers to a caller from an application ("client"). Therefore,
           browser and client can be used interchangeably.
+
+### Per-endpoint trace and correlation-id header names
+
+Not every caller uses the platform's default header names (`X-Trace-Id` for the trace-id,
+`X-Correlation-Id` for the business correlation-id). When one particular endpoint serves a legacy
+caller with its own convention, add the optional `trace.id.header` and/or `correlation.id.header`
+keys to that entry — they override the `application.properties` globals (`http.trace.id.header`,
+`http.correlation.id.header`) for this endpoint only:
+
+```yaml
+  - service: "legacy.orders"
+    methods: ['POST']
+    url: "/api/legacy/orders"
+    timeout: 15s
+    tracing: true
+    trace.id.header: 'X-Legacy-Trace'
+    correlation.id.header: 'X-Legacy-Cid'
+```
+
+Header capture is case-insensitive and the precedence is per-entry override, then the global,
+then the built-in default. A well-formed W3C `traceparent` header always takes precedence for the
+trace-id, so the override never interferes with OpenTelemetry-compliant callers. The correlation-id
+captured here is preserved end-to-end — it becomes the flow's `model.cid` and is available to every
+function via `PostOffice.getMyCorrelationId()`. See
+[Observability — header impedance matching](../observability.md#impedance-matching) for the full
+picture, including the Kafka counterpart and the two-convention bridging pattern.
 
 The optional `cors` and `headers` sections point to the specific CORS and HEADERS sections respectively.
 

--- a/docs/guides/rest-automation/rest-automation.json
+++ b/docs/guides/rest-automation/rest-automation.json
@@ -20,6 +20,8 @@
     { "field": "authentication", "required": false, "meaning": "a service route, or routing specs: 'default: svc' / 'header: svc' / 'header: value: svc'" },
     { "field": "upload", "required": false, "meaning": "true/false (default false) - enable multipart upload" },
     { "field": "tracing", "required": false, "meaning": "true/false (default false) - enable distributed tracing" },
+    { "field": "trace.id.header", "required": false, "meaning": "per-endpoint override of the global http.trace.id.header (default X-Trace-Id) - header name (quoted string) for a caller with its own trace-id header convention; a well-formed W3C traceparent still takes precedence" },
+    { "field": "correlation.id.header", "required": false, "meaning": "per-endpoint override of the global http.correlation.id.header (default X-Correlation-Id) - header name (quoted string) for a caller with its own business correlation-id header convention" },
     { "field": "trust_all_cert", "required": false, "meaning": "true/false - HTTPS relay only" },
     { "field": "url_rewrite", "required": false, "meaning": "list of exactly two strings [from, to] - HTTP(S) relay only" }
   ],

--- a/docs/guides/rest-automation/rest-grammar.md
+++ b/docs/guides/rest-automation/rest-grammar.md
@@ -48,10 +48,16 @@ related:
 | `authentication` | no | a service route, or routing specs: `'default: svc'`, `'header: svc'`, `'header: value: svc'` |
 | `upload` | no | `true`/`false` (default false) — enable multipart upload |
 | `tracing` | no | `true`/`false` (default false) — enable distributed tracing |
+| `trace.id.header` | no | per-endpoint override of the global `http.trace.id.header` (default `X-Trace-Id`) — impedance matching for a caller that sends its own trace-id header name; a well-formed W3C `traceparent` still takes precedence |
+| `correlation.id.header` | no | per-endpoint override of the global `http.correlation.id.header` (default `X-Correlation-Id`) — impedance matching for a caller that sends its own business correlation-id header name |
 | `trust_all_cert` | no | `true`/`false` — **HTTPS relay only** |
 | `url_rewrite` | no | a list of **exactly two** strings `[from, to]` — **HTTP(S) relay only** |
 
 Boolean fields (`upload`, `tracing`, `trust_all_cert`) are written **unquoted**, e.g. `tracing: true`.
+The header-override values are header names, written quoted like other strings, e.g.
+`trace.id.header: 'X-Legacy-Trace'` (header capture is case-insensitive; precedence is
+per-entry > `application.properties` global > built-in default — see
+[Observability](../observability.md#impedance-matching)).
 
 ## Binding modes {#binding}
 


### PR DESCRIPTION
## What

Documents the optional per-endpoint `trace.id.header` / `correlation.id.header` keys in all four
REST authoring surfaces: the rest-grammar.md field table (with quoting, case-insensitivity, and
precedence notes), the rest-automation.json machine-readable catalog, a worked legacy-caller
example in the AI agent guide, and syntax-table rows plus a prose section in the REST Automation
guide (precedence rule, W3C `traceparent` interplay, and the `model.cid` /
`getMyCorrelationId()` linkage).

## Why

The per-endpoint header-name overrides shipped in the 4.8.x line were documented in the
configuration reference and (as of #169) the Observability guide, but not in the REST automation
surfaces where an author — human or AI agent — actually writes rest.yaml. In particular, an AI
agent generating rest.yaml deterministically from `rest-automation.json` had no way to know the
keys exist. This closes the gap in the impedance-matching documentation story.

Verified: `check-rest-automation-grammar.py` and `check-doc-canon.py` both green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>