### PR TITLE
docs: cross-link the official Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A Java framework for building composable, event-driven applications from self-co
 
 > **New here?** [**Getting Started**](https://accenture.github.io/mercury-composable/guides/getting-started/) runs a working app in five minutes. **Building with an AI agent?** Start with the [**AI Developer Guide**](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/).
 
+> **Prefer Rust?** Mercury is also available as an official **Rust implementation** — the same
+> three layers and the same YAML flow syntax (flow files port unchanged), faithfully following
+> this project's behavior: [github.com/Accenture/mercury](https://github.com/Accenture/mercury)
+> · [documentation](https://accenture.github.io/mercury/).
+
 ## What is Mercury Composable?
 
 An application is assembled from **independent functions** — plain Java classes with no knowledge of one another — that communicate only through **events**. The flows that sequence them live in **YAML**, so orchestration is configuration, not code. Everything runs on Java 21 **virtual threads**, so straightforward blocking code performs like reactive, and each function's immutable input/output makes the design equally friendly to human developers and AI code assistants.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,3 +71,7 @@ A machine-readable map of the whole site lives at [`llms.txt`](llms.txt).
 - **Release notes:** [CHANGELOG](https://github.com/Accenture/mercury-composable/blob/main/CHANGELOG.md)
 - **Contributing:** [CONTRIBUTING](https://github.com/Accenture/mercury-composable/blob/main/CONTRIBUTING.md)
   · [Code of Conduct](https://github.com/Accenture/mercury-composable/blob/main/CODE_OF_CONDUCT.md)
+- **Rust version:** Mercury is also available as an official Rust implementation — same three
+  layers, same flow YAML, behavior-synced with this engine:
+  [github.com/Accenture/mercury](https://github.com/Accenture/mercury)
+  · [documentation](https://accenture.github.io/mercury/)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -55,6 +55,12 @@ These are self-contained; you should not need the engine source or the tutorial 
 - [Sync-over-Async](https://accenture.github.io/mercury-composable/guides/sync-over-async/): opt-in extension exposing synchronous REST request/response over an async cross-pod Kafka backend via a Redis return route keyed by correlation-id (sync.over.async.enabled, redis.* + sync.* config).
 - [Minimalist Service Mesh](https://accenture.github.io/mercury-composable/guides/service-mesh/): Kafka-based service discovery and routing.
 
+## Rust implementation
+- [Mercury for Rust](https://github.com/Accenture/mercury): the official Rust implementation — same
+  three layers, same flow YAML (flow files port unchanged), behavior-synced with this engine; its
+  docs live at [accenture.github.io/mercury](https://accenture.github.io/mercury/) with its own
+  llms.txt map. Building functions in Rust? Start there; the graph/flow DSLs are shared.
+
 ## Reference
 - [API Overview](https://accenture.github.io/mercury-composable/guides/api-overview/): PostOffice, Platform, EventEnvelope, configuration APIs.
 - [Annotations Reference](https://accenture.github.io/mercury-composable/guides/annotations-reference/): @PreLoad, @MainApplication, and the rest.


### PR DESCRIPTION
## What

Adds pointers to the official Rust implementation of Mercury on the three discovery
surfaces:

- **README** — a "Prefer Rust?" callout beside the getting-started pointers
- **docs home** — a "Rust version" entry in the Project section
- **llms.txt** — a "Rust implementation" section, so an AI agent asked to build in
  Rust routes itself to the right repo (the graph/flow DSLs are shared; the Rust
  repo's own llms.txt map takes over from there)

Docs-only; no engine changes.

## Why

The Rust port graduated to its official home — github.com/Accenture/mercury (the
repurposed original Mercury repository), with documentation at
accenture.github.io/mercury. It carries the same three layers and the same flow YAML
(flow files port unchanged), is behavior-synced with this engine (PRs #187–#203), and
its AI documentation was battle-tested alongside this repo's. The two projects'
llms.txt maps now cross-reference each other, completing the pair.

Co-Authored-By: Claude Code <noreply@anthropic.com>