### PR TITLE
chore(release): version 4.8.6 for field deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.8.6, 7/14/2026
+
+Maintenance release: the flow state-machine's read-only contract is now fully enforced, plus
+code-quality touch-up from the field pipeline scan.
+
+### Changed
+
+1. **BREAKING for misconfigured flows: reserved state-machine keys are fully enforced (#184).**
+   The flow-instance metadata (`model.cid`, `model.instance`, `model.flow`, `model.ttl`,
+   `model.trace`) and the `model.none` null constant are READ only. `model.trace` and
+   `model.none` now join the compile-time enforcement that already covered the other metadata
+   keys, and a **dynamic** mapping target (`x -> model.{model.pointer}`) whose pointer resolves
+   to a reserved key at runtime is now rejected as well - it aborts the task and routes the
+   error to the flow's exception handler.
+
+   **What the field will see:** an Event Script flow that overwrites a reserved key (e.g.
+   `... -> model.ttl`) logs an ERROR at application startup -
+   `Skip invalid task (input|output) <task> in <flow>.yml that overwrites the reserved
+   state-machine key '<key>'` - and the offending task is dropped, so the flow fails when
+   executed. **Remedy:** map the value to a non-reserved model key instead (e.g.
+   `model.my_ttl`). To READ metadata, use it as a mapping source (`model.ttl -> ttl`) - that
+   remains fully supported in both input and output mappings.
+
+2. **HttpRouter ingress refactored for clarity (#183)** - behavior-preserving: the trace-context
+   resolution (including the 4.8.5 conflated-header one-id rule) and the auth-service
+   reachability check are now cohesive helpers, guarded by the existing regression tests.
+
+### Fixed
+
+1. **Documentation corrections for the flow state machine (#184).** The Flow Configuration
+   Schema reference wrongly described `model.flow` (the flow configuration ID) and
+   `model.instance` (the flow instance ID) as aliases, omitted `model.cid`/`model.ttl`, and
+   contained an example that itself wrote to `model.trace`. The Event Script syntax guide now
+   states the metadata's READ-only contract explicitly.
+2. **Test-only quality items (#183):** the last `*Exception`-named non-Throwable test fixture
+   renamed (java:S2166) and a generous span-collection deadline in the OpenTelemetry flow-trace
+   test (same busy-CI-executor convention as the 4.8.5 boot deadlines).
+
+---
 ## Version 4.8.5, 7/14/2026
 
 Maintenance release: trace/correlation impedance-matching edge case and CI build reliability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.5) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.6) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.5) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.6) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.8.5";
+    private static final String VERSION = "4.8.6";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.8.5-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.8.5-exec.jar"]
+COPY target/kafka-standalone-4.8.6-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.8.6-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.8.5</version>
+    <version>4.8.6</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.5</version>
+            <version>4.8.6</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version sweep 4.8.5 -> 4.8.6 with the digit-lookahead guard: 32 poms + CLAUDE.md/GEMINI.md +
OtelForwarderContext.VERSION + kafka-standalone Dockerfile + a new CHANGELOG entry. No code
changes beyond the version constant - this releases what is already on main (#183 + #184).

## Why

The field wants the fully-enforced read-only state-machine contract (#184) in their pipeline
now, so that flows overwriting reserved keys surface at application startup and teams can
adjust their Event Script configs - one field app writing to `model.ttl` is already known, and
the field has agreed with the READ-only metadata design. The CHANGELOG entry is written as an
operational guide: the exact ERROR log signature they will see
(`Skip invalid task ... overwrites the reserved state-machine key ...`), why the flow then
fails, and the remedy (write to a non-reserved model key; reading metadata as a mapping source
stays fully supported in input and output mappings).

The release also carries the field-scan quality items (#183 - HttpRouter complexity refactor,
S2166 fixture rename, otel test deadline), so the field's next SonarQube cycle should report
zero open issues.

Verified: full reactor green with all tests at 4.8.6; pg-example 7/7.

Normal release flow: tag v4.8.6 on merge, then release text.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>