### PR TITLE
chore(minigraph): remove the companion-endpoint line from the UI welcome message

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/websocket/server/GraphUserInterface.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/websocket/server/GraphUserInterface.java
@@ -69,9 +69,10 @@ public class GraphUserInterface implements LambdaFunction {
                                 .setBody(Map.of("in", route, "type", "open")));
                     log.info("Started {}, {}, ip={}, path={}, query={}, token={}", route, txPath, ip, path, query, token);
                     // Surface session id to the client; inverse of id.replace('-','.')+".in" used by REST companion.
+                    // The session id is all a human needs to share with an AI agent; the
+                    // companion REST endpoints live in the AI docs, not the UI.
                     String publicId = route.substring(0, route.length() - IN_SUFFIX.length()).replace('.', '-');
-                    po.send(txPath, "session " + publicId + " started\n" +
-                            "Companion endpoint: /api/companion/" + publicId);
+                    po.send(txPath, "session " + publicId + " started");
                     break;
                 case WsEnvelope.CLOSE:
                     // the close event contains route and token for this websocket


### PR DESCRIPTION
## What

Removes the "Companion endpoint: /api/companion/{id}" line from the Playground
console's welcome message. The welcome now shows only `session {id} started`.

## Why

With the synchronous `/sync` companion endpoint in place, the welcome line showed the
legacy fire-and-forget endpoint form — the very endpoint the AI documentation steers
agents away from — causing confusion. A companion endpoint is by definition a REST
surface for AI agents, and agents derive it from the session id per the AI docs; the
session id line remains, as it is the one thing a human shares with an agent. Mirrors
the same change in the Rust port.

Co-Authored-By: Claude Code <noreply@anthropic.com>