### PR TITLE
fix(core): one generated id when trace-id and correlation-id share a header name

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -135,6 +135,14 @@ Per-entry overrides, for a single application that faces callers with different 
 overrides never breaks OpenTelemetry-compliant callers. The full key reference lives in the
 [Configuration Reference](configuration-reference.md#observability).
 
+> **Legacy conflation is supported.** Pointing the trace-id name at the correlation-id header
+> (`http.trace.id.header=X-Correlation-Id`) is a valid backward-compatibility setup for an estate whose
+> gateway only passes that one header. The edge keeps the two ids consistent: a supplied shared header
+> feeds **both** ids, and when the shared header is absent the edge resolves **one** id for both — from
+> the inbound `traceparent` when present, otherwise a single generated id — so the outgoing
+> `traceparent` and the shared header always carry the same trace id. Prefer migrating the gateway to
+> pass `traceparent` (and `X-Trace-Id`), then retiring the conflation.
+
 ```yaml
 # rest.yaml - one endpoint serves a legacy caller that sends its own header names
   - service: "legacy.orders"

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -250,9 +250,13 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private EventEnvelope toFlowRequest(Map<String, Object> dataset, Map<String, String> headers,
                                         String[] trace, String traceId, String tracePath) {
         // Capture the upstream business correlation-id from the effective header; generate a fresh one if absent.
+        // Legacy conflation config: when the trace-id and correlation-id share ONE header name, an absent
+        // shared header must yield ONE id - the resolved trace id (traceparent > shared header > fresh UUID)
+        // is authoritative and the correlation-id adopts it, keeping the outbound hop self-consistent.
         String businessCorrelationId = headers.get(correlationIdHeader);
         if (businessCorrelationId == null) {
-            businessCorrelationId = Utility.getInstance().getUuid();
+            businessCorrelationId = traceIdHeader != null && traceIdHeader.equalsIgnoreCase(correlationIdHeader)
+                    ? traceId : Utility.getInstance().getUuid();
         }
         EventEnvelope forward = new EventEnvelope();
         forward.setTo(EventScriptManager.SERVICE_NAME).setHeader(FLOW_ID, binding.flowId())

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -489,7 +489,8 @@ public class HttpRouter {
         String cidHeaderName = route.info.correlationIdHeader != null
                 ? route.info.correlationIdHeader : businessCorrelationIdHeader;
         String businessCorrelationId = req.getHeader(cidHeaderName);
-        if (businessCorrelationId == null) {
+        final boolean generatedCid = businessCorrelationId == null;
+        if (generatedCid) {
             businessCorrelationId = util.getUuid();
             req.setHeader(cidHeaderName, businessCorrelationId);
         }
@@ -509,6 +510,16 @@ public class HttpRouter {
             if (traceParent.length > 0) {
                 traceId = traceParent[0];
                 parentSpanId = traceParent[1];
+            }
+            // Legacy conflation config: when the trace-id and correlation-id share ONE header name
+            // (e.g. http.trace.id.header=X-Correlation-Id for a gateway that only passes that header),
+            // an absent shared header must yield ONE id, not two - otherwise the generated traceparent
+            // and the shared header would carry different ids on the outbound hop. The trace id (which
+            // also honors an inbound traceparent) is authoritative; the correlation-id adopts it.
+            String traceHeaderName = route.info.traceIdHeader != null ? route.info.traceIdHeader : traceIdHeader;
+            if (generatedCid && traceHeaderName.equalsIgnoreCase(cidHeaderName)) {
+                businessCorrelationId = traceId;
+                req.setHeader(cidHeaderName, traceId);
             }
         }
         final HttpRequestEvent requestEvent = new HttpRequestEvent(requestId, route, authService, traceId, tracePath);

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -100,6 +100,70 @@ class RestEndpointTest extends TestBase {
                 "business correlation-id captured from the per-endpoint 'correlation.id.header' override");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void conflatedHeaderNamesGenerateOneIdForTraceAndCid() throws InterruptedException {
+        // Legacy conflation config (/api/conflated/probe declares the SAME header name for
+        // trace.id.header and correlation.id.header): when the shared header is absent, the edge
+        // must generate ONE id serving both - a divergent pair would make the outbound hop
+        // self-inconsistent (traceparent carrying one id, the shared header another).
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/conflated/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertInstanceOf(String.class, probe.get("traceId"));
+        String generated = (String) probe.get("traceId");
+        assertEquals(32, generated.length());
+        assertFalse(generated.contains("-"));
+        assertEquals(generated, probe.get("cid"),
+                "the generated trace-id and correlation-id must be ONE id under a shared header name");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void conflatedHeaderSuppliedFeedsBothIds() throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/conflated/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json").setHeader("X-Shared-Id", "shared-0001");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals("shared-0001", probe.get("traceId"));
+        assertEquals("shared-0001", probe.get("cid"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void conflatedHeaderAdoptsTraceparentWhenSharedHeaderAbsent() throws InterruptedException {
+        // when a W3C traceparent arrives but the shared header does not, the trace id from the
+        // traceparent is authoritative and the correlation-id adopts it - one id, end to end
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String w3cTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/conflated/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json")
+                .setHeader("traceparent", "00-" + w3cTraceId + "-00f067aa0ba902b7-01");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals(w3cTraceId, probe.get("traceId"));
+        assertEquals(w3cTraceId, probe.get("cid"));
+    }
+
     @Test
     void optionsMethodTest() throws InterruptedException {
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -58,6 +58,17 @@ rest:
     trace.id.header: "X-Legacy-Trace"
     correlation.id.header: "X-Legacy-Cid"
 
+  # Legacy conflation config: ONE header name carries both the trace-id and the correlation-id
+  # (e.g. a gateway that only passes X-Correlation-Id). When the shared header is absent, the
+  # endpoint must generate ONE id for both - never two.
+  - service: "header.probe"
+    methods: ['GET']
+    url: "/api/conflated/probe"
+    timeout: 10s
+    tracing: true
+    trace.id.header: "X-Shared-Id"
+    correlation.id.header: "X-Shared-Id"
+
   # Simulates application A in an application-to-application HTTP call: this traced endpoint's
   # function calls /api/legacy/probe ("application B") through async.http.request, so tests can
   # assert that one distributed trace continues across the HTTP hop between the two.


### PR DESCRIPTION
## What

When the resolved trace-id header name equals the resolved correlation-id header name
(case-insensitive, per-entry override or global) and the shared header is absent from the inbound
request, both ingress paths now yield ONE id: the trace id is authoritative (it also honors an
inbound W3C `traceparent`) and the correlation-id adopts it. Applied to the HTTP ingress
(`HttpRouter`) and the Kafka flow adapter (`KafkaFlowConsumer`). Supplied headers are unchanged — a
provided shared header still feeds both ids, and a provided header alongside a `traceparent` still
honors each channel independently. Configurations with distinct header names are unaffected. New
`/api/conflated/probe` test fixture with three contract tests, and the Observability guide now
documents the legacy-conflation setup with its one-id guarantee.

## Why

Field validation of the backward-compatibility setup (`http.trace.id.header=X-Correlation-Id`, for
a gateway that only passes that one header) exposed an edge case: a request WITHOUT the shared
header produced two independently generated ids — the edge generated one UUID for the
correlation-id on the parsed request and another for the trace id (which reads the raw request,
where the generated cid is invisible). The outbound hop then carried a `traceparent` built from one
id while the shared header carried the other: a self-inconsistent wire that breaks id-based log
correlation precisely in the legacy estates the conflation config exists to serve.

Verified: platform-core, event-script-engine and minimalist-kafka suites all green; doc canon green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>