### PR TITLE
docs(minigraph): document the graph.math / graph.js statement grammar

### DIFF
--- a/docs/guides/knowledge-graph/command-reference.md
+++ b/docs/guides/knowledge-graph/command-reference.md
@@ -199,6 +199,54 @@ Configuration nodes used by `graph.api.fetcher` (see [Composing the layers](comp
 | **Provider** | `url`, `method`, `feature[]`, `input[]` (targets: `header.*`, `query.*`, `path_parameter.*`, `body.*`) |
 | **Dictionary** | `provider`, `input[]`, `output[]` (→ `result.*`) |
 
+## `graph.math` / `graph.js` statement grammar {#math-statements}
+
+A `graph.math` node runs an ordered list of `statement[]` lines. Five statement types:
+
+| Statement | Form | Purpose |
+|---|---|---|
+| `COMPUTE` | `COMPUTE: {var} -> {expr}` | evaluate a JS-like math/boolean expression; the result is stored in **this node's `result` namespace** — read it back as `{this-node}.result.{var}` or move it with `MAPPING` |
+| `IF` | multi-line (see below) | a boolean **decision** that redirects traversal to a named node |
+| `MAPPING` | `MAPPING: source -> target` | data mapping, identical to `graph.data.mapper` (**no** `{}` around source/target) |
+| `EXECUTE` | `EXECUTE: {node-name}` | run another `graph.math` node inline |
+| `RESET` | `RESET: {node-name}` | clear a node's run-once guard so it can execute again (advanced) |
+
+Expressions use `{namespace.key}` substitution (`{input.body.a}`, `{book.price}`, `{model.x}`). A node
+with **only** `MAPPING` statements is rejected — use `graph.data.mapper` instead. Statements run in order.
+
+**`IF` is a multi-line statement — this is the decision construct.** An `IF` **must** be paired with
+`THEN:` and `ELSE:`, or the engine aborts the run (`node {name} does not have if:, then: or else:`):
+
+```
+IF: <boolean expression>
+THEN: <node-name> | next
+ELSE: <node-name> | next
+```
+
+- `THEN:` / `ELSE:` each name the **node to jump to**, or the keyword **`next`** (fall through to the
+  natural graph traversal / next statement).
+- Append the whole triad as one multi-line value with `'''` … `'''` (see [lexical](#lexical)).
+
+Worked example — compute the sum, then branch on a comparison so each branch fills the response:
+
+```
+skill=graph.math
+statement[]=COMPUTE: sum -> {input.body.a} + {input.body.b}
+statement[]='''
+IF: {input.body.a} >= {input.body.b}
+THEN: ge-path
+ELSE: lt-path
+'''
+```
+
+**Traversal-control keywords** (optional; conventionally placed last):
+
+- `NEXT: {node-name}` — unconditionally jump to a node **by name** (it takes a *node name*, **not** a
+  connection/relation label).
+- `BEGIN` / `END` — delimit a statement block for **`for_each[]`** iterative execution; they are
+  **not** `IF`-block braces.
+- `DELAY: {milliseconds}` — defer completion (e.g. to simulate a slow service).
+
 ## Invariants {#invariants}
 
 Hard rules the engine enforces — violate them and generation fails:

--- a/docs/guides/knowledge-graph/minigraph-commands.json
+++ b/docs/guides/knowledge-graph/minigraph-commands.json
@@ -82,7 +82,19 @@
       "example": "skill=graph.data.mapper\nmapping[]=input.body.hr_id -> employee.id" },
     { "route": "graph.math", "help": "help graph-math.md", "required": ["statement[]"], "optional": ["for_each[]", "NEXT:", "DELAY:", "BEGIN", "END"],
       "statement_types": ["COMPUTE", "IF", "MAPPING", "EXECUTE", "RESET"],
-      "example": "skill=graph.math\nstatement[]=COMPUTE: amount -> (1 - {input.body.discount}) * {book.price}" },
+      "statement_syntax": {
+        "COMPUTE": "COMPUTE: {var} -> {expr}   (JS-like; {namespace.key} substitution; result stored in this node's result namespace, read as {this-node}.result.{var})",
+        "IF": "multi-line decision — MUST include THEN and ELSE or the run aborts ('node X does not have if:, then: or else:'):\nIF: <boolean expression>\nTHEN: <node-name> | next\nELSE: <node-name> | next\n(THEN/ELSE name the node to jump to, or the keyword 'next' to fall through; append the triad as one '''...''' multi-line value)",
+        "MAPPING": "MAPPING: source -> target   (identical to graph.data.mapper; no {} braces around source/target)",
+        "EXECUTE": "EXECUTE: {node-name}   (run another graph.math node inline)",
+        "RESET": "RESET: {node-name}   (clear a node's run-once guard; advanced)"
+      },
+      "notes": [
+        "NEXT: takes a NODE NAME (not a connection/relation label) — unconditional jump",
+        "BEGIN/END delimit a statement block for for_each[] iteration — they are NOT IF-block braces",
+        "a node with only MAPPING statements is rejected — use graph.data.mapper instead"
+      ],
+      "example": "skill=graph.math\nstatement[]=COMPUTE: sum -> {input.body.a} + {input.body.b}\nstatement[]='''\nIF: {input.body.a} >= {input.body.b}\nTHEN: ge-path\nELSE: lt-path\n'''" },
     { "route": "graph.js", "help": "help graph-js.md", "required": ["statement[]"], "optional": ["for_each[]", "NEXT:", "DELAY:"],
       "notes": ["full JavaScript via GraalVM; max 50 instances; prefer graph.math for simple math"],
       "example": "skill=graph.js\nstatement[]=COMPUTE: amount -> (1 - {input.body.discount}) * {book.price}" },


### PR DESCRIPTION
## What

Document the `graph.math` / `graph.js` **statement grammar** in the AI-facing knowledge-graph docs (documentation only — no engine/behavior change):

- **`command-reference.md`** — a new "statement grammar" section: the five statement types (`COMPUTE` / `IF` / `MAPPING` / `EXECUTE` / `RESET`) and, prominently, the decision construct
  ```
  IF: <boolean expression>
  THEN: <node-name> | next
  ELSE: <node-name> | next
  ```
  with a worked branch example, plus the three easy-to-miss points: `NEXT:` takes a **node name** (not a relation label), `BEGIN`/`END` delimit a **`for_each`** block (not `IF` braces), and `COMPUTE` stores its result in the node's **`result`** namespace.
- **`minigraph-commands.json`** — the `graph.math` entry gains a `statement_syntax` block (incl. the "MUST include `THEN` and `ELSE` or the run aborts" note, quoting the exact engine error), a `notes` array, and a branching `example`.

## Why

The docs previously *listed* the `graph.math` statement keywords but gave **no statement syntax**; the full grammar lived only in the interactive `help graph-math.md`, which an agent (or human) using the canonical AI-facing docs wouldn't read.

This surfaced in an AI-companion test. Given a plain-English problem ("compare `a` and `b`, branch two ways, return `{message, less_than, sum}`"), a capable agent — with only the AI docs — invented `IF … / BEGIN / NEXT: <relation> / END`, which the engine rejects: `node compare does not have if:, then: or else:` → *Graph traversal aborted*. The failure is silent to the caller (the companion POST returns HTTP 200; the parser error only reaches the WebSocket console). A keyword inventory without syntax was worse than silence — `BEGIN`/`END`/`NEXT:` read as misleading breadcrumbs.

After this fix, a fresh agent solved the same problem from the docs alone and the resulting graph ran correctly on every branch (including the `a == b` boundary).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)