### PR TITLE
chore(release): version 4.9.0 for field deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.9.0, 7/20/2026
+
+Feature release: the MiniGraph Playground becomes fully operable by AI agents — a synchronous
+companion endpoint with a truthful contract, self-service discovery of deployed graphs and flows,
+and battle-tested AI-agent documentation (hardened by 25 fresh-agent exercises across this engine
+and the Rust port; the last thirteen passed with zero documentation lookups). Also delivers two
+latent join-barrier fixes, numeric promotion for the simple-plugin arithmetic family, and
+cross-links to the official Rust implementation at github.com/Accenture/mercury.
 
 ### Added
 
-1. **Synchronous AI-companion endpoint (ADR-0008) (#189).** `POST /api/companion/{id}/sync` returns
+1. **Synchronous AI-companion endpoint (ADR-0008) (#189, example wiring #190).** `POST /api/companion/{id}/sync` returns
    the command outcome in-band as `{ok, output, error, result}` — the existing fire-and-forget
    `/api/companion/{id}` leaves an AI caller blind (outcome and errors were WebSocket-only). The same
    output is also teed to the session's WebSocket `.out`, so a watching human — and any
    `session subscribe`d session — sees it live (real-time human+AI collaboration). Additive; the
    existing endpoint and the WebSocket console are unchanged.
 
+2. **Discovery commands: `list graphs` and `list flows` (#199).** Read-only enumeration of the
+   deployable graph models (compiled registry ∪ deployed folder, each with its root node's
+   `purpose` — living documentation) and the Event Script flows — so valid `extension=` /
+   `extension=flow://` delegation targets are discoverable without an out-of-band brief, on the
+   console and both companion endpoints. The graph compiler now enforces a non-empty root
+   `purpose` so every listed model is self-describing.
+
+3. **`describe graph {graph-id}` — a deployed model's contract view (#200).** Purpose,
+   node/connection counts, and the `input.*`/`output.*` data surface derived from the model's own
+   mappings — completing self-service delegation: list → contract → delegate, all read-only.
+   Tutorial-3/5 fixture purposes differentiated so purpose-based discovery can tell them apart.
+
+4. **Numeric promotion for simple-plugin arithmetic + new `f:round` (#196).** `add`/`subtract`/
+   `multiply`/`div`/`mod`/`increment`/`decrement` and `gt`/`lt` now accept mixed numbers: whole
+   numbers promote to long (exact 64-bit arithmetic, including integer division), any decimal
+   argument promotes the whole computation to double — strictly widening, no previously-working
+   call changes. New `f:round(number[, places])` rounds half-up on the decimal representation
+   (`1.005` → `1.01` at 2 places; binary error never leaks into the decision).
+
+5. **AI-agent documentation hardening (#187, #203).** The `graph.math`/`graph.js` statement
+   grammar documented (#187); then the full grammar hardening back-ported from the Rust R&D
+   effort (#203): Provider & Dictionary authoring, the constants closed set + `f:`/`$.` source
+   forms, `help {topic}`, fork/join state-safety, iterative fetching with the guaranteed ordered
+   aggregation, the required Island knowledge layer, composite keys + array append, the
+   `graph.extension` delegation contract, failure routing with the canonical bounded-retry
+   pattern, the sync-envelope contract, and more — across `command-reference.md`,
+   `minigraph-commands.json`, `skills-reference.md`, `ai-agent-guide.md`, `llms.txt` (new
+   AI-agent map sections), `event-script/syntax.md`, and `help graph-api-fetcher.md`.
+
+6. **Cross-links to the official Rust implementation (#204).** README, docs home, and `llms.txt`
+   now point at github.com/Accenture/mercury (same three layers, same flow YAML; flow files port
+   unchanged) — the two projects' `llms.txt` maps reference each other.
+
 ### Fixed
 
-1. **`/api/companion/{id}/sync` now returns the whole `run` outcome (ADR-0008).** `run` is
+1. **`/api/companion/{id}/sync` now returns the whole `run` outcome (ADR-0008, #191/#193).** `run` is
    asynchronous — the command handler replies before the traveler streams its `Walk to…` / `Executed…`
    / `output` / terminal lines — so the FIFO sentinel raced (and usually beat) that tail and truncated
    the response to just `Walk to root` / `Walk to end`. A traversal is now drained on the traveler's
@@ -31,6 +71,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `Graph traversal aborted`, so `run` before `instantiate` returns promptly (`ok:false`) instead of
    waiting out the timeout. Synchronous commands keep the sentinel drain. This keeps the `/sync` REST
    contract byte-identical with the Rust port — the companion surface is language-neutral.
+
+2. **Companion endpoints limit `session` to the read-only status query (#194).** Executed through
+   the sync endpoint, `session subscribe` durably registered the ephemeral per-request capture
+   route as a subscriber (a dangling ghost). A companion is an *assistant to* a session, not a
+   WebSocket session of its own — the topology subcommands (`subscribe`/`unsubscribe`/`reset`)
+   are now rejected before dispatch on both companion endpoints, with the refusal returned
+   in-band and echoed to the live console.
+
+3. **`/sync` `ok` false-negative on import's benign fallback (#195).** `import graph from
+   {deployed}` succeeds via the classpath fallback but reported `ok:false` — the per-line
+   heuristic tripped on the benign "Graph model not found in /tmp/…" line. Classification is now
+   whole-output-aware: the not-found line is forgiven only when the same output carries the
+   fallback's success marker; a genuine miss stays `ok:false`.
+
+4. **Join barrier: only valid completions count (#197, #198).** The barrier's completion mark
+   meant "ran", not "completed" — it was stamped even when a branch failed into its `exception=`
+   route, and `RESET` left the stale mark behind, so a fork whose failing branch retries could
+   fire the join prematurely and silently lose that branch's data. The mark is now success-only
+   and `RESET` clears it (#197); a downstream join judges an upstream join by its recorded
+   outcome, not its run mark, so chained joins can't fire off a sunk barrier (#198). Traveler
+   (dry-run) and executor (deployed) behave identically.
+
+5. **`/sync` contract gaps (#201).** The 1-second identical-command dedup guard (a WebSocket
+   double-submit protection) silently swallowed a repeated command from the sync endpoint —
+   `ok:true` with empty output; `/sync` dispatches are now marked direct and bypass the guard
+   (the WS path keeps it). A malformed command answered with a `Syntax: …` usage hint now
+   classifies `ok:false` with the hint as the in-band error.
+
+6. **`flow-schema-reference.md` documented `error.status`; the engine key is `error.code`
+   (#203).** Doc corrected in all mapping examples (found while source-verifying the Rust
+   port's documentation site).
+
+### Changed
+
+1. **The Playground welcome message no longer prints the companion endpoint (#202).** With the
+   synchronous endpoint in place the line advertised the legacy fire-and-forget form; the
+   session id — the one thing a human shares with an AI agent — remains.
 
 ---
 ## Version 4.8.6, 7/14/2026

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.6) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.9.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.8.6) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.9.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -44,7 +44,7 @@ public class OtelForwarderContext {
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
     // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.8.6";
+    private static final String VERSION = "4.9.0";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/Dockerfile
+++ b/helpers/kafka-standalone/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 EXPOSE 9092
 WORKDIR /app
-COPY target/kafka-standalone-4.8.6-exec.jar .
-ENTRYPOINT ["java","-jar","kafka-standalone-4.8.6-exec.jar"]
+COPY target/kafka-standalone-4.9.0-exec.jar .
+ENTRYPOINT ["java","-jar","kafka-standalone-4.9.0-exec.jar"]

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.8.6</version>
+    <version>4.9.0</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.0</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version sweep 4.8.6 → 4.9.0 (digit-lookahead guard): 32 poms +
CLAUDE.md/GEMINI.md + `OtelForwarderContext.VERSION` + the kafka-standalone
Dockerfile — the same footprint as the 4.8.6 release. The CHANGELOG's Unreleased
section becomes the **4.9.0 release notes**, every entry carrying its PR number:

**Added** — the synchronous AI-companion endpoint (`/sync`, ADR-0008: #189/#190 with
the drain fix #191/#193); discovery commands `list graphs` / `list flows` (#199);
`describe graph {graph-id}` contract view (#200); numeric promotion + `f:round` for
the simple-plugin arithmetic family (#196); the AI-agent documentation hardening
(#187, #203); cross-links to the official Rust implementation (#204).

**Fixed** — companion endpoints limit `session` to the read-only status query (#194);
the `/sync` ok-heuristic false-negative (#195); the join-barrier pair — success-only
completion marks + chained joins judged by outcome (#197, #198); the `/sync` contract
gaps — dedup bypass for direct RPC + `Syntax:` usage classified as failure (#201);
`flow-schema-reference.md` `error.status` → `error.code` (#203).

**Changed** — the Playground welcome message no longer prints the companion endpoint (#202).

**Minor bump per semver**: this release adds features, not only fixes.

## Why

Everything merged since 4.8.6 (#187–#204) serves one arc: making the platform fully
operable by AI agents with a truthful command contract and self-sufficient
documentation — validated by 25 fresh-agent exercises across this engine and the Rust
port, the last thirteen passing with zero documentation lookups. The join-barrier and
contract fixes belong in the field; the release also formally introduces the official
Rust implementation to readers of this repo.

**Verified: full reactor green with all tests at 4.9.0 — 950 tests, 0 failures.**
(Local-run note: `rest-spring-3`'s test context binds port 8085; a leftover Playground
app on that port fails 4 tests spuriously — worth knowing for dev machines.)

Normal release flow: tag on merge.

Co-Authored-By: Claude Code <noreply@anthropic.com>