### PR TITLE
fix(minigraph): chained join judges an upstream join by its outcome

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphJoin.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphJoin.java
@@ -62,7 +62,17 @@ public class GraphJoin extends GraphLambdaFunction {
     private boolean nodeCompleted(String predecessor, GraphInstance graphInstance) {
         var graph = graphInstance.graph;
         var node = graph.findNodeByAlias(predecessor);
-        return node.getProperty(SKILL) != null?
-                graphInstance.skillRun.containsKey(predecessor) :graphInstance.nodeSeen.containsKey(predecessor);
+        var skill = node.getProperty(SKILL);
+        if (skill == null) {
+            return graphInstance.nodeSeen.containsKey(predecessor);
+        }
+        // A chained upstream JOIN is complete only when it actually FIRED: its
+        // skill runs (and is marked in skillRun) on every arriving branch,
+        // including evaluations that sink - the outcome it records in nodeSeen
+        // is the truth.
+        if (ROUTE.equals(skill)) {
+            return Boolean.TRUE.equals(graphInstance.nodeSeen.get(predecessor));
+        }
+        return graphInstance.skillRun.containsKey(predecessor);
     }
 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
@@ -328,6 +328,25 @@ class GraphTests {
         log.info("Join barrier waits for a retrying branch");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void chainedJoinCountsOnlyAFiredUpstreamJoin() throws TimeoutException {
+        // Chained joins: an upstream join that evaluated and SANK is still in
+        // skillRun (its skill ran fine), so the downstream join must judge it
+        // by the OUTCOME it recorded, not the run mark. slow-pre (200 ms) ->
+        // slow-x and fast-y feed j-one; j-one chains into j-two alongside
+        // pace-z (100 ms). fast-y makes j-one evaluate-and-sink at ~1 ms;
+        // pace-z reaches j-two at ~100 ms - before the fix, j-two counted the
+        // sunk j-one off its run mark, fired prematurely, and lost branch X.
+        var result = runGraph("unit-test-join-chain", Map.of("probe", true));
+        assertInstanceOf(Map.class, result);
+        var mm = new MultiLevelMap((Map<String, Object>) result);
+        assertEquals("X", mm.getElement("x"));
+        assertEquals("Y", mm.getElement("y"));
+        assertEquals("Z", mm.getElement("z"));
+        log.info("Chained join counts only a fired upstream join");
+    }
+
     private Object runGraph(String graphId, Map<String, Object> input) throws TimeoutException {
         var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setBody(input).setHeader("Content-Type", "application/json")

--- a/system/minigraph-playground-engine/src/test/resources/graph/unit-test-join-chain.json
+++ b/system/minigraph-playground-engine/src/test/resources/graph/unit-test-join-chain.json
@@ -1,0 +1,204 @@
+{
+  "nodes": [
+    {
+      "types": [
+        "Root"
+      ],
+      "alias": "root",
+      "properties": {
+        "purpose": "chained join barriers probe",
+        "name": "unit-test-join-chain"
+      }
+    },
+    {
+      "types": [
+        "Slow"
+      ],
+      "alias": "slow-pre",
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "DELAY: 200"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Mapper"
+      ],
+      "alias": "slow-x",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "text(X) -> model.x"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Mapper"
+      ],
+      "alias": "fast-y",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "text(Y) -> model.y"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Pacer"
+      ],
+      "alias": "pace-z",
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(Z) -> model.z",
+          "DELAY: 100"
+        ]
+      }
+    },
+    {
+      "types": [
+        "Join"
+      ],
+      "alias": "j-one",
+      "properties": {
+        "skill": "graph.join"
+      }
+    },
+    {
+      "types": [
+        "Join"
+      ],
+      "alias": "j-two",
+      "properties": {
+        "skill": "graph.join"
+      }
+    },
+    {
+      "types": [
+        "Mapper"
+      ],
+      "alias": "assemble",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "model.x -> output.body.x",
+          "model.y -> output.body.y",
+          "model.z -> output.body.z"
+        ]
+      }
+    },
+    {
+      "types": [
+        "End"
+      ],
+      "alias": "end",
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "branch-x",
+          "properties": {}
+        }
+      ],
+      "target": "slow-pre"
+    },
+    {
+      "source": "slow-pre",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ],
+      "target": "slow-x"
+    },
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "branch-y",
+          "properties": {}
+        }
+      ],
+      "target": "fast-y"
+    },
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "branch-z",
+          "properties": {}
+        }
+      ],
+      "target": "pace-z"
+    },
+    {
+      "source": "slow-x",
+      "relations": [
+        {
+          "type": "arrive",
+          "properties": {}
+        }
+      ],
+      "target": "j-one"
+    },
+    {
+      "source": "fast-y",
+      "relations": [
+        {
+          "type": "arrive",
+          "properties": {}
+        }
+      ],
+      "target": "j-one"
+    },
+    {
+      "source": "j-one",
+      "relations": [
+        {
+          "type": "chain",
+          "properties": {}
+        }
+      ],
+      "target": "j-two"
+    },
+    {
+      "source": "pace-z",
+      "relations": [
+        {
+          "type": "arrive",
+          "properties": {}
+        }
+      ],
+      "target": "j-two"
+    },
+    {
+      "source": "j-two",
+      "relations": [
+        {
+          "type": "joined",
+          "properties": {}
+        }
+      ],
+      "target": "assemble"
+    },
+    {
+      "source": "assemble",
+      "relations": [
+        {
+          "type": "done",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    }
+  ]
+}

--- a/system/minigraph-playground-engine/src/test/resources/graphs.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/graphs.yaml
@@ -26,3 +26,4 @@ graphs:
   - 'unit-test-task-4'
   - 'unit-test-task-5'
   - 'unit-test-join-retry'
+  - 'unit-test-join-chain'


### PR DESCRIPTION
## What

A join's own skill runs (and lands in skillRun) on every arriving branch, including
evaluations that SINK — so a downstream join in a chained-join topology counted a sunk
upstream join as complete and fired prematurely, dropping the slow branch's data.
nodeCompleted now judges a join predecessor by the outcome it records in nodeSeen
(true = fired) instead of the run mark. A new unit-test-join-chain graph reproduces the
premature fire deterministically (red before the fix: expected X, got null); module
suite green (69 tests).

## Why

Follow-up to #197, completing the same root cause ("ran" is not "completed") for the
chained-join shape, so multi-stage joins compose safely. The same fix ships in the Rust
port, keeping join semantics identical across engines.

Co-Authored-By: Claude Code <noreply@anthropic.com>