### PR TITLE
fix(minigraph): /sync contract gaps - dedup bypass for direct RPC + syntax-usage classified as failure

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
@@ -52,6 +52,7 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
     protected static final String MESSAGE = "message";
     protected static final String COMMAND = "command";
     protected static final String FORWARDED = "forwarded";
+    protected static final String DIRECT = "direct";
     protected static final String UNTYPED = "untyped";
     protected static final String NAME = "name";
     protected static final String ROOT = "root";

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -146,13 +146,16 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         try {
             // RPC the singleton handler with the capture route as `out`; handleEvent
             // returns once the command is dispatched (a traversal is still running).
+            // "direct" marks a synchronous companion RPC: not a flaky WS client, so
+            // the identical-command dedup guard does not apply (finding #62)
             po.request(new EventEnvelope()
                     .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
                     .setBody(Map.of(
                             "type", "command",
                             "in", inRoute,
                             "out", captureRoute,
-                            "message", command)),
+                            "message", command,
+                            "direct", true)),
                     COMMAND_TIMEOUT_MS).get();
             // Synchronous commands: enqueue the FIFO sentinel to mark the buffer drained.
             // Traversals: the capture route counts the latch down on the terminal line.
@@ -192,8 +195,12 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
     }
 
     private static boolean isErrorLine(String line) {
+        // a "Syntax: ..." usage hint is the engine's rejection of a malformed command —
+        // the command did nothing, so the caller must see ok:false (finding #63;
+        // no help page starts a line with "Syntax:", so no false positive)
         return line.startsWith("ERROR:") || line.contains("aborted") || line.contains("does not have")
-                || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'");
+                || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'")
+                || line.startsWith("Syntax:");
     }
 
     /**

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -140,6 +140,9 @@ public class GraphCommandService extends GraphLambdaFunction {
         var out = input.get(OUT);
         var message = input.get(MESSAGE);
         var forwarded = input.get(FORWARDED) instanceof Boolean flag && flag;
+        // "direct" marks a synchronous companion RPC (finding #62): not a flaky
+        // WS client, so the identical-command dedup guard does not apply
+        var direct = input.get(DIRECT) instanceof Boolean d && d;
         if (OPEN.equals(type) && in instanceof String inRoute) {
             sessions.put(inRoute, new GraphSession(inRoute));
             graphModels.put(inRoute, new MiniGraph());
@@ -159,12 +162,13 @@ public class GraphCommandService extends GraphLambdaFunction {
                 message instanceof String text) {
             var command = text.trim();
             if (!command.isEmpty()) {
-                handleCommand(po, command, inRoute, outRoute, forwarded);
+                handleCommand(po, command, inRoute, outRoute, forwarded, direct);
             }
         }
     }
 
-    private void handleCommand(PostOffice po, String command, String inRoute, String outRoute, boolean forwarded)
+    private void handleCommand(PostOffice po, String command, String inRoute, String outRoute,
+                               boolean forwarded, boolean direct)
             throws IOException {
         if (command.startsWith("{") && command.endsWith("}")) {
             handleJsonCommand(po, outRoute, command);
@@ -173,12 +177,16 @@ public class GraphCommandService extends GraphLambdaFunction {
                 singleOrMultiLineCommand(po, command, inRoute, outRoute);
                 return;
             }
-            var cached = cachedMessage.get(inRoute);
-            if (command.equals(cached)) {
-                log.debug("Duplicated message - {} for {}", command, inRoute);
-                return;
+            // the dedup guard protects the WS UI from double-submits; a synchronous
+            // companion RPC ("direct") is a deliberate request - never dropped (#62)
+            if (!direct) {
+                var cached = cachedMessage.get(inRoute);
+                if (command.equals(cached)) {
+                    log.debug("Duplicated message - {} for {}", command, inRoute);
+                    return;
+                }
+                cachedMessage.put(inRoute, command);
             }
-            cachedMessage.put(inRoute, command);
             var me = sessions.get(inRoute);
             if (me.isPrimary()) {
                 singleOrMultiLineCommand(po, command, inRoute, outRoute);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -311,6 +311,84 @@ class CompanionSyncTest {
         assertTrue(contractText.contains("output.body.name"), "derived output surface: " + contractText);
     }
 
+    /**
+     * Findings #62/#63 (HTTPS drive pre-flight): the /sync contract gaps.
+     * #62 - a synchronous companion RPC is a deliberate request: the 1-second
+     * identical-command dedup guard (a WS double-submit protection) must NOT
+     * silently swallow a repeat; the guard stays intact for the WS path.
+     * #63 - a malformed command answered with a "Syntax: ..." usage hint did
+     * nothing: the envelope must say ok:false with the hint as the error.
+     */
+    @Test
+    void companionSyncContractGapsClosed() throws Exception {
+        var po = EventEmitter.getInstance();
+        var platform = Platform.getInstance();
+        var sid = "ws-990005-2";
+        var inRoute = "ws.990005.2.in";
+
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", inRoute)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+
+        // #62 - the same command twice, back-to-back (well inside the 1s window):
+        // both must execute and both envelopes must carry the echo + output
+        var first = syncCommand(po, sid, "list nodes");
+        var second = syncCommand(po, sid, "list nodes");
+        assertEquals(Boolean.TRUE, first.get("ok"), "first repeat must execute: " + first);
+        assertEquals(Boolean.TRUE, second.get("ok"), "second repeat must execute: " + second);
+        assertTrue(String.valueOf(first.get("output")).contains("list nodes"),
+                "first envelope must carry the echo: " + first);
+        assertTrue(String.valueOf(second.get("output")).contains("list nodes"),
+                "second envelope must carry the echo (not silently dropped): " + second);
+
+        // #63 - a malformed command answered with the usage hint is a failed
+        // command: ok:false, the hint in-band as the error
+        var bad = syncCommand(po, sid, "connect a to b with type x");
+        assertEquals(Boolean.FALSE, bad.get("ok"), "usage response must classify as failure: " + bad);
+        assertInstanceOf(String.class, bad.get("error"));
+        assertTrue(((String) bad.get("error")).startsWith("Syntax:"),
+                "the usage hint must be the in-band error: " + bad);
+
+        // the WS-path guard is untouched: two identical NON-direct commands within
+        // the window - the second is dropped, so the console sees exactly one echo
+        var sid2 = "ws-990006-2";
+        var in2 = "ws.990006.2.in";
+        var out2 = "ws.990006.2.out";
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", in2)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid2); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        List<Object> teed = new CopyOnWriteArrayList<>();
+        LambdaFunction outTap = (hdr, body, inst) -> {
+            teed.add(body);
+            return null;
+        };
+        platform.registerPrivate(out2, outTap, 1);
+        try {
+            // dispatch via the 1-instance singleton (FIFO) so the pair is processed
+            // sequentially - the deterministic path for observing the guard
+            for (int i = 0; i < 2; i++) {
+                po.send(new EventEnvelope().setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
+                        .setBody(Map.of("type", "command", "in", in2, "out", out2,
+                                "message", "list nodes")));
+            }
+            Utility.getInstance().sleep(300);
+            var echoes = teed.stream()
+                    .filter(String.class::isInstance)
+                    .map(Object::toString)
+                    .filter(l -> l.contains("list nodes"))
+                    .count();
+            assertEquals(1, echoes,
+                    "WS double-submit guard must still drop the duplicate: " + teed);
+        } finally {
+            platform.release(out2);
+        }
+    }
+
     private EventEnvelope legacyCommand(EventEmitter po, String sid, String command) throws Exception {
         var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setUrl("/api/companion/{id}").setPathParameter("id", sid)


### PR DESCRIPTION
## What

Two fixes to the synchronous companion endpoint's (`/sync`) contract:

1. **Dedup bypass for direct RPC.** The 1-second identical-command dedup guard (a
   WebSocket double-submit protection in `GraphCommandService`) no longer applies to
   `/sync`: the endpoint marks its singleton dispatch `direct`, so a deliberately
   repeated command always executes and returns its full envelope. The WebSocket UI
   path keeps the guard unchanged.

2. **`Syntax:` usage hints classify as failure.** A malformed command (e.g.
   `connect a to b with type x`) is answered with a `Syntax: ...` usage hint and does
   nothing — the envelope now says `ok:false` with the hint as the in-band `error`.
   Safe by construction: the engine has a single `Syntax:` emission site and no help
   page starts a line with `Syntax:`, so there is no inverse false-positive.

Covered by `companionSyncContractGapsClosed` in `CompanionSyncTest`: back-to-back
repeats both execute with their echoes, the usage hint returns `ok:false`, and the
WS-path guard still drops a duplicate (dispatched via the 1-instance
`graph.command.singleton` for a deterministic sequential pair — the 50-instance
`graph.command.service` route processes concurrently). Module suite: **71 tests green**.

## Why

Both gaps were found by an AI-companion pre-flight against the Rust port and are
shared engine behavior. A scripted AI caller that pipelines commands hit the dedup
guard and received `ok:true` with an **empty** `output` — violating the documented
envelope (echo always present) — with no way to tell the command had been silently
dropped; LLM pacing had masked this through the entire 13-tutorial validation sweep.
Meanwhile a malformed command reported success despite doing nothing — the mirror
image of the earlier ok-heuristic false-negative fix (#195).

An RPC caller is not a flaky WebSocket client: its requests are deliberate, discrete,
and deserve truthful envelopes. Both fixes keep the `/sync` REST contract
byte-identical across the Java and Rust engines.

Co-Authored-By: Claude Code <noreply@anthropic.com>