### PR TITLE
fix(tests): make twin-kafka bridge boot independent of test-class order

### DIFF
--- a/system/minimalist-kafka/src/test/resources/application.properties
+++ b/system/minimalist-kafka/src/test/resources/application.properties
@@ -17,9 +17,13 @@ kafka.dlq.timeout.ms=20000
 # Kafka client config templates. Listed explicitly to document the override keys; classpath is the default.
 kafka.producer.properties=classpath:/kafka-producer.properties
 kafka.consumer.properties=classpath:/kafka-consumer.properties
-# Schema Registry: URL injected at runtime by the test (embedded registry on a random port); blank when
-# unset so schema features stay off. The id->schema cache is in-memory (platform ManagedCache).
-schema.registry.url=${SCHEMA_REGISTRY_URL:}
+# Schema Registry: URL injected at runtime by the test as a System property under this EXACT key
+# (System.setProperty("schema.registry.url", ...) - ConfigReader honors it live on every read);
+# blank when unset so schema features stay off. A plain blank, not ${SCHEMA_REGISTRY_URL:}: the
+# env-style reference is frozen at AppConfigReader singleton init (test-class order is
+# filesystem-dependent under surefire), and a build agent exporting the env var machine-wide
+# would leak into the test. The id->schema cache is in-memory (platform ManagedCache).
+schema.registry.url=
 schema.registry.cache.ttl=1h
 # Flow-failure handling (explicit even where matching code defaults). The DLQ topic itself is per-binding
 # (dlq-topic in kafka-flow-adapter.yaml), not a global setting.

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -184,6 +184,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
+                <configuration>
+                    <!-- Deterministic class order: surefire's default is filesystem order, which
+                         differs across CI environments. A field Jenkins agent ran the health-check
+                         test before the bridge test and exposed an initialization-order bug that
+                         GitHub CI's ordering never exercised. Alphabetical pins every environment
+                         to that same (adversarial) order so a regression fails everywhere. -->
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
@@ -85,16 +85,27 @@ class TwinKafkaBridgeTest {
                 "header.probe", "poison.source", "poison.dlq");
         // registry on the SECONDARY side only (asymmetric topology)
         registryB = new EmbeddedSchemaRegistry();
-        System.setProperty("SECONDARY_SCHEMA_REGISTRY_URL", registryB.baseUrl());
-        // point the producer/consumer templates at the two embedded brokers
+        // Inject via the EXACT config key, not the ${SECONDARY_SCHEMA_REGISTRY_URL} reference in
+        // application.properties: AppConfigReader resolves ${VAR} references ONCE when the singleton
+        // first loads, and another test class in this JVM may already have initialized it before this
+        // @BeforeAll runs (surefire's default run order is filesystem-dependent, so class order varies
+        // by CI environment - a field Jenkins build froze the reference to blank and the secondary
+        // adapter failed with "'secondary.schema.registry.url' is not configured" while GitHub CI
+        // passed). ConfigReader.get() checks System.getProperty(<exact key>) live on every read, so
+        // this override is immune to initialization order.
+        System.setProperty("secondary.schema.registry.url", registryB.baseUrl());
+        // point the producer/consumer templates at the two embedded brokers - safe as ${VAR} references
+        // because the templates are loaded fresh by each adapter/publisher AFTER this point
         System.setProperty("KAFKA_BOOTSTRAP_SERVERS", clusterA.bootstrapServers());
         System.setProperty("SECONDARY_KAFKA_BOOTSTRAP_SERVERS", clusterB.bootstrapServers());
         AutoStart.main(new String[0]);
         // both @MainApplication entry points must complete: primary + secondary adapters ready.
         // The deadline is deliberately generous: this boot brings up TWO embedded KRaft brokers,
