### PR TITLE
fix(tests): harden test configs against build-agent env-var leakage

### DIFF
--- a/examples/pg-example/src/test/resources/application.properties
+++ b/examples/pg-example/src/test/resources/application.properties
@@ -108,7 +108,12 @@ postgres.connection.pool=25
 logging.level.io.r2dbc.postgresql.QUERY=DEBUG
 logging.level.io.r2dbc.postgresql.PARAM=DEBUG
 #
-# test credentials - dummy user and password will be used for the embedded PostGreSQL server
+# Test credentials - dummy user and password for the embedded PostGreSQL server.
+# These ${} references are deliberate and NOT env-leakage-prone: PG_USER is pinned to
+# "postgres" by surefire's <environmentVariables> in this module's pom (surefire overrides
+# any inherited agent-level PG_USER, and env vars exist from JVM start, so there is no
+# test-class-order freeze). PG_PASSWORD is deliberately unset -> null; the zonky embedded
+# PostgreSQL uses trust auth, which ignores passwords entirely.
 #
 postgres.database=postgres
 postgres.host=127.0.0.1

--- a/extensions/opentelemetry-forwarder/src/test/resources/application.properties
+++ b/extensions/opentelemetry-forwarder/src/test/resources/application.properties
@@ -13,13 +13,15 @@ cloud.connector=none
 # Level-2 (Event Script) flow used by OtlpFlowTraceTest
 yaml.flow.automation=classpath:/flows.yaml
 
-# --- OpenTelemetry forwarder (config-driven; values support ${ENV_VAR:default} substitution) ---
-# Default endpoint points at the in-process mock collector (MockOtlpCollector on server.port 8299).
-otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://127.0.0.1:8299/api/v2/otlp/v1/traces}
-otel.service.name=${OTEL_SERVICE_NAME:mercury-otel-demo}
-# Credentials come from the environment with NO default (no hard-coded secret).
-# Unset here -> null -> "null" -> no auth header, which the mock accepts.
-otel.exporter.otlp.headers=${OTEL_EXPORTER_OTLP_HEADERS}
+# --- OpenTelemetry forwarder (in production, values support ${ENV_VAR:default} substitution) ---
+# Plain values, not ${OTEL_*:...} references: OTEL_* env vars are commonly exported machine-wide
+# on instrumented CI agents, and a leaked OTEL_EXPORTER_OTLP_ENDPOINT would silently redirect this
+# hermetic test away from the in-process mock collector (MockOtlpCollector on server.port 8299).
+otel.exporter.otlp.endpoint=http://127.0.0.1:8299/api/v2/otlp/v1/traces
+otel.service.name=mercury-otel-demo
+# Blank = no auth header (parseHeaders treats blank and "null" alike), which the mock accepts.
+# In production, credentials come from the environment via ${OTEL_EXPORTER_OTLP_HEADERS}.
+otel.exporter.otlp.headers=
 # Optional tuning (commented out -> the forwarder uses its built-in defaults):
 #   otel.exporter.otlp.timeout          per-export timeout in ms          (default 10000)
 #   otel.exporter.otlp.connect.timeout  TCP/TLS connect timeout in ms     (default 10000)

--- a/extensions/reactive-postgres/src/test/resources/application.properties
+++ b/extensions/reactive-postgres/src/test/resources/application.properties
@@ -103,7 +103,11 @@ postgres.connection.pool=25
 logging.level.io.r2dbc.postgresql.QUERY=DEBUG
 logging.level.io.r2dbc.postgresql.PARAM=DEBUG
 #
-# test credentials
+# Test credentials. These ${} references are deliberate and NOT env-leakage-prone:
+# PG_USER is pinned to "postgres" by surefire's <environmentVariables> in this module's pom
+# (surefire overrides any inherited agent-level PG_USER, and env vars exist from JVM start,
+# so there is no test-class-order freeze). PG_PASSWORD is deliberately unset -> null; the
+# zonky embedded PostgreSQL uses trust auth, which ignores passwords entirely.
 #
 postgres.database=postgres
 postgres.host=127.0.0.1

--- a/extensions/sync-over-async/src/test/resources/application.properties
+++ b/extensions/sync-over-async/src/test/resources/application.properties
@@ -32,7 +32,10 @@ sync.over.async.enabled=true
 # Redis connection (discrete startup parameters)
 redis.host=127.0.0.1
 redis.port=6379
-redis.password=${REDIS_PASSWORD:}
+# Plain blank (no auth on the embedded Redis), not ${REDIS_PASSWORD:}: a build agent exporting
+# that env var machine-wide would leak into this hermetic test and make Lettuce attempt AUTH.
+# The production idiom (secret via ${REDIS_PASSWORD:}) is documented in RedisConfig's javadoc.
+redis.password=
 redis.ssl=false
 redis.database=0
 redis.timeout.ms=5000


### PR DESCRIPTION
## What

Completes the sweep started by the twin-kafka Jenkins fix. sync-over-async's
`redis.password` and opentelemetry-forwarder's endpoint/service-name/headers are now plain
values in the test `application.properties` instead of `${ENV_VAR}` references; the
postgres modules' `${PG_USER}`/`${PG_PASSWORD}` references are kept and documented in place,
because they are pinned by surefire's `<environmentVariables>` (leak-immune, present from
JVM start) and zonky's trust auth deliberately ignores the null password.

## Why

A `${ENV_VAR}` reference in a test application.properties has two failure modes exposed by
the field Jenkins twin-kafka failure: AppConfigReader freezes the reference at singleton
init (test-class order is filesystem-dependent under surefire), and a build agent exporting
the variable machine-wide silently leaks it into a hermetic test. A leaked
`OTEL_EXPORTER_OTLP_ENDPOINT` — common on instrumented CI agents — would redirect the
forwarder test away from its in-process mock collector; a leaked `REDIS_PASSWORD` would
make Lettuce attempt AUTH against the embedded Redis, which has no auth. Behavior is
preserved in both conversions (RedisConfig maps null and blank alike; parseHeaders treats
blank and "null" alike), verified by all four module suites: sync-over-async 32,
opentelemetry-forwarder 22, reactive-postgres 19, pg-example 7 — zero failures.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>