### PR TITLE
fix(minigraph): register /sync route in the example app rest.yaml (completes #189)

### DIFF
--- a/examples/minigraph-playground/src/main/resources/rest.yaml
+++ b/examples/minigraph-playground/src/main/resources/rest.yaml
@@ -76,6 +76,16 @@ rest:
     headers: header_1
     tracing: true
 
+  # synchronous companion (ADR-0008) - returns the command outcome in-band
+  # {ok, output, error, result}; additive sibling of the endpoint above
+  - service: 'post.companion.command.sync'
+    methods: ['POST']
+    url: '/api/companion/{id}/sync'
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
   # MOCK endpoints
 
   - service: 'mock.mdm.profile'


### PR DESCRIPTION
## What

Adds the `POST /api/companion/{id}/sync` route to the **example app's** rest.yaml
(`examples/minigraph-playground/src/main/resources/rest.yaml`).

## Why

#189 added the synchronous companion endpoint and registered it in the **engine module's**
rest.yaml (main + test), but the standalone `examples/minigraph-playground` Spring Boot app loads
its *own* `src/main/resources/rest.yaml`. So when running the example app, `POST /api/companion/{id}/sync`
returned **404** (the fire-and-forget `POST /api/companion/{id}` still worked). The
`PostCompanionCommandSync` service is already on the classpath via the `minigraph-playground-engine`
dependency — only the route registration was missing. Completes #189.

Verified: the endpoint 404'd against a running example-app build lacking this route; with the route
added, the app registers `/api/companion/{id}/sync` (a live regression follows on the rebuilt app).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)