-        // a schema registry, and the full application - a busy CI executor exceeded 20s in the
-        // field, and the poll returns the moment both adapters are ready, so a large budget
-        // costs nothing on a fast machine.
+        // a schema registry, and the full application - the poll returns the moment both adapters
+        // are ready, so a large budget costs nothing on a fast machine. If this deadline ever
+        // expires, check the log for an AppStarter "Unable to start" ERROR before blaming a slow
+        // executor: a crashed @MainApplication never registers its adapter, and no deadline
+        // extension can fix that.
         long deadline = System.currentTimeMillis() + 90000;
         while ((KafkaRuntime.adapter() == null || SecondaryKafkaRuntime.adapter() == null)
                 && System.currentTimeMillis() < deadline) {
@@ -129,7 +140,7 @@ class TwinKafkaBridgeTest {
         }
         System.clearProperty("KAFKA_BOOTSTRAP_SERVERS");
         System.clearProperty("SECONDARY_KAFKA_BOOTSTRAP_SERVERS");
-        System.clearProperty("SECONDARY_SCHEMA_REGISTRY_URL");
+        System.clearProperty("secondary.schema.registry.url");
     }
 
     private static void createTopics(String bootstrapServers, String... topics) throws Exception {

--- a/system/twin-kafka/src/test/resources/application.properties
+++ b/system/twin-kafka/src/test/resources/application.properties
@@ -20,8 +20,11 @@ yaml.secondary.kafka.flow.adapter=classpath:/secondary-kafka-flow-adapter.yaml
 kafka.dlq.timeout.ms=20000
 kafka.flow.max.retries=3
 kafka.flow.retry.backoff.ms=500
-# primary registry deliberately unset (blank when the env var is absent)
-schema.registry.url=${SCHEMA_REGISTRY_URL:}
+# Primary registry deliberately blank (asymmetric topology: schema features OFF on cluster A).
+# A plain blank, not ${SCHEMA_REGISTRY_URL:}: a build agent that exports that env var machine-wide
+# would silently flip the primary side to registry-configured and break the asymmetry this test
+# proves. Tests that need a registry inject it by the exact config key (see the secondary below).
+schema.registry.url=
 # Secondary registry injected by TwinKafkaBridgeTest as a System property under this EXACT key
 # (System.setProperty("secondary.schema.registry.url", ...)), which ConfigReader honors live on
 # every read. A ${VAR} reference here would be frozen (blank) if another test class initialized

--- a/system/twin-kafka/src/test/resources/application.properties
+++ b/system/twin-kafka/src/test/resources/application.properties
@@ -22,8 +22,12 @@ kafka.flow.max.retries=3
 kafka.flow.retry.backoff.ms=500
 # primary registry deliberately unset (blank when the env var is absent)
 schema.registry.url=${SCHEMA_REGISTRY_URL:}
-# secondary registry injected by the test
-secondary.schema.registry.url=${SECONDARY_SCHEMA_REGISTRY_URL:}
+# Secondary registry injected by TwinKafkaBridgeTest as a System property under this EXACT key
+# (System.setProperty("secondary.schema.registry.url", ...)), which ConfigReader honors live on
+# every read. A ${VAR} reference here would be frozen (blank) if another test class initialized
+# the AppConfigReader singleton before the bridge test set the variable - test-class order is
+# filesystem-dependent under surefire, and one field Jenkins ordering hit exactly that.
+secondary.schema.registry.url=
 secondary.schema.registry.cache.ttl=1h
 
 # secondary header-name overrides: the secondary notification stamps these names on cluster B


### PR DESCRIPTION
## What

Fixes the recurring field Jenkins failure of `TwinKafkaBridgeTest.boot` — the one that
survived PR #178's 90-second deadline extension. The bridge test now injects the embedded
schema-registry URL as a System property under the **exact config key**
(`secondary.schema.registry.url`), which `ConfigReader` honors live on every read, instead
of a `${SECONDARY_SCHEMA_REGISTRY_URL}` reference that `AppConfigReader` resolves only once
at singleton initialization. The twin-kafka surefire config also pins
`runOrder=alphabetical` so every build environment runs the same test-class order, and the
boot comment now directs readers to check for an `AppStarter "Unable to start"` ERROR
before suspecting a slow executor.

## Why

The Jenkins log showed the real failure: `SecondaryKafkaAutoStart` crashed at startup with
`IllegalArgumentException: consumer[2] (topic 'schema.mirror') sets schema.enabled but
'secondary.schema.registry.url' is not configured` — seconds into the run. The 90s poll then
waited for an adapter that was already dead, so no deadline extension could ever fix it.

Root cause is an initialization-order race between test classes sharing one surefire JVM:
`SecondaryKafkaHealthCheckTest` (added in 4.8.4) touches `AppConfigReader.getInstance()` in
its constructor chain. When it runs before `TwinKafkaBridgeTest` — surefire's default run
order is filesystem-dependent, so the order differs between GitHub CI and the field's
Jenkins — the config singleton loads while `SECONDARY_SCHEMA_REGISTRY_URL` is still unset
and freezes the property to blank. Reproduced locally with
`-Dsurefire.runOrder=alphabetical`: identical failure at `boot:104` (93s) before the fix,
green in 30s after. Exact-key injection is the pattern minimalist-kafka's
`KafkaFlowAdapterTest` already uses; pinning alphabetical order makes GitHub CI exercise
the same adversarial ordering the field hit, so a regression fails everywhere.

Also from review: the remaining `schema.registry.url=${SCHEMA_REGISTRY_URL:}` lines in the
twin-kafka and minimalist-kafka test configs are now plain blanks - not freeze-susceptible,
but a build agent exporting that env var machine-wide would silently flip the primary
cluster to registry-configured and break the asymmetric topology the bridge test proves.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>