### PR TITLE
refactor(minigraph): resolve field Sonar quality-gate findings on 4.9.1

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-012842)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-173614)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -340,6 +340,17 @@
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-06-21 | uses: 1 | tier: working -->
 
 ## Open Threads
+
+- [ ] (field support — 2026-07-21) **v4.9.1 REJECTED by the field Sonar quality gate; remediation
+  in flight** on branch `fix/sonar-4-9-1-field-scan`. 19 issues (8 HIGH: S3776 complexity ×4 +
+  S1192 literals ×4; 11 MEDIUM: S5778 ×5, S125 ×2, S1168 ×2, S5961, S6126), all introduced by the
+  4.9.0/4.9.1 minigraph companion/discovery code (field's prior scan was pre-4.9). All 19 fixed
+  via helper extraction, constants, test splits, prose-comment rewording, and the `deployedModel`
+  empty-map contract — see session 2026-07-21-173614 for the per-issue map. Behavior-preserving;
+  71 minigraph + event-script tests green. Next: full reactor → PR → likely v4.9.2 for the field
+  to rescan. Durable lesson recorded: extract-as-you-go when touching methods near the S3776/S5961
+  thresholds.
+  <!-- id: thread-sonar-4-9-1-field-rejection | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-173614 -->
 
 - [x] (release in flight — 2026-07-21; CLOSED same day) **v4.9.1 SHIPPED via the normal flow** —
   tag `v4.9.1` on merge commit `26a132f9` (PR #208, CI green + local full reactor 942 tests),

--- a/memory/sessions/2026-07-21-173614.md
+++ b/memory/sessions/2026-07-21-173614.md
@@ -1,0 +1,52 @@
+# Session (2026-07-21T17:36:14Z)
+
+**Agent:** Claude Code
+
+## Work Done
+
+**Field Sonar gate rejected v4.9.1** — remediation on branch `fix/sonar-4-9-1-field-scan`.
+The field's scan (screenshots reviewed from a non-repo path per compartmentalization) flagged
+19 issues, all introduced by the 4.9.0/4.9.1 minigraph companion/discovery work (their prior
+scan was pre-4.9): 8 HIGH (S3776 cognitive complexity ×4, S1192 duplicated literals ×4) and
+11 MEDIUM (S5778 ×5, S125 ×2, S1168 ×2, S5961, S6126). Per [[field-sonar-covers-all-sources]],
+the gate holds Overall Code to zero blocker/critical/major — all 19 fixed:
+
+- **PostCompanionCommandSync**: `handleEvent` 20→~5 by extracting `commandFromBody`,
+  `captureFunction`, `dispatchAndDrain`, `refusedResponse`, `outcomeResponse`; `COMMAND` +
+  `TEXT_COMMAND_REQUIRED` constants; S125 prose comment reworded (kept finding-63 reference).
+- **GraphCommandService**: `handleCommand` 17→~8 (early returns + `isDuplicate`/`runAsPrimary`/
+  `forwardToPrimary`); `describeDeployedGraph` 19→~6 (`collectModelSurface`, `propertiesAsText`,
+  `appendSurface`); `collectPathTokens` 25→ small (`nextPathToken`, `isWordChar`, `isTokenChar`,
+  `trimToken` — behavior identical incl. the #206 unbalanced-bracket trim); `NODES`/`PROPERTIES`/
+  `TOTAL` constants; **`deployedModel` contract change: returns empty map instead of null**
+  (S1168; both callers updated to `isEmpty()` — never null now).
+- **SimplePluginNumberPromotionTest**: S5778 ×5 — plugin instances hoisted out of the
+  `assertThrows` lambdas (one invocation per lambda).
+- **CompanionSyncTest**: S5961 — phase 5 (failing traversal, already a fresh session) split
+  into its own test `failedRunDrainsOnTerminalNotTimeout` (27→24 assertions); S6126 — the
+  multi-line create-node command is now a text block.
+- **GraphTests**: S125 — the join-chain timing comment reworded as prose (no code-shaped
+  fragments), content preserved.
+
+**Verification:** event-script-engine + minigraph-playground-engine (71 tests) green; full
+reactor run recorded below.
+
+**Durable lesson:** S3776/S5961 have hard thresholds — a "small" addition to an
+already-at-limit method (the #206 trim loop took collectPathTokens 20→25; two exact-line
+assertions took the sync test 25→27) trips the NEXT field scan even when the change itself
+is sound. When touching a method/test near the limit, extract as you go.
+
+Also: Eric's IDE review round applied on top — precise `throws ExecutionException,
+InterruptedException` on `dispatchAndDrain` (better than the generic `throws Exception`),
+redundant `throws IOException` dropped from `forwardToPrimary`, doubled javadoc above
+`describeDeployedGraph` merged, redundant `@SuppressWarnings` removed in CompileGraphTest.
+One class of IDE edit reverted by agreement-in-substance: the spell-checker collapsed
+"miss prints"→"misprints" and "miss carries"→"miscarries" in four comments/messages
+(breaking the sentences); reworded so both grammar and the spell-checker are satisfied.
+Full reactor green (29 modules, 5:01); minigraph module re-verified after the review round.
+
+## Memory References
+
+- referenced: field-sonar-covers-all-sources (user memory: gate covers Overall Code)
+- referenced: release-4-8-3-shipped (field-scan release-cycle precedent)
+- referenced: thread-release-4-9-1 (this remediation follows the 4.9.1 rejection)

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginNumberPromotionTest.java
@@ -81,16 +81,19 @@ class SimplePluginNumberPromotionTest {
         assertEquals(2.35d, new RoundNumbers().calculate("2.345", 2));
         // a whole number is already exact and passes through unchanged
         assertEquals(5L, new RoundNumbers().calculate(5, 2));
-        assertThrows(IllegalArgumentException.class, () -> new RoundNumbers().calculate(1.5, 1.5));
-        assertThrows(IllegalArgumentException.class, () -> new RoundNumbers().calculate(1.5, -1));
+        var round = new RoundNumbers();
+        assertThrows(IllegalArgumentException.class, () -> round.calculate(1.5, 1.5));
+        assertThrows(IllegalArgumentException.class, () -> round.calculate(1.5, -1));
     }
 
     @Test
     void errorsStayErrors() {
+        var divide = new DivideNumbers();
+        var add = new AddNumbers();
         // a floating-point zero divisor is still division by zero
-        assertThrows(IllegalArgumentException.class, () -> new DivideNumbers().calculate(6, 0.0));
-        assertThrows(IllegalArgumentException.class, () -> new DivideNumbers().calculate(6, 0));
+        assertThrows(IllegalArgumentException.class, () -> divide.calculate(6, 0.0));
+        assertThrows(IllegalArgumentException.class, () -> divide.calculate(6, 0));
         // non-numeric text is still rejected
-        assertThrows(IllegalArgumentException.class, () -> new AddNumbers().calculate(1, "not-a-number"));
+        assertThrows(IllegalArgumentException.class, () -> add.calculate(1, "not-a-number"));
     }
 }

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/PostCompanionCommandSync.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,7 +58,7 @@ import java.util.concurrent.TimeUnit;
  * command's {@code out}; the capture route buffers each line (and tees it). The
  * end-of-transmission signal depends on the command shape: a <b>traversal</b>
  * ({@code run}) is asynchronous — the handler launches the traveler and replies
- * immediately, then the traveler streams its output afterwards — so it is drained
+ * immediately, then the traveler streams its output afterward — so it is drained
  * on the traveler's <b>terminal line</b> ("Graph traversal completed in N ms" |
  * "Graph traversal aborted"), always emitted last; every other command emits all
  * output before it replies, so a <b>FIFO sentinel</b> marks its buffer drained. A
@@ -70,6 +71,8 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
     private static final Logger log = LoggerFactory.getLogger(PostCompanionCommandSync.class);
 
     private static final String SYNC_SENTINEL = "__companion_sync_done__";
+    private static final String COMMAND = "command";
+    private static final String TEXT_COMMAND_REQUIRED = "Body must be a non-empty text/plain command";
     private static final long COMMAND_TIMEOUT_MS = 30000;
     private static final long DRAIN_TIMEOUT_MS = 5000;
 
@@ -79,13 +82,7 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         if (id == null) {
             throw new IllegalArgumentException("Missing path parameter: id");
         }
-        if (!(input.getBody() instanceof String raw)) {
-            throw new IllegalArgumentException("Body must be a non-empty text/plain command");
-        }
-        var command = raw.trim();
-        if (command.isEmpty()) {
-            throw new IllegalArgumentException("Body must be a non-empty text/plain command");
-        }
+        var command = commandFromBody(input);
         if (!GraphCommandService.hasSession(id)) {
             throw new AppException(404, "No active session for id " + id);
         }
@@ -99,21 +96,11 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         // subscribe path would also bind the ephemeral capture route as a subscriber).
         var topology = GraphCommandService.sessionTopologySubcommand(command);
         if (topology != null) {
-            var error = GraphCommandService.refuseSessionTopology(outRoute, command, topology);
-            var refused = new HashMap<String, Object>();
-            refused.put("ok", false);
-            refused.put("id", id);
-            refused.put("command", command);
-            refused.put("output", List.of("> " + command, error));
-            refused.put("error", error);
-            refused.put("result", null);
-            return new EventEnvelope().setHeader("Content-Type", "application/json").setBody(refused);
+            return refusedResponse(id, command, GraphCommandService.refuseSessionTopology(outRoute, command, topology));
         }
         var captureRoute = "companion.sync." + Utility.getInstance().getUuid();
-
         var po = new PostOffice(headers, instance);
         var platform = Platform.getInstance();
-        var emitter = EventEmitter.getInstance();
 
         // A private, per-call capture route: buffer each line for the in-band response and
         // tee it to the session's real WebSocket .out for the live human view.
@@ -123,7 +110,30 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         final var traversal = isTraversalCommand(command);
         List<Object> buffer = new CopyOnWriteArrayList<>();
         CountDownLatch drained = new CountDownLatch(1);
-        LambdaFunction capture = (hdr, body, inst) -> {
+        platform.registerPrivate(captureRoute, captureFunction(outRoute, traversal, buffer, drained), 1);
+        try {
+            dispatchAndDrain(po, id, command, inRoute, captureRoute, traversal, drained);
+        } finally {
+            platform.release(captureRoute);
+        }
+        return outcomeResponse(id, command, buffer);
+    }
+
+    private static String commandFromBody(AsyncHttpRequest input) {
+        if (!(input.getBody() instanceof String raw)) {
+            throw new IllegalArgumentException(TEXT_COMMAND_REQUIRED);
+        }
+        var command = raw.trim();
+        if (command.isEmpty()) {
+            throw new IllegalArgumentException(TEXT_COMMAND_REQUIRED);
+        }
+        return command;
+    }
+
+    private LambdaFunction captureFunction(String outRoute, boolean traversal,
+                                           List<Object> buffer, CountDownLatch drained) {
+        var emitter = EventEmitter.getInstance();
+        return (hdr, body, inst) -> {
             if (SYNC_SENTINEL.equals(body)) {
                 drained.countDown();
                 return null;
@@ -142,38 +152,53 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
             }
             return null;
         };
-        platform.registerPrivate(captureRoute, capture, 1);
-        try {
-            // RPC the singleton handler with the capture route as `out`; handleEvent
-            // returns once the command is dispatched (a traversal is still running).
-            // "direct" marks a synchronous companion RPC: not a flaky WS client, so
-            // the identical-command dedup guard does not apply (finding #62)
-            po.request(new EventEnvelope()
-                    .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
-                    .setBody(Map.of(
-                            "type", "command",
-                            "in", inRoute,
-                            "out", captureRoute,
-                            "message", command,
-                            "direct", true)),
-                    COMMAND_TIMEOUT_MS).get();
-            // Synchronous commands: enqueue the FIFO sentinel to mark the buffer drained.
-            // Traversals: the capture route counts the latch down on the terminal line.
-            if (!traversal) {
-                po.send(new EventEnvelope().setTo(captureRoute).setBody(SYNC_SENTINEL));
-            }
-            // The timeout is only a safety net (matched to the command timeout for a
-            // traversal); correctness comes from the signal, not from a timer.
-            var drainTimeout = traversal ? COMMAND_TIMEOUT_MS : DRAIN_TIMEOUT_MS;
-            if (!drained.await(drainTimeout, TimeUnit.MILLISECONDS)) {
-                log.warn("Companion sync drain timed out for {}", id);
-            }
-        } finally {
-            platform.release(captureRoute);
-        }
+    }
 
-        // Build the structured outcome from the captured output. Collect the console
-        // lines first, then classify with whole-output context (see firstErrorLine).
+    private void dispatchAndDrain(PostOffice po, String id, String command, String inRoute,
+                                  String captureRoute, boolean traversal, CountDownLatch drained)
+            throws ExecutionException, InterruptedException {
+        // RPC the singleton handler with the capture route as `out`; handleEvent
+        // returns once the command is dispatched (a traversal is still running).
+        // "direct" marks a synchronous companion RPC: not a flaky WS client, so
+        // the identical-command dedup guard does not apply (finding #62)
+        po.request(new EventEnvelope()
+                .setTo(GraphCommandService.SINGLETON_COMMAND_HANDLER)
+                .setBody(Map.of(
+                        "type", COMMAND,
+                        "in", inRoute,
+                        "out", captureRoute,
+                        "message", command,
+                        "direct", true)),
+                COMMAND_TIMEOUT_MS).get();
+        // Synchronous commands: enqueue the FIFO sentinel to mark the buffer drained.
+        // Traversals: the capture route counts the latch down on the terminal line.
+        if (!traversal) {
+            po.send(new EventEnvelope().setTo(captureRoute).setBody(SYNC_SENTINEL));
+        }
+        // The timeout is only a safety net (matched to the command timeout for a
+        // traversal); correctness comes from the signal, not from a timer.
+        var drainTimeout = traversal ? COMMAND_TIMEOUT_MS : DRAIN_TIMEOUT_MS;
+        if (!drained.await(drainTimeout, TimeUnit.MILLISECONDS)) {
+            log.warn("Companion sync drain timed out for {}", id);
+        }
+    }
+
+    private static EventEnvelope refusedResponse(String id, String command, String error) {
+        var refused = new HashMap<String, Object>();
+        refused.put("ok", false);
+        refused.put("id", id);
+        refused.put(COMMAND, command);
+        refused.put("output", List.of("> " + command, error));
+        refused.put("error", error);
+        refused.put("result", null);
+        return new EventEnvelope().setHeader("Content-Type", "application/json").setBody(refused);
+    }
+
+    /**
+     * Build the structured outcome from the captured output. Collect the console
+     * lines first, then classify with whole-output context (see firstErrorLine).
+     */
+    private static EventEnvelope outcomeResponse(String id, String command, List<Object> buffer) {
         List<String> output = new ArrayList<>();
         List<Object> result = new ArrayList<>();
         for (var item : buffer) {
@@ -187,7 +212,7 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
         var body = new HashMap<String, Object>();
         body.put("ok", error == null);
         body.put("id", id);
-        body.put("command", command);
+        body.put(COMMAND, command);
         body.put("output", output);
         body.put("error", error);
         body.put("result", result.isEmpty() ? null : result);
@@ -195,9 +220,10 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
     }
 
     private static boolean isErrorLine(String line) {
-        // a "Syntax: ..." usage hint is the engine's rejection of a malformed command —
-        // the command did nothing, so the caller must see ok:false (finding #63;
-        // no help page starts a line with "Syntax:", so no false positive)
+        // A usage hint beginning with the Syntax prefix is the engine's rejection of a
+        // malformed command. The command did nothing, so the caller must see ok=false
+        // per finding 63. No help page starts a line with that prefix, which rules out
+        // a false positive.
         return line.startsWith("ERROR:") || line.contains("aborted") || line.contains("does not have")
                 || line.startsWith("Invalid") || line.contains("not found") || line.contains("Please try 'help'")
                 || line.startsWith("Syntax:");
@@ -208,8 +234,8 @@ public class PostCompanionCommandSync implements TypedLambdaFunction<AsyncHttpRe
      * legitimately prints "Graph model not found in /tmp/..." before falling back
      * to the deployed classpath copy — a benign line that must not mark the
      * command failed. It is forgiven <b>only</b> when the same output also carries
-     * the fallback's success marker; a genuine miss prints the not-found line
-     * alone and stays an error.
+     * the fallback's success marker; a genuinely missing model prints the
+     * not-found line alone and stays an error.
      */
     private static String firstErrorLine(List<String> lines) {
         var deployedFallback = lines.stream().anyMatch(l -> l.contains("Found deployed graph model"));

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -60,6 +60,9 @@ public class GraphCommandService extends GraphLambdaFunction {
     private static final String DEFAULT_DEPLOY_DIR = "classpath:/graph";
     private static final String OUTCOME = "outcome";
     private static final String PLAYGROUND = "playground";
+    private static final String NODES = "nodes";
+    private static final String PROPERTIES = "properties";
+    private static final String TOTAL = "Total ";
     private static final String INVALID_GRAPH_NAME = "Invalid filename - must be a-z, A-Z, 0-9 with optional hyphen";
     private static final String SESSION_TAG = "Session ";
     private static final long EXPIRY = 20 * 1000L;
@@ -172,39 +175,55 @@ public class GraphCommandService extends GraphLambdaFunction {
             throws IOException {
         if (command.startsWith("{") && command.endsWith("}")) {
             handleJsonCommand(po, outRoute, command);
-        } else {
-            if (command.startsWith(SESSION) || forwarded) {
-                singleOrMultiLineCommand(po, command, inRoute, outRoute);
-                return;
-            }
-            // the dedup guard protects the WS UI from double-submits; a synchronous
-            // companion RPC ("direct") is a deliberate request - never dropped (#62)
-            if (!direct) {
-                var cached = cachedMessage.get(inRoute);
-                if (command.equals(cached)) {
-                    log.debug("Duplicated message - {} for {}", command, inRoute);
-                    return;
-                }
-                cachedMessage.put(inRoute, command);
-            }
-            var me = sessions.get(inRoute);
-            if (me.isPrimary()) {
-                singleOrMultiLineCommand(po, command, inRoute, outRoute);
-                for (var subOutRoute: me.getSubscribers()) {
-                    var subInRoute = GraphSession.getInRoute(subOutRoute);
-                    var forwardBody = Map.of(TYPE, COMMAND, IN, subInRoute, OUT, subOutRoute,
-                            MESSAGE, command, FORWARDED, true);
-                    po.send(new EventEnvelope().setTo(ROUTE).setBody(forwardBody));
-                }
-            } else {
-                // Except for the session commands, forward request to the primary session.
-                // Override the inRoute and outRoute accordingly.
-                var targetInRoute = GraphSession.getInRoute(me.getTargetId());
-                var targetOutRoute = GraphSession.getOutRoute(me.getTargetId());
-                var forwardBody = Map.of(TYPE, COMMAND, IN, targetInRoute, OUT, targetOutRoute, MESSAGE, command);
-                po.send(new EventEnvelope().setTo(ROUTE).setBody(forwardBody));
-            }
+            return;
         }
+        if (command.startsWith(SESSION) || forwarded) {
+            singleOrMultiLineCommand(po, command, inRoute, outRoute);
+            return;
+        }
+        // the dedup guard protects the WS UI from double-submits; a synchronous
+        // companion RPC ("direct") is a deliberate request - never dropped (#62)
+        if (!direct && isDuplicate(inRoute, command)) {
+            return;
+        }
+        var me = sessions.get(inRoute);
+        if (me.isPrimary()) {
+            runAsPrimary(po, command, inRoute, outRoute, me);
+        } else {
+            forwardToPrimary(po, command, me);
+        }
+    }
+
+    private boolean isDuplicate(String inRoute, String command) {
+        var cached = cachedMessage.get(inRoute);
+        if (command.equals(cached)) {
+            log.debug("Duplicated message - {} for {}", command, inRoute);
+            return true;
+        }
+        cachedMessage.put(inRoute, command);
+        return false;
+    }
+
+    private void runAsPrimary(PostOffice po, String command, String inRoute, String outRoute, GraphSession me)
+            throws IOException {
+        singleOrMultiLineCommand(po, command, inRoute, outRoute);
+        for (var subOutRoute: me.getSubscribers()) {
+            var subInRoute = GraphSession.getInRoute(subOutRoute);
+            var forwardBody = Map.of(TYPE, COMMAND, IN, subInRoute, OUT, subOutRoute,
+                    MESSAGE, command, FORWARDED, true);
+            po.send(new EventEnvelope().setTo(ROUTE).setBody(forwardBody));
+        }
+    }
+
+    /**
+     * Except for the session commands, forward request to the primary session.
+     * Override the inRoute and outRoute accordingly.
+     */
+    private void forwardToPrimary(PostOffice po, String command, GraphSession me) {
+        var targetInRoute = GraphSession.getInRoute(me.getTargetId());
+        var targetOutRoute = GraphSession.getOutRoute(me.getTargetId());
+        var forwardBody = Map.of(TYPE, COMMAND, IN, targetInRoute, OUT, targetOutRoute, MESSAGE, command);
+        po.send(new EventEnvelope().setTo(ROUTE).setBody(forwardBody));
     }
 
     private void singleOrMultiLineCommand(PostOffice po, String command, String inRoute, String outRoute)
@@ -421,7 +440,7 @@ public class GraphCommandService extends GraphLambdaFunction {
             if (root.get()) result.add(ROOT);
             result.addAll(nodes);
             if (end.get()) result.add(END);
-            po.send(new EventEnvelope().setTo(outRoute).setBody("Total "+result.size()+
+            po.send(new EventEnvelope().setTo(outRoute).setBody(TOTAL+result.size()+
                                                 " node"+(result.size() == 1? "" : "s")+" have been seen"));
             po.send(new EventEnvelope().setTo(outRoute).setBody(result));
         }
@@ -600,7 +619,7 @@ public class GraphCommandService extends GraphLambdaFunction {
     private void handleListCommand(PostOffice po, String inRoute, String outRoute, String type) {
         var graph = graphModels.get(inRoute);
         var sb = new StringBuilder();
-        if ("nodes".equalsIgnoreCase(type)) {
+        if (NODES.equalsIgnoreCase(type)) {
             listNodes(graph, sb);
         } else if ("connections".equalsIgnoreCase(type)) {
             listConnections(graph, sb);
@@ -632,15 +651,14 @@ public class GraphCommandService extends GraphLambdaFunction {
             var purpose = graphPurpose(id);
             sb.append(purpose == null? id : id + " - " + purpose).append('\n');
         }
-        sb.append("Total ").append(ids.size()).append(ids.size() == 1? " graph model" : " graph models").append('\n');
+        sb.append(TOTAL).append(ids.size()).append(ids.size() == 1? " graph model" : " graph models").append('\n');
         sb.append("Use 'describe graph {graph-id}' for a model's input/output contract");
     }
 
     /**
      * Discovery: the Event Script flows a graph.extension node can call
      * (extension=flow://{flow-id}).
-     */
-    /**
+     * <p>
      * Discovery: the CONTRACT view of a deployed graph model - purpose, size,
      * and the input/output surface derived from the model's node properties -
      * so an agent can wire extension= delegation without out-of-band
@@ -648,11 +666,11 @@ public class GraphCommandService extends GraphLambdaFunction {
      */
     private void describeDeployedGraph(PostOffice po, String outRoute, String graphId) {
         var model = deployedModel(graphId);
-        if (model == null) {
+        if (model.isEmpty()) {
             po.send(new EventEnvelope().setTo(outRoute).setBody("Graph model '" + graphId + "'" + NOT_FOUND));
             return;
         }
-        var nodes = model.get("nodes") instanceof List<?> n? n.size() : 0;
+        var nodes = model.get(NODES) instanceof List<?> n? n.size() : 0;
         var connections = model.get("connections") instanceof List<?> c? c.size() : 0;
         var sb = new StringBuilder();
         sb.append("Deployed graph model '").append(graphId).append("'\n");
@@ -663,41 +681,55 @@ public class GraphCommandService extends GraphLambdaFunction {
         sb.append("Nodes: ").append(nodes).append(", connections: ").append(connections).append('\n');
         var inputs = new TreeSet<String>();
         var outputs = new TreeSet<String>();
-        if (model.get("nodes") instanceof List<?> nodeList) {
-            for (var n : nodeList) {
-                if (n instanceof Map<?, ?> node && node.get("properties") != null) {
-                    String text;
-                    try {
-                        text = SimpleMapper.getInstance().getMapper().writeValueAsString(node.get("properties"));
-                    } catch (Exception e) {
-                        text = String.valueOf(node.get("properties"));
-                    }
-                    collectPathTokens(text, "input.", inputs);
-                    collectPathTokens(text, "output.", outputs);
-                }
-            }
-        }
-        sb.append("Input surface:\n");
-        if (inputs.isEmpty()) {
-            sb.append("  (none referenced)\n");
-        }
-        for (var path : inputs) {
-            sb.append("  ").append(path).append('\n');
-        }
-        sb.append("Output surface:\n");
-        if (outputs.isEmpty()) {
-            sb.append("  (none referenced)\n");
-        }
-        for (var path : outputs) {
-            sb.append("  ").append(path).append('\n');
-        }
+        collectModelSurface(model, inputs, outputs);
+        appendSurface(sb, "Input surface", inputs);
+        appendSurface(sb, "Output surface", outputs);
         sb.append("(derived from the model's data mappings)");
         po.send(new EventEnvelope().setTo(outRoute).setBody(sb.toString()));
     }
 
     /**
+     * Derive the input/output surface from every node's properties (mapping
+     * entries, plugin args, substitution variables in statements).
+     */
+    private void collectModelSurface(Map<String, Object> model, TreeSet<String> inputs, TreeSet<String> outputs) {
+        if (model.get(NODES) instanceof List<?> nodeList) {
+            for (var n : nodeList) {
+                if (n instanceof Map<?, ?> node && node.get(PROPERTIES) != null) {
+                    var text = propertiesAsText(node.get(PROPERTIES));
+                    collectPathTokens(text, "input.", inputs);
+                    collectPathTokens(text, "output.", outputs);
+                }
+            }
+        }
+    }
+
+    /**
+     * JSON form of a node's properties - the same text shape the Rust engine
+     * scans, so the derived contract stays byte-identical across engines.
+     */
+    private static String propertiesAsText(Object properties) {
+        try {
+            return SimpleMapper.getInstance().getMapper().writeValueAsString(properties);
+        } catch (Exception e) {
+            return String.valueOf(properties);
+        }
+    }
+
+    private static void appendSurface(StringBuilder sb, String title, TreeSet<String> paths) {
+        sb.append(title).append(":\n");
+        if (paths.isEmpty()) {
+            sb.append("  (none referenced)\n");
+        }
+        for (var path : paths) {
+            sb.append("  ").append(path).append('\n');
+        }
+    }
+
+    /**
      * A deployed/compiled graph model (compiled registry first, then the
-     * deployed location).
+     * deployed location). Returns an empty map when the graph id is unknown
+     * or its deployed JSON cannot be parsed.
      */
     @SuppressWarnings("unchecked")
     private Map<String, Object> deployedModel(String graphId) {
@@ -707,12 +739,12 @@ public class GraphCommandService extends GraphLambdaFunction {
         }
         var json = getDeployedGraphAsText(graphId);
         if (json == null) {
-            return null;
+            return Collections.emptyMap();
         }
         try {
             return SimpleMapper.getInstance().getMapper().readValue(json, Map.class);
         } catch (Exception e) {
-            return null;
+            return Collections.emptyMap();
         }
     }
 
@@ -722,41 +754,58 @@ public class GraphCommandService extends GraphLambdaFunction {
      */
     private void collectPathTokens(String text, String prefix, TreeSet<String> found) {
         int start = 0;
-        while (true) {
-            int begin = text.indexOf(prefix, start);
-            if (begin == -1) {
-                return;
-            }
-            if (begin > 0) {
-                char prev = text.charAt(begin - 1);
-                if (Character.isLetterOrDigit(prev) || prev == '_' || prev == '.') {
-                    start = begin + prefix.length();
-                    continue;
-                }
-            }
-            int end = begin + prefix.length();
-            while (end < text.length()) {
-                char c = text.charAt(end);
-                if (Character.isLetterOrDigit(c) || c == '.' || c == '_' || c == '-' || c == '[' || c == ']') {
-                    end++;
-                } else {
-                    break;
-                }
-            }
-            var token = text.substring(begin, end);
-            while (!token.isEmpty() && (token.endsWith(".") || token.endsWith("-") || token.endsWith("["))) {
-                token = token.substring(0, token.length() - 1);
-            }
-            // Trim a trailing ']' only when there is no matching '[' (unbalanced — can arise
-            // from non-JSON serialization forms where a list's closing bracket is absorbed).
-            while (token.endsWith("]") && token.indexOf('[') == -1) {
-                token = token.substring(0, token.length() - 1);
-            }
-            if (token.length() > prefix.length()) {
-                found.add(token);
-            }
-            start = end;
+        while (start != -1) {
+            start = nextPathToken(text, prefix, start, found);
         }
+    }
+
+    /**
+     * Scan one prefix occurrence from the start position, adding a well-formed
+     * token to the collection. Returns the next scan position, or -1 when the
+     * text is exhausted.
+     */
+    private int nextPathToken(String text, String prefix, int start, TreeSet<String> found) {
+        int begin = text.indexOf(prefix, start);
+        if (begin == -1) {
+            return -1;
+        }
+        // a mid-word match is part of a longer identifier, not a path token
+        if (begin > 0 && isWordChar(text.charAt(begin - 1))) {
+            return begin + prefix.length();
+        }
+        int end = begin + prefix.length();
+        while (end < text.length() && isTokenChar(text.charAt(end))) {
+            end++;
+        }
+        var token = trimToken(text.substring(begin, end));
+        if (token.length() > prefix.length()) {
+            found.add(token);
+        }
+        return end;
+    }
+
+    private static boolean isWordChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_' || c == '.';
+    }
+
+    private static boolean isTokenChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '.' || c == '_' || c == '-' || c == '[' || c == ']';
+    }
+
+    /**
+     * Strip trailing separators, then a trailing ']' when there is no matching
+     * '[' (unbalanced - can arise from non-JSON serialization forms where a
+     * list's closing bracket is absorbed).
+     */
+    private static String trimToken(String token) {
+        var result = token;
+        while (!result.isEmpty() && (result.endsWith(".") || result.endsWith("-") || result.endsWith("["))) {
+            result = result.substring(0, result.length() - 1);
+        }
+        while (result.endsWith("]") && result.indexOf('[') == -1) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
     }
 
     private void listFlows(StringBuilder sb) {
@@ -772,7 +821,7 @@ public class GraphCommandService extends GraphLambdaFunction {
             var description = flow == null? null : flow.description;
             sb.append(description == null || description.isBlank()? id : id + " - " + description.trim()).append('\n');
         }
-        sb.append("Total ").append(ids.size()).append(ids.size() == 1? " flow" : " flows");
+        sb.append(TOTAL).append(ids.size()).append(ids.size() == 1? " flow" : " flows");
     }
 
     /**
@@ -808,13 +857,10 @@ public class GraphCommandService extends GraphLambdaFunction {
      */
     private String graphPurpose(String graphId) {
         Map<String, Object> model = deployedModel(graphId);
-        if (model == null) {
-            return null;
-        }
-        if (model.get("nodes") instanceof List<?> nodes) {
+        if (model.get(NODES) instanceof List<?> nodes) {
             for (var n : nodes) {
                 if (n instanceof Map<?, ?> node && "root".equals(node.get("alias"))
-                        && node.get("properties") instanceof Map<?, ?> properties
+                        && node.get(PROPERTIES) instanceof Map<?, ?> properties
                         && properties.get("purpose") instanceof String purpose && !purpose.isBlank()) {
                     return purpose.trim();
                 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -110,8 +110,12 @@ class CompanionSyncTest {
             //    traversal, drained on the traveler's terminal line (emitted last), not a
             //    raced sentinel that truncates it. Build a runnable graph and run it.
             syncCommand(po, sid, "create node end");
-            syncCommand(po, sid, "create node mapper\nwith type mapper\nwith properties\n"
-                    + "skill=graph.data.mapper\nmapping[]=input.body.id -> output.body");
+            syncCommand(po, sid, """
+                    create node mapper
+                    with type mapper
+                    with properties
+                    skill=graph.data.mapper
+                    mapping[]=input.body.id -> output.body""");
             syncCommand(po, sid, "connect root to mapper with first");
             syncCommand(po, sid, "connect mapper to end with second");
             var instantiated = syncCommand(po, sid, "instantiate graph\ntext(hello world) -> input.body.id");
@@ -129,27 +133,33 @@ class CompanionSyncTest {
             assertNotNull(ran.get("result"), "sync run returns the output.body as structured result: " + ran);
             assertTrue(String.valueOf(ran.get("result")).contains("hello world"),
                     "structured result carries the run's output.body: " + ran.get("result"));
-
-            // 5) a failing traversal (run before instantiate, fresh session) still returns
-            //    promptly with the uniform terminal - the drain never hangs to the timeout.
-            var badIn = "ws.990009.2.in";
-            var badId = "ws-990009-2";
-            po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
-                    .setBody(Map.of("type", "open", "in", badIn)));
-            for (int i = 0; i < 50 && !GraphCommandService.hasSession(badId); i++) {
-                Utility.getInstance().sleep(20);
-            }
-            long started = System.currentTimeMillis();
-            var badRun = syncCommand(po, badId, "run");
-            assertTrue(System.currentTimeMillis() - started < 10000,
-                    "a failed run must drain on the terminal, not the safety timeout");
-            assertEquals(Boolean.FALSE, badRun.get("ok"), "run with no instance -> ok:false: " + badRun);
-            var badRunOutput = ((List<?>) badRun.get("output")).stream().map(String::valueOf).toList();
-            assertTrue(badRunOutput.stream().anyMatch("Graph traversal aborted"::equals),
-                    "every run ends with a terminal, even on early failure: " + badRunOutput);
         } finally {
             platform.release(outRoute);
         }
+    }
+
+    /**
+     * A failing traversal (run before instantiate, fresh session) still returns
+     * promptly with the uniform terminal - the drain never hangs to the timeout.
+     */
+    @Test
+    void failedRunDrainsOnTerminalNotTimeout() throws Exception {
+        var po = EventEmitter.getInstance();
+        var badIn = "ws.990009.2.in";
+        var badId = "ws-990009-2";
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", badIn)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(badId); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        long started = System.currentTimeMillis();
+        var badRun = syncCommand(po, badId, "run");
+        assertTrue(System.currentTimeMillis() - started < 10000,
+                "a failed run must drain on the terminal, not the safety timeout");
+        assertEquals(Boolean.FALSE, badRun.get("ok"), "run with no instance -> ok:false: " + badRun);
+        var badRunOutput = ((List<?>) badRun.get("output")).stream().map(String::valueOf).toList();
+        assertTrue(badRunOutput.stream().anyMatch("Graph traversal aborted"::equals),
+                "every run ends with a terminal, even on early failure: " + badRunOutput);
     }
 
     /**
@@ -226,7 +236,7 @@ class CompanionSyncTest {
      * "Graph model not found in /tmp/..." before falling back to the deployed
      * classpath copy — a benign line that must not mark the command failed. It is
      * forgiven only when the same output also carries the fallback's success marker;
-     * a genuine miss prints the not-found line alone and stays {@code ok:false}.
+     * a genuinely missing model prints the not-found line alone and stays {@code ok:false}.
      */
     @Test
     void companionSyncImportFallbackReportsOk() throws Exception {
@@ -260,12 +270,12 @@ class CompanionSyncTest {
                 "the benign fallback must not be classified an error: " + imported);
         assertNull(imported.get("error"), "no error on a successful fallback import: " + imported);
 
-        // 2) a genuine miss prints the not-found line alone and stays an error
+        // 2) a genuinely missing model prints the not-found line alone and stays an error
         var missed = syncCommand(po, sid, "import graph from no-such-graph-xyz");
         assertEquals(Boolean.FALSE, missed.get("ok"), "a genuine miss stays ok:false: " + missed);
         assertInstanceOf(String.class, missed.get("error"));
         assertTrue(((String) missed.get("error")).contains("not found"),
-                "the genuine miss carries the not-found error in-band: " + missed);
+                "the not-found error is returned in-band for a genuine miss: " + missed);
     }
 
     /**

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/start/CompileGraphTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/start/CompileGraphTest.java
@@ -44,7 +44,6 @@ class CompileGraphTest {
         assertFalse(CompiledGraphs.graphExists("tutorial-99"));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     void deprecatedTypeMatchingSyntaxIsConvertedAtCompileTime() {
         Map<String, Object> model = CompiledGraphs.getGraph("hellojs");

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
@@ -333,11 +333,12 @@ class GraphTests {
     void chainedJoinCountsOnlyAFiredUpstreamJoin() throws TimeoutException {
         // Chained joins: an upstream join that evaluated and SANK is still in
         // skillRun (its skill ran fine), so the downstream join must judge it
-        // by the OUTCOME it recorded, not the run mark. slow-pre (200 ms) ->
-        // slow-x and fast-y feed j-one; j-one chains into j-two alongside
-        // pace-z (100 ms). fast-y makes j-one evaluate-and-sink at ~1 ms;
-        // pace-z reaches j-two at ~100 ms - before the fix, j-two counted the
-        // sunk j-one off its run mark, fired prematurely, and lost branch X.
+        // by the OUTCOME it recorded, not the run mark. Topology: slow-pre at
+        // 200 ms feeds slow-x, and together with fast-y they feed j-one, which
+        // chains into j-two alongside pace-z at 100 ms. Timing: fast-y makes
+        // j-one evaluate-and-sink at about 1 ms while pace-z reaches j-two at
+        // about 100 ms. Before the fix, j-two counted the sunk j-one off its
+        // run mark, fired prematurely, and lost branch X.
         var result = runGraph("unit-test-join-chain", Map.of("probe", true));
         assertInstanceOf(Map.class, result);
         var mm = new MultiLevelMap((Map<String, Object>) result);


### PR DESCRIPTION
## What

Resolves all 19 SonarQube findings reported by an enterprise quality-gate scan of v4.9.1 —
8 HIGH and 11 MEDIUM, all in the 4.9.0/4.9.1 minigraph companion/discovery code. Every fix
is behavior-preserving:

- **Cognitive complexity (S3776 ×4)** — extract focused helpers:
  `PostCompanionCommandSync.handleEvent` 20→~5 (validation, capture function,
  dispatch-and-drain, and response building each extracted);
  `GraphCommandService.handleCommand` 17→~8 (early returns +
  `isDuplicate`/`runAsPrimary`/`forwardToPrimary`); `describeDeployedGraph` 19→~6
  (`collectModelSurface`/`propertiesAsText`/`appendSurface`); `collectPathTokens` 25→small
  (`nextPathToken` + character-class and token-trim helpers — the #206 unbalanced-bracket
  behavior preserved exactly).
- **Duplicated string literals (S1192 ×4)** — constants for `"command"`, `"Total "`,
  `"nodes"`, `"properties"`.
- **Test-quality findings** — S5778 ×5: plugin instances hoisted out of `assertThrows`
  lambdas so each lambda holds exactly one invocation; S5961: the 27-assertion sync
  companion test split at its natural seam (the failing-traversal phase already used its
  own fresh session — now a dedicated test); S6126: multi-line command → text block.
- **S125 ×2** — comments that pattern-matched as commented-out code were actually prose;
  reworded with content preserved.
- **S1168 ×2** — `deployedModel` returns an empty map instead of null (callers updated).

## Why

The enterprise quality gate holds the whole codebase — not just new code — to zero
blocker/critical/major issues, so these findings block v4.9.1 adoption in the field.
Beyond unblocking the scan, the extractions genuinely improve the code: two of the
complexity overruns were caused by otherwise-sound recent additions (#206's bracket-trim
loop, tightened test assertions) pushing already-at-threshold methods over the line —
the new helper structure leaves headroom for future changes.

Includes a maintainer IDE review round: precise checked exceptions on `dispatchAndDrain`,
redundant `throws`/`@SuppressWarnings` removed, a doubled javadoc merged, and comment
wording made spell-checker-safe.

Verified: full reactor green (29 modules, all tests); minigraph-playground-engine (71
tests) and event-script-engine re-verified after the review round.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)