### PR TITLE
fix(tests): generous app-boot readiness deadlines for busy CI executors

### DIFF
--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
@@ -97,7 +97,8 @@ class KafkaFlowAdapterTest {
         AutoStart.main(new String[0]);
         // KafkaFlowAutoStart (@MainApplication) runs after the engine is up: it sets the publisher and
         // starts the adapter. A non-null adapter is our readiness signal.
-        long deadline = System.currentTimeMillis() + 20000;
+        // generous for busy CI executors - the poll returns as soon as the adapter is ready
+        long deadline = System.currentTimeMillis() + 90000;
         while (KafkaRuntime.adapter() == null && System.currentTimeMillis() < deadline) {
             Utility.getInstance().sleep(100);
         }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
@@ -77,7 +77,8 @@ class KafkaHealthCheckTest {
         assertEquals("Kafka client is starting up", ((Map<String, Object>) first).get("status"));
         // once warm-up completes, checks report the live cluster status
         Map<String, Object> live = null;
-        long deadline = System.currentTimeMillis() + 20000;
+        // generous for busy CI executors - the poll returns as soon as warm-up completes
+        long deadline = System.currentTimeMillis() + 60000;
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
             if ("Kafka cluster is reachable".equals(result.get("status"))) {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
@@ -57,7 +57,7 @@ class KafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void infoDescribesTheKafkaDependency() throws Exception {
+    void infoDescribesTheKafkaDependency() {
         var health = new KafkaHealthCheck(consumerProps(kafka.bootstrapServers()), 0);
         var result = health.handleEvent(INFO, null, 1);
         assertInstanceOf(Map.class, result);
@@ -68,7 +68,7 @@ class KafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void startupReturnsPlaceholderThenLiveStatus() throws Exception {
+    void startupReturnsPlaceholderThenLiveStatus() {
         var health = new KafkaHealthCheck(consumerProps(kafka.bootstrapServers()), 60000);
         // within the grace period, the first check is a placeholder healthy status - the Kafka
         // client warms up in the background so /health never blocks during app start-up
@@ -94,7 +94,7 @@ class KafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void probesImmediatelyWhenGraceExpired() throws Exception {
+    void probesImmediatelyWhenGraceExpired() {
         var health = new KafkaHealthCheck(consumerProps(kafka.bootstrapServers()), 0);
         Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
         assertEquals("Kafka cluster is reachable", result.get("status"));

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
@@ -75,7 +75,8 @@ class SecondaryKafkaHealthCheckTest {
         assertInstanceOf(Map.class, first);
         assertEquals("Kafka client is starting up", ((Map<String, Object>) first).get("status"));
         Map<String, Object> live = null;
-        long deadline = System.currentTimeMillis() + 20000;
+        // generous for busy CI executors - the poll returns as soon as warm-up completes
+        long deadline = System.currentTimeMillis() + 60000;
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
             if ("Kafka cluster is reachable".equals(result.get("status"))) {

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
@@ -57,7 +57,7 @@ class SecondaryKafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void infoDescribesTheSecondaryKafkaDependency() throws Exception {
+    void infoDescribesTheSecondaryKafkaDependency() {
         var health = new SecondaryKafkaHealthCheck(consumerProps(secondaryCluster.bootstrapServers()), 0);
         var result = health.handleEvent(INFO, null, 1);
         assertInstanceOf(Map.class, result);
@@ -69,7 +69,7 @@ class SecondaryKafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void startupReturnsPlaceholderThenLiveStatus() throws Exception {
+    void startupReturnsPlaceholderThenLiveStatus() {
         var health = new SecondaryKafkaHealthCheck(consumerProps(secondaryCluster.bootstrapServers()), 60000);
         var first = health.handleEvent(HEALTH, null, 1);
         assertInstanceOf(Map.class, first);
@@ -91,7 +91,7 @@ class SecondaryKafkaHealthCheckTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void unreachableSecondaryFailsWhileLiveInstanceStaysHealthy() throws Exception {
+    void unreachableSecondaryFailsWhileLiveInstanceStaysHealthy() {
         // the two probes are independent: a dead secondary must not poison a healthy one
         var healthy = new SecondaryKafkaHealthCheck(consumerProps(secondaryCluster.bootstrapServers()), 0);
         Properties bad = consumerProps("127.0.0.1:65530");

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
@@ -90,8 +90,12 @@ class TwinKafkaBridgeTest {
         System.setProperty("KAFKA_BOOTSTRAP_SERVERS", clusterA.bootstrapServers());
         System.setProperty("SECONDARY_KAFKA_BOOTSTRAP_SERVERS", clusterB.bootstrapServers());
         AutoStart.main(new String[0]);
-        // both @MainApplication entry points must complete: primary + secondary adapters ready
-        long deadline = System.currentTimeMillis() + 20000;
+        // both @MainApplication entry points must complete: primary + secondary adapters ready.
+        // The deadline is deliberately generous: this boot brings up TWO embedded KRaft brokers,
+        // a schema registry, and the full application - a busy CI executor exceeded 20s in the
+        // field, and the poll returns the moment both adapters are ready, so a large budget
+        // costs nothing on a fast machine.
+        long deadline = System.currentTimeMillis() + 90000;
         while ((KafkaRuntime.adapter() == null || SecondaryKafkaRuntime.adapter() == null)
                 && System.currentTimeMillis() < deadline) {
             Utility.getInstance().sleep(100);


### PR DESCRIPTION
## What

Extends the app-boot readiness deadlines in four Kafka test suites: the `TwinKafkaBridgeTest` and
`KafkaFlowAdapterTest` boot polls go from 20s to 90s, and the two health-check warm-up polls go
from 20s to 60s. A readiness poll returns the moment the condition is met, so the larger budget
costs nothing on fast machines — it only absorbs CI variance.

## Why

A field CI build failed in `TwinKafkaBridgeTest.boot` ("secondary Kafka flow adapter should have
started"). The boot brings up two embedded KRaft brokers, a schema registry, and the full
application before polling readiness — the primary adapter made the 20s deadline and the secondary
did not, i.e. the application was starting normally but a busy Jenkins executor needed more time.
Readiness deadlines on shared CI must be sized for the slowest executor, not the developer laptop.
Test-only change; released artifacts are unaffected.

Verified: minimalist-kafka suite 96 green; twin-kafka suite 9 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>