### PR TITLE
feat(event-script): numeric promotion for the simple-plugin arithmetic family

### DIFF
--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/AddNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/AddNumbers.java
@@ -22,8 +22,6 @@ import com.accenture.models.SimplePlugin;
 import com.accenture.util.SimplePluginUtils;
 import com.accenture.models.PluginFunction;
 
-import java.util.Arrays;
-
 @SimplePlugin
 public class AddNumbers implements PluginFunction {
 

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/AddNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/AddNumbers.java
@@ -35,10 +35,8 @@ public class AddNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length < 2) {
-            throw new IllegalArgumentException("Expected at least two Whole Numbers to add");
+            throw new IllegalArgumentException("Expected at least two Numbers to add");
         }
-        return SimplePluginUtils.promoteInput(input)
-                .reduce(Long::sum)
-                .orElseThrow(() -> new IllegalArgumentException("Could not add the input: " + Arrays.toString(input)));
+        return SimplePluginUtils.reduceNumbers(Long::sum, Double::sum, input);
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/DecrementNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/DecrementNumbers.java
@@ -33,8 +33,9 @@ public class DecrementNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length == 1) {
-            return SimplePluginUtils.promoteNumber(input[0]) - 1L;
+            Number n = SimplePluginUtils.promoteNumber(input[0]);
+            return n instanceof Double d ? d - 1.0d : n.longValue() - 1L;
         }
-        throw new IllegalArgumentException("Expected exactly one Whole Number to decrement");
+        throw new IllegalArgumentException("Expected exactly one Number to decrement");
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/DivideNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/DivideNumbers.java
@@ -35,13 +35,11 @@ public class DivideNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length < 2) {
-            throw new IllegalArgumentException("Expected at least two Whole Numbers to divide");
+            throw new IllegalArgumentException("Expected at least two Numbers to divide");
         }
         // only divisors can trigger division by zero - a zero dividend is valid
         SimplePluginUtils.divideByZeroCheck(Arrays.copyOfRange(input, 1, input.length));
-        return SimplePluginUtils.promoteInput(input)
-                .reduce((l1, l2) -> l1 / l2)
-                .orElseThrow(() -> new IllegalArgumentException("Could not divide the input: " + Arrays.toString(input)));
+        return SimplePluginUtils.reduceNumbers((l1, l2) -> l1 / l2, (d1, d2) -> d1 / d2, input);
     }
 
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/IncrementNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/IncrementNumbers.java
@@ -33,8 +33,9 @@ public class IncrementNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length == 1) {
-            return SimplePluginUtils.promoteNumber(input[0]) + 1L;
+            Number n = SimplePluginUtils.promoteNumber(input[0]);
+            return n instanceof Double d ? d + 1.0d : n.longValue() + 1L;
         }
-        throw new IllegalArgumentException("Expected exactly one Whole Number to increment");
+        throw new IllegalArgumentException("Expected exactly one Number to increment");
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/ModulusNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/ModulusNumbers.java
@@ -38,9 +38,6 @@ public class ModulusNumbers implements PluginFunction {
             throw new IllegalArgumentException("Modulus expects only two values but got " + Arrays.toString(input));
         }
         SimplePluginUtils.divideByZeroCheck(input[1]);
-        return SimplePluginUtils.promoteInput(input)
-                .reduce((l1, l2) -> l1 % l2)
-                .orElseThrow(() ->
-                        new IllegalArgumentException("Could not get modulus for the input: " + Arrays.toString(input)));
+        return SimplePluginUtils.reduceNumbers((l1, l2) -> l1 % l2, (d1, d2) -> d1 % d2, input);
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/MultiplyNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/MultiplyNumbers.java
@@ -22,8 +22,6 @@ import com.accenture.util.SimplePluginUtils;
 import com.accenture.models.SimplePlugin;
 import com.accenture.models.PluginFunction;
 
-import java.util.Arrays;
-
 @SimplePlugin
 public class MultiplyNumbers implements PluginFunction {
 

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/MultiplyNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/MultiplyNumbers.java
@@ -35,11 +35,9 @@ public class MultiplyNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length < 2) {
-            throw new IllegalArgumentException("Expected at least two Whole Numbers to multiply");
+            throw new IllegalArgumentException("Expected at least two Numbers to multiply");
         }
