### PR TITLE
chore(quality): resolve field SonarQube findings from the 4.8.3 pipeline scan

### DIFF
--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1812,7 +1812,7 @@ A top-level exception handler should not throw exception. Otherwise it may go in
 
 Therefore, we recommend that an exception handler should return regular result set in a PoJo or a Map object.
 
-An example of task-level exception handler is shown in the "HelloException.class" in the "task" folder
+An example of task-level exception handler is shown in the "HelloExceptionHandler.class" in the "task" folder
 where it set the status code in the result set so that the system can map the status code
 from the result set to the next task or to the HTTP output status code.
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -305,7 +305,7 @@ A log line from a traced function then carries the resolved `context` (from the 
     "timestamp": "2026-06-30T21:17:03Z"
   },
   "time": "2026-06-30 14:17:03.575",
-  "source": "com.accenture.demo.tasks.HelloException.handleEvent(HelloException.java:51)",
+  "source": "com.accenture.demo.tasks.HelloExceptionHandler.handleEvent(HelloExceptionHandler.java:51)",
   "thread": 297,
   "message": "User defined exception handler - status=404 error=Profile 100 not found"
 }

--- a/examples/composable-example/src/main/java/com/accenture/demo/models/Profile.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/models/Profile.java
@@ -24,18 +24,50 @@ import java.util.Map;
 
 public class Profile {
 
-    public Integer id;
-    public String name;
-    public String address;
-    public String telephone;
+    private Integer id;
+    private String name;
+    private String address;
+    private String telephone;
 
     public static Profile create(int id, String name, String address, String telephone) {
         var profile = new Profile();
-        profile.id = id;
-        profile.name = name;
-        profile.address = address;
-        profile.telephone = telephone;
+        profile.setId(id);
+        profile.setName(name);
+        profile.setAddress(address);
+        profile.setTelephone(telephone);
         return profile;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getTelephone() {
+        return telephone;
+    }
+
+    public void setTelephone(String telephone) {
+        this.telephone = telephone;
     }
 
     @SuppressWarnings("unchecked")

--- a/examples/composable-example/src/main/java/com/accenture/demo/models/ProfileConfirmation.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/models/ProfileConfirmation.java
@@ -23,7 +23,31 @@ import java.util.Map;
 
 public class ProfileConfirmation {
 
-    public String type;
-    public Map<String, Object> profile;
-    public List<String> secure;
+    private String type;
+    private Map<String, Object> profile;
+    private List<String> secure;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getProfile() {
+        return profile;
+    }
+
+    public void setProfile(Map<String, Object> profile) {
+        this.profile = profile;
+    }
+
+    public List<String> getSecure() {
+        return secure;
+    }
+
+    public void setSecure(List<String> secure) {
+        this.secure = secure;
+    }
 }

--- a/examples/composable-example/src/main/java/com/accenture/demo/start/MainApp.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/start/MainApp.java
@@ -28,6 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+// S5443 (publicly writable directory): /tmp/keystore holds a DEMO encryption key generated at startup -
+// throwaway local data for the worked example, no confidentiality requirement
+@SuppressWarnings("java:S5443")
 @MainApplication
 public class MainApp implements EntryPoint {
     private static final Logger log = LoggerFactory.getLogger(MainApp.class);

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/CreateProfile.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/CreateProfile.java
@@ -45,7 +45,7 @@ public class CreateProfile implements TypedLambdaFunction<Profile, ProfileConfir
      */
     @Override
     public ProfileConfirmation handleEvent(Map<String, String> headers, Profile input, int instance) {
-        if (input.id == null) {
+        if (input.getId() == null) {
             throw new IllegalArgumentException("Missing id");
         }
         String requiredFields = headers.get(REQUIRED_FIELDS);
@@ -70,9 +70,9 @@ public class CreateProfile implements TypedLambdaFunction<Profile, ProfileConfir
             }
         }
         ProfileConfirmation result = new ProfileConfirmation();
-        result.profile = data.getMap();
-        result.type = "CREATE";
-        result.secure = pFields;
+        result.setProfile(data.getMap());
+        result.setType("CREATE");
+        result.setSecure(pFields);
         return result;
     }
 }

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/DeleteProfile.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/DeleteProfile.java
@@ -29,6 +29,9 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+// S5443 (publicly writable directory): /tmp/store IS the demo's simulated database by design -
+// throwaway local data, no confidentiality or integrity requirement
+@SuppressWarnings("java:S5443")
 @PreLoad(route="v1.delete.profile", instances=10)
 public class DeleteProfile implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/GetProfile.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/GetProfile.java
@@ -28,6 +28,9 @@ import org.platformlambda.core.util.Utility;
 import java.io.File;
 import java.util.Map;
 
+// S5443 (publicly writable directory): /tmp/store IS the demo's simulated database by design -
+// throwaway local data, no confidentiality or integrity requirement
+@SuppressWarnings("java:S5443")
 @PreLoad(route="v1.get.profile", instances=10)
 public class GetProfile implements TypedLambdaFunction<Map<String, Object>, Profile> {
 

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/HelloExceptionHandler.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/HelloExceptionHandler.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 @PreLoad(route="v1.hello.exception", instances=10)
-public class HelloException implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
-    private static final Logger log = LoggerFactory.getLogger(HelloException.class);
+public class HelloExceptionHandler implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+    private static final Logger log = LoggerFactory.getLogger(HelloExceptionHandler.class);
 
     private static final String TYPE = "type";
     private static final String ERROR = "error";

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/SaveProfile.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/SaveProfile.java
@@ -30,6 +30,9 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
+// S5443 (publicly writable directory): /tmp/store IS the demo's simulated database by design -
+// throwaway local data, no confidentiality or integrity requirement
+@SuppressWarnings("java:S5443")
 @PreLoad(route="v1.save.profile", instances=10)
 public class SaveProfile implements TypedLambdaFunction<Map<String, Object>, Void> {
     private static final Logger log = LoggerFactory.getLogger(SaveProfile.class);

--- a/examples/composable-example/src/test/java/com/accenture/flows/FlowTest.java
+++ b/examples/composable-example/src/test/java/com/accenture/flows/FlowTest.java
@@ -25,6 +25,7 @@ import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -43,7 +44,7 @@ class FlowTest extends TestBase {
         PostOffice po = PostOffice.trackable("unit.test", "1000", "TEST /flow/tests");
         // try to retrieve a non-exist profile will get HTTP-404
         AsyncHttpRequest request = new AsyncHttpRequest();
-        request.setTargetHost(HOST).setMethod("GET")
+        request.setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/no-such-profile");
         EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
@@ -56,7 +57,7 @@ class FlowTest extends TestBase {
         // create a profile
         Profile profile = Profile.create(300, "Peter", "100 World Blvd", "888-123-0000");
         AsyncHttpRequest request1 = new AsyncHttpRequest();
-        request1.setTargetHost(HOST).setMethod("POST")
+        request1.setTargetHost(host).setMethod("POST")
                 .setHeader("content-type", "application/json")
                 .setHeader("accept", "application/json")
                 .setBody(profile).setUrl("/api/profile");
@@ -71,10 +72,10 @@ class FlowTest extends TestBase {
         assertEquals("***", mm1.getElement("profile.telephone"));
         assertEquals("CREATE", mm1.getElement("type"));
         // since "create profile" write operation is asynchronous, let's give it a brief moment to complete
-        Thread.sleep(1000);
+        Utility.getInstance().sleep(1000);
         // retrieve the profile
         AsyncHttpRequest request2 = new AsyncHttpRequest()
-                .setTargetHost(HOST).setMethod("GET")
+                .setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/"+profileId);
         EventEnvelope req2 = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request2);
@@ -88,7 +89,7 @@ class FlowTest extends TestBase {
         assertEquals("888-123-0000", mm2.getElement("telephone"));
         // delete the profile
         AsyncHttpRequest request3 = new AsyncHttpRequest()
-                .setTargetHost(HOST).setMethod("DELETE")
+                .setTargetHost(host).setMethod("DELETE")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/"+profileId);
         EventEnvelope req3 = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request3);
@@ -107,7 +108,7 @@ class FlowTest extends TestBase {
         PostOffice po = PostOffice.trackable("unit.test", "2000", "TEST /health/check");
         // try to retrieve a non-exist profile will get HTTP-404
         AsyncHttpRequest request = new AsyncHttpRequest();
-        request.setTargetHost(HOST).setMethod("GET")
+        request.setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/health");
         EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);

--- a/examples/composable-example/src/test/java/com/accenture/support/TestBase.java
+++ b/examples/composable-example/src/test/java/com/accenture/support/TestBase.java
@@ -33,14 +33,14 @@ public class TestBase {
     private static final AtomicInteger startCounter = new AtomicInteger(0);
     protected static final CryptoApi crypto = new CryptoApi();
     protected static boolean strongCrypto;
-    protected static String HOST;
+    protected static String host;
 
     @BeforeAll
     static void setup() {
         // execute only once
         if (startCounter.incrementAndGet() == 1) {
             AppConfigReader config = AppConfigReader.getInstance();
-            HOST = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8100");
+            host = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8100");
             AutoStart.main(new String[0]);
             strongCrypto = crypto.strongCryptoSupported();
             if (!strongCrypto) {

--- a/examples/kotlin-example/src/main/kotlin/com/accenture/demo/tasks/HelloExceptionHandler.kt
+++ b/examples/kotlin-example/src/main/kotlin/com/accenture/demo/tasks/HelloExceptionHandler.kt
@@ -7,7 +7,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @PreLoad(route = "v1.hello.exception", instances = 10)
-class HelloException : TypedLambdaFunction<Map<String?, Any?>, Map<String?, Any?>> {
+class HelloExceptionHandler : TypedLambdaFunction<Map<String?, Any?>, Map<String?, Any?>> {
     override fun handleEvent(
         headers: Map<String?, String?>,
         input: Map<String?, Any?>,
@@ -30,7 +30,7 @@ class HelloException : TypedLambdaFunction<Map<String?, Any?>, Map<String?, Any?
     }
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(HelloException::class.java)
+        private val log: Logger = LoggerFactory.getLogger(HelloExceptionHandler::class.java)
 
         private const val TYPE = "type"
         private const val ERROR = "error"

--- a/examples/kotlin-example/src/test/java/com/accenture/flows/FlowTest.java
+++ b/examples/kotlin-example/src/test/java/com/accenture/flows/FlowTest.java
@@ -25,6 +25,7 @@ import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -43,7 +44,7 @@ class FlowTest extends TestBase {
         PostOffice po = new PostOffice("unit.test", "1000", "TEST /flow/tests");
         // try to retrieve a non-exist profile will get HTTP-404
         AsyncHttpRequest request = new AsyncHttpRequest();
-        request.setTargetHost(HOST).setMethod("GET")
+        request.setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/no-such-profile");
         EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
@@ -57,7 +58,7 @@ class FlowTest extends TestBase {
         Profile profile = new Profile(Map.of("id", 300, "name", "Peter",
                         "address", "100 World Blvd", "telephone", "888-123-0000"));
         AsyncHttpRequest request1 = new AsyncHttpRequest();
-        request1.setTargetHost(HOST).setMethod("POST")
+        request1.setTargetHost(host).setMethod("POST")
                 .setHeader("content-type", "application/json")
                 .setHeader("accept", "application/json")
                 .setBody(profile).setUrl("/api/profile");
@@ -72,10 +73,10 @@ class FlowTest extends TestBase {
         assertEquals("***", mm1.getElement("profile.telephone"));
         assertEquals("CREATE", mm1.getElement("type"));
         // since "create profile" write operation is asynchronous, let's give it a brief moment to complete
-        Thread.sleep(1000);
+        Utility.getInstance().sleep(1000);
         // retrieve the profile
         AsyncHttpRequest request2 = new AsyncHttpRequest()
-                .setTargetHost(HOST).setMethod("GET")
+                .setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/"+profileId);
         EventEnvelope req2 = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request2);
@@ -89,7 +90,7 @@ class FlowTest extends TestBase {
         assertEquals("888-123-0000", mm2.getElement("telephone"));
         // delete the profile
         AsyncHttpRequest request3 = new AsyncHttpRequest()
-                .setTargetHost(HOST).setMethod("DELETE")
+                .setTargetHost(host).setMethod("DELETE")
                 .setHeader("accept", "application/json")
                 .setUrl("/api/profile/"+profileId);
         EventEnvelope req3 = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request3);
@@ -108,7 +109,7 @@ class FlowTest extends TestBase {
         PostOffice po = new PostOffice("unit.test", "2000", "TEST /health/check");
         // try to retrieve a non-exist profile will get HTTP-404
         AsyncHttpRequest request = new AsyncHttpRequest();
-        request.setTargetHost(HOST).setMethod("GET")
+        request.setTargetHost(host).setMethod("GET")
                 .setHeader("accept", "application/json")
                 .setUrl("/health");
         EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);

--- a/examples/kotlin-example/src/test/java/com/accenture/support/TestBase.java
+++ b/examples/kotlin-example/src/test/java/com/accenture/support/TestBase.java
@@ -33,14 +33,14 @@ public class TestBase {
     private static final AtomicInteger startCounter = new AtomicInteger(0);
     protected static final CryptoApi crypto = new CryptoApi();
     protected static boolean strongCrypto;
-    protected static String HOST;
+    protected static String host;
 
     @BeforeAll
     static void setup() {
         // execute only once
         if (startCounter.incrementAndGet() == 1) {
             AppConfigReader config = AppConfigReader.getInstance();
-            HOST = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8100");
+            host = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8100");
             AutoStart.main(new String[0]);
             strongCrypto = crypto.strongCryptoSupported();
             if (!strongCrypto) {

--- a/examples/lambda-example/src/main/java/org/platformlambda/example/MainApp.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/example/MainApp.java
@@ -22,12 +22,9 @@ import org.platformlambda.core.annotations.MainApplication;
 import org.platformlambda.core.models.EntryPoint;
 import org.platformlambda.core.system.AutoStart;
 import org.platformlambda.core.system.Platform;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @MainApplication
 public class MainApp implements EntryPoint {
-    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
 
     public static void main(String[] args) {
         AutoStart.main(args);

--- a/examples/rest-spring-3-example/src/main/java/com/accenture/examples/rest/AsyncHelloConcurrent.java
+++ b/examples/rest-spring-3-example/src/main/java/com/accenture/examples/rest/AsyncHelloConcurrent.java
@@ -56,7 +56,7 @@ public class AsyncHelloConcurrent {
             event.setHeader("request", "#"+(i+1));
             parallelEvents.add(event);
         }
-        return Mono.create(callback -> {
+        return Mono.create(callback ->
             po.asyncRequest(parallelEvents, 3000)
                 .onSuccess(events -> {
                     Map<String, Object> results = new HashMap<>();
@@ -74,7 +74,6 @@ public class AsyncHelloConcurrent {
                     }
                     callback.success(results);
                 })
-                .onFailure(ex -> callback.error(new AppException(408, ex.getMessage())));
-        });
+                .onFailure(ex -> callback.error(new AppException(408, ex.getMessage()))));
     }
 }

--- a/examples/rest-spring-4-example/src/main/java/com/accenture/examples/rest/AsyncHelloConcurrent.java
+++ b/examples/rest-spring-4-example/src/main/java/com/accenture/examples/rest/AsyncHelloConcurrent.java
@@ -56,7 +56,7 @@ public class AsyncHelloConcurrent {
             event.setHeader("request", "#"+(i+1));
             parallelEvents.add(event);
         }
-        return Mono.create(callback -> {
+        return Mono.create(callback ->
             po.asyncRequest(parallelEvents, 3000)
                 .onSuccess(events -> {
                     Map<String, Object> results = new HashMap<>();
@@ -74,7 +74,6 @@ public class AsyncHelloConcurrent {
                     }
                     callback.success(results);
                 })
-                .onFailure(ex -> callback.error(new AppException(408, ex.getMessage())));
-        });
+                .onFailure(ex -> callback.error(new AppException(408, ex.getMessage()))));
     }
 }

--- a/examples/scheduler-example/src/main/java/org/platformlambda/quartz/rest/ScheduleAdmin.java
+++ b/examples/scheduler-example/src/main/java/org/platformlambda/quartz/rest/ScheduleAdmin.java
@@ -32,6 +32,9 @@ import org.platformlambda.scheduler.services.JobExecutor;
 import java.io.File;
 import java.util.*;
 
+// S5443 (publicly writable directory): /tmp/scheduler-states IS the sample resolver's state store by design -
+// throwaway local data; production resolvers persist to a database or distributed cache
+@SuppressWarnings("java:S5443")
 @PreLoad(route="v1.schedule.admin", instances=10)
 public class ScheduleAdmin implements TypedLambdaFunction<AsyncHttpRequest, EventEnvelope> {
     private static final Utility util = Utility.getInstance();

--- a/examples/scheduler-example/src/main/java/org/platformlambda/quartz/services/StateResolver.java
+++ b/examples/scheduler-example/src/main/java/org/platformlambda/quartz/services/StateResolver.java
@@ -52,6 +52,9 @@ import java.util.Map;
  *      header (type = expires, name = job_name)
  *      return true or false
  */
+// S5443 (publicly writable directory): /tmp/scheduler-states IS the sample resolver's state store by design -
+// throwaway local data; production resolvers persist to a database or distributed cache
+@SuppressWarnings("java:S5443")
 @PreLoad(route="v1.state.resolver")
 public class StateResolver implements TypedLambdaFunction<Map<String, Object>, Boolean> {
     private static final Logger log = LoggerFactory.getLogger(StateResolver.class);
@@ -67,7 +70,7 @@ public class StateResolver implements TypedLambdaFunction<Map<String, Object>, B
     private static final String END = "end";
     private static final String ELAPSED = "elapsed";
     private static final String NONE = "none";
-    private static final long TEN_SECONDS = 10 * 1000;
+    private static final long TEN_SECONDS = 10L * 1000;
 
     public StateResolver() {
         File dir = new File(TEMP_FOLDER);

--- a/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ApiRequestTest.java
+++ b/examples/twin-kafka-demo/src/test/java/com/accenture/twin/demo/tasks/ApiRequestTest.java
@@ -66,20 +66,29 @@ class ApiRequestTest {
 
     @Test
     void invalidRequestsAreRejected() {
+        // arguments are built OUTSIDE each assertThrows lambda so the single invocation that may
+        // throw is the function under test (java:S5778)
         // missing command header = a broken flow definition
+        Map<String, String> noHeaders = Map.of();
+        Map<String, Object> idOnly = Map.of("id", "1");
         AppException noCommand = assertThrows(AppException.class,
-                () -> api.handleEvent(Map.of(), Map.of("id", "1"), 1));
+                () -> api.handleEvent(noHeaders, idOnly, 1));
         assertEquals(500, noCommand.getStatus());
         // UPSERT without a profile body
+        Map<String, String> upsert = Map.of("command", "UPSERT");
+        Map<String, Object> emptyBody = new HashMap<>();
         AppException noProfile = assertThrows(AppException.class,
-                () -> api.handleEvent(Map.of("command", "UPSERT"), new HashMap<>(), 1));
+                () -> api.handleEvent(upsert, emptyBody, 1));
         assertEquals(400, noProfile.getStatus());
         // non-positive or non-numeric id
+        Map<String, String> read = Map.of("command", "READ");
+        Map<String, Object> nonNumericId = Map.of("id", "zero");
         AppException badId = assertThrows(AppException.class,
-                () -> api.handleEvent(Map.of("command", "READ"), Map.of("id", "zero"), 1));
+                () -> api.handleEvent(read, nonNumericId, 1));
         assertEquals(400, badId.getStatus());
+        Map<String, Object> negativeId = Map.of("id", "-5");
         AppException negative = assertThrows(AppException.class,
-                () -> api.handleEvent(Map.of("command", "READ"), Map.of("id", "-5"), 1));
+                () -> api.handleEvent(read, negativeId, 1));
         assertEquals(400, negative.getStatus());
     }
 }

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
@@ -157,14 +157,14 @@ class TwinKafkaBridgeTest {
                 "business correlation-id survived both Kafka hops");
         assertEquals(TRACE_A, received.get("traceId"),
                 "trace-id stayed continuous across cluster A, the bridge flow, and cluster B");
-        ConsumerRecord<String, byte[]> record = pollOne(clusterB.bootstrapServers(),
+        ConsumerRecord<String, byte[]> rec = pollOne(clusterB.bootstrapServers(),
                 "bridge.mirror", "bridge-mirror-wire-" + Utility.getInstance().getUuid());
-        assertNotNull(record, "the bridged record should be visible on cluster B");
-        assertEquals(cid, headerValue(record, "X-Secondary-Cid"),
+        assertNotNull(rec, "the bridged rec should be visible on cluster B");
+        assertEquals(cid, headerValue(rec, "X-Secondary-Cid"),
                 "the bridge stamps the configured secondary correlation-id header");
-        assertEquals(TRACE_A, headerValue(record, "X-Secondary-Trace"),
+        assertEquals(TRACE_A, headerValue(rec, "X-Secondary-Trace"),
                 "the bridge stamps the configured secondary trace-id header");
-        assertNull(headerValue(record, "cid"),
+        assertNull(headerValue(rec, "cid"),
                 "the bridge flow must not leak the default correlation-id header name");
     }
 
@@ -233,7 +233,7 @@ class TwinKafkaBridgeTest {
      * application.properties) on cluster-B records - observed with a raw consumer on the wire.
      */
     @Test
-    void secondaryOutboundHeaderOverrides() throws Exception {
+    void secondaryOutboundHeaderOverrides() {
         String cid = "override-" + Utility.getInstance().getUuid();
         PostOffice po = PostOffice.trackable("unit.test", TRACE_B, "TEST /secondary/headers");
         po.send(new EventEnvelope().setTo("secondary.kafka.notification")
@@ -241,16 +241,16 @@ class TwinKafkaBridgeTest {
                 .setHeader("X-Secondary-Cid", cid)
                 .setBody("{\"hello\":\"header probe\"}".getBytes(StandardCharsets.UTF_8))
                 .setTraceId(TRACE_B).setTracePath("TEST /secondary/headers"));
-        ConsumerRecord<String, byte[]> record = pollOne(clusterB.bootstrapServers(),
+        ConsumerRecord<String, byte[]> rec = pollOne(clusterB.bootstrapServers(),
                 "header.probe", "header-probe-group");
-        assertNotNull(record, "the probe record should arrive on cluster B");
-        assertEquals(cid, headerValue(record, "X-Secondary-Cid"),
+        assertNotNull(rec, "the probe rec should arrive on cluster B");
+        assertEquals(cid, headerValue(rec, "X-Secondary-Cid"),
                 "business correlation-id stamped under the SECONDARY override name");
-        assertEquals(TRACE_B, headerValue(record, "X-Secondary-Trace"),
+        assertEquals(TRACE_B, headerValue(rec, "X-Secondary-Trace"),
                 "trace-id stamped under the SECONDARY override name");
-        assertTrue(String.valueOf(headerValue(record, "traceparent")).contains(TRACE_B),
+        assertTrue(String.valueOf(headerValue(rec, "traceparent")).contains(TRACE_B),
                 "W3C traceparent is stamped alongside the legacy trace-id header");
-        assertNull(headerValue(record, "cid"),
+        assertNull(headerValue(rec, "cid"),
                 "the global default name is not used when the secondary override is set");
     }
 
@@ -260,17 +260,17 @@ class TwinKafkaBridgeTest {
      * cluster B (RetryPolicy carries the secondary publisher).
      */
     @Test
-    void secondaryDeadLettersLandOnSecondaryCluster() throws Exception {
+    void secondaryDeadLettersLandOnSecondaryCluster() {
         PostOffice po = PostOffice.trackable("unit.test", TRACE_B, "TEST /secondary/dlq");
         po.send(new EventEnvelope().setTo("secondary.kafka.notification")
                 .setHeader(KafkaHeaders.TOPIC, "poison.source")
                 .setBody("{\"hello\":\"boom\"}".getBytes(StandardCharsets.UTF_8))
                 .setTraceId(TRACE_B).setTracePath("TEST /secondary/dlq"));
         // 3 retries at 500ms backoff, then the dead-letter write to the secondary cluster
-        ConsumerRecord<String, byte[]> record = pollOne(clusterB.bootstrapServers(),
+        ConsumerRecord<String, byte[]> rec = pollOne(clusterB.bootstrapServers(),
                 "poison.dlq", "dlq-probe-group");
-        assertNotNull(record, "the exhausted record should land on the secondary cluster's DLQ topic");
-        assertEquals("{\"hello\":\"boom\"}", new String(record.value(), StandardCharsets.UTF_8),
+        assertNotNull(rec, "the exhausted rec should land on the secondary cluster's DLQ topic");
+        assertEquals("{\"hello\":\"boom\"}", new String(rec.value(), StandardCharsets.UTF_8),
                 "the dead letter carries the original payload");
     }
 
@@ -288,17 +288,18 @@ class TwinKafkaBridgeTest {
             long deadline = System.currentTimeMillis() + 60000;
             while (System.currentTimeMillis() < deadline) {
                 ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofSeconds(2));
-                for (ConsumerRecord<String, byte[]> r : records) {
-                    return r;
+                var it = records.iterator();
+                if (it.hasNext()) {
+                    return it.next();
                 }
             }
         }
         return null;
     }
 
-    /** Read a record header as UTF-8 text (null when absent). */
-    private static String headerValue(ConsumerRecord<String, byte[]> record, String name) {
-        var header = record.headers().lastHeader(name);
+    /** Read a rec header as UTF-8 text (null when absent). */
+    private static String headerValue(ConsumerRecord<String, byte[]> rec, String name) {
+        var header = rec.headers().lastHeader(name);
         return header == null ? null : new String(header.value(), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## What

Resolves every finding from the field SonarQube scan (gate passed; this is the quality
touch-up before the official v4.8.3 release): two bugs (int-multiplication assigned to
`long` in the scheduler sample's StateResolver; a loop-with-one-iteration in a twin-kafka
test helper), the eleven new-code smells (assertThrows lambdas reduced to one invocation,
`record` renamed as a restricted identifier, superfluous `throws` clauses), fourteen
example-app smells (public PoJo fields now have accessors, `HelloException` renamed to
`HelloExceptionHandler` in its Java and Kotlin twins, `Thread.sleep` replaced with the
blocking-queue `Utility.sleep` in tests, `HOST` field renamed to `host`, an unused logger
removed, single-statement lambdas unbraced), and the nine `/tmp` security hotspots in the
worked examples, suppressed with justification following the ProfileStore precedent — the
temp store IS the demo's simulated database by design.

## Why

The field pipeline (Snyk + Sonar) passed against 4.8.3, and this round of touch-up clears
the remaining non-blocking findings so the official v4.8.3 releases with a clean scan.
Behavior is unchanged: route names, flows, and demo semantics are untouched — only naming,
accessors, test hygiene, and justified suppressions.

Verified: full reactor green with all tests; documentation canon check green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>