### PR TITLE
fix(minigraph): limit the session command to read-only on companion endpoints

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommand.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommand.java
@@ -53,6 +53,14 @@ public class PostCompanionCommand implements TypedLambdaFunction<AsyncHttpReques
         var route = id.replace('-', '.');
         var inRoute = route + ".in";
         var outRoute = route + ".out";
+        // Same restriction as the synchronous endpoint: only the read-only "session"
+        // status query is available from a companion (a companion is an assistant to
+        // the session in the URL, not a WebSocket session of its own).
+        var topology = GraphCommandService.sessionTopologySubcommand(command);
+        if (topology != null) {
+            throw new IllegalArgumentException(
+                    GraphCommandService.refuseSessionTopology(outRoute, command, topology));
+        }
         // use the singleton version of the GraphCommandService to eliminate chance of racing condition
         var po = new PostOffice(headers, instance);
         po.send(new EventEnvelope()

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -93,6 +93,22 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         var route = id.replace('-', '.');
         var inRoute = route + ".in";
         var outRoute = route + ".out";
+        // Reject session-topology commands before dispatch: only the read-only "session"
+        // status query is available from a companion (a companion is an assistant to the
+        // session in the URL, not a WebSocket session of its own; executed here the
+        // subscribe path would also bind the ephemeral capture route as a subscriber).
+        var topology = GraphCommandService.sessionTopologySubcommand(command);
+        if (topology != null) {
+            var error = GraphCommandService.refuseSessionTopology(outRoute, command, topology);
+            var refused = new HashMap<String, Object>();
+            refused.put("ok", false);
+            refused.put("id", id);
+            refused.put("command", command);
+            refused.put("output", List.of("> " + command, error));
+            refused.put("error", error);
+            refused.put("result", null);
+            return new EventEnvelope().setHeader("Content-Type", "application/json").setBody(refused);
+        }
         var captureRoute = "companion.sync." + Utility.getInstance().getUuid();
 
         var po = new PostOffice(headers, instance);

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -295,6 +295,50 @@ public class GraphCommandService extends GraphLambdaFunction {
         return graphModels.containsKey(inRoute);
     }
 
+    /**
+     * Session-topology subcommands (subscribe/unsubscribe/reset) are a WebSocket-session
+     * privilege on both companion endpoints: a companion is an <b>assistant to</b> the
+     * session named in the URL, not a WebSocket session of its own. On the synchronous
+     * endpoint they would also bind the per-request capture route
+     * ({@code companion.sync.<uuid>}, released when the POST returns) as a durable
+     * subscriber. Only the read-only {@code session} status query is allowed.
+     *
+     * @param command the trimmed command text
+     * @return the offending subcommand, or null when the command is allowed
+     */
+    public static String sessionTopologySubcommand(String command) {
+        var words = command.trim().split("\\s+");
+        if (words.length < 2 || !"session".equalsIgnoreCase(words[0])) {
+            return null;
+        }
+        var sub = words[1].toLowerCase();
+        return switch (sub) {
+            case "subscribe", "unsubscribe", "reset" -> sub;
+            default -> null;
+        };
+    }
+
+    /**
+     * Refuse a session-topology command on a companion endpoint: echo the refusal to the
+     * session's live console (the watching human sees what the AI caller sees) and return
+     * the error text for the endpoint's own reply shape.
+     *
+     * @param outRoute the session's WebSocket output route
+     * @param command the offending command
+     * @param sub the offending subcommand from {@link #sessionTopologySubcommand(String)}
+     * @return the refusal message
+     */
+    public static String refuseSessionTopology(String outRoute, String command, String sub) {
+        var error = "session " + sub + " is not available on the companion endpoint - a companion is an " +
+                "assistant to this session, not a WebSocket session; use the read-only 'session' " +
+                "command here, and manage subscriptions from a WebSocket-connected session";
+        var emitter = EventEmitter.getInstance();
+        for (var line : new String[]{"> " + command, error}) {
+            emitter.send(new EventEnvelope().setTo(outRoute).setBody(line));
+        }
+        return error;
+    }
+
     private void handleCommandPartTwo(PostOffice po, String inRoute, String outRoute, List<String> words) {
         if (words.size() > 2 && words.getFirst().equalsIgnoreCase("connect")) {
             handleConnectCommand(po, inRoute, outRoute, words);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -151,6 +151,82 @@ class CompanionSyncTest {
         }
     }
 
+    /**
+     * A companion is an <b>assistant to</b> a session, not a WebSocket session of its own —
+     * so both companion endpoints limit the {@code session} command to the read-only status
+     * query: the topology subcommands (subscribe/unsubscribe/reset) are rejected before
+     * dispatch. Executed on the sync path they would durably register the per-request
+     * {@code companion.sync.<uuid>} capture route as a subscriber.
+     */
+    @Test
+    void companionEndpointsLimitSessionCommandToReadOnly() throws Exception {
+        var po = EventEmitter.getInstance();
+        var platform = Platform.getInstance();
+        var sid = "ws-990002-2";
+        var inRoute = "ws.990002.2.in";
+        var outRoute = "ws.990002.2.out";
+
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", inRoute)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+
+        List<Object> teed = new CopyOnWriteArrayList<>();
+        LambdaFunction outTap = (hdr, body, inst) -> {
+            teed.add(body);
+            return null;
+        };
+        platform.registerPrivate(outRoute, outTap, 1);
+        try {
+            // 1) every topology-mutating form is rejected in-band on the sync endpoint
+            for (var command : List.of("session subscribe ws-990001-2", "session unsubscribe", "session reset")) {
+                var refused = syncCommand(po, sid, command);
+                assertEquals(Boolean.FALSE, refused.get("ok"), "rejected: " + refused);
+                assertInstanceOf(String.class, refused.get("error"));
+                assertTrue(((String) refused.get("error")).contains("not available on the companion endpoint"),
+                        "refusal reason returned in-band: " + refused);
+            }
+
+            // 2) nothing was registered: this session's read-only status query still works
+            //    and shows no subscription; no capture route appears anywhere
+            var status = syncCommand(po, sid, "session");
+            assertEquals(Boolean.TRUE, status.get("ok"), "read-only 'session' stays allowed: " + status);
+            var statusText = String.valueOf(status.get("output"));
+            assertFalse(statusText.contains("subscribed to"),
+                    "the rejected subscribe must not mark this session as subscribed: " + status);
+            assertFalse(statusText.contains("companion.sync"),
+                    "no capture-route subscriber may be registered: " + status);
+
+            // 3) the refusal is also teed to the session's WS console for the human
+            Utility.getInstance().sleep(200);
+            assertTrue(teed.stream().filter(String.class::isInstance).map(Object::toString)
+                            .anyMatch(l -> l.contains("not available on the companion endpoint")),
+                    "refusal must be visible on the live console: " + teed);
+
+            // 4) the fire-and-forget endpoint enforces the same restriction with a 400,
+            //    while its read-only 'session' status query still dispatches (accepted)
+            var refusedLegacy = legacyCommand(po, sid, "session subscribe ws-990001-2");
+            assertEquals(400, refusedLegacy.getStatus(), "legacy endpoint refuses with 400");
+            assertTrue(String.valueOf(refusedLegacy.getBody()).contains("not available on the companion endpoint"),
+                    "legacy refusal carries the reason: " + refusedLegacy.getBody());
+            var statusLegacy = legacyCommand(po, sid, "session");
+            assertEquals(200, statusLegacy.getStatus(),
+                    "read-only 'session' stays allowed on the legacy endpoint: " + statusLegacy.getBody());
+        } finally {
+            platform.release(outRoute);
+        }
+    }
+
+    private EventEnvelope legacyCommand(EventEmitter po, String sid, String command) throws Exception {
+        var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
+                .setUrl("/api/companion/{id}").setPathParameter("id", sid)
+                .setHeader("Content-Type", "text/plain").setHeader("Accept", "application/json")
+                .setBody(command);
+        return po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(req), 10000).get();
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> syncCommand(EventEmitter po, String sid, String command) throws Exception {
         var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)


### PR DESCRIPTION
## What

Both AI-companion endpoints — `POST /api/companion/{id}` (fire-and-forget) and
`POST /api/companion/{id}/sync` — now reject the session-topology subcommands
(`session subscribe` / `session unsubscribe` / `session reset`) before dispatch; the
read-only `session` status query remains available. The refusal is returned in-band
(`ok:false` + `error` on `/sync`, HTTP 400 on the fire-and-forget endpoint) and is also
echoed to the session's live WebSocket console, so a watching human sees exactly what the
AI caller sees. Implementation: shared statics in `GraphCommandService`
(`sessionTopologySubcommand` / `refuseSessionTopology`) used by both REST handlers; new
test `companionEndpointsLimitSessionCommandToReadOnly` drives both endpoints over the real
wire (module suite: 65 tests green).

## Why

A companion is an **assistant to** the session named in the URL, not a WebSocket session
of its own — session topology belongs to WebSocket-connected sessions. Concretely,
`session subscribe` issued through `/sync` durably registered the **per-request capture
route** (`companion.sync.<uuid>`, released when the POST returns) as a subscriber. This
was observed live during the tutorial-5 AI-companion validation exercise on the Rust port
(its `docs/AI-companion-test.md`, finding #14): the primary session reported
`subscribed by ["companion.sync.<uuid>"]` while the caller's session claimed
`subscribed to <primary>` — a dangling ephemeral route and asymmetric session state. The
refusal text is byte-identical to the Rust port's, keeping the companion REST contract
language-neutral across engines (same principle as #189/#193).

Co-Authored-By: Claude Code <noreply@anthropic.com>