### PR TITLE
feat(minigraph): synchronous AI-companion endpoint (ADR-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Synchronous AI-companion endpoint (ADR-0008) (#189).** `POST /api/companion/{id}/sync` returns
+   the command outcome in-band as `{ok, output, error, result}` — the existing fire-and-forget
+   `/api/companion/{id}` leaves an AI caller blind (outcome and errors were WebSocket-only). The same
+   output is also teed to the session's WebSocket `.out`, so a watching human — and any
+   `session subscribe`d session — sees it live (real-time human+AI collaboration). Additive; the
+   existing endpoint and the WebSocket console are unchanged.
+
+---
 ## Version 4.8.6, 7/14/2026
 
 Maintenance release: the flow state-machine's read-only contract is now fully enforced, plus

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -23,8 +23,8 @@ in that ADR's own *Rationale* section.
 ---
 
 ## ADR-0008 — Synchronous AI-companion endpoint: in-band command outcome + live tee {#adr-0008}
-**Status:** Proposed · **Date:** 2026-07-18T18:13:53.000Z · **Serves:** vision-mercury-composable
-<!-- id: adr-0008 | status: proposed -->
+**Status:** Accepted · **Date:** 2026-07-18T18:13:53.000Z · **Serves:** vision-mercury-composable
+<!-- id: adr-0008 | status: accepted -->
 
 **Abstract.** Add an **additive** synchronous companion endpoint —
 `POST /api/companion/{session-id}/sync` — that returns the command's **outcome in-band** as a
@@ -70,7 +70,11 @@ EventEnvelope — the envelope is a Map). **Reference implementation** (Rust por
 (`companion_sync_returns_outcome_in_band`), a design note (`docs/design/ai-companion-sync.md`), and a
 **live multi-party demo** in which a fresh AI companion built + ran a decision graph autonomously via
 `/sync` — self-correcting from in-band errors (including a retired-skill dead end) while an architect
-and a subscribed product owner watched in real time.
+and a subscribed product owner watched in real time. **Now implemented in this Java engine**:
+`PostCompanionCommandSync` (route `post.companion.command.sync`, dev-gated) with `CompanionSyncTest`,
+mirroring the Rust design — a private per-call capture route (`registerPrivate`) supplied as the
+command's `out`, RPC to the singleton command handler, a FIFO sentinel to mark the buffer drained, and
+a best-effort tee to the session's WebSocket `.out`.
 
 ---
 

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -1,0 +1,164 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.rest;
+
+import com.accenture.minigraph.services.GraphCommandService;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.Utility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Synchronous AI-companion endpoint (ADR-0008) — the additive sibling of
+ * {@link PostCompanionCommand}. Where the fire-and-forget endpoint returns
+ * {@code {status:"accepted"}} and streams the real outcome only to the WebSocket
+ * console, this endpoint returns the command's <b>outcome in-band</b> as
+ * {@code {ok, id, command, output, error, result}} so an AI agent can self-correct
+ * without a human relaying the console. Each output line is <b>also teed</b> to the
+ * session's real WebSocket {@code .out} route, so a watching human — and, via the
+ * command service's subscriber fan-out, any {@code session subscribe}d session —
+ * sees the same output live (real-time human+AI collaboration).
+ * <p>
+ * Mechanism: dispatch the command to the singleton command handler over
+ * request-response RPC with a private, per-call capture route supplied as the
+ * command's {@code out}; the capture route buffers each line (and tees it), then a
+ * FIFO sentinel marks the buffer fully drained. The existing endpoint and the
+ * WebSocket console are unchanged.
+ */
+@OptionalService("app.env=dev")
+@PreLoad(route = "post.companion.command.sync", instances = 10)
+public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+    private static final Logger log = LoggerFactory.getLogger(PostCompanionCommandSync.class);
+
+    private static final String SYNC_SENTINEL = "__companion_sync_done__";
+    private static final long COMMAND_TIMEOUT_MS = 30000;
+    private static final long DRAIN_TIMEOUT_MS = 5000;
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) throws Exception {
+        var id = input.getPathParameter("id");
+        if (id == null) {
+            throw new IllegalArgumentException("Missing path parameter: id");
+        }
+        if (!(input.getBody() instanceof String raw)) {
+            throw new IllegalArgumentException("Body must be a non-empty text/plain command");
+        }
+        var command = raw.trim();
+        if (command.isEmpty()) {
+            throw new IllegalArgumentException("Body must be a non-empty text/plain command");
+        }
+        if (!GraphCommandService.hasSession(id)) {
+            throw new AppException(404, "No active session for id " + id);
+        }
+        // Inverse of GraphUserInterface's public session id mapping.
+        var route = id.replace('-', '.');
+        var inRoute = route + ".in";
+        var outRoute = route + ".out";
+        var captureRoute = "companion.sync." + Utility.getInstance().getUuid();
+
+        var po = new PostOffice(headers, instance);
+        var platform = Platform.getInstance();
+        var emitter = EventEmitter.getInstance();
+
+        // A private, per-call capture route: buffer each line for the in-band response and
+        // tee it to the session's real WebSocket .out for the live human view.
+        List<Object> buffer = new CopyOnWriteArrayList<>();
+        CountDownLatch drained = new CountDownLatch(1);
+        LambdaFunction capture = (hdr, body, inst) -> {
+            if (SYNC_SENTINEL.equals(body)) {
+                drained.countDown();
+            } else {
+                buffer.add(body);
+                try {
+                    emitter.send(new EventEnvelope().setTo(outRoute).setBody(body));
+                } catch (Exception e) {
+                    // best-effort tee: the .out route may have no live WebSocket
+                    log.debug("Tee to {} skipped - {}", outRoute, e.getMessage());
+                }
+            }
+            return null;
+        };
+        platform.registerPrivate(captureRoute, capture, 1);
+        try {
+            // RPC the singleton handler with the capture route as `out`; its handleEvent
+            // completes (returns) only after all command output has been enqueued.
+            po.request(new EventEnvelope()
+                    .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
+                    .setBody(Map.of(
+                            "type", "command",
+                            "in", inRoute,
+                            "out", captureRoute,
+                            "message", command)),
+                    COMMAND_TIMEOUT_MS).get();
+            // The sentinel is enqueued after the command's (FIFO) output, so seeing it means
+            // the buffer is fully drained - deterministic, no arbitrary sleep.
+            po.send(new EventEnvelope().setTo(captureRoute).setBody(SYNC_SENTINEL));
+            if (!drained.await(DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                log.warn("Companion sync drain timed out for {}", id);
+            }
+        } finally {
+            platform.release(captureRoute);
+        }
+
+        // Build the structured outcome from the captured output.
+        List<String> output = new ArrayList<>();
+        List<Object> result = new ArrayList<>();
+        String error = null;
+        for (var item : buffer) {
+            if (item instanceof String line) {
+                if (error == null && isErrorLine(line)) {
+                    error = line;
+                }
+                output.add(line);
+            } else {
+                result.add(item);
+            }
+        }
+        var body = new HashMap<String, Object>();
+        body.put("ok", error == null);
+        body.put("id", id);
+        body.put("command", command);
+        body.put("output", output);
+        body.put("error", error);
+        body.put("result", result.isEmpty() ? null : result);
+        return new EventEnvelope().setHeader("Content-Type", "application/json").setBody(body);
+    }
+
+    private static boolean isErrorLine(String line) {
+        return line.startsWith("ERROR:") || line.contains("aborted") || line.contains("does not have")
+                || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'");
+    }
+}

--- a/system/minigraph-playground-engine/src/main/resources/rest.yaml
+++ b/system/minigraph-playground-engine/src/main/resources/rest.yaml
@@ -76,6 +76,16 @@ rest:
     headers: header_1
     tracing: true
 
+  # synchronous companion (ADR-0008) - returns the command outcome in-band
+  # {ok, output, error, result}; additive sibling of the endpoint above
+  - service: 'post.companion.command.sync'
+    methods: ['POST']
+    url: '/api/companion/{id}/sync'
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
   # MOCK endpoints
 
   - service: 'mock.mdm.profile'

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -1,0 +1,121 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.playground;
+
+import com.accenture.minigraph.services.GraphCommandService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the synchronous AI-companion endpoint (ADR-0008): it returns the command
+ * outcome in-band ({@code ok}/{@code output}/{@code error}/{@code result}) instead of a
+ * fire-and-forget acknowledgement, and tees the same output to the session's WebSocket
+ * {@code .out} route so a human watches live.
+ */
+class CompanionSyncTest {
+    private static final String ASYNC_HTTP_CLIENT = "async.http.request";
+    private static String target;
+
+    @BeforeAll
+    static void setup() {
+        AutoStart.main(new String[0]);
+        var config = AppConfigReader.getInstance();
+        var port = config.getProperty("rest.server.port", config.getProperty("server.port", "8085"));
+        target = "http://127.0.0.1:" + port;
+    }
+
+    @Test
+    void syncCompanionReturnsOutcomeInBandAndTees() throws Exception {
+        var po = EventEmitter.getInstance();
+        var platform = Platform.getInstance();
+        var sid = "ws-990001-2";
+        var inRoute = "ws.990001.2.in";
+        var outRoute = "ws.990001.2.out";
+
+        // create the session (mimic the WebSocket "open" event)
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", inRoute)));
+        boolean ready = false;
+        for (int i = 0; i < 50 && !ready; i++) {
+            if (GraphCommandService.hasSession(sid)) {
+                ready = true;
+            } else {
+                Thread.sleep(20);
+            }
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+
+        // stand in for the session's WebSocket .out route, to prove the tee (live human view)
+        List<Object> teed = new CopyOnWriteArrayList<>();
+        LambdaFunction outTap = (hdr, body, inst) -> {
+            teed.add(body);
+            return null;
+        };
+        platform.registerPrivate(outRoute, outTap, 1);
+        try {
+            // 1) an invalid command -> ok:false, error present in-band (the blind spot, closed)
+            var bad = syncCommand(po, sid, "flibbertigibbet not a command");
+            assertEquals(Boolean.FALSE, bad.get("ok"), "invalid command -> ok:false");
+            assertInstanceOf(String.class, bad.get("error"), "error text returned in-band, not WS-only");
+
+            // 2) a valid command -> ok:true, error null, output populated
+            var good = syncCommand(po, sid, "create node root\nwith type Root");
+            assertEquals(Boolean.TRUE, good.get("ok"), "valid command -> ok:true");
+            assertNull(good.get("error"), "no error on success");
+            assertInstanceOf(List.class, good.get("output"));
+            assertFalse(((List<?>) good.get("output")).isEmpty(), "console output returned in-band");
+
+            // 3) the tee: the same output also reached the session's WebSocket .out route
+            Thread.sleep(200);
+            var teedText = teed.stream()
+                    .filter(String.class::isInstance)
+                    .map(Object::toString)
+                    .reduce("", (a, b) -> a + "\n" + b);
+            assertTrue(teedText.contains("node root created"),
+                    "sync output must be teed to the session's WS .out for the live human view: " + teed);
+        } finally {
+            platform.release(outRoute);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> syncCommand(EventEmitter po, String sid, String command) throws Exception {
+        var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
+                .setUrl("/api/companion/{id}/sync").setPathParameter("id", sid)
+                .setHeader("Content-Type", "text/plain").setHeader("Accept", "application/json")
+                .setBody(command);
+        var resp = po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(req), 10000).get();
+        assertEquals(200, resp.getStatus(), "sync endpoint returns 200 with the outcome in the body");
+        assertInstanceOf(Map.class, resp.getBody());
+        return (Map<String, Object>) resp.getBody();
+    }
+}

--- a/system/minigraph-playground-engine/src/test/resources/rest.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/rest.yaml
@@ -77,6 +77,14 @@ rest:
     headers: header_1
     tracing: true
 
+  - service: 'post.companion.command.sync'
+    methods: ['POST']
+    url: '/api/companion/{id}/sync'
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
   # MOCK endpoints
 
   - service: 'mock.mdm.profile'


### PR DESCRIPTION
Implements **ADR-0008** (merged in #188).

## What

Adds an **additive** synchronous AI-companion endpoint — **`POST /api/companion/{id}/sync`**
(`post.companion.command.sync`, dev-gated) — the sibling of the fire-and-forget
`POST /api/companion/{id}`:

- Returns the command's outcome **in-band** as `{ ok, id, command, output, error, result }` instead
  of `{status:"accepted"}`. An AI agent can now **self-correct** from the returned `error` without a
  human relaying the WebSocket console; `result` carries a run/inspect result (e.g. `output.body`).
- **Tees** each output line to the session's real WebSocket `.out`, so a watching human — and, via
  the command service's existing subscriber fan-out, any `session subscribe`d session (e.g. a product
  owner) — sees the same output **live**: real-time human+AI collaboration.
- **Additive & backward-compatible**: the existing `post.companion.command` endpoint and the
  WebSocket console are unchanged.

New class `PostCompanionCommandSync`; `rest.yaml` route (main + test); `CompanionSyncTest`; ADR-0008
flipped to **Accepted**; `CHANGELOG` updated.

## Why

The current companion surface is a **write-only command bus**: `PostCompanionCommand` is
fire-and-forget, and the real outcome — success text *and errors* — reaches only the WebSocket
console, so an AI agent driving it over HTTP is blind and must poll `graph/session` + `inspect` to
guess (a *rejected* command leaves the model unchanged with no error, so polling can't even tell
"no-op" from "rejected"). Found empirically in an AI-companion validation exercise: an agent posted an
invalid `graph.math` node, got HTTP 200, and never saw `node … does not have if:, then: or else:` →
*graph traversal aborted*. See ADR-0008 for the full rationale.

## Mechanism

Mirrors the proven Rust reference implementation (`acn-ericlaw/mercury`): dispatch the command to the
singleton command handler over **request-response RPC** with a **private per-call capture route**
(`platform.registerPrivate`) supplied as the command's `out`; the capture route buffers each line
(and tees it), and a **FIFO sentinel** enqueued after the command marks the buffer fully drained
(deterministic, no arbitrary sleep). The `say()`-based command functions are untouched.

## Tests

`CompanionSyncTest` (drives the endpoint over real HTTP): invalid command → `ok:false` with the
error **in-band**; valid command → `ok:true` with `output`; and the tee is asserted via a stand-in at
the session's `.out`. **Full `minigraph-playground-engine` suite green: 64 tests, 0 failures**
(SessionManagement, Playground, tutorials, etc. — no regressions).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)