### PR TITLE
fix(minigraph): join barrier must not count failed or reset branches

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
@@ -326,6 +326,10 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
         var nodes = util.split(command, "[],; ");
         for (var name : nodes) {
             graphInstance.nodeSeen.remove(name);
+            // forget the completion mark too - a join barrier consults skillRun,
+            // so a reset (retrying) node must not satisfy the barrier until it
+            // re-executes successfully
+            graphInstance.skillRun.remove(name);
             var node = graph.findNodeByAlias(name);
             if (node != null) {
                 stateMachine.removeElement(name);

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
@@ -169,11 +169,17 @@ public class GraphExecutor extends GraphLambdaFunction {
             }
             var graph = graphInstance.graph;
             var node = graph.findNodeByAlias(nodeName);
-            graphInstance.skillRun.put(nodeName, true);
             checkFrequency(po, graphInstance, nodeName, parentSpanId);
             // Skill handler can also set status and error in its node properties instead of throwing exception
             var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
             var resultError = stateMachine.getElement(nodeName + "." + ERROR);
+            // Mark the skill complete only when it did NOT fail (status + error set,
+            // e.g. an exception-routed fetcher): a join barrier consults skillRun,
+            // so a failed branch must not satisfy the barrier while it retries.
+            // GraphTraveler keeps identical semantics.
+            if (!(processStatus instanceof Integer && resultError != null)) {
+                graphInstance.skillRun.put(nodeName, true);
+            }
             // Skill handler would set status and error in its node properties
             // e.g. the HTTP response status code to the API fetcher >= 400
             var errorHandler = node.getProperty(EXCEPTION);

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
@@ -120,7 +120,6 @@ public class GraphTraveler extends GraphLambdaFunction {
             }
             var graph = graphInstance.graph;
             var node = graph.findNodeByAlias(nodeName);
-            graphInstance.skillRun.put(nodeName, true);
             checkFrequency(po, graphInstance, nodeName);
             // advise user that the node with skill has been executed
             var skill = node.getProperty(SKILL);
@@ -131,6 +130,13 @@ public class GraphTraveler extends GraphLambdaFunction {
             // e.g. the HTTP response status code to the API fetcher >= 400
             var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
             var resultError = stateMachine.getElement(nodeName + "." + ERROR);
+            // Mark the skill complete only when it did NOT fail (status + error set,
+            // e.g. an exception-routed fetcher): a join barrier consults skillRun,
+            // so a failed branch must not satisfy the barrier while it retries.
+            // GraphExecutor keeps identical semantics.
+            if (!(processStatus instanceof Integer && resultError != null)) {
+                graphInstance.skillRun.put(nodeName, true);
+            }
             var errorHandler = node.getProperty(EXCEPTION);
             if (processStatus instanceof Integer rc && resultError != null && errorHandler == null) {
                 var errorMap = getErrorMap(resultError, target);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
@@ -310,6 +310,38 @@ class GraphTests {
         log.info("High frequency detected");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void joinBarrierWaitsForRetryingBranch() throws TimeoutException {
+        // Join + RESET interplay: a join barrier must not count a branch whose
+        // skill FAILED into its exception= route (skillRun is success-only), and
+        // RESET clears the completion mark with the guard and state. Branch A
+        // fails on the exception flag and retries through pause (300 ms) ->
+        // recover-a while branch B reaches the join first - before the fix, the
+        // join fired prematurely off the failed-run mark and silently lost
+        // branch A from the output.
+        var result = runGraph("unit-test-join-retry", Map.of("person_id", 100, "exception", true));
+        assertInstanceOf(Map.class, result);
+        var mm = new MultiLevelMap((Map<String, Object>) result);
+        assertEquals("Peter", mm.getElement("a-name"));
+        assertEquals("B", mm.getElement("b"));
+        log.info("Join barrier waits for a retrying branch");
+    }
+
+    private Object runGraph(String graphId, Map<String, Object> input) throws TimeoutException {
+        var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
+                .setBody(input).setHeader("Content-Type", "application/json")
+                .setHeader("Accept", "application/json")
+                .setUrl("/api/graph/" + graphId);
+        var event = new EventEnvelope().setTo("async.http.request").setBody(request);
+        var po = PostOffice.trackable("unit.test", String.format("%032x", 999), "TEST /graph/" + graphId);
+        var response = po.asyncRequest(event, TIMEOUT).await(TIMEOUT, TimeUnit.MILLISECONDS);
+        if (response.hasError()) {
+            log.error("HTTP-{} - {}", response.getStatus(), response.getBody());
+        }
+        return response.getBody();
+    }
+
     private Object runTutorial(int chapter, Map<String, Object> input) throws TimeoutException {
         var request = new AsyncHttpRequest().setMethod(input.isEmpty()? "GET" : "POST").setTargetHost(target);
         if (!input.isEmpty()) {

--- a/system/minigraph-playground-engine/src/test/resources/graph/unit-test-join-retry.json
+++ b/system/minigraph-playground-engine/src/test/resources/graph/unit-test-join-retry.json
@@ -1,0 +1,202 @@
+{
+  "nodes": [
+    {
+      "types": [
+        "Root"
+      ],
+      "alias": "root",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "f:defaultValue(input.body.exception, boolean(false)) -> model.exception"
+        ],
+        "purpose": "join barrier + exception-retry interplay probe",
+        "name": "unit-test-join-retry"
+      }
+    },
+    {
+      "types": [
+        "Fetcher"
+      ],
+      "alias": "fetch-a",
+      "properties": {
+        "skill": "graph.api.fetcher",
+        "dictionary": [
+          "person-name"
+        ],
+        "exception": "pause",
+        "input": [
+          "input.body.person_id -> person_id",
+          "model.exception -> exception"
+        ],
+        "output": [
+          "result.name -> model.a-name"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Pacer"
+      ],
+      "alias": "br-b",
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(B) -> model.b-value",
+          "DELAY: 100"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Pause"
+      ],
+      "alias": "pause",
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "NEXT: recover-a",
+          "DELAY: 300"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Recovery"
+      ],
+      "alias": "recover-a",
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "RESET: fetch-a, pause, recover-a",
+          "MAPPING: boolean(false) -> model.exception",
+          "NEXT: fetch-a"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Join"
+      ],
+      "alias": "join-ab",
+      "properties": {
+        "skill": "graph.join"
+      }
+    },
+    {
+      "types": [
+        "Mapper"
+      ],
+      "alias": "assemble",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "model.a-name -> output.body.a-name",
+          "model.b-value -> output.body.b"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Dictionary"
+      ],
+      "alias": "person-name",
+      "properties": {
+        "output": [
+          "response.profile.name -> result.name"
+        ],
+        "input": [
+          "person_id",
+          "exception:false"
+        ],
+        "provider": "mdm-profile",
+        "purpose": "name of a person"
+      }
+    },
+    {
+      "types": [
+        "Provider"
+      ],
+      "alias": "mdm-profile",
+      "properties": {
+        "input": [
+          "text(application/json) -> header.accept",
+          "exception -> header.x-exception",
+          "person_id -> path_parameter.id"
+        ],
+        "method": "GET",
+        "purpose": "Master Data Management's profile management endpoint",
+        "url": "http://127.0.0.1:${rest.server.port:8080}/api/mdm/profile/{id}"
+      }
+    },
+    {
+      "types": [
+        "End"
+      ],
+      "alias": "end",
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "branch-a",
+          "properties": {}
+        }
+      ],
+      "target": "fetch-a"
+    },
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "branch-b",
+          "properties": {}
+        }
+      ],
+      "target": "br-b"
+    },
+    {
+      "source": "fetch-a",
+      "relations": [
+        {
+          "type": "arrive",
+          "properties": {}
+        }
+      ],
+      "target": "join-ab"
+    },
+    {
+      "source": "br-b",
+      "relations": [
+        {
+          "type": "arrive",
+          "properties": {}
+        }
+      ],
+      "target": "join-ab"
+    },
+    {
+      "source": "join-ab",
+      "relations": [
+        {
+          "type": "joined",
+          "properties": {}
+        }
+      ],
+      "target": "assemble"
+    },
+    {
+      "source": "assemble",
+      "relations": [
+        {
+          "type": "done",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    }
+  ]
+}

