### PR TITLE
Release v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.10.0, 7/22/2026
+
+Feature release: cross-language Event-over-HTTP interoperability with the official
+[Rust implementation](https://github.com/Accenture/mercury) — language-neutral wire format,
+a ready-to-run demo pair covering both calling patterns, application log context on by
+default, and RPC span-lineage telemetry. Validated by live bidirectional Java ⇄ Rust
+interop drives — see the
+[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/).
 
 ### Added
 
-1. **Language-neutral event envelope wire format for Event over HTTP interoperability.**
+1. **Language-neutral event envelope wire format for Event over HTTP interoperability
+   (#212, #213).**
    The serialized envelope is now, by default, a MsgPack map with descriptive string keys
    (`id`, `to`, `headers`, `body`, …) that any MsgPack-capable language can encode and
    decode — documented as a self-contained spec in the new
@@ -26,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    its response. Outbound selection: `event.over.http.format` (default `standard`;
    `compact` is the fallback for peers on older versions) plus a per-call
    `x-event-format` header.
-2. **Application log context is now on by default.** platform-core ships a built-in
+2. **Application log context is now on by default (#215).** platform-core ships a built-in
    `default-log-context.yaml` so the structured JSON appenders (`log.format=json` or
    `compact`) stamp the standard trace context (`cid`, `traceId`, `tracePath`, `spanId`,
    `parentSpanId`, `service`, `timestamp`) into every log line a traced function emits —
@@ -34,11 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `app-log-context.yaml`, or opt out with the new `app.log.context=false` key in
    application.properties. Applications already providing an `app-log-context.yaml` are
    unaffected. Plain-text logging (`log.format=text`, the default) is unaffected.
-3. **RPC telemetry now records span lineage.** The `round_trip` record a caller emits for
+3. **RPC telemetry now records span lineage (#215).** The `round_trip` record a caller emits for
    each RPC response carries `span_id` (the callee's span) and `parent_span_id` (the
    caller's span), so trace visualizers can chain RPC round-trips into the span tree —
-   including across Event-over-HTTP hops.
-4. **Ready-to-run Event-over-HTTP demo in the examples — both patterns.** The
+   including across Event-over-HTTP hops. The span id is adopted only from a direct
+   responder; a relayed reply (e.g. an event flow answering on behalf of the flow adapter)
+   keeps `parent_span_id` without claiming another function's span.
+4. **Ready-to-run Event-over-HTTP demo in the examples — both patterns (#215).** The
    lambda-example exposes a public `hello.world` echo with a `hello.declarative` alias.
    The composable-example's `POST /api/event/http/demo` endpoint runs a flow whose task is
    that foreign alias route — resolved through `event-over-http.yaml` with zero
@@ -51,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-1. **Retired the rest-spring-example Event-over-HTTP demo.** The `HelloPoJoEventOverHttp` /
+1. **Retired the rest-spring-example Event-over-HTTP demo (#215).** The `HelloPoJoEventOverHttp` /
    `HelloPoJoEventOverHttpByConfig` controllers, their `event-over-http.yaml`, and the
    `lambda.example.port` / `yaml.event.over.http` keys are removed from both
    rest-spring-3-example and rest-spring-4-example, and the `hello.pojo2` alias is removed
@@ -66,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    client adds a one-second grace period, so a remote Event-over-HTTP call with a TTL
    that is not a whole number of seconds gets its in-band 408 from the remote side
    instead of a transport-level read timeout.
-2. **Logger recursion warning on startup eliminated.** The log-context configuration is
+2. **Logger recursion warning on startup eliminated (#215).** The log-context configuration is
    initialized before log4j2 reconfigures to the JSON/compact appenders, so its first
    log lines no longer re-enter an appender that is still initializing
    ("Recursive call to appender").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.9.2) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.9.2) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.0) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-22-234845)
+- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-23-015717)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -353,6 +353,16 @@
 
 ## Open Threads
 
+- [ ] (release in flight — 2026-07-22) **v4.10.0 release prep on `chore/release-4.10.0`.**
+  Feature release: wire format (#212/#213), D1 timeout fix (#214), demo pair + default-on log
+  context + RPC span lineage (#215). Both gates passed before the branch was cut: Java PR #215
+  merged (`9d8ae12a`, CI green ×3 rounds) and Rust mercury PR #167 merged (`c64d0683` — parity
+  batch + I1/I2/I3 telemetry fixes); live bidirectional interop drives PASSED in full (both
+  patterns, both directions, span-accurate — permanent record:
+  `docs/test-reports/event-over-http-interop.md`). Sweep done (32 poms + CLAUDE/GEMINI +
+  instructions.md coordinates), CHANGELOG dated 7/22/2026. Close when tagged + release published.
+  <!-- id: thread-release-4-10-0 | created: 2026-07-22 | last_used: 2026-07-22 | uses: 1 | tier: working | origin: 2026-07-23-015717 -->
+
 - [ ] (design — 2026-07-21, human gate PENDING) **Common event envelope wire format for
   cross-language interop (Event over HTTP with the Rust port).** Design DRAFTED at
   `draft-design-specs/event-envelope-interop-design.md` — standard envelope = MsgPack map
@@ -405,9 +415,13 @@
   PR #166 (merge `e36e5dc5`, commits f62a69bf/230ee55b/258f3578). The "redundant D2 chip
   session" turned out not to exist (session list + transcript search clean); repo memory
   protocol protects against late arrivals anyway. Interop test processes stopped.**
-  REMAINING: cut the Java release carrying the wire format + D1 fix (version number
-  open — 4.10.0 suggested; it is a feature release). → serves
-  `vision-mercury-composable` (polyglot deployment)
+  **UPDATE 2026-07-22 (evening): the full release-gate cycle completed** — Java PR #215
+  (demo pair, default-on log context, RPC span lineage + the spanIdFromResponder
+  refinement) and Rust mercury PR #167 (parity batch + I1/I2/I3 telemetry fixes) BOTH
+  merged; live bidirectional pattern drives (programmatic + declarative) PASSED in full
+  with span-accurate telemetry; permanent record at
+  `docs/test-reports/event-over-http-interop.md`. REMAINING: the v4.10.0 release itself —
+  see [[thread-release-4-10-0]]. → serves `vision-mercury-composable` (polyglot deployment)
   <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-215951 -->
 
 - [ ] (field support — 2026-07-21) **v4.9.1 REJECTED by the field Sonar quality gate; remediation

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -13,7 +13,7 @@ readers to it (docs/README references were removed 2026-07-20).
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.6.1`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.0`)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-22-234845.md
+++ b/memory/sessions/2026-07-22-234845.md
@@ -64,6 +64,87 @@ composable-example → Rust hello-world AND Rust hello-flow → lambda-example. 
 HelloWorld javadoc mentions two composable-example endpoints (programmatic + declarative) but
 rest.yaml has only the declarative one.
 
+**Also (same session, `ffb45ff1`):** added the PROGRAMMATIC Event-over-HTTP demo endpoint to
+composable-example per Eric — `/api/event/http/programmatic` → flow `event-over-http-programmatic`
+→ task `v1.event.over.http.rpc` (`EventOverHttpRpc`), which passes the peer's `/api/event` URL
+directly to `po.request(req, timeout, headers, endpoint, true)` calling `hello.world` by its
+PRIMARY route (no event-over-http.yaml entry) — the two endpoints now illustrate both patterns
+against the same peer function, which is why the echo has two route names. Loopback e2e test
+(`EventOverHttpDemoTest`, test config points peer.demo.* back at the test server; works because
+the declarative map is consulted BEFORE local discovery and inbound /api/event carries the
+x-event-api recursion guard). Live two-app verification: both endpoints 200; one span tree across
+JVMs (task.executor → v1.event.over.http.rpc a16f4f6e → hello.world 878bf9e0 with parent
+a16f4f6e); default log context stamped the trace onto lambda-example's application log. Docs
+"The programmatic twin" subsection + CHANGELOG updated; pushed. Rust agent briefed to mirror it
+(item 7).
+
+**Also (same session, `eef10959`):** retired the rest-spring Event-over-HTTP demo per Eric —
+the composable-example programmatic+declarative pair is the single canonical walk-through
+(the Spring-controller demo diluted it and modeled imperative orchestration in a controller,
+against [[event-script-over-code]]). Removed from BOTH rest-spring-3/4-example:
+HelloPoJoEventOverHttp(ByConfig), event-over-http.yaml, lambda.example.port +
+yaml.event.over.http keys, and the pojo/http test rows (mesh endpoint test kept); removed the
+`hello.pojo2` alias from lambda-example's HelloPoJo (Eric confirmed explicitly). Guide's
+test-drive + configuration sections rewritten around the composable demo (hello.declarative
+example, `{#zero-code-demo}` anchor). All four affected example suites green (7/7/10/5);
+strict docs build clean; pushed.
+
+**Also (same session, PR #215 + `140640d8`/`1c28fbb0`):** Eric opened PR #215 for the branch. CI
+caught a REAL defect in the span-lineage change via event-script-engine's SpanPropagationTest
+(unique-span-id invariant): the inbox adopted the reply's span id unconditionally, but a flow
+reply is RELAYED — produced by the flow's final task (a callback-treated function that already
+reported its own span) — so the round_trip record misattributed that span to
+event.script.manager AND duplicated it. Fix `140640d8`: `InboxBase.spanIdFromResponder` adopts
+the reply span only when `reply.from` == requested route (direct RPC, where the RPC tag
+suppressed the worker-side record and the inbox record is THE record for the span). **Durable
+mechanism (Eric probed this explicitly):** both RPC and callback events carry replyTo; the
+discriminator is the RPC tag, stamped only by the inbox request paths — WorkerHandler emits the
+worker-side record when `journaled || rpc == null || notDelivered`, so callbacks self-record and
+RPC targets are recorded by the caller's inbox. Residual benign edge: journaled+RPC targets
+produce two records with the SAME span id (journal view + round_trip view) — same span, merges
+cleanly; deliberately not guarded. Verified: PostOfficeTest 75/75, SpanPropagationTest 4/4, full
+reactor 28 modules green, CI pass in 5m06s. Follow-up `1c28fbb0` (Rust-review findings): both
+demo flows' `text(application/json) -> output.body.content-type` was a no-op typo → header form;
+my_route docs claim scoped to Java callees (Rust worker doesn't inject it). **Rust parity batch
+COMPLETE** (agent, branch `feature/parity-log-context-aliases` in ~/sandbox/mercury, NOT pushed,
+243 tests green): route aliases in #[preload], log context default-on (same file/key names), RPC
+round_trip telemetry implemented from scratch WITH span lineage (the port had no caller-side
+record at all), demo endpoint pair in hello-flow (port 8086→8100), docs. Interop facts: Rust
+hello-world 8085 (hello.world + hello.declarative public), hello-flow 8100 (same two demo
+endpoints as composable-example).
+
+**Also (same session): INTEROP DRIVE 2 CONDUCTED (the v4.10.0 release gate) — functionality
+6/6 PASS both directions, both patterns** (report `/tmp/event-over-http-interop-drive2-report.md`).
+Java composable-example → Rust hello-world AND Rust hello-flow → Java lambda-example, zero config
+changes. Java→Rust: fully connected cross-language span tree both patterns (Rust event.api.service
+parents onto the Java caller's span; Java async.http.response parents back onto the Rust function
+span). Rust→Java: declarative fully chained (matches Java-caller behavior); programmatic chained
+by trace id only. Three RUST-side telemetry findings briefed to the Rust session for PR #167:
+I1 callee double-emits per RPC-served span (no RPC-tag suppression); I2 round_trip adopts relayed
+reply's span id (the pre-refinement mirror of our 140640d8 fix); I3 programmatic event_over_http
+client doesn't stamp the caller span on the wire (declarative path does). None block the Java
+content; Java telemetry correct in all runs. Java PR #215 CI fully green at `1c28fbb0`. Rust
+branch pushed at Eric's direction; Rust PR #167 open.
+
+**Also (same session): I1/I2/I3 FIXED in Rust (`8328d720`, pushed to PR #167) and RE-DRIVE
+PASSED — the v4.10.0 interop gate is fully closed.** Rust now mirrors the Java telemetry
+contract exactly: worker-record suppression for RPC-served spans (one record per span, verified
+— zero duplicates), spanIdFromResponder gate (no foreign span adoption on relayed replies), and
+the programmatic event_over_http client stamps the caller span on the wire (Java callee records
+parent onto the Rust task span in BOTH patterns; parents cross-checked as real caller spans).
+Bonus parity: callee annotations now ride the reply envelope (wire-compatible field, crosses
+Event-over-HTTP hops both directions). Rust workspace 244 green + new one-record-per-span
+regression. Report updated: /tmp/event-over-http-interop-drive2-report.md. REMAINING for
+v4.10.0: merge PR #215 (Java, CI green) + PR #167 (Rust), then Java release prep (version sweep
+4.9.2→4.10.0 with digit lookahead, CHANGELOG date, release notes leading with the interop story).
+
+**Also (same session, `51073204`):** the interop report is now a PERMANENT docs page per Eric —
+`docs/test-reports/event-over-http-interop.md` (new docs/test-reports/ area, nav under Reference,
+linked from the Event over HTTP guide's See also). Public adaptation of the /tmp report: covers
+both drives (wire-format drive + pattern drive), functionality 6/6, span-level continuity
+evidence, and the I1–I3 findings WITH resolution — honest-evidence framing ("recording them here
+is deliberate"). Strict docs build green; pushed onto PR #215.
+
 ## Memory References
 
 - referenced: thread-event-envelope-interop, trace-thread-keyed-mono-gotcha,

--- a/memory/sessions/2026-07-23-015717.md
+++ b/memory/sessions/2026-07-23-015717.md
@@ -1,0 +1,40 @@
+# Session (2026-07-23T01:57:17.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**v4.10.0 release prep** on branch `chore/release-4.10.0` (from main at `9d8ae12a`, the PR #215
+squash merge). Both release-gate PRs merged today: Java #215 (CI fully green through three
+rounds) and Rust mercury #167 (merge `c64d0683` — parity batch + the I1/I2/I3 interop telemetry
+fixes). The interop gate passed in full: live bidirectional drives, both patterns, functionality
+6/6 and span-accurate telemetry after the Rust fixes; the permanent record is the docs page
+`docs/test-reports/event-over-http-interop.md` (Eric's call — reader-facing honest evidence;
+the /tmp working reports were deleted at his direction).
+
+Release mechanics this session:
+- Version sweep 4.9.2 → 4.10.0: 32 poms + CLAUDE.md/GEMINI.md (perl with `(?!\d)` digit
+  lookahead), plus the long-stale `memory/instructions.md` coordinates line (was still 4.6.1).
+- CHANGELOG: Unreleased → "Version 4.10.0, 7/22/2026" with a release-summary paragraph leading
+  with the cross-language interop story + link to the interop test report; PR refs stamped on
+  all entries (#212/#213 wire format, #215 the rest); span-lineage entry now notes the
+  direct-responder-only span adoption.
+- Full reactor build+test at 4.10.0 run as the gate before pushing.
+
+Process note (small stumble, resolved): the post-commit hook had auto-committed the session log
+on the feature branch while later enrichments were uncommitted, which blocked `git checkout
+main`; resolved via stash → checkout → pull → pop (enrichments now sit on top of the merged
+copy).
+
+Rust repo housekeeping: memory review ritual (overdue, 11 ≥ 10) is running in the Rust session
+at Eric's direction — dedicated commit on main, not pushed, report pending.
+
+## Memory References
+
+- referenced: thread-event-envelope-interop, log-context-on-by-default,
+  release-4-8-1-shipped (release-sweep digit-lookahead precedent), trace-thread-keyed-mono-gotcha
+- updated: thread-event-envelope-interop (PRs #215 + mercury #167 merged; interop gate CLOSED;
+  release in flight)
+- created: thread-release-4-10-0 (tier: working)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.9.2</version>
+    <version>4.10.0</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version bump 4.9.2 → 4.10.0 across the 32 module poms and version references, and the
CHANGELOG dated for release. The 4.10.0 content merged ahead of this branch:

- **Language-neutral event envelope wire format** for Event over HTTP (#212, #213) — MsgPack
  map with descriptive keys, automatic inbound format detection, response mirroring,
  `event.over.http.format` / `x-event-format` selection, golden conformance vectors shared
  with the official Rust implementation.
- **Event-over-HTTP demo pair** (#215) — the composable-example's declarative and
  programmatic endpoints against the lambda-example's public echo; doubles as a
  cross-language demo against the Rust counterpart examples with zero config changes. The
  rest-spring Event-over-HTTP demo is retired in its favor.
- **Application log context on by default** (#215) — built-in `default-log-context.yaml`
  stamps cid/trace/span context into structured log lines; override with your own
  `app-log-context.yaml` or opt out via `app.log.context=false`.
- **RPC span-lineage telemetry** (#215) — `round_trip` records carry `span_id` /
  `parent_span_id` (direct responders only), chaining RPC round-trips into the span tree
  across Event-over-HTTP hops.
- **HTTP client sub-second TTL fix** (#214).

## Why

This is the cross-language interoperability release: a Java application and a Rust
application can now call each other's functions over Event-over-HTTP with no configuration,
no code, and continuous distributed traces — validated by live bidirectional interop drives
covering both calling patterns in both directions, recorded permanently in the new
[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/)
docs page. The Rust port entered the release in lock-step (mercury PR #167), so the shipped
examples of the two engines are drop-in counterparts of each other.

## Verification

- Full reactor build + test at 4.10.0: BUILD SUCCESS (all 28 modules).
- Version sweep verified: zero residual `4.9.2` references outside historical records.
- All content PRs individually CI-green before merge; interop validated live in both
  directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>