### PR TITLE
fix(minigraph): drain companion /sync on the traversal terminal, not a racing sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `session subscribe`d session — sees it live (real-time human+AI collaboration). Additive; the
    existing endpoint and the WebSocket console are unchanged.
 
+### Fixed
+
+1. **`/api/companion/{id}/sync` now returns the whole `run` outcome (ADR-0008).** `run` is
+   asynchronous — the command handler replies before the traveler streams its `Walk to…` / `Executed…`
+   / `output` / terminal lines — so the FIFO sentinel raced (and usually beat) that tail and truncated
+   the response to just `Walk to root` / `Walk to end`. A traversal is now drained on the traveler's
+   **terminal line** (`Graph traversal completed in N ms` | `Graph traversal aborted`), always emitted
+   last. To make that signal reliable, every `run` now ends with one terminal line: the early-failure
+   paths (no instance yet, missing root/end node) emit their reason *then* the canonical
+   `Graph traversal aborted`, so `run` before `instantiate` returns promptly (`ok:false`) instead of
+   waiting out the timeout. Synchronous commands keep the sentinel drain. This keeps the `/sync` REST
+   contract byte-identical with the Rust port — the companion surface is language-neutral.
+
 ---
 ## Version 4.8.6, 7/14/2026
 

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -74,7 +74,18 @@ and a subscribed product owner watched in real time. **Now implemented in this J
 `PostCompanionCommandSync` (route `post.companion.command.sync`, dev-gated) with `CompanionSyncTest`,
 mirroring the Rust design — a private per-call capture route (`registerPrivate`) supplied as the
 command's `out`, RPC to the singleton command handler, a FIFO sentinel to mark the buffer drained, and
-a best-effort tee to the session's WebSocket `.out`.
+a best-effort tee to the session's WebSocket `.out`. **End-of-transmission refinement (both ports):**
+the sentinel is correct only for *synchronous* commands, which emit all output before the handler
+replies. A traversal (`run`) is *asynchronous* — the handler launches the traveler and replies
+immediately, then the traveler streams its output afterwards — so a post-reply sentinel races (and
+usually beats) that tail and truncates the capture. A traversal is therefore drained on the traveler's
+**terminal line** (`Graph traversal completed in N ms` | `Graph traversal aborted`), which is always
+emitted last. To make that signal reliable, **every `run` now ends with one terminal line**: the
+early-failure paths (no instance yet, missing root/end node) emit their reason *then* the canonical
+`Graph traversal aborted`, so a companion mistake such as `run` before `instantiate` returns promptly
+(`ok:false`) instead of waiting out the timeout. The bounded wait is only a safety net; correctness
+comes from the signal. This keeps the REST contract byte-identical across the Rust and Java engines —
+the companion surface is language-neutral.
 
 ---
 

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -54,9 +54,15 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * Mechanism: dispatch the command to the singleton command handler over
  * request-response RPC with a private, per-call capture route supplied as the
- * command's {@code out}; the capture route buffers each line (and tees it), then a
- * FIFO sentinel marks the buffer fully drained. The existing endpoint and the
- * WebSocket console are unchanged.
+ * command's {@code out}; the capture route buffers each line (and tees it). The
+ * end-of-transmission signal depends on the command shape: a <b>traversal</b>
+ * ({@code run}) is asynchronous — the handler launches the traveler and replies
+ * immediately, then the traveler streams its output afterwards — so it is drained
+ * on the traveler's <b>terminal line</b> ("Graph traversal completed in N ms" |
+ * "Graph traversal aborted"), always emitted last; every other command emits all
+ * output before it replies, so a <b>FIFO sentinel</b> marks its buffer drained. A
+ * sentinel would race (and usually beat) the traversal tail, truncating the
+ * capture. The existing endpoint and the WebSocket console are unchanged.
  */
 @OptionalService("app.env=dev")
 @PreLoad(route = "post.companion.command.sync", instances = 10)
@@ -95,26 +101,35 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
 
         // A private, per-call capture route: buffer each line for the in-band response and
         // tee it to the session's real WebSocket .out for the live human view.
