### PR TITLE
fix(minigraph): describe graph output surface no longer absorbs a stray trailing bracket

### DIFF
--- a/memory/sessions/2026-07-20-215330.md
+++ b/memory/sessions/2026-07-20-215330.md
@@ -1,0 +1,24 @@
+# Session (2026-07-20T21:53:30Z)
+
+**Agent:** Claude Code
+
+## Work Done
+
+Fixed the stray trailing `]` in `describe graph` contract output (Java engine).
+
+**Root cause:** `GraphCommandService.describeDeployedGraph` called `String.valueOf(node.get("properties"))` which produces Java's `AbstractMap.toString()` form (`{mapping=[... -> output.body], skill=...}`). The `collectPathTokens` tokenizer absorbed the list's closing `]`, and the trailing-trim loop only stripped `.`, `-`, `[` — not `]`.
+
+**Changes:**
+- [`system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java`](../../../system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java)
+  - Line ~669: serialize properties via `SimpleMapper.getInstance().getMapper().writeValueAsString(...)` before scanning (with fallback to `String.valueOf` on exception). This restores byte-identical output to the Rust engine.
+  - `collectPathTokens` (~line 742): added an unbalanced-`]` trim pass — strips a trailing `]` when the token contains no `[`. Defensive hardening; can't arise from JSON-quoted text.
+- [`system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java`](../../../system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java)
+  - Lines 310-311: tightened `contains("input.body.person_id")` / `contains("output.body.name")` to exact-line form `contains("  input.body.person_id\n")` / `contains("  output.body.name\n")` so a trailing-character regression fails.
+
+**Verification:** `CompanionSyncTest` — 5 tests, 0 failures (BUILD SUCCESS).
+
+Finding originated from the Rust port session; Rust engine was already clean. Java-only defect.
+
+## Memory References
+
+(none — this is a targeted bug fix; no new project facts or decisions)

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -666,7 +666,12 @@ public class GraphCommandService extends GraphLambdaFunction {
         if (model.get("nodes") instanceof List<?> nodeList) {
             for (var n : nodeList) {
                 if (n instanceof Map<?, ?> node && node.get("properties") != null) {
-                    var text = String.valueOf(node.get("properties"));
+                    String text;
+                    try {
+                        text = SimpleMapper.getInstance().getMapper().writeValueAsString(node.get("properties"));
+                    } catch (Exception e) {
+                        text = String.valueOf(node.get("properties"));
+                    }
                     collectPathTokens(text, "input.", inputs);
                     collectPathTokens(text, "output.", outputs);
                 }
@@ -740,6 +745,11 @@ public class GraphCommandService extends GraphLambdaFunction {
             }
             var token = text.substring(begin, end);
             while (!token.isEmpty() && (token.endsWith(".") || token.endsWith("-") || token.endsWith("["))) {
+                token = token.substring(0, token.length() - 1);
+            }
+            // Trim a trailing ']' only when there is no matching '[' (unbalanced — can arise
+            // from non-JSON serialization forms where a list's closing bracket is absorbed).
+            while (token.endsWith("]") && token.indexOf('[') == -1) {
                 token = token.substring(0, token.length() - 1);
             }
             if (token.length() > prefix.length()) {

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -307,8 +307,8 @@ class CompanionSyncTest {
         assertEquals(Boolean.TRUE, contract.get("ok"), "describe graph {id} -> ok:true: " + contract);
         var contractText = String.valueOf(contract.get("output"));
         assertTrue(contractText.contains("Deployed graph model 'tutorial-3'"), "header: " + contractText);
-        assertTrue(contractText.contains("input.body.person_id"), "derived input surface: " + contractText);
-        assertTrue(contractText.contains("output.body.name"), "derived output surface: " + contractText);
+        assertTrue(contractText.contains("  input.body.person_id\n"), "derived input surface (exact line): " + contractText);
+        assertTrue(contractText.contains("  output.body.name\n"), "derived output surface (exact line): " + contractText);
     }
 
     /**


### PR DESCRIPTION
## What

`describe graph {graph-id}` rendered the derived output surface with a stray closing
bracket (`output.body]`) whenever a dotted-path token was the last element of a mapping
list. Three changes in `minigraph-playground-engine`:

- **Root-cause fix** — `describeDeployedGraph` now serializes each node's `properties`
  to JSON before scanning for `input.*` / `output.*` path tokens, instead of using
  `String.valueOf` (Java's `AbstractMap.toString()` form, `{mapping=[... -> output.body], ...}`,
  whose unquoted closing `]` the tokenizer absorbed).
- **Tokenizer hardening** — `collectPathTokens` trims a trailing `]` when the token has
  no matching `[` (unbalanced bracket), so the tokenizer stays robust regardless of the
  serialization feeding it. Genuine array indices like `output.body[0]` are untouched.
- **Test tightening** — `CompanionSyncTest`'s surface assertions now match the exact
  line (`"  output.body.name\n"`) rather than a substring, so a trailing-character
  regression fails the suite (the old `contains("output.body.name")` matched the broken
  `output.body.name]` too).

## Why

The `describe graph` contract view (PR #200) is a shared contract across the Java and
Rust engines — both should print byte-identical output for the same model. The Rust
engine scans the JSON serialization of `properties` and was verified clean; the Java
engine scanned the `toString()` form and picked up the list's closing bracket. This
restores cross-engine parity at the root (same scanned text shape) rather than only
patching the symptom, and closes the test gap that let the defect ship.

Found by the Rust-port session while cross-verifying the two engines; confirmed live on
the playground example app (:8085), where tutorial-1/2/3 all showed the bracketed form.

Verification: `CompanionSyncTest` 5/5 green.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)