### PR TITLE
test(event-script): regression guard for trace continuity of declarative HTTP tasks

### DIFF
--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -349,6 +349,75 @@ class FlowTests extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void declarativeHttpTaskPropagatesTraceContext() throws ExecutionException, InterruptedException {
+        // The application-to-application case using DECLARATIVE means: a traced flow's task invokes
+        // "async.http.request" via input data mapping (process: 'async.http.request'), the same way
+        // a programmatic caller would use PostOffice. The outbound HTTP call must carry the flow's
+        // trace context (X-Trace-Id + W3C traceparent) so the downstream application continues the
+        // SAME distributed trace. The echo endpoint returns the headers it received on the wire.
+        final long timeout = 8000;
+        final String traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        final String traceparent = "00-" + traceId + "-00f067aa0ba902b7-01";
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("accept", "application/json")
+                .setHeader("content-type", "application/json")
+                .setHeader("traceparent", traceparent)
+                .setUrl("/api/http/client/by/config/trace");
+        request.setBody(Map.of("hello", "trace"));
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        // send from an UNTRACED context so the explicitly set traceparent passes through to the
+        // ingress endpoint (tracing: true), which adopts it as the flow's trace context
+        EventEnvelope result = EventEmitter.getInstance().eRequest(req, timeout).get();
+        assertInstanceOf(Map.class, result.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) result.getBody());
+        // the declarative async.http.request task stamped the flow's trace context downstream
+        assertEquals(traceId, map.getElement("headers.x-trace-id"),
+                "flow's trace-id should be stamped on the outbound declarative HTTP call");
+        String forwarded = String.valueOf(map.getElement("headers.traceparent"));
+        assertTrue(forwarded.contains(traceId),
+                "W3C traceparent should carry the flow's trace-id, got: " + forwarded);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void declarativeSinkHttpTaskPropagatesTraceContext() throws ExecutionException, InterruptedException {
+        // The same declarative application-to-application case, in the field's exact flow shape:
+        // an immediate response task followed by a fire-and-forget (execution: sink) task that
+        // invokes "async.http.request". The sink task's outbound call must still carry the flow's
+        // trace context. The recorder endpoint captures the headers received on the wire because
+        // a sink task's result never reaches the flow output.
+        final long timeout = 8000;
+        final String traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        final String traceparent = "00-" + traceId + "-00f067aa0ba902b7-01";
+        com.accenture.service.TraceRecorderEndpoint.RECEIVED_HEADERS.clear();
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("accept", "application/json")
+                .setHeader("content-type", "application/json")
+                .setHeader("traceparent", traceparent)
+                .setUrl("/api/http/sink/trace");
+        request.setBody(Map.of("hello", "sink"));
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        // untraced sender so the explicitly set traceparent passes through to the traced ingress
+        EventEnvelope result = EventEmitter.getInstance().eRequest(req, timeout).get();
+                assertEquals("accepted", result.getBody());
+        // the sink task fires after the response - poll the recorder for the wire-level headers
+        Map<String, String> received = null;
+        try {
+            received = com.accenture.service.TraceRecorderEndpoint.RECEIVED_HEADERS.poll(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        assertNotNull(received, "the sink task should have delivered the downstream HTTP call");
+        assertEquals(traceId, received.get("x-trace-id"),
+                "flow's trace-id should be stamped on the sink task's outbound HTTP call");
+        assertTrue(String.valueOf(received.get("traceparent")).contains(traceId),
+                "W3C traceparent should carry the flow's trace-id, got: " + received.get("traceparent"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void noSuchFlowTest() throws ExecutionException, InterruptedException {
         final long timeout = 8000;
         AsyncHttpRequest request = new AsyncHttpRequest();

--- a/system/event-script-engine/src/test/java/com/accenture/service/TraceRecorderEndpoint.java
+++ b/system/event-script-engine/src/test/java/com/accenture/service/TraceRecorderEndpoint.java
@@ -1,0 +1,44 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.service;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Records the HTTP headers received on the wire so a test can assert what a fire-and-forget
+ * (sink) task actually sent - a sink task's result never reaches the flow output.
+ */
+@PreLoad(route = TraceRecorderEndpoint.ROUTE, instances = 10)
+public class TraceRecorderEndpoint implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+
+    public static final String ROUTE = "trace.recorder.endpoint";
+    public static final BlockingQueue<Map<String, String>> RECEIVED_HEADERS = new ArrayBlockingQueue<>(10);
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+        RECEIVED_HEADERS.offer(input.getHeaders());
+        return Map.of("status", "recorded");
+    }
+}

--- a/system/event-script-engine/src/test/resources/flows.yaml
+++ b/system/event-script-engine/src/test/resources/flows.yaml
@@ -40,6 +40,7 @@ flows:
   - 'children/child-three.yml'
   - 'children/echo-flow.yml'
   - 'http-client-by-config.yml'
+  - 'http-client-sink-trace.yml'
   - 'autostart.yml'
   - 'pluggableFunctions/arithmetic.yml'
   - 'pluggableFunctions/types.yml'

--- a/system/event-script-engine/src/test/resources/flows/http-client-sink-trace.yml
+++ b/system/event-script-engine/src/test/resources/flows/http-client-sink-trace.yml
@@ -1,0 +1,54 @@
+flow:
+  id: 'http-client-sink-trace'
+  description: 'Mirror the field shape: immediate response, then a SINK task calling the Async HTTP client'
+  ttl: 10s
+
+first.task: 'immediate.response'
+
+tasks:
+  - name: 'immediate.response'
+    input:
+      - 'input.body -> model.request'
+    process: 'no.op'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'text(accepted) -> output.body'
+    description: 'Acknowledge the request immediately'
+    execution: response
+    next:
+      - 'fan.out'
+
+  - name: 'fan.out'
+    input:
+      - 'model.request -> body'
+    process: 'no.op'
+    output: []
+    description: 'Continue after the response: fire the forward call and end the flow'
+    execution: parallel
+    next:
+      - 'forward.request'
+      - 'finish'
+
+  - name: 'forward.request'
+    input:
+      - 'text(application/json) -> headers.content-type'
+      - 'text(application/json) -> headers.accept'
+      - 'text(POST) -> method'
+      - 'text(http://127.0.0.1:${server.port}) -> host'
+      - 'text(/api/trace/recorder) -> url'
+      - 'model.request -> body'
+      - 'int(30000) -> timeout'
+      - 'text(Bearer demo-token) -> headers.Authorization'
+    process: 'async.http.request'
+    output:
+      - 'result -> model.forward_result'
+    description: 'Forward the request to a downstream application - fire and forget'
+    execution: sink
+
+  - name: 'finish'
+    input:
+      - 'model.request -> body'
+    process: 'no.op'
+    output: []
+    description: 'End of flow'
+    execution: end

--- a/system/event-script-engine/src/test/resources/rest.yaml
+++ b/system/event-script-engine/src/test/resources/rest.yaml
@@ -324,6 +324,19 @@ rest:
     timeout: 10s
     tracing: true
 
+  - service: "trace.recorder.endpoint"
+    methods: ['POST']
+    url: "/api/trace/recorder"
+    timeout: 10s
+    tracing: true
+
+  - service: "http.flow.adapter"
+    methods: ['POST']
+    url: "/api/http/sink/trace"
+    flow: 'http-client-sink-trace'
+    timeout: 10s
+    tracing: true
+
   - service: "http.flow.adapter"
     methods: ['GET']
     url: "/api/pluggableFunctions/arithmetic"


### PR DESCRIPTION
## What

Two regression tests for the previously untested declarative path of the async HTTP client —
a flow task with `process: 'async.http.request'` built by input data mapping. Both are driven
with a caller-supplied W3C `traceparent` through a traced ingress endpoint: one asserts the
wire-level `X-Trace-Id` + `traceparent` via an echo endpoint; the other reproduces the field's
exact flow shape (immediate `response` task, then a fire-and-forget `execution: sink` task
firing after the HTTP response) using a new recorder fixture, since a sink task's result never
reaches the flow output. New fixtures: `http-client-sink-trace.yml`, `/api/http/sink/trace` and
`/api/trace/recorder` endpoints, and the `TraceRecorderEndpoint` test function.

## Why

A field team reported that traceId propagates when AsyncHttpClient is used programmatically but
not declaratively on 4.7.x. Investigation result: **both tests pass on current main AND on the
v4.7.1 tag** (verified in a worktree), and the engine's task dispatch is identical between the
two — the declarative path stamps the flow's trace context correctly in both variants, so the
field symptom is not a framework defect (remaining suspects are environmental: the downstream
endpoint's `tracing: true` flag, a gateway stripping trace headers, or validation watching the
retired `X-Correlation-Id` conflation). The tests stay as permanent coverage so the declarative
contract can never silently regress.

Verified: event-script-engine suite 135 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>