### PR TITLE
fix(minigraph): bump js-yaml to 4.3.0 in the webapp lockfile (npm audit)

### DIFF
--- a/memory/sessions/2026-07-21-012842.md
+++ b/memory/sessions/2026-07-21-012842.md
@@ -25,6 +25,16 @@ Normal release flow per [[thread-release-4-8-4-tag-deferred]] ruling: tag on mer
 Earlier same day (separate logs): PR #206 fix session (2026-07-20-215330), docs overhaul
 session (2026-07-20-222709).
 
+Also (same session): **dependabot HIGH alert #29 diagnosed + remediated** (branch
+`fix/webapp-js-yaml-audit`). The alert is `js-yaml` 4.2.0 in the minigraph-playground
+webapp's `package-lock.json` (GHSA-52cp-r559-cp3m — YAML merge-key quadratic CPU). It is a
+**dev-only transitive** (`cosmiconfig → js-yaml`, dev=true): not in the webapp's production
+dependencies, never bundled into the shipped UI — build-time exposure only, so runtime risk
+nil, but dependabot/field Snyk flag the lockfile regardless. Fix: `npm audit fix` lock-only
+bump to js-yaml 4.3.0 (range `^4.1.0` already admitted it; no package.json change). Verified:
+`npm audit` 0 vulnerabilities, webapp 124 tests green, production build green; no UI-bundle
+redeploy needed.
+
 ## Memory References
 
 - referenced: release-4-8-3-shipped / thread-release-4-8-4-tag-deferred (release flow: normal

--- a/system/minigraph-playground-engine/webapp/package-lock.json
+++ b/system/minigraph-playground-engine/webapp/package-lock.json
@@ -1970,9 +1970,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

Lockfile-only bump of `js-yaml` 4.2.0 → 4.3.0 in
`system/minigraph-playground-engine/webapp/package-lock.json` via `npm audit fix`, clearing
the dependabot HIGH alert (GHSA-52cp-r559-cp3m — YAML merge-key chains force quadratic CPU
consumption). No package.json change; the existing `^4.1.0` range already admits the patched
version.

## Why

js-yaml is a dev-only transitive dependency (`cosmiconfig → js-yaml`) of the webapp build
toolchain — it is not a production dependency and never reaches the UI bundle shipped in the
engine JAR, so runtime exposure is nil. But dependabot and enterprise scanners flag the
lockfile regardless of scope, so remediating at the source keeps the repo's security signal
clean for every downstream scan.

Verified: `npm audit` clean (0 vulnerabilities), webapp tests 124/124 green, production
build green. No UI-bundle redeploy needed.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)