### PR TITLE
docs(config-reference): add missing otel exporter keys

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -163,6 +163,8 @@ below tune it. The `otel.*` keys are read by the `opentelemetry-forwarder` exten
 | `otel.trace.forwarder.enabled` | `boolean` | `true` | Used by the `opentelemetry-forwarder` extension. `false` makes the forwarder a no-op (jar present, no export). |
 | `otel.exporter.otlp.endpoint` | `String` | `http://localhost:4318/v1/traces` | OTLP/HTTP traces endpoint the `opentelemetry-forwarder` extension exports spans to. |
 | `otel.exporter.otlp.timeout` | `int` (ms) | `10000` | OTLP export timeout for the `opentelemetry-forwarder` extension. |
+| `otel.exporter.otlp.connect.timeout` | `int` (ms) | `10000` | TCP/TLS connect timeout for the `opentelemetry-forwarder` extension's OTLP exporter, separate from the export timeout. |
+| `otel.exporter.otlp.compression` | `String` | `none` | OTLP request-body compression for the `opentelemetry-forwarder` extension: `gzip` or `none`. `gzip` cuts egress bandwidth for high trace volumes. |
 | `otel.service.name` | `String` | `application.name` | `service.name` resource attribute the `opentelemetry-forwarder` extension stamps on every exported span. |
 | `otel.exporter.otlp.headers` | `String` (comma-sep `key=value`) | — | Request headers for the `opentelemetry-forwarder` extension — **where backend API credentials go** (e.g. `Authorization=Api-Token …` for Dynatrace, `X-SF-Token=…` for Splunk). Source it from the environment with **no default** — `otel.exporter.otlp.headers=${OTEL_EXPORTER_OTLP_HEADERS}` — so no secret is hard-coded; unset resolves to no headers. |
 

--- a/memory/sessions/2026-07-16-233326.md
+++ b/memory/sessions/2026-07-16-233326.md
@@ -1,0 +1,14 @@
+# Session (2026-07-16T23:33:26.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** docs-only fix on `main` at v4.8.6.
+
+Added two missing rows to `docs/guides/configuration-reference.md` → "Distributed Tracing &
+Observability": `otel.exporter.otlp.connect.timeout` (int ms, default 10000) and
+`otel.exporter.otlp.compression` (String, default `none`, `gzip|none`). Both keys exist in
+`OpenTelemetryForwarder.java` and the module README (`extensions/opentelemetry-forwarder`) but
+were absent from the central reference table (gap introduced when the keys shipped in v4.6.1;
+noticed during an observability documentation review). Table style matched; no other changes.
+
+## Memory References
+(none — lite log)


### PR DESCRIPTION
## What

Add two rows to `docs/guides/configuration-reference.md` → "Distributed Tracing & Observability":

- `otel.exporter.otlp.connect.timeout` — `int` (ms), default `10000`: TCP/TLS connect timeout for the `opentelemetry-forwarder` extension's OTLP exporter, separate from the export timeout.
- `otel.exporter.otlp.compression` — `String`, default `none` (`gzip`|`none`): OTLP request-body compression.

Includes the lite session log `memory/sessions/2026-07-16-233326.md`. Docs-only; no code or behavior changes.

## Why

Both keys have existed since v4.6.1 — implemented in `OpenTelemetryForwarder.java` and documented in the module README (`extensions/opentelemetry-forwarder/README.md`) — but the central configuration reference never picked them up, so anyone tuning the forwarder from the reference table alone would not discover them. The reference should be the complete inventory of supported keys; this closes the gap found during an observability documentation review.

---
Co-Authored-By: Claude Code