### PR TITLE
feat(minigraph): describe graph {graph-id} - a deployed model's contract view

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -624,13 +624,123 @@ public class GraphCommandService extends GraphLambdaFunction {
             var purpose = graphPurpose(id);
             sb.append(purpose == null? id : id + " - " + purpose).append('\n');
         }
-        sb.append("Total ").append(ids.size()).append(ids.size() == 1? " graph model" : " graph models");
+        sb.append("Total ").append(ids.size()).append(ids.size() == 1? " graph model" : " graph models").append('\n');
+        sb.append("Use 'describe graph {graph-id}' for a model's input/output contract");
     }
 
     /**
      * Discovery: the Event Script flows a graph.extension node can call
      * (extension=flow://{flow-id}).
      */
+    /**
+     * Discovery: the CONTRACT view of a deployed graph model - purpose, size,
+     * and the input/output surface derived from the model's node properties -
+     * so an agent can wire extension= delegation without out-of-band
+     * knowledge or trial execution.
+     */
+    private void describeDeployedGraph(PostOffice po, String outRoute, String graphId) {
+        var model = deployedModel(graphId);
+        if (model == null) {
+            po.send(new EventEnvelope().setTo(outRoute).setBody("Graph model '" + graphId + "'" + NOT_FOUND));
+            return;
+        }
+        var nodes = model.get("nodes") instanceof List<?> n? n.size() : 0;
+        var connections = model.get("connections") instanceof List<?> c? c.size() : 0;
+        var sb = new StringBuilder();
+        sb.append("Deployed graph model '").append(graphId).append("'\n");
+        var purpose = graphPurpose(graphId);
+        if (purpose != null) {
+            sb.append("Purpose: ").append(purpose).append('\n');
+        }
+        sb.append("Nodes: ").append(nodes).append(", connections: ").append(connections).append('\n');
+        var inputs = new TreeSet<String>();
+        var outputs = new TreeSet<String>();
+        if (model.get("nodes") instanceof List<?> nodeList) {
+            for (var n : nodeList) {
+                if (n instanceof Map<?, ?> node && node.get("properties") != null) {
+                    var text = String.valueOf(node.get("properties"));
+                    collectPathTokens(text, "input.", inputs);
+                    collectPathTokens(text, "output.", outputs);
+                }
+            }
+        }
+        sb.append("Input surface:\n");
+        if (inputs.isEmpty()) {
+            sb.append("  (none referenced)\n");
+        }
+        for (var path : inputs) {
+            sb.append("  ").append(path).append('\n');
+        }
+        sb.append("Output surface:\n");
+        if (outputs.isEmpty()) {
+            sb.append("  (none referenced)\n");
+        }
+        for (var path : outputs) {
+            sb.append("  ").append(path).append('\n');
+        }
+        sb.append("(derived from the model's data mappings)");
+        po.send(new EventEnvelope().setTo(outRoute).setBody(sb.toString()));
+    }
+
+    /**
+     * A deployed/compiled graph model (compiled registry first, then the
+     * deployed location).
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> deployedModel(String graphId) {
+        Map<String, Object> model = CompiledGraphs.getGraph(graphId);
+        if (model != null) {
+            return model;
+        }
+        var json = getDeployedGraphAsText(graphId);
+        if (json == null) {
+            return null;
+        }
+        try {
+            return SimpleMapper.getInstance().getMapper().readValue(json, Map.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Collect dotted-path tokens starting with the prefix from free text
+     * (mapping entries, plugin args, substitution variables in statements).
+     */
+    private void collectPathTokens(String text, String prefix, TreeSet<String> found) {
+        int start = 0;
+        while (true) {
+            int begin = text.indexOf(prefix, start);
+            if (begin == -1) {
+                return;
+            }
+            if (begin > 0) {
+                char prev = text.charAt(begin - 1);
+                if (Character.isLetterOrDigit(prev) || prev == '_' || prev == '.') {
+                    start = begin + prefix.length();
+                    continue;
+                }
+            }
+            int end = begin + prefix.length();
+            while (end < text.length()) {
+                char c = text.charAt(end);
+                if (Character.isLetterOrDigit(c) || c == '.' || c == '_' || c == '-' || c == '[' || c == ']') {
+                    end++;
+                } else {
+                    break;
+                }
+            }
+            var token = text.substring(begin, end);
+            while (!token.isEmpty() && (token.endsWith(".") || token.endsWith("-") || token.endsWith("["))) {
+                token = token.substring(0, token.length() - 1);
+            }
+            if (token.length() > prefix.length()) {
+                found.add(token);
+            }
+            start = end;
+        }
+    }
+
     private void listFlows(StringBuilder sb) {
         var ids = new ArrayList<>(Flows.getAllFlows());
         if (ids.isEmpty()) {
@@ -678,19 +788,10 @@ public class GraphCommandService extends GraphLambdaFunction {
     /**
      * The root node's "purpose" property of a deployed/compiled graph model.
      */
-    @SuppressWarnings("unchecked")
     private String graphPurpose(String graphId) {
-        Map<String, Object> model = CompiledGraphs.getGraph(graphId);
+        Map<String, Object> model = deployedModel(graphId);
         if (model == null) {
-            var json = getDeployedGraphAsText(graphId);
-            if (json == null) {
-                return null;
-            }
-            try {
-                model = SimpleMapper.getInstance().getMapper().readValue(json, Map.class);
-            } catch (Exception e) {
-                return null;
-            }
+            return null;
         }
         if (model.get("nodes") instanceof List<?> nodes) {
             for (var n : nodes) {
@@ -1244,7 +1345,9 @@ public class GraphCommandService extends GraphLambdaFunction {
 
     private void handleDescribeCommand(PostOffice po, String inRoute, String outRoute, List<String> words)
             throws IOException {
-        if (words.size() > 1 && words.get(1).equalsIgnoreCase(GRAPH)) {
+        if (words.size() == 3 && words.get(1).equalsIgnoreCase(GRAPH)) {
+            describeDeployedGraph(po, outRoute, words.get(2));
+        } else if (words.size() > 1 && words.get(1).equalsIgnoreCase(GRAPH)) {
             describeGraph(po, inRoute, outRoute);
         } else if (words.size() == 3 && words.get(1).equalsIgnoreCase(SKILL)) {
             describeSkill(po, outRoute, words.get(2));

--- a/system/minigraph-playground-engine/src/main/resources/graph/tutorial-3.json
+++ b/system/minigraph-playground-engine/src/main/resources/graph/tutorial-3.json
@@ -93,7 +93,7 @@
       ],
       "alias": "root",
       "properties": {
-        "purpose": "Demonstrate data sourcing using the Data Dictionary method",
+        "purpose": "Demonstrate data sourcing using the Data Dictionary method - fetch one person profile (name and address) by person_id",
         "name": "tutorial-3"
       }
     }

--- a/system/minigraph-playground-engine/src/main/resources/graph/tutorial-5.json
+++ b/system/minigraph-playground-engine/src/main/resources/graph/tutorial-5.json
@@ -124,7 +124,7 @@
       ],
       "alias": "root",
       "properties": {
-        "purpose": "Demonstrate data sourcing using the Data Dictionary method",
+        "purpose": "Demonstrate parallel data sourcing composition - fan out two profile fetches and join the results into a profile list",
         "name": "tutorial-5"
       }
     }

--- a/system/minigraph-playground-engine/src/main/resources/help/help tutorial 3.md
+++ b/system/minigraph-playground-engine/src/main/resources/help/help tutorial 3.md
@@ -19,7 +19,7 @@ create node root
 with type Root
 with properties
 name=tutorial-3
-purpose=Demonstrate data sourcing using the Data Dictionary method
+purpose=Demonstrate data sourcing using the Data Dictionary method - fetch one person profile (name and address) by person_id
 ```
 
 ```

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -300,6 +300,15 @@ class CompanionSyncTest {
         var flowText = String.valueOf(flows.get("output"));
         assertTrue(flowText.contains("extension=flow://{flow-id} targets"), "flows header: " + flowText);
         assertTrue(flowText.contains("graph-executor"), "the engine's own flow must be listed: " + flowText);
+
+        // the contract view of a deployed model: purpose, size, and the
+        // input/output surface derived from the model's own mappings
+        var contract = syncCommand(po, sid, "describe graph tutorial-3");
+        assertEquals(Boolean.TRUE, contract.get("ok"), "describe graph {id} -> ok:true: " + contract);
+        var contractText = String.valueOf(contract.get("output"));
+        assertTrue(contractText.contains("Deployed graph model 'tutorial-3'"), "header: " + contractText);
+        assertTrue(contractText.contains("input.body.person_id"), "derived input surface: " + contractText);
+        assertTrue(contractText.contains("output.body.name"), "derived output surface: " + contractText);
     }
 
     private EventEnvelope legacyCommand(EventEmitter po, String sid, String command) throws Exception {


### PR DESCRIPTION
## What

Adds a read-only `describe graph {graph-id}` command that renders a deployed graph
model's **contract view**: its purpose, node/connection counts, and the
`input.*` / `output.*` data surface derived from the model's own data mappings,
plugin arguments, and statement substitutions. The plain `describe graph` form still
describes the current draft; the `list graphs` footer now advertises the new form, so
the discovery arc is fully self-service: **list → contract → delegate**, all read-only.
An unknown id returns `Graph model '{graph-id}' not found`.

The tutorial-3 and tutorial-5 fixture purposes are differentiated (tutorial-3: fetch one
person profile by `person_id`; tutorial-5: parallel fan-out of two profile fetches joined
into a profile list), with the `help tutorial 3` transcript synced. Covered by a `/sync`
test in `CompanionSyncTest`; module suite 70 tests green.

## Why

The post-sweep discovery drive surfaced finding #53: an agent could *find* a deployed
model via `list graphs`, but had to probe its input/output contract by trial execution —
the one step of delegation that still needed out-of-band knowledge. Finding #54
compounded it: tutorial-3 and tutorial-5 carried identical purposes, defeating
purpose-based selection between them.

This completes the self-service delegation arc on the existing command surface (no new
REST endpoints — `/sync` already exposes every command to agents) and mirrors the Rust
port, keeping the companion surface byte-identical across both engines.

Co-Authored-By: Claude Code <noreply@anthropic.com>