### PR TITLE
fix(minigraph): classify companion /sync outcome with whole-output context

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -169,20 +169,18 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
             platform.release(captureRoute);
         }
 
-        // Build the structured outcome from the captured output.
+        // Build the structured outcome from the captured output. Collect the console
+        // lines first, then classify with whole-output context (see firstErrorLine).
         List<String> output = new ArrayList<>();
         List<Object> result = new ArrayList<>();
-        String error = null;
         for (var item : buffer) {
             if (item instanceof String line) {
-                if (error == null && isErrorLine(line)) {
-                    error = line;
-                }
                 output.add(line);
             } else {
                 result.add(item);
             }
         }
+        String error = firstErrorLine(output);
         var body = new HashMap<String, Object>();
         body.put("ok", error == null);
         body.put("id", id);
@@ -196,6 +194,27 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
     private static boolean isErrorLine(String line) {
         return line.startsWith("ERROR:") || line.contains("aborted") || line.contains("does not have")
                 || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'");
+    }
+
+    /**
+     * Whole-output-aware error classification. {@code import graph from {deployed}}
+     * legitimately prints "Graph model not found in /tmp/..." before falling back
+     * to the deployed classpath copy — a benign line that must not mark the
+     * command failed. It is forgiven <b>only</b> when the same output also carries
+     * the fallback's success marker; a genuine miss prints the not-found line
+     * alone and stays an error.
+     */
+    private static String firstErrorLine(List<String> lines) {
+        var deployedFallback = lines.stream().anyMatch(l -> l.contains("Found deployed graph model"));
+        for (var line : lines) {
+            if (deployedFallback && line.startsWith("Graph model not found in")) {
+                continue;
+            }
+            if (isErrorLine(line)) {
+                return line;
+            }
+        }
+        return null;
     }
 
     /**

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -30,6 +30,7 @@ import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -217,6 +218,54 @@ class CompanionSyncTest {
         } finally {
             platform.release(outRoute);
         }
+    }
+
+    /**
+     * The {@code ok} flag is derived from the console lines with <b>whole-output</b>
+     * context: {@code import graph from {deployed}} legitimately prints
+     * "Graph model not found in /tmp/..." before falling back to the deployed
+     * classpath copy — a benign line that must not mark the command failed. It is
+     * forgiven only when the same output also carries the fallback's success marker;
+     * a genuine miss prints the not-found line alone and stays {@code ok:false}.
+     */
+    @Test
+    void companionSyncImportFallbackReportsOk() throws Exception {
+        var po = EventEmitter.getInstance();
+        var sid = "ws-990003-2";
+        var inRoute = "ws.990003.2.in";
+
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", inRoute)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+
+        // guarantee the fallback path: the graph must exist ONLY as a deployed classpath copy
+        // (tutorial-113 ships in classpath:/graph and no test exports it, but a stale temp
+        // copy from an earlier manual run would short-circuit the fallback)
+        var temp = new File("/tmp/graph", "tutorial-113.json");
+        if (temp.exists()) {
+            assertTrue(temp.delete(), "stale temp copy must be removed to exercise the fallback");
+        }
+
+        // 1) deployed-only graph: the benign not-found line is forgiven -> ok:true
+        var imported = syncCommand(po, sid, "import graph from tutorial-113");
+        var lines = ((List<?>) imported.get("output")).stream().map(String::valueOf).toList();
+        assertTrue(lines.stream().anyMatch(l -> l.startsWith("Graph model not found in")),
+                "the fallback prints the benign not-found line first: " + lines);
+        assertTrue(lines.stream().anyMatch(l -> l.startsWith("Found deployed graph model")),
+                "the deployed copy must be found for this test to be meaningful: " + lines);
+        assertEquals(Boolean.TRUE, imported.get("ok"),
+                "the benign fallback must not be classified an error: " + imported);
+        assertNull(imported.get("error"), "no error on a successful fallback import: " + imported);
+
+        // 2) a genuine miss prints the not-found line alone and stays an error
+        var missed = syncCommand(po, sid, "import graph from no-such-graph-xyz");
+        assertEquals(Boolean.FALSE, missed.get("ok"), "a genuine miss stays ok:false: " + missed);
+        assertInstanceOf(String.class, missed.get("error"));
+        assertTrue(((String) missed.get("error")).contains("not found"),
+                "the genuine miss carries the not-found error in-band: " + missed);
     }
 
     private EventEnvelope legacyCommand(EventEmitter po, String sid, String command) throws Exception {


### PR DESCRIPTION
## What

The synchronous AI-companion endpoint derives its `ok` flag from the captured console
lines. `import graph from {deployed}` legitimately prints "Graph model not found in
/tmp/..." before falling back to the deployed classpath copy, and the per-line
`isErrorLine` heuristic classified that benign line as a failure — a succeeding import
returned `ok:false` with an `error` field.

Classification now runs over the whole captured output (`firstErrorLine`): the
not-found line is forgiven only when the same output also carries the fallback's
success marker ("Found deployed graph model"); a genuine miss prints the not-found
line alone and stays `ok:false`. Verified against the import handler that a real miss
emits nothing after the not-found line, so the forgiveness rule cannot mask a real
failure. A new test (`companionSyncImportFallbackReportsOk`) covers both directions;
the module suite is green (66 tests).

## Why

An AI agent using `/sync` self-corrects from `ok`/`error` in-band. A false negative on
a working command misleads the agent into "fixing" a command that succeeded — the exact
failure mode the synchronous endpoint (ADR-0008) exists to prevent. Found during the
tutorial-12 pre-flight of the AI-companion validation sweep (finding #40). The same fix
ships in the Rust port, keeping the `/sync` REST contract byte-identical across engines;
both engines have been validated live.

Co-Authored-By: Claude Code <noreply@anthropic.com>