--- a/system/minigraph-playground-engine/src/test/resources/graphs.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/graphs.yaml
@@ -25,3 +25,4 @@ graphs:
   - 'unit-test-task-3'
   - 'unit-test-task-4'
   - 'unit-test-task-5'
+  - 'unit-test-join-retry'


### PR DESCRIPTION
## What

The join barrier consults skillRun to decide whether an upstream branch completed, but the
mark meant "ran" rather than "completed": a fetcher that failed into its exception= route
was stamped before the status check, and RESET cleared nodeSeen and node state while
leaving the stale completion mark. A fork whose failing branch retries could fire the join
prematurely off the stale mark, silently losing that branch's data from the output. Two
complementary fixes, identical in GraphTraveler (dry-run) and GraphExecutor (deployed
graphs): skillRun is marked only when the skill did not fail, and resetNodes clears
skillRun with nodeSeen and node state. A new unit-test-join-retry graph reproduces the
premature fire deterministically (red on the old code: expected Peter, got null); module
suite green (68 tests).

## Why

A retry loop feeding a join was an untested combination flagged while validating the
tutorial-12 resilience pattern. The old semantics' failure mode was a silently incomplete
output — the worst kind; the new "success-only and current" completion means the barrier
waits for the retrying branch, and a permanently failing branch surfaces as a visible
timeout instead. The same fix ships in the Rust port so both engines keep identical join
semantics.

Co-Authored-By: Claude Code <noreply@anthropic.com>