### PR TITLE
feat(core): language-neutral event envelope wire format for Event over HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Language-neutral event envelope wire format for Event over HTTP interoperability.**
+   The serialized envelope is now, by default, a MsgPack map with descriptive string keys
+   (`id`, `to`, `headers`, `body`, …) that any MsgPack-capable language can encode and
+   decode — documented as a self-contained spec in the new
+   [Event Envelope Wire Format](https://accenture.github.io/mercury-composable/guides/event-envelope-wire-format/)
+   reference, with golden conformance vectors shared with the official Rust implementation.
+   New API: `EventEnvelope.Format {COMPACT, STANDARD}`, `toMap(Format)`, `toBytes(Format)`;
+   the no-argument forms preserve their existing behavior (`toMap()` = standard map,
+   `toBytes()` = classic compact wire), so in-process callers and the Kafka service mesh
+   are untouched. Inbound decoding detects the format automatically (the two key
+   namespaces are disjoint) and the `/api/event` service mirrors the requester's format in
+   its response. Outbound selection: `event.over.http.format` (default `standard`;
+   `compact` is the fallback for peers on older versions) plus a per-call
+   `x-event-format` header.
+
+---
 ## Version 4.9.2, 7/21/2026
 
 Code-quality patch release: resolves all 19 SonarQube findings reported by an enterprise

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -406,6 +406,20 @@ Temporary folder used to buffer large async HTTP response bodies.
 
 Connection timeout in milliseconds for the built-in async HTTP client.
 
+### `event.over.http.format`
+
+| Type | Default |
+|------|---------|
+| `String` | `standard` |
+
+Serialization format for outbound [Event over HTTP](event-over-http.md) calls: `standard`
+(the language-neutral [wire format](event-envelope-wire-format.md), interoperable with the
+Rust implementation and future ports) or `compact` (the classic single-character-key
+format — a fallback for peers on older versions). Inbound decoding always accepts both
+formats automatically, and the `/api/event` service replies in the requester's format.
+Overridable per call (or per target in `yaml.event.over.http`) with the
+`x-event-format` header.
+
 ---
 
 ## Distributed Tracing & Observability {#observability}

--- a/docs/guides/event-envelope-wire-format.md
+++ b/docs/guides/event-envelope-wire-format.md
@@ -1,0 +1,240 @@
+---
+title: Event Envelope Wire Format
+summary: The language-neutral serialized form of an EventEnvelope for Event over HTTP interoperability.
+layer: reference
+audience: [developer, reference, ai-agent]
+keywords: [event envelope, wire format, msgpack, interoperability, event over http, serialization, polyglot]
+---
+
+# Event Envelope Wire Format
+
+*Reference: the serialized event envelope contract shared by every language implementation.*
+
+> **At a glance**
+>
+> - **What** — the standard wire format: one MsgPack map with descriptive string keys that
+>   any MsgPack-capable language (Java, Rust, Node.js, Python, Go, …) can encode and decode
+>   with its idiomatic tooling — no custom codec.
+> - **Why it matters** — it is the interoperability contract for
+>   [Event over HTTP](event-over-http.md) between different language runtimes, and the
+>   template for any future event-to-bytes transport.
+> - **For** developers integrating runtimes across languages, and implementers of new
+>   language ports. This page is self-contained: a new implementation needs nothing else.
+
+Two serialized forms exist. The **standard** format on this page is the language-neutral
+contract and the default for Event over HTTP. The **compact** format (single-character map
+keys) is the classic same-language form that remains the default for `toBytes()` and the
+Kafka service mesh; it is documented here only as far as detection requires.
+
+## The envelope
+
+A serialized envelope is a single **MsgPack map with string keys**. No MsgPack extension
+types are used. The envelope is self-contained — no out-of-band metadata is needed to
+decode it.
+
+## Core fields
+
+### `id`
+
+| Type | Required |
+|------|----------|
+| str | always |
+
+Unique event instance id — an opaque string (UUID recommended). Encoders always emit it.
+
+### `to`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Target route name, e.g. `hello.world`.
+
+### `from`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Sender route name, used for observability and reply semantics.
+
+### `reply_to`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Route that should receive the response, when the sender expects one.
+
+### `cid`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Business correlation id, preserved end-to-end.
+
+### `trace_id`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Distributed trace id.
+
+### `trace_path`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+Trace path, e.g. `GET /api/hello`.
+
+### `span_id`
+
+| Type | Required |
+|------|----------|
+| str | when set |
+
+The sender's span id, carried so the receiver knows its own parent span.
+
+### `status`
+
+| Type | Required |
+|------|----------|
+| int | when set (default 200) |
+
+HTTP-style status code. A value ≥ 400 marks the event as an error.
+
+### `headers`
+
+| Type | Required |
+|------|----------|
+| map of str → str | always (may be empty) |
+
+User-defined parameters. Encoders always emit this field — an empty map when there are no
+headers — so statically-typed decoders need no per-field default handling.
+
+### `body`
+
+| Type | Required |
+|------|----------|
+| any MsgPack value | when set |
+
+The payload: a map, array, string, integer, float, boolean, binary (`bin`), or nil.
+An absent `body` means nil.
+
+### `exec_time`
+
+| Type | Required |
+|------|----------|
+| float | when set |
+
+Function execution time in milliseconds.
+
+### `round_trip`
+
+| Type | Required |
+|------|----------|
+| float | when set |
+
+End-to-end response time in milliseconds.
+
+## Extension fields
+
+Optional fields a receiver MAY use and MAY ignore. Implementations that do not produce
+them remain fully conformant.
+
+### `tags`
+
+| Type | Required |
+|------|----------|
+| map of str → str | optional |
+
+Routing metadata (e.g. `optional`, `json`, `broadcast`).
+
+### `annotations`
+
+| Type | Required |
+|------|----------|
+| map of str → any | optional |
+
+Trace annotations recorded by the sender.
+
+### `stack`
+
+| Type | Required |
+|------|----------|
+| str | optional |
+
+Stack-trace text — the **portable** error detail. The portable error contract is
+`status` (≥ 400) + `body` (error message) + optional `stack`.
+
+### `obj_type`
+
+| Type | Required |
+|------|----------|
+| str | optional |
+
+Language-specific payload type hint (a PoJo class name for Java). Advisory only.
+
+### `exception`
+
+| Type | Required |
+|------|----------|
+| bin | optional |
+
+A language-native serialized exception object (Java only today). Meaningful only to a
+receiver of the same language — cross-language receivers MUST ignore it. Use `stack` for
+portable diagnostics.
+
+## Encoding rules
+
+1. **Map keys are strings** — including all keys inside a map-valued `body`.
+2. **Optional fields**: encoders SHOULD omit unset fields; encoding nil is equally valid.
+   Decoders MUST treat *absent* and *nil* identically.
+3. **Unknown keys MUST be ignored** by decoders (forward compatibility).
+4. **Numbers**: encoders use the smallest natural MsgPack width; decoders MUST accept any
+   integer width for integer fields and float32 or float64 for float fields.
+5. **Binary** values use the MsgPack `bin` family; strings are UTF-8 `str`.
+6. **Timestamps** travel as ISO-8601 UTC strings with millisecond precision
+   (e.g. `2026-07-21T12:00:00.000Z`) — never as MsgPack extension types.
+7. **No byte-identical guarantee**: map ordering is unspecified. Conformance is semantic —
+   decode, compare values.
+
+## Format detection
+
+The compact format's keys are all exactly **one character**; standard keys are all
+**two or more**. A decoder therefore detects the format from the first map key without any
+negotiation, version field, or content-type variant. The Java implementation accepts both
+formats on every decode path.
+
+## Selecting the outbound format (Java)
+
+Outbound format is transport policy. For Event over HTTP:
+
+- `event.over.http.format = standard | compact` in application.properties — the
+  application default (`standard` when unset).
+- `x-event-format: standard | compact` in the optional headers of
+  `po.request(event, timeout, headers, endpoint, rpc)` — a per-call override, also usable
+  per target in the `yaml.event.over.http` configuration's `headers` section. The header
+  is consumed by the client and never sent to the peer.
+- The `/api/event` service **mirrors** the requester's format in its response, so callers
+  need no response-side configuration.
+
+Use `compact` as a fallback when the peer is an older Java runtime that does not yet
+decode the standard format.
+
+## Conformance vectors
+
+Golden vectors (MsgPack bytes as base64, with expected decoded values) are maintained at
+`system/platform-core/src/test/resources/envelope-vectors/vectors.json` and shared with
+the official [Rust implementation](https://github.com/Accenture/mercury). A new
+implementation is conformant when it decodes every vector to the expected values and its
+own encodings round-trip through another implementation.
+
+## See also
+
+- [Event over HTTP](event-over-http.md) — the transport this contract serves
+- [Event Envelope Reference](event-envelope-reference.md) — the in-memory API
+- [Configuration Reference](configuration-reference.md) — `event.over.http.format`

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -50,6 +50,24 @@ This will expose the Event API endpoint at port 8085 and URL "/api/event".
 In kubernetes, The Event API endpoint of each application is reachable through internal DNS and there is no need
 to create "ingress" for this purpose.
 
+### Wire format and cross-language interoperability
+
+The serialized event envelope rides on the HTTP request body as MsgPack bytes. By default
+it uses the language-neutral **standard** format documented in the
+[Event Envelope Wire Format](event-envelope-wire-format.md) reference, so an application
+built with the official [Rust implementation](https://github.com/Accenture/mercury) (or a
+future language port) can call — and be called by — a Java application with no
+configuration.
+
+Inbound decoding always accepts both the standard and the classic **compact** format
+automatically, and the `/api/event` service replies in whatever format the request
+arrived in. When calling an older Java peer that does not yet understand the standard
+format, select the compact fallback globally with `event.over.http.format=compact`, or
+per call by adding the `x-event-format: compact` header to the optional headers of the
+Event-over-HTTP API (also usable in the `headers` section of a `yaml.event.over.http`
+target). The header is a client-side instruction — it is consumed by the sender, never
+transmitted.
+
 ## Test drive Event API
 
 You may now test drive the Event API service.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,6 +66,7 @@ These are self-contained; you should not need the engine source or the tutorial 
 - [Annotations Reference](https://accenture.github.io/mercury-composable/guides/annotations-reference/): @PreLoad, @MainApplication, and the rest.
 - [Configuration Reference](https://accenture.github.io/mercury-composable/guides/configuration-reference/): application.properties / application.yml keys.
 - [Event Envelope Reference](https://accenture.github.io/mercury-composable/guides/event-envelope-reference/): the EventEnvelope and PostOffice API.
+- [Event Envelope Wire Format](https://accenture.github.io/mercury-composable/guides/event-envelope-wire-format/): the language-neutral serialized envelope contract for Event over HTTP interop (self-contained spec — implement a new language port from this page alone).
 - [Reserved Names & Headers](https://accenture.github.io/mercury-composable/guides/reserved-names-and-headers/): system-reserved routes and headers.
 - [Actuators & HTTP Client](https://accenture.github.io/mercury-composable/guides/actuators-and-http-client/): built-in actuator endpoints and the AsyncHttpRequest API.
 - [Architecture Decision Records](https://accenture.github.io/mercury-composable/arch-decisions/ADR/): the durable architecture decisions (decoupled functions, virtual-thread engine, Map/PoJo I/O, the three paradigm layers, one-atom-four-roles) with their rationale.

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-180843)
+- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-215951)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -340,6 +340,38 @@
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-06-21 | uses: 1 | tier: working -->
 
 ## Open Threads
+
+- [ ] (design — 2026-07-21, human gate PENDING) **Common event envelope wire format for
+  cross-language interop (Event over HTTP with the Rust port).** Design DRAFTED at
+  `draft-design-specs/event-envelope-interop-design.md` — standard envelope = MsgPack map
+  with descriptive string keys (the existing `toMap()` form promoted to a wire contract);
+  compact 1-char keys and standard ≥2-char keys are disjoint → decoders sniff both, no
+  negotiation; encode: requester chooses (config + per-call header), responder mirrors;
+  Java `exceptionBytes` (ObjectOutputStream) excluded — portable error = status + message
+  + stack text. Rust port is the interop testbed but is READ-ONLY from this repo's
+  sessions (another session owns Rust edits). Includes draft ADR text. **Design REVIEWED
+  by Eric 2026-07-21: default = `standard` (Event over HTTP is transport, not storage —
+  no serialized data outlives the exchange; upgrade both sides together), `compact` kept
+  as explicit fallback for slow-to-upgrade installations (FIFO-vs-BDB precedent);
+  config `event.over.http.format` + per-request `x-event-format` header CONFIRMED.**
+  **API shape AGREED 2026-07-21:** `enum Format {COMPACT, STANDARD}`; `toMap(Format)` /
+  `toBytes(Format)`; no-arg `toMap()`=STANDARD, no-arg `toBytes()`=COMPACT (both preserve
+  today's behavior — EventEmitter's `of(event.toMap())` clone path depends on the
+  standard no-arg); `load()` sniffs. Outbound format = transport policy (groundwork for
+  Redis/S3 event-to-bytes transports). Mesh investigated: compact on every hop today,
+  Java-only fleet, stays out of v1 scope (MultipartPayload segmentation is a second
+  proprietary layer). **Phase 1 IMPLEMENTED 2026-07-21** on branch
+  `feature/event-envelope-standard-format`: Format enum API, sniffing load +
+  getWireFormat(), EventEmitter format resolution at both encode points, EventApiService
+  response mirroring, 8 new tests incl. golden vectors
+  (`system/platform-core/src/test/resources/envelope-vectors/vectors.json` — share with
+  the Rust session), spec page `docs/guides/event-envelope-wire-format.md`. Spec
+  adjustment from implementation: body is when-set on encode (MsgPack.packMap skips
+  nulls); Rust decoder needs a serde default on `body`. Next: PR review/merge, then
+  Phase 2 (Rust /api/event, OTHER session) + live two-runtime interop test; version
+  number for the carrying release still open. → serves `vision-mercury-composable`
+  (polyglot deployment)
+  <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-215951 -->
 
 - [ ] (field support — 2026-07-21) **v4.9.1 REJECTED by the field Sonar quality gate; remediation
   MERGED (PR #210, `7110561c`), v4.9.2 release in flight for the field rescan.** 19 issues

--- a/memory/sessions/2026-07-21-215951.md
+++ b/memory/sessions/2026-07-21-215951.md
@@ -1,0 +1,82 @@
+# Session (2026-07-21T21:59:51Z)
+
+**Agent:** Claude Code
+
+## Work Done
+
+**Designed the common event envelope wire format for cross-language interop** (Eric's
+request: the Rust port has an Event-over-HTTP feature gap; the Java compact single-char
+keys are proprietary; derive a generic MsgPack presentation any language can implement).
+Design doc: `draft-design-specs/event-envelope-interop-design.md` (gitignored draft;
+graduates into a docs reference page at implementation). Rust port examined READ-ONLY —
+another session owns its edits.
+
+**Investigation findings (both codebases):**
+- Java `EventEnvelope.toBytes()/load()` = MsgPack with 18 single-char flag keys ("0" id,
+  "T" to, "F" from, "R" reply_to, "t"/"p"/"s" trace, "X" cid, "S" status, "H" headers,
+  "B" body, "7" tags, "6" annotations, "4" exception, "5" stack, "O" obj_type,
+  "1" exec_time, "2" round_trip). BUT `toMap()/fromMap()` already maintain a descriptive
+  snake_case form — the common format is a promotion of the existing in-memory form, not
+  an invention.
+- Rust `EventEnvelope` (crates/platform-core/src/envelope.rs) already serializes the
+  descriptive form via `rmp_serde::to_vec_named`: core fields id/to/from/reply_to/cid/
+  trace_id/trace_path/span_id/status/headers/body/exec_time. No tags/annotations/
+  round_trip/exception/stack/obj_type. No /api/event yet (the gap).
+- Java `exceptionBytes` is `ObjectOutputStream` Java serialization — non-portable by
+  definition; excluded from the standard format (portable error = status + body message +
+  stack text).
+
+**Design pillars:** (1) standard envelope = MsgPack map with descriptive string keys;
+required-on-encode id/headers/body, everything else optional, unknown keys ignored, no
+MsgPack ext types, ISO-8601 strings for timestamps; (2) compact and standard key
+namespaces are DISJOINT (1-char vs ≥2-char) → decoders sniff, no negotiation needed;
+(3) encode policy: requester chooses (config `event.over.http.format` + per-call header),
+responder mirrors the request's format; compact stays the default for one release, then
+flips; (4) three-phase plan: Java encode/decode+sniff+docs spec page → Rust /api/event
+(other session, testbed) → future ports from the spec page alone; (5) golden-vector
+fixtures shared across repos + live two-runtime interop tests + fresh-agent test on the
+spec page; (6) draft ADR text included (human gate).
+
+Also: **design REVIEWED and key decisions confirmed by Eric same day** — default =
+`standard` (his insight: Event over HTTP is transport, not storage; no serialized payload
+outlives the exchange, so both parties upgrade together and the migration caution is
+unnecessary); `compact` kept as the explicit fallback for slow-to-upgrade installations
+(the FIFO-vs-BDB elastic-queue precedent); config key `event.over.http.format` and
+per-request `x-event-format` header confirmed as designed. Design doc §4/§8 updated.
+Still open, non-blocking: version number, Kafka-mesh migration, golden-vector home.
+
+Also: **API shape agreed** (Eric proposed `toMap(boolean standard)` with compact default;
+review found today's `toMap()` is already the standard form with in-process callers —
+EventEmitter's `EventEnvelope.of(event.toMap())` clone path — so a compact default would
+silently break cloning; boolean selector also invites Sonar S2301). Agreed final shape:
+`enum Format {COMPACT, STANDARD}`; `toMap(Format)` / `toBytes(Format)`; no-arg
+`toMap()` = STANDARD and no-arg `toBytes()` = COMPACT (both preserving today's behavior);
+`load()` sniffs automatically. Eric: "the enum is future proof." Outbound format is
+transport policy — groundwork for future event-to-bytes transports (Redis, S3).
+
+Also: **Phase 1 IMPLEMENTED** (branch `feature/event-envelope-standard-format`, Java only —
+Rust untouched per Eric's instruction). Delivered: (1) `EventEnvelope.Format` enum +
+`toMap(Format)`/`toBytes(Format)` with behavior-preserving no-arg defaults + sniffing
+`load()` + `getWireFormat()` (the mirroring observable); (2) EventEmitter: `httpEventFormat`
+resolution (per-call `x-event-format` header consumed client-side and stripped, else
+`event.over.http.format` config, default standard) applied at both encode points
+(asyncRequest + eRequest — yaml.event.over.http per-target headers get the override for
+free); (3) EventApiService mirrors the request's detected format in responses (COMPACT
+fallback when the request never decoded); (4) tests: 5 new EventEnvelopeTest cases
+(28/28 green), 2 EventHttpTest mirroring cases over the real HTTP stack (15/15), and
+`EnvelopeWireFormatVectorTest` + 6 frozen golden vectors in
+`src/test/resources/envelope-vectors/vectors.json` (semantic comparison, canonicalized —
+byte order is not part of the contract) for the Rust side to mirror; (5) docs: new
+self-contained spec page `event-envelope-wire-format.md` (nav + llms.txt + event-over-http
+guide + config-reference key), CHANGELOG Unreleased entry.
+**Implementation findings:** `MsgPack.packMap` skips null values (unless
+`serializer.null.transport`) → spec adjusted: required-on-encode = id + headers only; body
+when-set, decoders default missing body to nil (Rust needs a serde default on `body` —
+noted for the other session). The `optional` TAG makes `getBody()` wrap in Optional —
+avoid it as a demo tag in tests.
+
+## Memory References
+
+- referenced: typed-io-map-or-pojo, instant-serialization (serialization conventions the
+  spec inherits), conv-serialization-gotchas (integer-width rule in the spec)
+- created: thread-event-envelope-interop

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
     - Annotations Reference: guides/annotations-reference.md
     - Configuration Reference: guides/configuration-reference.md
     - Event Envelope Reference: guides/event-envelope-reference.md
+    - Event Envelope Wire Format: guides/event-envelope-wire-format.md
     - Reserved Names & Headers: guides/reserved-names-and-headers.md
     - Actuators & HTTP Client: guides/actuators-and-http-client.md
     - Release Notes: https://github.com/Accenture/mercury-composable/blob/main/CHANGELOG.md

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
@@ -104,6 +104,23 @@ public class EventEnvelope {
     private Float executionTime;
     private Float roundTrip;
     private boolean exRestored = false;
+    private Format wireFormat;
+
+    /**
+     * Serialized representations of an event envelope.
+     * <p>
+     * COMPACT is the classic wire format using single-character map keys.
+     * STANDARD is the language-neutral interchange format using descriptive
+     * map keys (see the "Event Envelope wire format" reference page) so that
+     * any MsgPack-capable language can encode and decode it.
+     * <p>
+     * Decoding is automatic: {@link #load(byte[])} detects the format because
+     * the two key namespaces are disjoint (compact keys are exactly one
+     * character; standard keys are all longer). Encoding is transport policy:
+     * a transport selects the format explicitly via {@link #toBytes(Format)}
+     * or {@link #toMap(Format)}.
+     */
+    public enum Format { COMPACT, STANDARD }
 
     public static EventEnvelope of() {
         return new EventEnvelope();
@@ -821,12 +838,44 @@ public class EventEnvelope {
             Object o = msgPack.unpack(bytes);
             if (o instanceof Map) {
                 Map<String, Object> message = (Map<String, Object>) o;
-                loadKeyValuePart1(message);
-                loadKeyValuePart2(message);
+                if (isStandardFormat(message)) {
+                    wireFormat = Format.STANDARD;
+                    fromMap(message);
+                } else {
+                    wireFormat = Format.COMPACT;
+                    loadKeyValuePart1(message);
+                    loadKeyValuePart2(message);
+                }
             }
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * The compact and standard key namespaces are disjoint: compact keys are
+     * exactly one character while standard keys are all longer, so the format
+     * of a serialized envelope is detected from its keys without any
+     * out-of-band signal. An empty map decodes as an empty envelope either way.
+     */
+    private static boolean isStandardFormat(Map<String, Object> message) {
+        for (String k : message.keySet()) {
+            if (k.length() > 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The serialization format detected by the most recent {@link #load(byte[])},
+     * or null if this envelope was not created from a serialized form. A
+     * transport that answers a request can mirror the requester's format.
+     *
+     * @return the detected wire format or null
+     */
+    public Format getWireFormat() {
+        return wireFormat;
     }
 
     @SuppressWarnings("unchecked")
@@ -894,15 +943,34 @@ public class EventEnvelope {
     }
 
     /**
-     * Serialize the EventEnvelope as a byte array
+     * Serialize the EventEnvelope as a byte array in the classic compact format.
+     * <p>
+     * This no-argument form is equivalent to {@code toBytes(Format.COMPACT)} and
+     * preserves the historical wire behavior for same-language transports
+     * (service mesh, streams). A transport that needs cross-language
+     * interoperability selects {@link Format#STANDARD} explicitly.
      *
      * @return byte array
      * @throws IllegalArgumentException in case of encoding errors
      */
     public byte[] toBytes() {
-        Map<String, Object> message = packSomeKeyValues();
+        return toBytes(Format.COMPACT);
+    }
+
+    /**
+     * Serialize the EventEnvelope as a byte array in the given format.
+     * <p>
+     * The format is transport policy: the envelope owns both representations
+     * and a transport (Event over HTTP today; other event-to-bytes transports
+     * in the future) decides which one rides on its wire.
+     *
+     * @param format COMPACT (single-character keys) or STANDARD (descriptive keys)
+     * @return byte array
+     * @throws IllegalArgumentException in case of encoding errors
+     */
+    public byte[] toBytes(Format format) {
         try {
-            return msgPack.pack(packMoreKeyValues(message));
+            return msgPack.pack(toMap(format));
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }
@@ -1040,8 +1108,40 @@ public class EventEnvelope {
         }
     }
 
+    /**
+     * Export this envelope as a map with descriptive (standard) keys.
+     * Equivalent to {@code toMap(Format.STANDARD)}.
+     *
+     * @return map of key-values
+     */
     public Map<String, Object> toMap() {
-        return toKeyValuePart2(toKeyValuePart1());
+        return toMap(Format.STANDARD);
+    }
+
+    /**
+     * Export this envelope as a map in the given format.
+     * <p>
+     * The STANDARD map always carries {@code id} and {@code headers} (the
+     * language-neutral wire contract's required fields); {@code body} is
+     * present when set. The COMPACT map is the classic single-character-key
+     * representation used by {@link #toBytes()}.
+     *
+     * @param format COMPACT or STANDARD
+     * @return map of key-values
+     */
+    public Map<String, Object> toMap(Format format) {
+        if (format == Format.COMPACT) {
+            return packMoreKeyValues(packSomeKeyValues());
+        }
+        if (id == null) {
+            // every envelope has an identity - self-heal before export
+            id = util.getUuid();
+        }
+        Map<String, Object> message = toKeyValuePart2(toKeyValuePart1());
+        // "headers" is required-on-encode in the standard wire contract,
+        // so statically-typed decoders need no per-field default plumbing
+        message.put(HEADERS_FIELD, headers);
+        return message;
     }
 
     private Map<String, Object> toKeyValuePart1() {

--- a/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
@@ -70,10 +70,12 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                 try {
                     handleRequest(sessionInfo, headers, instance, b, input, timeout, async);
                 } catch (Exception e) {
-                    sendError(input, 400, e.getMessage());
+                    // the envelope could not be decoded, so its format is unknown -
+                    // fall back to the classic compact format for the error reply
+                    sendError(input, EventEnvelope.Format.COMPACT, 400, e.getMessage());
                 }
             } else {
-                sendError(input, 500, "Invalid event-over-http data format");
+                sendError(input, EventEnvelope.Format.COMPACT, 500, "Invalid event-over-http data format");
             }
         }
         return null;
@@ -83,13 +85,18 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                                byte[] requestBody, EventEnvelope input,
                                long timeout, boolean async) {
         EventEnvelope request = new EventEnvelope(requestBody);
+        // Mirror the requester's serialization format in the response so a
+        // caller on either wire format (compact or standard) needs no
+        // configuration to read the reply.
+        EventEnvelope.Format format = request.getWireFormat() == null?
+                EventEnvelope.Format.COMPACT : request.getWireFormat();
         // propagate session info if any
         sessionInfo.forEach(request::setHeader);
         PostOffice po = new PostOffice(headers, instance);
         if (request.getTo() != null) {
             if (po.exists(request.getTo())) {
                 if (Platform.getInstance().isPrivate(request.getTo())) {
-                    sendError(input, 403, request.getTo() + PRIVATE_FUNCTION);
+                    sendError(input, format, 403, request.getTo() + PRIVATE_FUNCTION);
                 } else {
                     if (async) {
                         // Drop-n-forget
@@ -99,37 +106,37 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                         ackBody.put(DELIVERED, true);
                         ackBody.put(TIME, new Date());
                         EventEnvelope pending = new EventEnvelope().setStatus(202).setBody(ackBody);
-                        sendResponse(input, pending);
+                        sendResponse(input, format, pending);
                     } else {
                         // RPC
                         po.asyncRequest(request, timeout)
-                                .onSuccess(result -> sendResponse(input, result))
-                                .onFailure(e -> sendError(input, 408, e.getMessage()));
+                                .onSuccess(result -> sendResponse(input, format, result))
+                                .onFailure(e -> sendError(input, format, 408, e.getMessage()));
                     }
                 }
             } else {
-                sendError(input, 404, ROUTE + request.getTo() + NOT_FOUND);
+                sendError(input, format, 404, ROUTE + request.getTo() + NOT_FOUND);
             }
         } else {
-            sendError(input, 400, MISSING_ROUTING_PATH);
+            sendError(input, format, 400, MISSING_ROUTING_PATH);
         }
     }
 
-    private void sendResponse(EventEnvelope input, EventEnvelope result) {
+    private void sendResponse(EventEnvelope input, EventEnvelope.Format format, EventEnvelope result) {
         try {
             EventEnvelope response = new EventEnvelope().setTo(input.getReplyTo())
                     .setFrom(EVENT_API_SERVICE)
                     .setTrace(input.getTraceId(), input.getTracePath())
                     .setCorrelationId(input.getCorrelationId())
                     .setHeader(CONTENT_TYPE, OCTET_STREAM)
-                    .setBody(result.toBytes());
+                    .setBody(result.toBytes(format));
             EventEmitter.getInstance().send(response);
         } catch (IllegalArgumentException e) {
             log.error("Unable to send response {} -> {} - {}", EVENT_API_SERVICE, input.getReplyTo(), e.getMessage());
         }
     }
 
-    private void sendError(EventEnvelope input, int status, String error) {
+    private void sendError(EventEnvelope input, EventEnvelope.Format format, int status, String error) {
         try {
             EventEnvelope result = new EventEnvelope().setStatus(status).setBody(error);
             EventEnvelope response = new EventEnvelope().setTo(input.getReplyTo())
@@ -138,7 +145,7 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                     .setCorrelationId(input.getCorrelationId())
                     .setHeader(CONTENT_TYPE, OCTET_STREAM)
                     .setStatus(status)
-                    .setBody(result.toBytes());
+                    .setBody(result.toBytes(format));
             EventEmitter.getInstance().send(response);
         } catch (IllegalArgumentException e) {
             log.error("Unable to send error {} -> {} - {}", EVENT_API_SERVICE, input.getReplyTo(), e.getMessage());

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -71,6 +71,10 @@ public class EventEmitter {
     private static final String X_TTL = "x-ttl";
     private static final String X_ASYNC = "x-async";
     private static final String X_TRACE_ID = "x-trace-id";
+    private static final String X_EVENT_FORMAT = "x-event-format";
+    private static final String EVENT_HTTP_FORMAT_PROPERTY = "event.over.http.format";
+    private static final String COMPACT_FORMAT = "compact";
+    private static final String STANDARD_FORMAT = "standard";
     private static final String ROUTE_SUBSTITUTION = "route.substitution";
     private static final String ROUTE_SUBSTITUTION_YAML = "yaml.route.substitution";
     private static final String ROUTE_SUBSTITUTION_FEATURE = "application.feature.route.substitution";
@@ -665,6 +669,36 @@ public class EventEmitter {
         return eventHttpTargets.get(slash == -1? route : route.substring(0, slash));
     }
 
+    /**
+     * Resolve the envelope serialization format for an outgoing Event-over-HTTP
+     * call. A per-call "x-event-format" header (including one declared per target
+     * in yaml.event.over.http) overrides the application default from the
+     * "event.over.http.format" property. The default is the language-neutral
+     * STANDARD format; "compact" selects the classic single-character-key format
+     * as a fallback for peers that have not upgraded yet.
+     */
+    private EventEnvelope.Format httpEventFormat(Map<String, String> headers) {
+        if (headers != null) {
+            for (Map.Entry<String, String> kv : headers.entrySet()) {
+                if (X_EVENT_FORMAT.equalsIgnoreCase(kv.getKey())) {
+                    return parseEventFormat(kv.getValue());
+                }
+            }
+        }
+        return parseEventFormat(AppConfigReader.getInstance()
+                .getProperty(EVENT_HTTP_FORMAT_PROPERTY, STANDARD_FORMAT));
+    }
+
+    private EventEnvelope.Format parseEventFormat(String value) {
+        if (COMPACT_FORMAT.equalsIgnoreCase(value)) {
+            return EventEnvelope.Format.COMPACT;
+        }
+        if (!STANDARD_FORMAT.equalsIgnoreCase(value)) {
+            log.warn("Unknown event envelope format '{}' - using {}", value, STANDARD_FORMAT);
+        }
+        return EventEnvelope.Format.STANDARD;
+    }
+
     public Map<String, String> getEventHttpHeaders(String route) {
         int slash = route.indexOf('@');
         return eventHttpHeaders.get(slash == -1? route : route.substring(0, slash));
@@ -825,10 +859,13 @@ public class EventEmitter {
         if (!rpc) {
             req.setHeader(X_ASYNC, "true");
         }
-        // optional HTTP request headers
+        // optional HTTP request headers ("x-event-format" is a client-side
+        // serialization instruction - consumed here, not sent to the peer)
         if (headers != null) {
             for (Map.Entry<String, String> kv : headers.entrySet()) {
-                req.setHeader(kv.getKey(), kv.getValue());
+                if (!X_EVENT_FORMAT.equalsIgnoreCase(kv.getKey())) {
+                    req.setHeader(kv.getKey(), kv.getValue());
+                }
             }
         }
         // propagate trace context: X-Trace-Id plus W3C "traceparent" (traceId + spanId) if available
@@ -842,7 +879,7 @@ public class EventEmitter {
         }
         req.setUrl(url.getPath());
         req.setTargetHost(getTargetFromUrl(url));
-        byte[] b = event.toBytes();
+        byte[] b = event.toBytes(httpEventFormat(headers));
         req.setBody(b);
         req.setContentLength(b.length);
         EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
@@ -961,10 +998,13 @@ public class EventEmitter {
         if (!rpc) {
             req.setHeader(X_ASYNC, "true");
         }
-        // optional HTTP request headers
+        // optional HTTP request headers ("x-event-format" is a client-side
+        // serialization instruction - consumed here, not sent to the peer)
         if (headers != null) {
             for (Map.Entry<String, String> kv : headers.entrySet()) {
-                req.setHeader(kv.getKey(), kv.getValue());
+                if (!X_EVENT_FORMAT.equalsIgnoreCase(kv.getKey())) {
+                    req.setHeader(kv.getKey(), kv.getValue());
+                }
             }
         }
         // propagate trace context: X-Trace-Id plus W3C "traceparent" (traceId + spanId) if available
@@ -978,7 +1018,7 @@ public class EventEmitter {
         }
         req.setUrl(url.getPath());
         req.setTargetHost(getTargetFromUrl(url));
-        byte[] b = event.toBytes();
+        byte[] b = event.toBytes(httpEventFormat(headers));
         req.setBody(b);
         req.setContentLength(b.length);
         EventEnvelope apiRequest = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);

--- a/system/platform-core/src/test/java/org/platformlambda/core/EnvelopeWireFormatVectorTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EnvelopeWireFormatVectorTest.java
@@ -1,0 +1,96 @@
+/*
+    Copyright 2018-2026 Accenture Technology
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package org.platformlambda.core;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.serializers.SimpleMapper;
+import org.platformlambda.core.util.Utility;
+
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Golden vectors for the event envelope wire format - the cross-language
+ * interoperability contract. The fixture file is shared verbatim with the
+ * official Rust port, so any change that fails this test would also break a
+ * peer implementation decoding the same bytes.
+ * <p>
+ * The comparison is semantic (decoded field values), never byte-identical:
+ * MsgPack map ordering is unspecified and differs between languages.
+ */
+class EnvelopeWireFormatVectorTest {
+
+    private static final String VECTOR_FILE = "/envelope-vectors/vectors.json";
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void goldenVectorsDecodeAndRoundTrip() throws Exception {
+        Map<String, Object> fixture;
+        try (InputStream in = this.getClass().getResourceAsStream(VECTOR_FILE)) {
+            assertNotNull(in, "vector fixture must exist: " + VECTOR_FILE);
+            String json = Utility.getInstance().stream2str(in);
+            fixture = SimpleMapper.getInstance().getMapper().readValue(json, Map.class);
+        }
+        List<Map<String, Object>> vectors = (List<Map<String, Object>>) fixture.get("vectors");
+        assertFalse(vectors.isEmpty());
+        for (Map<String, Object> vector : vectors) {
+            String name = (String) vector.get("name");
+            EventEnvelope.Format format = EventEnvelope.Format.valueOf(
+                    ((String) vector.get("format")).toUpperCase());
+            byte[] bytes = Base64.getDecoder().decode((String) vector.get("base64"));
+            Map<String, Object> expect = (Map<String, Object>) vector.get("expect");
+            // 1) the frozen bytes decode with automatic format detection
+            EventEnvelope decoded = new EventEnvelope(bytes);
+            assertEquals(format, decoded.getWireFormat(), name + ": detected format");
+            assertStandardView(name, expect, decoded);
+            // 2) re-encode in the same format and decode again - semantic round trip
+            EventEnvelope roundTrip = new EventEnvelope(decoded.toBytes(format));
+            assertStandardView(name + " (round trip)", expect, roundTrip);
+        }
+    }
+
+    /**
+     * Compare the decoded envelope against the expected values through its
+     * standard map view, using canonicalized JSON rendering (sorted map keys)
+     * for deep semantic equality - map ordering is not part of the contract.
+     */
+    private void assertStandardView(String name, Map<String, Object> expect, EventEnvelope decoded) {
+        Map<String, Object> actual = decoded.toMap(EventEnvelope.Format.STANDARD);
+        var mapper = SimpleMapper.getInstance().getMapper();
+        for (Map.Entry<String, Object> kv : expect.entrySet()) {
+            String expectedJson = mapper.writeValueAsString(canonical(kv.getValue()));
+            String actualJson = mapper.writeValueAsString(canonical(actual.get(kv.getKey())));
+            assertEquals(expectedJson, actualJson, name + ": field '" + kv.getKey() + "'");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object canonical(Object value) {
+        if (value instanceof Map) {
+            Map<String, Object> sorted = new TreeMap<>();
+            ((Map<String, Object>) value).forEach((k, v) -> sorted.put(k, canonical(v)));
+            return sorted;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::canonical).toList();
+        }
+        return value;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventEnvelopeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventEnvelopeTest.java
@@ -18,6 +18,7 @@ import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.Kv;
 import org.platformlambda.core.models.PoJo;
+import org.platformlambda.core.serializers.MsgPack;
 import org.platformlambda.core.serializers.SimpleMapper;
 import org.platformlambda.core.system.EventEmitter;
 import org.platformlambda.core.util.AppConfigReader;
@@ -26,6 +27,7 @@ import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.*;
 import java.util.*;
@@ -413,5 +415,125 @@ class EventEnvelopeTest {
         assertInstanceOf(RuntimeException.class, ex);
         assertEquals(400, target.getStatus());
         assertEquals(message, ex.getMessage());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void standardFormatRoundTrip() throws IOException {
+        EventEnvelope source = fullyLoadedEnvelope();
+        byte[] b = source.toBytes(EventEnvelope.Format.STANDARD);
+        // the wire carries descriptive keys - the language-neutral contract
+        Map<String, Object> raw = (Map<String, Object>) new MsgPack().unpack(b);
+        assertTrue(raw.containsKey("id"));
+        assertTrue(raw.containsKey("to"));
+        assertTrue(raw.containsKey("reply_to"));
+        assertTrue(raw.containsKey("trace_id"));
+        assertTrue(raw.containsKey("headers"));
+        assertTrue(raw.containsKey("body"));
+        for (String k : raw.keySet()) {
+            assertTrue(k.length() > 1, "standard keys are all longer than one character: " + k);
+        }
+        EventEnvelope restored = new EventEnvelope(b);
+        assertEquals(EventEnvelope.Format.STANDARD, restored.getWireFormat());
+        assertEnvelopeEquals(source, restored);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void compactFormatUnchanged() throws IOException {
+        EventEnvelope source = fullyLoadedEnvelope();
+        // the no-argument form remains the classic compact wire format
+        byte[] b = source.toBytes();
+        Map<String, Object> raw = (Map<String, Object>) new MsgPack().unpack(b);
+        for (String k : raw.keySet()) {
+            assertEquals(1, k.length(), "compact keys are single characters: " + k);
+        }
+        EventEnvelope restored = new EventEnvelope(b);
+        assertEquals(EventEnvelope.Format.COMPACT, restored.getWireFormat());
+        assertEnvelopeEquals(source, restored);
+    }
+
+    @Test
+    void loadSniffsBothFormats() {
+        EventEnvelope source = fullyLoadedEnvelope();
+        EventEnvelope fromStandard = new EventEnvelope(source.toBytes(EventEnvelope.Format.STANDARD));
+        EventEnvelope fromCompact = new EventEnvelope(source.toBytes(EventEnvelope.Format.COMPACT));
+        assertEnvelopeEquals(fromStandard, fromCompact);
+        // an envelope not created from bytes has no wire format
+        assertNull(source.getWireFormat());
+    }
+
+    @Test
+    void noArgToMapIsStandardAndClonable() {
+        EventEnvelope source = fullyLoadedEnvelope();
+        Map<String, Object> map = source.toMap();
+        assertTrue(map.containsKey("id"));
+        assertTrue(map.containsKey("headers"));
+        // the in-process clone path (EventEnvelope.of(event.toMap())) must survive
+        EventEnvelope clone = EventEnvelope.of(source.toMap());
+        assertEnvelopeEquals(source, clone);
+    }
+
+    @Test
+    void standardMapAlwaysCarriesIdAndHeaders() {
+        // even a bare envelope satisfies the wire contract's required fields
+        EventEnvelope bare = new EventEnvelope();
+        Map<String, Object> map = bare.toMap(EventEnvelope.Format.STANDARD);
+        assertNotNull(map.get("id"));
+        assertInstanceOf(Map.class, map.get("headers"));
+        assertTrue(((Map<?, ?>) map.get("headers")).isEmpty());
+    }
+
+    private EventEnvelope fullyLoadedEnvelope() {
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("text", "hello world");
+        nested.put("number", 12345);
+        nested.put("unicode", "你好世界");
+        nested.put("list", List.of(1, 2, 3));
+        nested.put("binary", "hello".getBytes());
+        return new EventEnvelope()
+                .setTo("target.route").setFrom("source.route").setReplyTo("reply.route")
+                .setCorrelationId("cid-1001").setTrace("trace-2002", "GET /api/demo")
+                .setHeader("x-demo", "true").setHeader("session", "abc")
+                .setStatus(200).setBody(nested)
+                .setExecutionTime(1.5f).setRoundTrip(2.5f)
+                .addTag("routing", "demo").setAnnotations(Map.of("note", "n1"));
+    }
+
+    private void assertEnvelopeEquals(EventEnvelope expected, EventEnvelope actual) {
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getTo(), actual.getTo());
+        assertEquals(expected.getFrom(), actual.getFrom());
+        assertEquals(expected.getReplyTo(), actual.getReplyTo());
+        assertEquals(expected.getCorrelationId(), actual.getCorrelationId());
+        assertEquals(expected.getTraceId(), actual.getTraceId());
+        assertEquals(expected.getTracePath(), actual.getTracePath());
+        assertEquals(expected.getStatus(), actual.getStatus());
+        assertEquals(expected.getHeaders(), actual.getHeaders());
+        assertEquals(normalizeBinary(expected.getBody()), normalizeBinary(actual.getBody()));
+        assertEquals(expected.getTags(), actual.getTags());
+        assertEquals(expected.getAnnotations(), actual.getAnnotations());
+        assertEquals(expected.getExecutionTime(), actual.getExecutionTime());
+        assertEquals(expected.getRoundTrip(), actual.getRoundTrip());
+    }
+
+    /**
+     * byte[] does not implement value equality - render binary values as
+     * base64 strings recursively so nested structures compare semantically.
+     */
+    @SuppressWarnings("unchecked")
+    private Object normalizeBinary(Object value) {
+        if (value instanceof byte[] b) {
+            return Base64.getEncoder().encodeToString(b);
+        }
+        if (value instanceof Map) {
+            Map<String, Object> result = new HashMap<>();
+            ((Map<String, Object>) value).forEach((k, v) -> result.put(k, normalizeBinary(v)));
+            return result;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::normalizeBinary).toList();
+        }
+        return value;
     }
 }

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
@@ -347,4 +347,51 @@ class EventHttpTest extends TestBase {
         assertEquals("demo", map.getElement("headers.user"));
         assertEquals(numberThree, map.getElement("body"));
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void standardFormatIsDefaultAndMirrored() throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        long timeout = 3000;
+        Map<String, String> securityHeaders = new HashMap<>();
+        securityHeaders.put("Authorization", "demo");
+        PostOffice po = PostOffice.trackable("unit.test", "9001", "TEST /remote/event/standard");
+        EventEnvelope event = new EventEnvelope().setTo("hello.world")
+                .setBody("interop").setHeader("hello", "world");
+        Future<EventEnvelope> response = po.asyncRequest(event, timeout, securityHeaders,
+                "http://127.0.0.1:"+port+"/api/event", true);
+        response.onSuccess(bench::add);
+        EventEnvelope result = bench.poll(timeout, TimeUnit.MILLISECONDS);
+        assertNotNull(result);
+        assertEquals(200, result.getStatus());
+        // the service mirrors the requester's format - with the standard default,
+        // the response envelope arrives in the standard wire format
+        assertEquals(EventEnvelope.Format.STANDARD, result.getWireFormat());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) result.getBody());
+        assertEquals("interop", map.getElement("body"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void compactFallbackByHeaderIsMirrored() throws InterruptedException {
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        long timeout = 3000;
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "demo");
+        // the per-call serialization instruction - consumed by the client, not sent
+        headers.put("x-event-format", "compact");
+        PostOffice po = PostOffice.trackable("unit.test", "9002", "TEST /remote/event/compact");
+        EventEnvelope event = new EventEnvelope().setTo("hello.world")
+                .setBody("legacy").setHeader("hello", "world");
+        Future<EventEnvelope> response = po.asyncRequest(event, timeout, headers,
+                "http://127.0.0.1:"+port+"/api/event", true);
+        response.onSuccess(bench::add);
+        EventEnvelope result = bench.poll(timeout, TimeUnit.MILLISECONDS);
+        assertNotNull(result);
+        assertEquals(200, result.getStatus());
+        // the compact request is understood (sniffed) and the reply mirrors it
+        assertEquals(EventEnvelope.Format.COMPACT, result.getWireFormat());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) result.getBody());
+        assertEquals("legacy", map.getElement("body"));
+    }
 }

--- a/system/platform-core/src/test/resources/envelope-vectors/vectors.json
+++ b/system/platform-core/src/test/resources/envelope-vectors/vectors.json
@@ -1,0 +1,114 @@
+{
+  "comment": "Golden vectors for the event envelope wire format. Decode base64 as MsgPack and compare with 'expect' semantically. Shared with the Rust port for cross-language verification.",
+  "vectors": [
+    {
+      "name": "standard-minimal",
+      "format": "standard",
+      "base64": "gqdoZWFkZXJzgKJpZKVlMDAwMQ==",
+      "expect": {
+        "headers": {},
+        "id": "e0001"
+      }
+    },
+    {
+      "name": "standard-scalar-body",
+      "format": "standard",
+      "base64": "hadoZWFkZXJzgaVoZWxsb6V3b3JsZKJpZKVlMDAwMqJ0b6toZWxsby53b3JsZKRib2R5q2hlbGxvIHdvcmxkpnN0YXR1c8zI",
+      "expect": {
+        "headers": {
+          "hello": "world"
+        },
+        "id": "e0002",
+        "to": "hello.world",
+        "body": "hello world",
+        "status": 200
+      }
+    },
+    {
+      "name": "standard-full-metadata",
+      "format": "standard",
+      "base64": "jqdoZWFkZXJzgqJrMaJ2MaJrMqJ2Mqh0cmFjZV9pZKp0cmFjZS0yMDAyq2Fubm90YXRpb25zgaRub3Rlom4xpGJvZHmobWV0YWRhdGGkdGFnc4Gncm91dGluZ6RkZW1vqHJlcGx5X3Rvq3JlcGx5LnJvdXRlqWV4ZWNfdGltZco/wAAApGZyb22sc291cmNlLnJvdXRlomlkpWUwMDAzonRvrHRhcmdldC5yb3V0Zap0cmFjZV9wYXRorUdFVCAvYXBpL2RlbW+qcm91bmRfdHJpcMpAIAAAo2NpZKhjaWQtMTAwMaZzdGF0dXPMyA==",
+      "expect": {
+        "headers": {
+          "k1": "v1",
+          "k2": "v2"
+        },
+        "trace_id": "trace-2002",
+        "annotations": {
+          "note": "n1"
+        },
+        "body": "metadata",
+        "tags": {
+          "routing": "demo"
+        },
+        "reply_to": "reply.route",
+        "exec_time": 1.5,
+        "from": "source.route",
+        "id": "e0003",
+        "to": "target.route",
+        "trace_path": "GET /api/demo",
+        "round_trip": 2.5,
+        "cid": "cid-1001",
+        "status": 200
+      }
+    },
+    {
+      "name": "standard-nested-body",
+      "format": "standard",
+      "base64": "hKdoZWFkZXJzgKJpZKVlMDAwNKJ0b6xuZXN0ZWQucm91dGWkYm9keYikdGV4dKtoZWxsbyB3b3JsZKd1bmljb2Rls+S9oOWlveS4lueVjCDOuyDimLqnaW50ZWdlcs0wOaRsb25nzwAgAAAAAAABp2RlY2ltYWzLQAwAAAAAAACkZmxhZ8OkbGlzdJMBAgOmbmVzdGVkgahpc29fdGltZbgyMDI2LTA3LTIxVDEyOjAwOjAwLjAwMFo=",
+      "expect": {
+        "headers": {},
+        "id": "e0004",
+        "to": "nested.route",
+        "body": {
+          "text": "hello world",
+          "unicode": "你好世界 λ ☺",
+          "integer": 12345,
+          "long": 9007199254740993,
+          "decimal": 3.5,
+          "flag": true,
+          "list": [
+            1,
+            2,
+            3
+          ],
+          "nested": {
+            "iso_time": "2026-07-21T12:00:00.000Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "standard-portable-error",
+      "format": "standard",
+      "base64": "hqdoZWFkZXJzgKVzdGFja7FsaW5lIG9uZQpsaW5lIHR3b6JpZKVlMDAwNaJ0b6tlcnJvci5yb3V0ZaRib2R5r3JvdXRlIG5vdCBmb3VuZKZzdGF0dXPNAZQ=",
+      "expect": {
+        "headers": {},
+        "stack": "line one\nline two",
+        "id": "e0005",
+        "to": "error.route",
+        "body": "route not found",
+        "status": 404
+      }
+    },
+    {
+      "name": "compact-full-metadata",
+      "format": "compact",
+      "base64": "iqEwpWUwMDA2oXCtR0VUIC9hcGkvZGVtb6FSq3JlcGx5LnJvdXRloUKmbGVnYWN5oVPMyKFUrHRhcmdldC5yb3V0ZaF0qnRyYWNlLTIwMDKhRqxzb3VyY2Uucm91dGWhWKhjaWQtMTAwMaFIgaJrMaJ2MQ==",
+      "expect": {
+        "headers": {
+          "k1": "v1"
+        },
+        "trace_id": "trace-2002",
+        "reply_to": "reply.route",
+        "from": "source.route",
+        "id": "e0006",
+        "to": "target.route",
+        "trace_path": "GET /api/demo",
+        "body": "legacy",
+        "cid": "cid-1001",
+        "status": 200
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Introduces the **standard** serialized event envelope — a MsgPack map with descriptive
string keys (`id`, `to`, `headers`, `body`, …) — as the default wire format for Event over
HTTP, replacing the proprietary single-character-key encoding on that transport. Any
MsgPack-capable language can now encode and decode the envelope with its idiomatic
tooling; the classic **compact** format remains fully supported.

- **API** — `EventEnvelope.Format {COMPACT, STANDARD}`, `toMap(Format)`, `toBytes(Format)`.
  The no-argument forms preserve their existing behavior (`toMap()` = standard map,
  `toBytes()` = compact wire), so in-process cloning, the Kafka service mesh, and stream
  paths are untouched — verified by the full reactor.
- **Automatic detection** — the compact and standard key namespaces are disjoint
  (single-character vs longer keys), so `load()` sniffs the format on every decode: no
  negotiation, no version field, no flag-day. `getWireFormat()` exposes what was detected.
- **Transport policy** — outbound format is chosen by the transport:
  `event.over.http.format` (default `standard`; `compact` as the fallback for peers on
  older versions) with a per-call `x-event-format` header override (consumed client-side,
  never transmitted; also usable per target in `yaml.event.over.http`). The `/api/event`
  service **mirrors** the requester's format in its response.
- **Spec + conformance** — a new self-contained reference page,
  [Event Envelope Wire Format](https://accenture.github.io/mercury-composable/guides/event-envelope-wire-format/),
  documents the field registry and encoding rules so a new language port can be
  implemented from the page alone; six golden vectors
  (`system/platform-core/src/test/resources/envelope-vectors/vectors.json`) are the
  cross-language conformance suite, to be shared verbatim with the Rust port.

## Why

The official Rust implementation has an Event over HTTP feature gap, and the compact
single-character keys — undocumented outside the Java source — were the barrier: the two
runtimes could not exchange envelopes, and every future port (Node.js re-port, Python, Go)
would face the same wall. The standard format is the existing descriptive `toMap()` form
promoted to a documented, normative contract, so this is a promotion of what both
implementations already almost share rather than an invention.

Event over HTTP is transport, not storage — no serialized payload outlives the exchange —
so the maintainer-reviewed design defaults to the standard format immediately, keeping
compact as an explicit fallback (the FIFO-vs-BDB precedent). The envelope owns its
representations; transports own format policy — laying the groundwork for future
event-to-bytes transports (Redis, S3). Design details and the review decisions are
recorded in the session logs riding in this PR.

Verified: full reactor green (951 tests, 0 failures, 29 modules). New coverage: envelope
round-trips in both formats, format sniffing, live HTTP response-format mirroring, and the
golden-vector decode/round-trip suite. The Rust port is deliberately untouched — its
`/api/event` implementation against this spec is a separate workstream.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)