### PR TITLE
test: adopt cross-engine parity follow-ups from the Rust-port exchange

### DIFF
--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -34,8 +34,11 @@ rest.server.port=8085
 rest.automation=true
 ```
 
-and then check if the following entry is configured in the "rest.yaml" endpoint definition file. 
-If not, update "rest.yaml" accordingly. The "timeout" value is set to 60 seconds to fit common use cases.
+The Event API endpoint is one of the **default system endpoints** (alongside the actuator
+endpoints): when REST automation starts, the following entry is merged into your "rest.yaml"
+automatically if you have not defined `POST /api/event` yourself — no configuration is needed.
+Define it explicitly only to customize the entry, for example to change the 60-second default
+timeout or to attach an authentication service (shown later in this page).
 
 ```yaml
   - service: [ "event.api.service" ]
@@ -45,7 +48,7 @@ If not, update "rest.yaml" accordingly. The "timeout" value is set to 60 seconds
     tracing: true
 ```
 
-This will expose the Event API endpoint at port 8085 and URL "/api/event". 
+This exposes the Event API endpoint at port 8085 and URL "/api/event". 
 
 In kubernetes, The Event API endpoint of each application is reachable through internal DNS and there is no need
 to create "ingress" for this purpose.

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-21 | agent: Claude Code (2026-07-21-215951)
+- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-004243)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -373,8 +373,14 @@
   for the Rust session: `/tmp/event-envelope-rust-handoff.md` (contract summary, compact
   decision + flag table, /api/event semantics, vector procedure, interop test plan) —
   Eric will ask this repo's session to REVIEW the Rust implementation for consistency
-  afterward. Next: PR merge, Phase 2 (Rust, OTHER session), live two-runtime interop
-  test; version number for the carrying release still open. → serves
+  afterward. **Phase 2 IMPLEMENTED in the Rust session (mercury increments 59-61, PRs
+  #163-#165) and REVIEWED for consistency 2026-07-22: high fidelity, no blockers** —
+  vectors byte-identical, envelope/service/client semantics match (see session
+  2026-07-22-004243 for the asymmetry list). Review follow-up: new additive golden vector
+  `standard-trace-context` (span_id coverage, their finding) on branch
+  `test/fetcher-cache-key-guard`; Rust re-syncs vectors.json + bumps its count assertion
+  (note: `/tmp/event-envelope-vectors-update.md`). Next: live two-runtime interop test;
+  version number for the carrying release still open. → serves
   `vision-mercury-composable` (polyglot deployment)
   <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-215951 -->
 

--- a/memory/sessions/2026-07-22-004243.md
+++ b/memory/sessions/2026-07-22-004243.md
@@ -1,0 +1,57 @@
+# Session (2026-07-22T00:42:43Z)
+
+**Agent:** Claude Code
+
+## Work Done
+
+**Adopted the fetcher cache-key regression guard from the Rust session** (hand-off note
+`/tmp/fetcher-cache-key-regression-handoff.md`; parity finding F6 — the Rust port had
+regressed to keying the provider cache on the whole staged fetch map, fixed it in mercury
+PR #158, and asked Java to add the equivalent call-counting guard since Java's behavior
+was already correct but untested). Branch `test/fetcher-cache-key-guard`, test-only:
+
+- `mock/CacheCounter.java` (test tree) — `mock.cache.counter`, AtomicLong counter returned
+  as `{count: n}`; route added to test rest.yaml (`GET /api/cache/counter/{id}`).
+- Fixture `graph/unit-test-cache-key.json` — translated verbatim from the Rust fixture
+  (`rust-cache-key.json`; graph models port unchanged): two fetchers → same provider via
+  two dictionaries declaring the same input (`person_id`) while staging different
+  undeclared `extra` params (alpha/beta). Registered in test graphs.yaml.
+- `GraphTests.fetcherCacheKeyUsesDictionaryDeclaredInputsOnly` — asserts the provider is
+  called EXACTLY once per run (counter delta) and both fetches see the same cached
+  response. **Passes on current main** — Java's dictionary-scoped key confirmed correct.
+
+Module green: 72 tests. Note: CompileGraph logs pre-existing cosmetic
+`missing '->'` ERRORs for plain-name Dictionary inputs (tutorial-3/5/6/12 + the new
+fixture alike) — the known [[thread-compilegraph-syntax-validation]] gap, not new.
+
+NB: Eric's message said the Rust session implemented event-over-http (Phase 2) — the
+hand-off file was this separate F6 ask; the event-over-http consistency review is still
+pending a pointer to the Rust implementation.
+
+Also: **Rust event-over-http Phase 2 consistency review DONE** (read-only, merges
+#163/#164/#165 = increments 59-61 at `64f3903a`). VERDICT: consistent with the spec and
+hand-off, high fidelity — vectors byte-identical; envelope serde exactly per the hand-off
+(body nil-default, skip_serializing_if, id+headers always, round_trip adopted);
+service status strings byte-identical to Java; x-ttl min-1000/x-async/202-ack/408 parity;
+compact rejected with the recommended 400 message; client stamps x-trace-id + traceparent.
+Deliberate acceptable asymmetries: Rust registers the service PRIVATE + rejects
+self-targeting (stricter than Java's silent no-op — possible future Java tightening);
+Rust client surfaces timeout as Err locally (wire behavior identical).
+CORRECTION (Eric's review of my review): I claimed /api/event ships by default only in
+Rust — WRONG. Java has the same mechanism: `default-rest.yaml` (POST /api/event + six
+actuator endpoints) merged by `RoutingEntry.addDefaultEndpoints` keyed on url+methods;
+the platform-core test rest.yaml even overrides it deliberately (its comment says so).
+The two engines are symmetric here. Real fix: event-over-http.md told readers to add the
+rest.yaml entry manually — reworded to document the default merge (override only to
+customize timeout/authentication). Their flag-backs: (1) vectors
+never exercised span_id — ACCEPTED, new additive vector `standard-trace-context` (e0007)
+appended to vectors.json (Java vector test green; Rust must re-copy + bump its
+`assert_eq!(standard, 5)` to 6 — note at `/tmp/event-envelope-vectors-update.md`);
+(2) round_trip conformance-required — intentional, §3.1 core field, no change.
+
+## Memory References
+
+- referenced: thread-event-envelope-interop (Phase 2 reported implemented in the Rust
+  session; consistency review still to come)
+- referenced: thread-compilegraph-syntax-validation (the cosmetic ERROR noise this
+  fixture also triggers)

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/mock/CacheCounter.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/mock/CacheCounter.java
@@ -1,0 +1,48 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.mock;
+
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Call-counting mock provider for the fetcher cache-key regression guard
+ * (parity finding F6). Each call increments a counter and returns it, so a
+ * test can assert exactly how many times a graph run reached the provider.
+ */
+@OptionalService("app.env=dev")
+@PreLoad(route = "mock.cache.counter", instances = 10)
+public class CacheCounter implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+
+    private static final AtomicLong COUNTER = new AtomicLong(0);
+
+    public static long current() {
+        return COUNTER.get();
+    }
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+        return Map.of("count", COUNTER.incrementAndGet());
+    }
+}

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tutorials/GraphTests.java
@@ -348,6 +348,28 @@ class GraphTests {
         log.info("Chained join counts only a fired upstream join");
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void fetcherCacheKeyUsesDictionaryDeclaredInputsOnly() throws TimeoutException {
+        // Parity guard (finding F6, mirrored in the Rust port): the provider cache key
+        // is built from the DICTIONARY-DECLARED inputs only. Two fetchers call the same
+        // provider through different dictionaries that declare the same input
+        // (person_id) while each fetcher stages a different undeclared parameter
+        // (extra=alpha vs extra=beta). Correct behavior: one provider call, second
+        // fetch served from cache. A regression to keying on the whole staged fetch
+        // map would make it two calls.
+        long before = com.accenture.minigraph.mock.CacheCounter.current();
+        var result = runGraph("unit-test-cache-key", Map.of("person_id", 100));
+        assertInstanceOf(Map.class, result);
+        var mm = new MultiLevelMap((Map<String, Object>) result);
+        long after = com.accenture.minigraph.mock.CacheCounter.current();
+        assertEquals(1, after - before,
+                "the provider must be called exactly once - the second fetch reads the cache");
+        assertEquals(mm.getElement("count1"), mm.getElement("count2"),
+                "both fetches must see the same cached response");
+        log.info("Fetcher cache key is scoped to dictionary-declared inputs");
+    }
+
     private Object runGraph(String graphId, Map<String, Object> input) throws TimeoutException {
         var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setBody(input).setHeader("Content-Type", "application/json")

--- a/system/minigraph-playground-engine/src/test/resources/graph/unit-test-cache-key.json
+++ b/system/minigraph-playground-engine/src/test/resources/graph/unit-test-cache-key.json
@@ -1,0 +1,127 @@
+{
+  "nodes": [
+    {
+      "types": ["Root"],
+      "alias": "root",
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": ["input.body.person_id -> model.person_id"],
+        "purpose": "Regression probe: the provider cache key is built from dictionary-declared inputs only (parity F6)",
+        "name": "unit-test-cache-key"
+      }
+    },
+    {
+      "types": ["Fetcher"],
+      "alias": "fetcher-1",
+      "properties": {
+        "skill": "graph.api.fetcher",
+        "input": [
+          "input.body.person_id -> person_id",
+          "text(alpha) -> extra"
+        ],
+        "dictionary": ["cache-name"],
+        "output": ["result.count -> output.body.count1"]
+      }
+    },
+    {
+      "types": ["Fetcher"],
+      "alias": "fetcher-2",
+      "properties": {
+        "skill": "graph.api.fetcher",
+        "input": [
+          "input.body.person_id -> person_id",
+          "text(beta) -> extra"
+        ],
+        "dictionary": ["cache-echo"],
+        "output": ["result.count -> output.body.count2"]
+      }
+    },
+    {
+      "types": ["Dictionary"],
+      "alias": "cache-name",
+      "properties": {
+        "input": ["person_id"],
+        "output": ["response.count -> result.count"],
+        "provider": "counter-api",
+        "purpose": "call count as seen by the first fetch"
+      }
+    },
+    {
+      "types": ["Dictionary"],
+      "alias": "cache-echo",
+      "properties": {
+        "input": ["person_id"],
+        "output": ["response.count -> result.count"],
+        "provider": "counter-api",
+        "purpose": "call count as seen by the second fetch"
+      }
+    },
+    {
+      "types": ["Provider"],
+      "alias": "counter-api",
+      "properties": {
+        "method": "GET",
+        "url": "http://127.0.0.1:${rest.server.port:8080}/api/cache/counter/{id}",
+        "input": [
+          "text(application/json) -> header.accept",
+          "person_id -> path_parameter.id"
+        ],
+        "purpose": "call-counting mock endpoint"
+      }
+    },
+    {
+      "types": ["Island"],
+      "alias": "dictionary",
+      "properties": {
+        "skill": "graph.island"
+      }
+    },
+    {
+      "types": ["End"],
+      "alias": "end",
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [{"type": "fetch", "properties": {}}],
+      "target": "fetcher-1"
+    },
+    {
+      "source": "fetcher-1",
+      "relations": [{"type": "then", "properties": {}}],
+      "target": "fetcher-2"
+    },
+    {
+      "source": "fetcher-2",
+      "relations": [{"type": "complete", "properties": {}}],
+      "target": "end"
+    },
+    {
+      "source": "root",
+      "relations": [{"type": "contains", "properties": {}}],
+      "target": "dictionary"
+    },
+    {
+      "source": "dictionary",
+      "relations": [{"type": "data", "properties": {}}],
+      "target": "cache-name"
+    },
+    {
+      "source": "dictionary",
+      "relations": [{"type": "data", "properties": {}}],
+      "target": "cache-echo"
+    },
+    {
+      "source": "cache-name",
+      "relations": [{"type": "provider", "properties": {}}],
+      "target": "counter-api"
+    },
+    {
+      "source": "cache-echo",
+      "relations": [{"type": "provider", "properties": {}}],
+      "target": "counter-api"
+    }
+  ]
+}

--- a/system/minigraph-playground-engine/src/test/resources/graphs.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/graphs.yaml
@@ -27,3 +27,4 @@ graphs:
   - 'unit-test-task-5'
   - 'unit-test-join-retry'
   - 'unit-test-join-chain'
+  - 'unit-test-cache-key'

--- a/system/minigraph-playground-engine/src/test/resources/rest.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/rest.yaml
@@ -110,6 +110,14 @@ rest:
     cors: cors_1
     headers: header_1
     tracing: true
+
+  - service: 'mock.cache.counter'
+    methods: ['GET']
+    url: '/api/cache/counter/{id}'
+    timeout: 10s
+    cors: cors_1
+    headers: header_1
+    tracing: true
 #
 # CORS HEADERS for pre-flight (HTTP OPTIONS) and normal responses
 #

--- a/system/platform-core/src/test/resources/envelope-vectors/vectors.json
+++ b/system/platform-core/src/test/resources/envelope-vectors/vectors.json
@@ -92,6 +92,25 @@
       }
     },
     {
+      "name": "standard-trace-context",
+      "format": "standard",
+      "base64": "iqdoZWFkZXJzgaJrMaJ2Mah0cmFjZV9pZNkgMGFmNzY1MTkxNmNkNDNkZDg0NDhlYjIxMWM4MDMxOWOnc3Bhbl9pZLBiN2FkNmI3MTY5MjAzMzMxpGZyb22sY2FsbGVyLnJvdXRlomlkpWUwMDA3onRvrHRyYWNlZC5yb3V0Zap0cmFjZV9wYXRos1BVVCAvYXBpL3RyYWNlL2RlbW+kYm9kea10cmFjZSBjb250ZXh0o2NpZKhjaWQtMzAwM6ZzdGF0dXPMyA==",
+      "expect": {
+        "headers": {
+          "k1": "v1"
+        },
+        "trace_id": "0af7651916cd43dd8448eb211c80319c",
+        "span_id": "b7ad6b7169203331",
+        "from": "caller.route",
+        "id": "e0007",
+        "to": "traced.route",
+        "trace_path": "PUT /api/trace/demo",
+        "body": "trace context",
+        "cid": "cid-3003",
+        "status": 200
+      }
+    },
+    {
       "name": "compact-full-metadata",
       "format": "compact",
       "base64": "iqEwpWUwMDA2oXCtR0VUIC9hcGkvZGVtb6FSq3JlcGx5LnJvdXRloUKmbGVnYWN5oVPMyKFUrHRhcmdldC5yb3V0ZaF0qnRyYWNlLTIwMDKhRqxzb3VyY2Uucm91dGWhWKhjaWQtMTAwMaFIgaJrMaJ2MQ==",


### PR DESCRIPTION
## What

Three small items from the Rust port's hand-offs and the Event-over-HTTP Phase-2
consistency review — test and docs only, no production change:

1. **Fetcher cache-key regression guard (parity finding F6).** Java's provider cache key
   was already correct — scoped to dictionary-declared inputs only — but had no test
   locking it down. The new guard mirrors the Rust port's: a call-counting mock endpoint
   (`mock.cache.counter`) plus the `unit-test-cache-key` fixture graph (translated
   verbatim from the Rust fixture — graph models port unchanged), in which two fetchers
   reach one provider through two dictionaries declaring the same input (`person_id`)
   while each stages a different undeclared parameter, with the knowledge layer isolated
   behind a `graph.island` node per the grammar. The test asserts the provider is called
   **exactly once** per run and both fetches read the same cached response; a regression
   to whole-map keying would make it two calls.

2. **New golden vector `standard-trace-context` (e0007).** The Rust session's conformance
   review found the wire-format vectors never exercised `span_id` — the field that
   cross-language trace parenting rides on. Additive only: vectors e0001–e0006 are
   byte-unchanged. The Rust port re-syncs `vectors.json` and bumps its vector-count
   assertion from 5 to 6.

3. **event-over-http.md correction.** `/api/event` is a *default system endpoint*
   (`default-rest.yaml`, merged by `RoutingEntry.addDefaultEndpoints` keyed on
   url + methods) — the guide wrongly told readers to add the rest.yaml entry manually.
   An explicit entry is only for customization such as timeout or authentication.

## Why

The two engines hold each other honest: the Rust port regressed on the cache key, fixed
it, and asked both repositories to carry the guard so neither can drift again; its
conformance review of our golden vectors exposed the span_id blind spot in the interop
contract we published in #212. Adopting both keeps the cross-language contract enforced
by tests on both sides rather than by convention. The guide fix removes a documented
instruction that contradicts actual behavior — caught while verifying a review claim
against the code.

Verified: minigraph-playground-engine 72 tests green (the new guard passes on current
main, confirming the cache key is correct today); platform-core golden-vector suite green
with 7 vectors; docs strict build and canon checks green.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)