-        return SimplePluginUtils.promoteInput(input)
-                .reduce((l1, l2) -> l1 * l2)
-                .orElseThrow(() -> new IllegalArgumentException("Could not multiply the input: " + Arrays.toString(input)));
+        return SimplePluginUtils.reduceNumbers((l1, l2) -> l1 * l2, (d1, d2) -> d1 * d2, input);
     }
 
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/RoundNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/RoundNumbers.java
@@ -1,0 +1,66 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.arithmetic;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+import com.accenture.util.SimplePluginUtils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * f:round(number[, decimal_places]) - half-up rounding (ties away from zero)
+ * applied to the number's SHORTEST decimal representation
+ * (BigDecimal.valueOf), so binary floating-point representation error does
+ * not leak into the rounding decision: 1.005 rounds to 1.01 at 2 places,
+ * where a naive multiply-round-divide would give 1.0. A whole-number input
+ * is already exact and passes through unchanged. Companion to the numeric
+ * promotion of the arithmetic family - use it to tame floating-point
+ * precision artifacts after decimal arithmetic.
+ */
+@SimplePlugin
+public class RoundNumbers implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "round";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        if (input.length < 1 || input.length > 2) {
+            throw new IllegalArgumentException("Expected a number and optional decimal places to round");
+        }
+        int decimalPlaces = 0;
+        if (input.length == 2) {
+            if (SimplePluginUtils.promoteNumber(input[1]) instanceof Long dp && dp >= 0) {
+                decimalPlaces = dp.intValue();
+            } else {
+                throw new IllegalArgumentException("Decimal places for round must be a whole number >= 0");
+            }
+        }
+        Number n = SimplePluginUtils.promoteNumber(input[0]);
+        if (n instanceof Long whole) {
+            // a whole number is already exact - rounding never changes it
+            return whole;
+        }
+        return BigDecimal.valueOf(n.doubleValue()).setScale(decimalPlaces, RoundingMode.HALF_UP).doubleValue();
+    }
+}

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/SubtractNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/SubtractNumbers.java
@@ -35,10 +35,8 @@ public class SubtractNumbers implements PluginFunction {
     @Override
     public Object calculate(Object... input) {
         if (input.length < 2) {
-            throw new IllegalArgumentException("Expected at least two Whole Numbers to subtract");
+            throw new IllegalArgumentException("Expected at least two Numbers to subtract");
         }
-        return SimplePluginUtils.promoteInput(input)
-                .reduce((a,b) -> a - b)
-                .orElseThrow(() -> new IllegalArgumentException("Could not subtract the input: " + Arrays.toString(input)));
+        return SimplePluginUtils.reduceNumbers((a, b) -> a - b, (a, b) -> a - b, input);
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/SubtractNumbers.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/arithmetic/SubtractNumbers.java
@@ -22,8 +22,6 @@ import com.accenture.util.SimplePluginUtils;
 import com.accenture.models.SimplePlugin;
 import com.accenture.models.PluginFunction;
 
-import java.util.Arrays;
-
 @SimplePlugin
 public class SubtractNumbers implements PluginFunction {
 

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/GreaterThanOperator.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/GreaterThanOperator.java
@@ -35,8 +35,12 @@ public class GreaterThanOperator implements PluginFunction {
         if (input.length != 2) {
             throw new IllegalArgumentException("Input is required to compare using 'Greater Than'");
         }
-        Long first = SimplePluginUtils.promoteNumber(input[0]);
-        Long second = SimplePluginUtils.promoteNumber(input[1]);
-        return first > second;
+        Number first = SimplePluginUtils.promoteNumber(input[0]);
+        Number second = SimplePluginUtils.promoteNumber(input[1]);
+        // both whole => exact long comparison; otherwise numeric promotion to double
+        if (first instanceof Long a && second instanceof Long b) {
+            return a > b;
+        }
+        return first.doubleValue() > second.doubleValue();
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/LessThanOperator.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/LessThanOperator.java
@@ -35,8 +35,12 @@ public class LessThanOperator implements PluginFunction {
         if (input.length != 2) {
             throw new IllegalArgumentException("Input is required to compare using 'Less Than'");
         }
-        Long first = SimplePluginUtils.promoteNumber(input[0]);
-        Long second = SimplePluginUtils.promoteNumber(input[1]);
-        return first < second;
+        Number first = SimplePluginUtils.promoteNumber(input[0]);
+        Number second = SimplePluginUtils.promoteNumber(input[1]);
+        // both whole => exact long comparison; otherwise numeric promotion to double
+        if (first instanceof Long a && second instanceof Long b) {
+            return a < b;
+        }
+        return first.doubleValue() < second.doubleValue();
     }
 }

--- a/system/event-script-engine/src/main/java/com/accenture/util/SimplePluginUtils.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/SimplePluginUtils.java
@@ -19,6 +19,9 @@
 package com.accenture.util;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.LongBinaryOperator;
 import java.util.stream.Stream;
 
 public class SimplePluginUtils {
@@ -28,23 +31,68 @@ public class SimplePluginUtils {
     public static void divideByZeroCheck(Object... input) {
         boolean anyZero = Arrays.stream(input)
                 .map(SimplePluginUtils::promoteNumber)
-                .anyMatch(l -> l == 0L);
+                .anyMatch(n -> n.doubleValue() == 0.0d);
         if (anyZero) {
             throw new IllegalArgumentException("Dividing the input: " + Arrays.toString(input) + " would cause Division By Zero");
         }
     }
 
-    public static Stream<Long> promoteInput(Object... input) {
+    public static Stream<Number> promoteInput(Object... input) {
         return Arrays.stream(input).map(SimplePluginUtils::promoteNumber);
     }
 
-    public static Long promoteNumber(Object o) {
+    /**
+     * Java-style numeric promotion: whole numbers and whole-number strings
+     * promote to Long, floating-point values and decimal strings to Double
+     * (generalized from whole-number-only); anything else is an error.
+     */
+    public static Number promoteNumber(Object o) {
         return switch (o) {
             case Short s -> s.longValue();
             case Integer i -> i.longValue();
             case Long l -> l;
-            case String s -> Long.valueOf(s);
-            default -> throw new IllegalArgumentException("Cannot convert the object to a whole number: " + o);
+            case Float f -> f.doubleValue();
+            case Double d -> d;
+            case String s -> parseNumber(s);
+            default -> throw new IllegalArgumentException("Cannot convert the object to a number: " + o);
         };
+    }
+
+    private static Number parseNumber(String s) {
+        var text = s.trim();
+        try {
+            return Long.valueOf(text);
+        } catch (NumberFormatException e) {
+            try {
+                return Double.valueOf(text);
+            } catch (NumberFormatException e2) {
+                throw new IllegalArgumentException("Cannot convert the object to a number: " + s);
+            }
+        }
+    }
+
+    /**
+     * Reduce with numeric promotion decided over ALL args first (so the
+     * result is order-independent): any floating-point arg promotes the
+     * whole computation to double; all-integral inputs keep exact long
+     * arithmetic - including integer division, exactly as before this
+     * generalization.
+     */
+    public static Object reduceNumbers(LongBinaryOperator longOp, DoubleBinaryOperator doubleOp, Object... input) {
+        List<Number> numbers = promoteInput(input).toList();
+        boolean floating = numbers.stream().anyMatch(Double.class::isInstance);
+        if (floating) {
+            double total = numbers.getFirst().doubleValue();
+            for (int i = 1; i < numbers.size(); i++) {
+                total = doubleOp.applyAsDouble(total, numbers.get(i).doubleValue());
+            }
+            return total;
+        } else {
+            long total = numbers.getFirst().longValue();
+            for (int i = 1; i < numbers.size(); i++) {
+                total = longOp.applyAsLong(total, numbers.get(i).longValue());
+            }
+            return total;
+        }
     }
 }

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginLoaderTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginLoaderTest.java
@@ -64,6 +64,7 @@ public class SimplePluginLoaderTest {
                 Arguments.of(new MultiplyNumbers(), new Object[]{5,5}),
                 Arguments.of(new DivideNumbers(), new Object[]{10,5}),
                 Arguments.of(new ModulusNumbers(), new Object[]{10,5}),
+                Arguments.of(new RoundNumbers(), new Object[]{2.345, 2}),
                 Arguments.of(new DateGenerator(), new Object[]{}),
                 Arguments.of(new UUIDGenerator(), new Object[]{}),
                 Arguments.of(new EqualsOperator(), new Object[]{5,5}),

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
@@ -1,0 +1,80 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.automation;
+
+import com.accenture.services.plugins.arithmetic.*;
+import com.accenture.services.plugins.logical.GreaterThanOperator;
+import com.accenture.services.plugins.logical.LessThanOperator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Numeric promotion for the simple-plugin family (generalized from
+ * whole-number-only): any floating-point argument promotes the whole
+ * computation to Double, decided over ALL arguments so the result is
+ * order-independent; all-integral inputs keep exact Long arithmetic —
+ * including integer division, exactly as before the generalization.
+ */
+class SimplePluginNumberPromotionTest {
+
+    @Test
+    void allIntegralInputsKeepExactLongArithmetic() {
+        assertEquals(11L, new AddNumbers().calculate(6, "2", 3));
+        assertEquals(1L, new SubtractNumbers().calculate(6, 2, 3));
+        assertEquals(25L, new MultiplyNumbers().calculate(5, 5));
+        // integer division is preserved for whole-number inputs
+        assertEquals(1L, new DivideNumbers().calculate(6, 4));
+        assertEquals(1L, new ModulusNumbers().calculate(7, 3));
+        assertEquals(7L, new IncrementNumbers().calculate(6));
+        assertEquals(5L, new DecrementNumbers().calculate(6));
+    }
+
+    @Test
+    void anyFloatingArgumentPromotesToDouble() {
+        assertEquals(8.5d, new AddNumbers().calculate(6, 2.5));
+        // order-independent: promotion is decided over all args, not fold order
+        assertEquals(8.5d, new AddNumbers().calculate(2.5, 6));
+        assertEquals(6.5d, new AddNumbers().calculate(1, "2.5", 3));
+        assertEquals(10.0d, new MultiplyNumbers().calculate(2.5, 4));
+        assertEquals(1.5d, new DivideNumbers().calculate(6.0, 4));
+        assertEquals(1.5d, new ModulusNumbers().calculate(7.5, 2));
+        assertEquals(3.5d, new IncrementNumbers().calculate(2.5));
+        assertEquals(1.5d, new DecrementNumbers().calculate(2.5));
+    }
+
+    @Test
+    void comparisonsFollowTheSamePromotion() {
+        // both whole => exact long comparison
+        assertEquals(true, new GreaterThanOperator().calculate(5, 3));
+        assertEquals(false, new LessThanOperator().calculate(5, 3));
+        // mixed types compare as double
+        assertEquals(true, new GreaterThanOperator().calculate(2.5, 2));
+        assertEquals(true, new LessThanOperator().calculate("2.5", 3));
+    }
+
+    @Test
+    void errorsStayErrors() {
+        // a floating-point zero divisor is still division by zero
+        assertThrows(IllegalArgumentException.class, () -> new DivideNumbers().calculate(6, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> new DivideNumbers().calculate(6, 0));
+        // non-numeric text is still rejected
+        assertThrows(IllegalArgumentException.class, () -> new AddNumbers().calculate(1, "not-a-number"));
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
@@ -70,6 +70,22 @@ class SimplePluginNumberPromotionTest {
     }
 
     @Test
+    void roundIsHalfUpOnTheDecimalRepresentation() {
+        assertEquals(2.35d, new RoundNumbers().calculate(2.345, 2));
+        // the classic trap: a naive multiply-round-divide yields 1.0
+        assertEquals(1.01d, new RoundNumbers().calculate(1.005, 2));
+        assertEquals(3.0d, new RoundNumbers().calculate(2.5));
+        // ties round away from zero
+        assertEquals(-3.0d, new RoundNumbers().calculate(-2.5));
+        assertEquals(3.142d, new RoundNumbers().calculate(3.14159, 3));
+        assertEquals(2.35d, new RoundNumbers().calculate("2.345", 2));
+        // a whole number is already exact and passes through unchanged
+        assertEquals(5L, new RoundNumbers().calculate(5, 2));
+        assertThrows(IllegalArgumentException.class, () -> new RoundNumbers().calculate(1.5, 1.5));
+        assertThrows(IllegalArgumentException.class, () -> new RoundNumbers().calculate(1.5, -1));
+    }
+
+    @Test
     void errorsStayErrors() {
         // a floating-point zero divisor is still division by zero
         assertThrows(IllegalArgumentException.class, () -> new DivideNumbers().calculate(6, 0.0));


### PR DESCRIPTION
## What

The add/subtract/multiply/div/mod plugins (and increment/decrement, gt/lt) handled only
whole numbers — `promoteNumber` rejected Float/Double, so any decimal value (API prices,
computed doubles) failed simple arithmetic. `promoteNumber` now promotes integral values
(and whole-number strings) to Long, and floating-point values (and decimal strings) to
Double. The result type is decided over ALL arguments before folding, so results are
order-independent: any floating argument promotes the whole computation to Double, while
all-integral inputs keep exact Long arithmetic including integer division — every
previously-working call returns the identical result; only previously-erroring calls
start working. Comparisons follow the same rule (whole pairs stay exact Long). New
SimplePluginNumberPromotionTest covers both worlds and the error paths; module suites
green (event-script-engine 140, minigraph-playground-engine 67).

## Why

Simple arithmetic belongs in a simple plugin — it does not make sense to require a
composable function for a calculation a plugin can do. The gap surfaced concretely while
specifying graph.math for_each: an f:add accumulator over COMPUTE results (which are
doubles) failed with "Cannot convert the object to a whole number". The same enhancement
ships in the Rust port, keeping plugin semantics identical across engines.

Co-Authored-By: Claude Code <noreply@anthropic.com>