+        // A traversal (`run`) streams its output after the handler replies; every other
+        // command emits all output before replying. One latch serves both: it fires on
+        // the traveler's terminal line for a traversal, or on the FIFO sentinel otherwise.
+        final var traversal = isTraversalCommand(command);
         List<Object> buffer = new CopyOnWriteArrayList<>();
         CountDownLatch drained = new CountDownLatch(1);
         LambdaFunction capture = (hdr, body, inst) -> {
             if (SYNC_SENTINEL.equals(body)) {
                 drained.countDown();
-            } else {
-                buffer.add(body);
-                try {
-                    emitter.send(new EventEnvelope().setTo(outRoute).setBody(body));
-                } catch (Exception e) {
-                    // best-effort tee: the .out route may have no live WebSocket
-                    log.debug("Tee to {} skipped - {}", outRoute, e.getMessage());
-                }
+                return null;
+            }
+            buffer.add(body);
+            try {
+                emitter.send(new EventEnvelope().setTo(outRoute).setBody(body));
+            } catch (Exception e) {
+                // best-effort tee: the .out route may have no live WebSocket
+                log.debug("Tee to {} skipped - {}", outRoute, e.getMessage());
+            }
+            // A traversal is drained on its terminal line (emitted last), so once seen
+            // every prior line is already buffered - deterministic, no racing sentinel.
+            if (traversal && body instanceof String line && isTraversalTerminal(line)) {
+                drained.countDown();
             }
             return null;
         };
         platform.registerPrivate(captureRoute, capture, 1);
         try {
-            // RPC the singleton handler with the capture route as `out`; its handleEvent
-            // completes (returns) only after all command output has been enqueued.
+            // RPC the singleton handler with the capture route as `out`; handleEvent
+            // returns once the command is dispatched (a traversal is still running).
             po.request(new EventEnvelope()
                     .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
                     .setBody(Map.of(
@@ -123,10 +138,15 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
                             "out", captureRoute,
                             "message", command)),
                     COMMAND_TIMEOUT_MS).get();
-            // The sentinel is enqueued after the command's (FIFO) output, so seeing it means
-            // the buffer is fully drained - deterministic, no arbitrary sleep.
-            po.send(new EventEnvelope().setTo(captureRoute).setBody(SYNC_SENTINEL));
-            if (!drained.await(DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            // Synchronous commands: enqueue the FIFO sentinel to mark the buffer drained.
+            // Traversals: the capture route counts the latch down on the terminal line.
+            if (!traversal) {
+                po.send(new EventEnvelope().setTo(captureRoute).setBody(SYNC_SENTINEL));
+            }
+            // The timeout is only a safety net (matched to the command timeout for a
+            // traversal); correctness comes from the signal, not from a timer.
+            var drainTimeout = traversal ? COMMAND_TIMEOUT_MS : DRAIN_TIMEOUT_MS;
+            if (!drained.await(drainTimeout, TimeUnit.MILLISECONDS)) {
                 log.warn("Companion sync drain timed out for {}", id);
             }
         } finally {
@@ -160,5 +180,24 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
     private static boolean isErrorLine(String line) {
         return line.startsWith("ERROR:") || line.contains("aborted") || line.contains("does not have")
                 || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'");
+    }
+
+    /**
+     * The Playground's only <b>asynchronous</b> command: {@code run} launches the
+     * traveler, which streams its output after the command handler has already
+     * replied — so the sentinel drain races the traversal tail. A traversal is
+     * drained on its terminal line instead (see {@link #isTraversalTerminal}).
+     */
+    private static boolean isTraversalCommand(String command) {
+        return "run".equalsIgnoreCase(command);
+    }
+
+    /**
+     * The traveler's end-of-transmission lines. One of these is <b>always</b>
+     * emitted last (success or failure), so the synchronous endpoint drains a
+     * traversal deterministically — no timer, no truncated capture.
+     */
+    private static boolean isTraversalTerminal(String line) {
+        return line.startsWith("Graph traversal completed in") || line.equals("Graph traversal aborted");
     }
 }

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
@@ -79,6 +79,11 @@ public class GraphTraveler extends GraphLambdaFunction {
             var error = new EventEnvelope().setTo(event.getReplyTo()).setStatus(rc).setBody(e.getMessage())
                                                 .setCorrelationId(event.getCorrelationId());
             po.send(error);
+            // Uniform end-of-transmission even when the traversal fails before it
+            // starts (no graph instance yet, missing root/end) - no GraphInstance
+            // exists here, so emit the terminal line directly to the reply route.
+            po.send(new EventEnvelope().setTo(event.getReplyTo()).setStatus(400)
+                    .setBody("Graph traversal aborted").setCorrelationId(event.getCorrelationId()));
         }
     }
 
@@ -132,7 +137,7 @@ public class GraphTraveler extends GraphLambdaFunction {
                 var cid = graphInstance.getCorrelationId();
                 var error = new EventEnvelope().setTo(replyTo).setCorrelationId(cid).setBody(errorMap).setStatus(rc);
                 po.send(error);
-                sendError(po, graphInstance, "Graph traversal aborted");
+                emitAborted(po, graphInstance);
             } else if (!graphInstance.complete.get()) {
                 var next = String.valueOf(response.getBody());
                 decideNext(po, node, next, graphInstance);
@@ -266,13 +271,33 @@ public class GraphTraveler extends GraphLambdaFunction {
         var error = new EventEnvelope().setTo(out).setCorrelationId(graphInstance.getCorrelationId())
                                         .setBody(response.getBody()).setStatus(response.getStatus());
         po.send(error);
-        sendError(po, graphInstance, "Graph traversal aborted");
+        emitAborted(po, graphInstance);
     }
 
+    /**
+     * Canonical failure terminal — the mirror of the success terminal in
+     * {@code executionComplete}. Marks the traversal complete and emits the single
+     * end-of-transmission line the synchronous companion endpoint drains on, so
+     * <b>every</b> {@code run} finishes with either "Graph traversal completed in N ms"
+     * or "Graph traversal aborted" — a deterministic signal, never a timeout.
+     */
+    private void emitAborted(PostOffice po, GraphInstance graphInstance) {
+        graphInstance.complete.set(true);
+        po.send(new EventEnvelope().setTo(graphInstance.getReplyTo())
+                .setCorrelationId(graphInstance.getCorrelationId())
+                .setBody("Graph traversal aborted").setStatus(400));
+    }
+
+    /**
+     * Emit a specific failure reason and then the canonical {@link #emitAborted}
+     * terminal, so the human/companion sees <i>why</i> and any watcher (the sync
+     * endpoint included) still gets the uniform end-of-transmission line last.
+     */
     private void sendError(PostOffice po, GraphInstance graphInstance, String message) {
         graphInstance.complete.set(true);
         var error = new EventEnvelope().setTo(graphInstance.getReplyTo())
                             .setCorrelationId(graphInstance.getCorrelationId()).setBody(message).setStatus(400);
         po.send(error);
+        emitAborted(po, graphInstance);
     }
 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -28,6 +28,7 @@ import org.platformlambda.core.system.AutoStart;
 import org.platformlambda.core.system.EventEmitter;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ class CompanionSyncTest {
             if (GraphCommandService.hasSession(sid)) {
                 ready = true;
             } else {
-                Thread.sleep(20);
+                Utility.getInstance().sleep(20);
             }
         }
         assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
@@ -95,13 +96,56 @@ class CompanionSyncTest {
             assertFalse(((List<?>) good.get("output")).isEmpty(), "console output returned in-band");
 
             // 3) the tee: the same output also reached the session's WebSocket .out route
-            Thread.sleep(200);
+            Utility.getInstance().sleep(200);
             var teedText = teed.stream()
                     .filter(String.class::isInstance)
                     .map(Object::toString)
                     .reduce("", (a, b) -> a + "\n" + b);
             assertTrue(teedText.contains("node root created"),
                     "sync output must be teed to the session's WS .out for the live human view: " + teed);
+
+            // 4) a traversal (`run`) is asynchronous - the handler replies before the
+            //    traveler streams its output. The sync response must carry the WHOLE
+            //    traversal, drained on the traveler's terminal line (emitted last), not a
+            //    raced sentinel that truncates it. Build a runnable graph and run it.
+            syncCommand(po, sid, "create node end");
+            syncCommand(po, sid, "create node mapper\nwith type mapper\nwith properties\n"
+                    + "skill=graph.data.mapper\nmapping[]=input.body.id -> output.body");
+            syncCommand(po, sid, "connect root to mapper with first");
+            syncCommand(po, sid, "connect mapper to end with second");
+            var instantiated = syncCommand(po, sid, "instantiate graph\ntext(hello world) -> input.body.id");
+            assertEquals(Boolean.TRUE, instantiated.get("ok"), "instantiate -> ok:true: " + instantiated);
+
+            var ran = syncCommand(po, sid, "run");
+            assertEquals(Boolean.TRUE, ran.get("ok"), "sync run -> ok:true: " + ran);
+            var runOutput = ((List<?>) ran.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(runOutput.stream().anyMatch("Walk to root"::equals),
+                    "sync run captures the traversal start: " + runOutput);
+            assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Executed mapper with skill graph.data.mapper")),
+                    "sync run captures mid-traversal skill execution: " + runOutput);
+            assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Graph traversal completed in")),
+                    "sync run must capture the traversal terminal (drain waited for it): " + runOutput);
+            assertNotNull(ran.get("result"), "sync run returns the output.body as structured result: " + ran);
+            assertTrue(String.valueOf(ran.get("result")).contains("hello world"),
+                    "structured result carries the run's output.body: " + ran.get("result"));
+
+            // 5) a failing traversal (run before instantiate, fresh session) still returns
+            //    promptly with the uniform terminal - the drain never hangs to the timeout.
+            var badIn = "ws.990009.2.in";
+            var badId = "ws-990009-2";
+            po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                    .setBody(Map.of("type", "open", "in", badIn)));
+            for (int i = 0; i < 50 && !GraphCommandService.hasSession(badId); i++) {
+                Utility.getInstance().sleep(20);
+            }
+            long started = System.currentTimeMillis();
+            var badRun = syncCommand(po, badId, "run");
+            assertTrue(System.currentTimeMillis() - started < 10000,
+                    "a failed run must drain on the terminal, not the safety timeout");
+            assertEquals(Boolean.FALSE, badRun.get("ok"), "run with no instance -> ok:false: " + badRun);
+            var badRunOutput = ((List<?>) badRun.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(badRunOutput.stream().anyMatch("Graph traversal aborted"::equals),
+                    "every run ends with a terminal, even on early failure: " + badRunOutput);
         } finally {
             platform.release(outRoute);
         }


### PR DESCRIPTION
## What

`POST /api/companion/{id}/sync` (ADR-0008) now returns the **whole** `run` outcome. `run` is the only asynchronous command — the command handler launches the traveler and replies immediately, then the traveler streams `Walk to…` / `Executed…` / the `output` map / a terminal line to `out` **after** the reply. The FIFO sentinel enqueued right after the reply raced (and usually beat) that async tail, truncating the `/sync` response to just `Walk to root` / `Walk to end`.

- A traversal is now drained on the traveler's **terminal line** — `Graph traversal completed in N ms` (success) or `Graph traversal aborted` (failure) — which is always emitted last, so once it is seen every prior line is already buffered. One `CountDownLatch` serves both cases: it fires on the terminal line for a traversal, or on the FIFO sentinel for a synchronous command.
- To make that signal reliable, **every `run` now ends with exactly one terminal line.** The early-failure paths (no instance yet, missing root/end node) emit their reason **then** the canonical `Graph traversal aborted` (`emitAborted`), so a companion mistake such as `run` before `instantiate` returns promptly with `ok:false` instead of waiting out the timeout. The bounded wait is only a safety net; correctness comes from the signal, not a timer.
- `CompanionSyncTest` now builds a runnable graph and asserts the full traversal capture (`Walk to root`, `Executed mapper …`, `Graph traversal completed …`) + the `output.body` `result` + the live tee, plus a no-instance `run` returning `ok:false` with the terminal, promptly. Full minigraph module: **64 tests green**.

## Why

The AI-companion interaction with MiniGraph is **language-neutral** — it speaks the REST protocol, so it must behave identically whether the engine is Java or the Rust port (`acn-ericlaw/mercury`). A truncated `run` response broke that contract: an AI companion (or a human) driving `/sync` saw only the traversal *start*, not the result, and had to fall back to `inspect`. This change makes the `/sync` contract byte-identical across both engines and removes a timeout hang on a common companion mistake. Mirrors the Rust fix commit-for-commit.

---

**Stacked on #190** (base is `fix/companion-sync-example-restyaml`, which adds the `/sync` route to the standalone example app's `rest.yaml`). GitHub will auto-retarget this PR's base to `main` when #190 merges. Review this PR's own diff only (`GraphTraveler.java`, `PostCompanionCommandSync.java`, `CompanionSyncTest.java`, ADR-0008, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>