### PR TITLE
fix(core): HTTP client read timeout must round the TTL up, with grace

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-004243)
+- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-015924)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -379,8 +379,20 @@
   2026-07-22-004243 for the asymmetry list). Review follow-up: new additive golden vector
   `standard-trace-context` (span_id coverage, their finding) on branch
   `test/fetcher-cache-key-guard`; Rust re-syncs vectors.json + bumps its count assertion
-  (note: `/tmp/event-envelope-vectors-update.md`). Next: live two-runtime interop test;
-  version number for the carrying release still open. → serves
+  (note: `/tmp/event-envelope-vectors-update.md`). **LIVE BIDIRECTIONAL INTEROP TEST
+  PASSED 2026-07-22** (report `/tmp/event-over-http-interop-test-report.md`; session
+  2026-07-22-015924): Java→Rust 7/7, Rust→Java 6/7 (last case blocked only by the Rust
+  client's mirror of defect D1 — flagged to the Rust repo), trace continuity both ways.
+  Drive found+fixed a REAL pre-existing Java bug (D1: getTimeoutSeconds floor-division →
+  1s HTTP read timeout; fixed on branch `fix/http-client-response-timeout` with
+  regression test — NEEDS PR). **UPDATE same day: Rust→Java also 7/7 — D2 fixed in the
+  Rust working tree (div_ceil + grace, regression test, 162/162) and the blocked case
+  re-verified live; D3 (example echo binary drop) fixed; declarative
+  `yaml.event.over.http` routing implemented for parity (increment 62, live zero-code
+  cross-language proof verified in Java telemetry).** All Rust work uncommitted on
+  `feature/interop-test-service` awaiting Eric; a redundant D2 task-chip session on the
+  Rust side needs standing down. Next: PR the Java D1 fix; Eric reviews/commits the Rust
+  branch; version number for the carrying release still open. → serves
   `vision-mercury-composable` (polyglot deployment)
   <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-215951 -->
 

--- a/memory/sessions/2026-07-22-015924.md
+++ b/memory/sessions/2026-07-22-015924.md
@@ -1,0 +1,79 @@
+# Session (2026-07-22T01:59:24Z)
+
+**Agent:** Claude Code
+
+## Work Done
+
+**Live bidirectional Event-over-HTTP interop test drive (Java ⇄ Rust) — COMPLETE.**
+Full report: `/tmp/event-over-http-interop-test-report.md`. Coordination model per Eric:
+a subagent operated the Rust repo (updated examples/hello-world with a public
+`hello.world` echo + `sleep_ms`, ran the app on 8086, fired the Rust→Java leg with the
+production `event_over_http` client); this session ran the Java side (lambda-example
+8085; a scratchpad interop-driver app on 8299 hosting public `demo.sleeper.echo` and
+firing the Java→Rust matrix) and compiled the report.
+
+**Final results: Java→Rust 7/7 PASS; Rust→Java 6/7 PASS** (the seventh blocked only by
+the flagged Rust-client mirror bug; Java-side behavior proven correct at raw protocol).
+Trace continuity verified BOTH directions (ids in the report; cross-language span
+parenting observed). Contract elements proven: body fidelity incl. binary + 2^53+1
+integers + unicode, in-band 403/404/408, 202 ack, x-ttl/x-async, visibility boundary,
+compact rejection, W3C trace headers.
+
+**Defect D1 — real pre-existing Java bug found and FIXED** (branch
+`fix/http-client-response-timeout`, needs PR): `AsyncHttpRequest.getTimeoutSeconds()`
+had `Math.max(1, ms)/1000` — misplaced parenthesis, floor division → the HTTP client's
+reactor-netty responseTimeout capped at floor(ttl/1000) s (0 for sub-second TTLs), so a
+peer exhausting its full TTL (in-band 408 AT the deadline) died with
+ReadTimeoutException as 500/null. Reproduced Java↔Java (control test proved it
+pre-existing). Fix: ceiling division + 1s min in getTimeoutSeconds; +1s wire-level grace
+on AsyncHttpClient.responseTimeout (caller's RPC deadline still governs). Regression:
+`hello.sleeper` public full-TTL-exhausting function in platform-core TestBase +
+`EventHttpTest.remoteTimeoutArrivesInBand` (16/16; full platform-core suite green;
+verified live vs the Rust peer: in-band "408 Request timeout for 1500 ms").
+
+**Defect D2 — the SAME bug class exists in the Rust client**
+(http_client.rs timeout_seconds: ms.max(1000)/1000 floor) — flagged for the Rust repo
+(subagent left a task chip); their /api/event SERVICE side is correct.
+
+**Defect D3 — Rust example echo dropped binary bodies** (serde_json detour; JSON has no
+byte type; Nil-strip removed the body key) — fixed by the subagent in the Rust working
+tree. Durable cross-language lesson: handle envelope bodies in the MsgPack value domain;
+a JSON detour silently loses binary.
+
+Non-defects for the record: lambda-example `hello.world` is private BY DESIGN (the docs'
+test-drive target `hello.pojo` is public with an explicit isPrivate=false); the driver's
+Java↔Java 403 on `demo.sleeper.echo` before adding isPrivate=false confirmed @PreLoad's
+private-by-default on the wire.
+
+Also learned (scratchpad driver): AutoStart runs EVERY @MainApplication EntryPoint on the
+classpath — a second "utility" entry point hijacks the app (fold modes into one entry
+point); `web.component.scan` rejects single-segment packages.
+
+Also: **D2 FIXED in the Rust working tree** (delegated to the Rust-side subagent at Eric's
+direction, mirroring the Java D1 shape: `div_ceil` + 1s wire grace + ttl+100ms local wait;
+regression test `remote_timeout_arrives_in_band`; platform-core 162/162; the blocked
+matrix case re-run PASSED live → **Rust→Java now effectively 7/7**; report updated).
+CAUTION relayed to Eric: the agent's D2 task chip had already been started as a separate
+session — must be stood down to avoid a conflicting change. Also: **declarative
+`yaml.event.over.http` routing found MISSING in the Rust port** (their config-reference
+lists the key as absent; no send-path hook) — Eric: "powerful feature - zero code at user
+app level"; parity implementation dispatched to the subagent (fixture shape = the Java
+test-resources event-over-http.yaml; behavioral reference = declarativeEventOverHttpTest).
+
+Also: **declarative `yaml.event.over.http` routing IMPLEMENTED in the Rust port**
+(subagent, increment 62, working tree): config loader (Java fixture shape, `${...}`
+substitution, `@instance` stripping), send/request hooks with the x-event-api recursion
+guard, callback + async modes, Java-twin declarative test, docs. Rust workspace 237/237,
+clippy/fmt clean. **Live zero-code cross-language proof**: a Rust `po.request`/`po.send`
+with only a yaml map entry reached the JAVA `demo.sleeper.echo` and returned its reply —
+verified independently in the Java telemetry (02:52 UTC hits). Deliberate deviations
+documented by the agent (lazy OnceLock registry; `request_direct` internal bypass;
+combined test fn; `send_later` now routes through `send()`). All Rust work awaits Eric's
+review on `feature/interop-test-service`, uncommitted.
+
+## Memory References
+
+- referenced: thread-event-envelope-interop (live two-runtime test = the thread's final
+  milestone before release; UPDATE recorded there)
+- referenced: field-trace-propagation-4-6-3-diagnosis (the two-app trace-validation
+  topology reused for the cross-language pair)

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -188,7 +188,11 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         if (relaxedHeaderSize) {
             client = client.httpResponseDecoder(spec -> spec.maxHeaderSize(16 * 1024));
         }
-        client = client.responseTimeout(Duration.ofSeconds(request.getTimeoutSeconds()));
+        // one extra second of grace over the request TTL so a peer that spends
+        // its whole TTL and then replies (e.g. an Event-over-HTTP 408 sent AT
+        // the deadline) is still readable; the caller's own RPC timeout - not
+        // this wire-level read timeout - governs the user-visible deadline
+        client = client.responseTimeout(Duration.ofSeconds(request.getTimeoutSeconds() + 1L));
         if (request.isSecure()) {
             if (request.isTrustAllCert()) {
                 Http11SslContextSpec http11Context = Http11SslContextSpec.forClient()

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/AsyncHttpRequest.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/AsyncHttpRequest.java
@@ -387,7 +387,10 @@ public class AsyncHttpRequest {
         if (timeout == null) {
             return -1;
         }
-        return Math.max(1, Utility.getInstance().str2int(timeout)) / 1000;
+        // ceiling division with a one-second minimum: the X-TTL header is in
+        // milliseconds and a fractional second must round UP, never down to
+        // zero (1,500 ms is a 2-second budget, not 1)
+        return Math.max(1, (Utility.getInstance().str2int(timeout) + 999) / 1000);
     }
 
     public AsyncHttpRequest setTimeoutSeconds(int timeoutSeconds) {

--- a/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
+++ b/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
@@ -61,6 +61,7 @@ public class TestBase {
     protected static final String HELLO_WORLD = "hello.world";
     protected static final String HELLO_MOCK = "hello.mock";
     protected static final String HELLO_LIST = "hello.list";
+    protected static final String HELLO_SLEEPER = "hello.sleeper";
     protected static final String CLOUD_CONNECTOR_HEALTH = "cloud.connector.health";
     protected static final String APP_ID = Utility.getInstance().getDateUuid()+"-"+System.getProperty("user.name");
     private static final String HTTPS_SERVICE_LOADED = "https.service.loaded";
@@ -96,6 +97,16 @@ public class TestBase {
             platform.registerPrivate(HELLO_LIST, (headers, input, instance) ->
                     Collections.singletonList(input), 5);
             platform.makePublic(HELLO_MOCK);
+            // a public function that can exhaust its caller's whole TTL - the regression
+            // target for the Event-over-HTTP remote-timeout path (a peer that replies
+            // with its own 408 AT the deadline must still be readable by the caller)
+            platform.registerPrivate(HELLO_SLEEPER, (headers, input, instance) -> {
+                if (input instanceof Map<?, ?> map && map.get("sleep_ms") != null) {
+                    util.sleep(Math.min(10000, util.str2long(String.valueOf(map.get("sleep_ms")))));
+                }
+                return input;
+            }, 5);
+            platform.makePublic(HELLO_SLEEPER);
             if (generatePrivateKeyAndCert()) {
                 System.setProperty("rest.server.ssl.cert", "file:%s".formatted(CERTIFICATE_PATH));
                 System.setProperty("rest.server.ssl.key", "file:%s".formatted(PRIVATE_KEY_PATH));

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
@@ -348,6 +348,33 @@ class EventHttpTest extends TestBase {
         assertEquals(numberThree, map.getElement("body"));
     }
 
+    @Test
+    void remoteTimeoutArrivesInBand() throws InterruptedException {
+        // Regression: the HTTP client's wire-level read timeout must outlive the
+        // request TTL. A peer that spends its whole TTL and replies with its own
+        // in-band 408 AT the deadline (~ttl + a few ms) was previously killed by a
+        // ReadTimeoutException at floor(ttl/1000) seconds - a misplaced parenthesis
+        // in AsyncHttpRequest.getTimeoutSeconds() (max(1, ms)/1000 instead of
+        // max(1, ms/1000) with ceiling), surfacing as status=500 with a null body.
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        long timeout = 1500;
+        Map<String, String> securityHeaders = new HashMap<>();
+        securityHeaders.put("Authorization", "demo");
+        PostOffice po = PostOffice.trackable("unit.test", "9003", "TEST /remote/event/timeout");
+        EventEnvelope event = new EventEnvelope().setTo(HELLO_SLEEPER)
+                .setBody(Map.of("sleep_ms", 3000));
+        Future<EventEnvelope> response = po.asyncRequest(event, timeout, securityHeaders,
+                "http://127.0.0.1:"+port+"/api/event", true);
+        response.onSuccess(bench::add);
+        EventEnvelope result = bench.poll(timeout + 2000, TimeUnit.MILLISECONDS);
+        assertNotNull(result);
+        assertEquals(408, result.getStatus(),
+                "the remote's own timeout must arrive in-band, not die on the wire: " + result.getBody());
+        assertInstanceOf(String.class, result.getBody());
+        assertTrue(String.valueOf(result.getBody()).contains("1500"),
+                "the remote reports the TTL it enforced: " + result.getBody());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void standardFormatIsDefaultAndMirrored() throws InterruptedException {


### PR DESCRIPTION
## What

Fixes a latent defect in the async HTTP client's timeout derivation.
`AsyncHttpRequest.getTimeoutSeconds()` computed `Math.max(1, ms) / 1000` — a misplaced
parenthesis turning the intended one-second floor into **floor division of the whole
TTL**: an `x-ttl` of 1,500 ms produced a 1-second reactor-netty `responseTimeout`, and a
sub-second TTL produced **zero**. Any peer that legitimately spends its whole TTL and
replies at the deadline — exactly what an Event-over-HTTP service does when it sends its
in-band 408 — was killed on the wire by a `ReadTimeoutException` and surfaced to the
caller as status 500 with a null body.

- `getTimeoutSeconds()` now uses ceiling division with a one-second minimum (1,500 ms is
  a 2-second budget, not 1).
- `AsyncHttpClient` grants one extra second of wire-level grace over the request TTL; the
  caller's own RPC timeout — not the wire read timeout — governs the user-visible
  deadline.
- New regression: a public full-TTL-exhausting `hello.sleeper` test function plus
  `EventHttpTest.remoteTimeoutArrivesInBand`, asserting the remote's in-band 408 arrives
  intact instead of dying on the wire.

## Why

Found during the 2026-07-22 live cross-language interoperability test drive between this
engine and the official Rust implementation (Event over HTTP, standard wire format from
#212): the timeout matrix case failed with 500/null while a raw-protocol probe of the
same peer returned a clean in-band 408. A Java↔Java control test reproduced the identical
failure, proving the defect pre-existing and peer-independent — it had simply never been
observable, because only a full-TTL-exhausting peer exposes it. Notably, the Rust port
carried the same bug class in its own client and fixed it the same day with the mirrored
shape and a twin regression test — the two engines now hold each other honest on this
path in both test suites.

Verified: EventHttpTest 16/16, full platform-core suite green, and live against the Rust
runtime — the interop timeout case now returns in-band `408 Request timeout for 1500 ms`
(bidirectional matrix final: 7/7 both directions).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)