### PR TITLE
The /api/event edge is a visible span; declarative rename + Event-over-HTTP authentication demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Event-over-HTTP authentication demo.** The lambda-example overrides the default
+   `/api/event` endpoint with a demo authentication service (`event.api.auth`) that
+   validates the caller's `authorization` header against a shared secret resolved from the
+   environment (`demo.peer.token=${DEMO_PEER_TOKEN:demo}` on both peers - no hard-coded
+   credential). The composable-example presents the token declaratively (a `headers` block
+   in `event-over-http.yaml`) and programmatically (the request API's security headers),
+   and session info injected by the auth service rides to the target function.
+
+### Changed
+
+1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin:**
+   `/api/event/http/demo` → `/api/event/http/declarative` and flow id
+   `event-over-http-demo` → `event-over-http-declarative` in the composable-example.
+
+### Fixed
+
+1. **The "/api/event" edge is now a visible span in the trace.** `event.api.service` was
+   zero-tracing, so the target function of a remote call parented onto a span from another
+   application with nothing in between, and the HTTP response leg floated with no parent.
+   The service is now traced: its span parents onto the remote caller's span, the target
+   function parents onto it, and the response leg chains onto it as well. This is the
+   reference behavior for other language implementations.
+
+---
 ## Version 4.10.0, 7/22/2026
 
 Feature release: cross-language Event-over-HTTP interoperability with the official

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -167,7 +167,7 @@ sequenceDiagram
     participant U as curl
     participant C as composable-example (8100)
     participant L as lambda-example (8085)
-    U->>C: POST /api/event/http/demo
+    U->>C: POST /api/event/http/declarative
     Note over C: flow task "hello.declarative"<br/>route is not local — resolved<br/>via event-over-http.yaml
     C->>L: POST /api/event<br/>(MsgPack envelope + trace context)
     Note over L: hello.declarative echo<br/>(alias of hello.world)
@@ -202,12 +202,12 @@ event.http:
     target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
 ```
 
-and the REST endpoint `GET/POST /api/event/http/demo` (see `rest.yaml`) runs the flow
-`event-over-http-demo` whose task simply names the route:
+and the REST endpoint `GET/POST /api/event/http/declarative` (see `rest.yaml`) runs the flow
+`event-over-http-declarative` whose task simply names the route:
 
 ```yaml
 tasks:
-  - name: 'event-over-http-demo'
+  - name: 'event-over-http-declarative'
     input:
       - 'input.header -> header'
       - 'input.body -> *'
@@ -241,7 +241,7 @@ tasks:
 
     ```shell
     curl -s -X POST -H "content-type: application/json" \
-         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/demo
+         -d '{"hello": "world"}' http://127.0.0.1:8100/api/event/http/declarative
     ```
 
 4. The lambda-example's echo function replies through the same path in reverse — the response
@@ -251,9 +251,9 @@ tasks:
     {
       "body": { "hello": "world" },
       "headers": {
-        "x-flow-id": "event-over-http-demo",
+        "x-flow-id": "event-over-http-declarative",
         "my_trace_id": "51fb9a95cb6b47169dd83771283aebc2",
-        "my_trace_path": "POST /api/event/http/demo",
+        "my_trace_path": "POST /api/event/http/declarative",
         "...": "..."
       },
       "instance": 4,
@@ -297,6 +297,51 @@ the primary route `hello.world`, the declarative endpoint calls the alias
 (and therefore which pattern) served the call.
 Choose declarative when the target address is deployment configuration (the usual case);
 choose programmatic when the code must compute or vary the target at runtime.
+
+### Authentication: the event.api.auth demo
+
+The demo pair also shows how to protect the Event API endpoint. The lambda-example
+overrides the default `/api/event` entry in its `rest.yaml` to attach an authentication
+service:
+
+```yaml
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    authentication: 'event.api.auth'
+    tracing: true
+```
+
+The `event.api.auth` function (class `EventApiAuth`) validates the caller's
+`authorization` header against a shared secret that **both peers resolve from the
+environment** — never hard-code a real credential in source or configuration files:
+
+```properties
+# application.properties on both sides - "demo" is the local-development fallback
+demo.peer.token=${DEMO_PEER_TOKEN:demo}
+```
+
+On the calling side, the declarative route presents the token as a security header in
+`event-over-http.yaml`:
+
+```yaml
+event.http:
+  - route: 'hello.declarative'
+    target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+    # security headers (optional. Added for this demo only)
+    headers:
+      authorization: '${DEMO_PEER_TOKEN:demo}'
+```
+
+and the programmatic task passes the same token in the `headers` argument of the request
+API. A wrong or missing token gets an HTTP-401 without ever reaching the target function.
+
+When authentication passes, headers returned by the auth service become **session info**
+that rides to the target function as read-only headers — the demo's auth service adds
+`user: demo`, so you can see it echoed in the response body as proof that the request went
+through authentication. Replace the demo class with your own OAuth 2.0 bearer-token
+validation for production use.
 
 ### Same demo, different language
 
@@ -347,7 +392,8 @@ The following configuration adds authentication service to the Event API endpoin
 
 This enforces every incoming request to the Event API endpoint to be authenticated by the "v1.api.auth" service
 before passing to the Event API service. You can plug in your own authentication service such as OAuth 2.0 
-"bearer token" validation.
+"bearer token" validation. A complete working example is the
+[event.api.auth demo](#authentication-the-eventapiauth-demo) above.
 
 Please refer to [REST Automation](rest-automation/index.md) for details.
 ## See also

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -1,7 +1,8 @@
 ---
 title: Interop Test Report — Event over HTTP, Java ⇄ Rust
 summary: Permanent record of the live bidirectional interoperability validation between the
-  Java and Rust implementations, covering the programmatic and declarative patterns.
+  Java and Rust implementations - wire format, calling patterns, and telemetry presentation
+  parity - kept as a playbook for future language ports.
 layer: reference
 audience: [developer, architect]
 keywords: [interop, event over http, rust, wire format, test report, tracing]
@@ -11,13 +12,16 @@ keywords: [interop, event over http, rust, wire format, test report, tracing]
 
 *Live bidirectional interoperability validation between the Java engine
 ([mercury-composable](https://github.com/Accenture/mercury-composable)) and the official
-Rust implementation ([mercury](https://github.com/Accenture/mercury)), conducted
-2026-07-22 as the release gate for the v4.10 line.*
+Rust implementation ([mercury](https://github.com/Accenture/mercury)): the wire-format and
+calling-pattern drives conducted 2026-07-22 as the release gate for the v4.10 line, and the
+telemetry presentation-parity drive conducted 2026-07-23.*
 
 This report is a permanent record. It documents what was tested, the evidence collected,
 and — in the interest of honest engineering — the defects the drives surfaced and how each
 was fixed and re-verified. Everything here is reproducible from the shipped examples by
 following the [Event over HTTP](../guides/event-over-http.md#zero-code-demo) walk-through.
+It is also kept as a **playbook for future language ports** (e.g. Python) — see the
+learnings section at the end.
 
 ## Background: the wire-format validation drive
 
@@ -121,3 +125,118 @@ span-accurate across the language boundary in both directions. The shipped examp
 drop-in cross-language counterparts, and the walk-through in the
 [Event over HTTP guide](../guides/event-over-http.md#zero-code-demo) reproduces this
 validation with a single `curl`.
+
+## The presentation-parity drive (2026-07-23)
+
+After v4.10.0 shipped, a manual review of all four direction combinations
+(java-to-java, rust-to-rust, java-to-rust, rust-to-java) side by side — the way a
+DevSecOps operator reads an aggregated log stream — raised the bar from "trace continuity
+works" to a stronger requirement:
+
+> **Field installations stay polyglot for a long time. Operators aggregate both engines'
+> telemetry and logs in one place, and any presentation difference is a support burden.
+> The same-language logs of the two engines must be exact structural replicas of each
+> other — then cross-language runs are symmetric by construction.**
+
+That review surfaced loose ends the per-direction drives had not:
+
+- **Java:** the `/api/event` edge connected to no span — `event.api.service` was a
+  zero-tracing relay, so the remote target function parented onto a span from another
+  application with nothing in between, and the HTTP response leg floated unparented.
+- **Rust:** an incomplete application log-context block (constants only) appeared on
+  telemetry and system lines that carry no request trace; the first-leg
+  `http.flow.adapter` span was never recorded (its RPC-style dispatch suppressed the
+  worker record), leaving `parent_span_id` values that pointed at spans no record
+  reported; and reserved `my_*` metadata could leak into HTTP response headers.
+
+### Method: a normalized reference signature
+
+The Java engine is the reference implementation. After fixing the Java `/api/event` edge
+(the service is now traced: its span parents onto the remote caller's span, the target
+function parents onto it, and both response legs chain onto real spans), a live
+java-to-java run was distilled into a **normalized trace signature**: per calling pattern,
+the exact set of telemetry records — service name, parent edge (expressed symbolically so
+span-id values don't matter), record kind (`round_trip` for RPC-served spans vs
+`exec-only` for callback-served worker records), and path. Volatile fields (ids, origins,
+timestamps, durations, thread/instance numbers, ordering) are exempt; everything else must
+match record-for-record.
+
+**Declarative pattern — 8 records:**
+
+| side | service | parent (span owner) | kind | path |
+|------|---------|---------------------|------|------|
+| caller | http.flow.adapter | (root) | exec-only | POST /api/event/http/declarative |
+| caller | task.executor | http.flow.adapter@caller | exec-only | POST /api/event/http/declarative |
+| callee | event.api.auth | http.flow.adapter@caller | round_trip | POST /api/event |
+| callee | event.api.service | http.flow.adapter@caller | exec-only | POST /api/event |
+| callee | hello.declarative | event.api.service@callee | round_trip | POST /api/event/http/declarative |
+| callee | hello.pojo | hello.declarative@callee | exec-only | POST /api/event/http/declarative |
+| callee | async.http.response | event.api.service@callee | exec-only | POST /api/event |
+| caller | async.http.response | hello.declarative@callee | exec-only | POST /api/event/http/declarative |
+
+**Programmatic pattern — 9 records:** identical shape with the caller's
+`v1.event.over.http.rpc` task span between the flow adapter and the callee (the callee's
+`event.api.auth` / `event.api.service` parent onto it), the callee function being
+`hello.world`, and one deliberate asymmetry: the caller's `async.http.response` parents
+onto the **callee's function span** in the declarative pattern (the flow task's reply *is*
+the remote reply) but onto the **local task span** in the programmatic one (the flow's
+reply is produced locally by that task).
+
+The signature also pins the invariants: one record per span, no dangling parents, HTTP
+response headers free of reserved `my_*` metadata, and the log-context gating rule — a
+`context` block appears **only** on log lines emitted inside a traced function execution;
+telemetry and system lines carry none at all.
+
+### Reaching the bar required refactoring, not patching
+
+Matching the signature exposed genuine low-level variance in the Rust port's RPC
+implementation, resolved structurally: its REST automation now dispatches endpoint
+services as **callbacks** through a registered `async.http.response` service (the Java
+twin) instead of RPC through a oneshot inbox — which is what made the first-leg and
+response-leg spans real — and the business correlation-id moved to the reserved
+envelope-header channel for exact `PostOffice` parity. The log context was re-gated to
+render only inside a traced, non-zero-traced worker execution. The same drive added the
+`event.api.auth` authentication demo to both engines (a shared token resolved from the
+`DEMO_PEER_TOKEN` environment variable — authentication appears in the trace as a real
+span, and its session info rides to the target function as proof).
+
+### Result: empty diff in all four directions
+
+| Direction | Declarative (8 records) | Programmatic (9 records) |
+|-----------|-------------------------|--------------------------|
+| java → java (reference) | — | — |
+| rust → rust | **empty diff** | **empty diff** |
+| java → rust | **empty diff** | **empty diff** |
+| rust → java | **empty diff** | **empty diff** |
+
+Exactly as predicted: once the same-language logs were replicas, the cross-language runs
+were symmetric with no additional work. Authentication verified in every direction
+(session proof in the echo; wrong or missing token → HTTP-401), response headers clean,
+and zero context blocks on untraced lines in either engine.
+
+## Learnings for future language ports
+
+This validation arc is the playbook for bringing the next language (e.g. Python) into the
+family:
+
+1. **Golden conformance vectors first.** The wire format is proven byte-identically with
+   vectors shared verbatim between repositories — no prose interpretation.
+2. **Same-language baseline before cross-language testing.** Distill a live run of the
+   reference engine (java-to-java) into a normalized trace signature; the new port must
+   produce an **empty diff** on its own same-language run. Cross-language symmetry then
+   follows by construction — do not chase cross-language differences directly.
+3. **The signature is more than topology.** It pins record kinds (round_trip vs
+   exec-only), path values, one-record-per-span, no dangling parents, log-context gating,
+   and transport-header hygiene — the things an operator actually sees in an aggregated
+   view. Presentation parity is a standing invariant, not a one-off acceptance test:
+   polyglot installations put both engines' output in front of the same DevSecOps team.
+4. **Expect refactoring, not configuration.** Matching the signature will surface genuine
+   low-level differences (RPC vs callback dispatch, context scoping). Fix the structure;
+   telemetry-layer workarounds recreate the drift later.
+5. **The demo pair is the reusable test vehicle.** A new port implements the hello-world /
+   hello-flow counterparts on the same ports and route names, and every drive in this
+   report — functionality, trace continuity, authentication, signature diff — runs against
+   it unchanged, with zero configuration.
+6. **Live drives find what unit tests do not.** Every drive in this story surfaced real
+   defects (timeout truncation, span misattribution, context leakage, an invisible relay
+   edge) that per-repository test suites had not caught.

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -44,8 +44,9 @@ applications as-is.
 | Caller (port 8100) | Java composable-example | Rust hello-flow |
 | Callee (port 8085) | Rust hello-world | Java lambda-example |
 
-Endpoints exercised on each caller: `POST /api/event/http/demo` (declarative),
-`POST /api/event/http/programmatic`, and `GET /api/event/http/demo`. **Zero configuration
+Endpoints exercised on each caller: `POST /api/event/http/demo` (declarative; renamed to
+`/api/event/http/declarative` after v4.10.0), `POST /api/event/http/programmatic`, and
+`GET /api/event/http/demo`. **Zero configuration
 changes between drives** — the callees are drop-in counterparts of each other (same port,
 same public routes `hello.world` / `hello.declarative`), which is the point of the demo.
 

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/EventOverHttpRpc.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/EventOverHttpRpc.java
@@ -25,19 +25,18 @@ import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.AppConfigReader;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * Demonstrates the PROGRAMMATIC Event-over-HTTP pattern - the counterpart of the
- * declarative demo in flows/event-over-http-demo.yml.<p>
+ * declarative demo in flows/event-over-http-declarative.yml.<p>
  *
  * This task calls the peer's "hello.world" function by passing the peer's Event API
  * endpoint URL directly to the PostOffice request API. Because the target address is
  * given programmatically, "hello.world" does NOT appear in event-over-http.yaml -
  * compare with "hello.declarative" (an alias of the same peer function), which is
  * resolved through that configuration file instead. The two REST endpoints
- * "/api/event/http/programmatic" and "/api/event/http/demo" therefore hit the same
+ * "/api/event/http/programmatic" and "/api/event/http/declarative" therefore hit the same
  * peer function through the two different patterns.<p>
  *
  * Since this function runs in a virtual thread, future.get() suspends the virtual
@@ -49,6 +48,7 @@ public class EventOverHttpRpc implements LambdaFunction {
     private static final String HELLO_WORLD = "hello.world";
     private static final String PEER_HOST = "peer.demo.host";
     private static final String PEER_PORT = "peer.demo.port";
+    private static final String DEMO_TOKEN_KEY = "demo.peer.token";
 
     @Override
     public Object handleEvent(Map<String, String> headers, Object input, int instance) throws Exception {
@@ -57,9 +57,13 @@ public class EventOverHttpRpc implements LambdaFunction {
         String host = config.getProperty(PEER_HOST, "127.0.0.1");
         String port = config.getProperty(PEER_PORT, "8085");
         String eventEndpoint = "http://" + host + ":" + port + "/api/event";
+        // the peer's /api/event endpoint is protected by the event.api.auth demo -
+        // present the shared token (resolved from the DEMO_PEER_TOKEN environment
+        // variable) as a security header on the HTTP request
+        Map<String, String> securityHeaders = Map.of("authorization", config.getProperty(DEMO_TOKEN_KEY, "demo"));
         EventEnvelope req = new EventEnvelope().setTo(HELLO_WORLD).setBody(input);
         headers.forEach(req::setHeader);
-        EventEnvelope response = po.request(req, 10000, Collections.emptyMap(), eventEndpoint, true).get();
+        EventEnvelope response = po.request(req, 10000, securityHeaders, eventEndpoint, true).get();
         if (response.getStatus() != 200) {
             throw new AppException(response.getStatus(), String.valueOf(response.getError()));
         }

--- a/examples/composable-example/src/main/resources/application.properties
+++ b/examples/composable-example/src/main/resources/application.properties
@@ -110,3 +110,11 @@ api.origin=*
 yaml.event.over.http=classpath:/event-over-http.yaml
 peer.demo.host=127.0.0.1
 peer.demo.port=8085
+#
+# Shared demo secret for the Event-over-HTTP authentication demo. The called
+# party's "event.api.auth" service expects this value in the "authorization"
+# header. Resolved from the DEMO_PEER_TOKEN environment variable so no real
+# credential is ever hard-coded ("demo" is the fallback for local development
+# only). The declarative side reads the same variable in event-over-http.yaml.
+#
+demo.peer.token=${DEMO_PEER_TOKEN:demo}

--- a/examples/composable-example/src/main/resources/event-over-http.yaml
+++ b/examples/composable-example/src/main/resources/event-over-http.yaml
@@ -1,3 +1,6 @@
 event.http:
   - route: 'hello.declarative'
     target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port}/api/event'
+    # security headers (optional. Added for this demo only)
+    headers:
+      authorization: '${DEMO_PEER_TOKEN:demo}'

--- a/examples/composable-example/src/main/resources/flows.yaml
+++ b/examples/composable-example/src/main/resources/flows.yaml
@@ -2,7 +2,7 @@ flows:
   - 'get-profile.yml'
   - 'create-profile.yml'
   - 'delete-profile.yml'
-  - 'event-over-http-demo.yml'
+  - 'event-over-http-declarative.yml'
   - 'event-over-http-programmatic.yml'
 
 location: 'classpath:/flows/'

--- a/examples/composable-example/src/main/resources/flows/event-over-http-declarative.yml
+++ b/examples/composable-example/src/main/resources/flows/event-over-http-declarative.yml
@@ -1,13 +1,13 @@
 flow:
-  id: 'event-over-http-demo'
+  id: 'event-over-http-declarative'
   description: 'Demonstrate Event-over-Http protocol using declarative means'
   ttl: 10s
   exception: 'v1.hello.exception'
 
-first.task: 'event-over-http-demo'
+first.task: 'event-over-http-declarative'
 
 tasks:
-  - name: 'event-over-http-demo'
+  - name: 'event-over-http-declarative'
     input:
       - 'input.header -> header'
       - 'input.body -> *'

--- a/examples/composable-example/src/main/resources/rest.yaml
+++ b/examples/composable-example/src/main/resources/rest.yaml
@@ -33,8 +33,8 @@ rest:
 
   - service: "http.flow.adapter"
     methods: ['GET', 'POST']
-    url: "/api/event/http/demo"
-    flow: 'event-over-http-demo'
+    url: "/api/event/http/declarative"
+    flow: 'event-over-http-declarative'
     timeout: 15s
     cors: cors_1
     headers: header_1

--- a/examples/composable-example/src/test/java/com/accenture/flows/EventOverHttpDemoTest.java
+++ b/examples/composable-example/src/test/java/com/accenture/flows/EventOverHttpDemoTest.java
@@ -85,7 +85,7 @@ class EventOverHttpDemoTest extends TestBase {
 
     @Test
     void declarativeEventOverHttpDemo() throws ExecutionException, InterruptedException {
-        var response = new MultiLevelMap(invokeDemoEndpoint("/api/event/http/demo"));
+        var response = new MultiLevelMap(invokeDemoEndpoint("/api/event/http/declarative"));
         assertEquals("world", response.getElement("body.hello"));
         assertEquals(Platform.getInstance().getOrigin(), response.getElement("origin"));
     }

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/EventApiAuth.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/EventApiAuth.java
@@ -1,0 +1,64 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.services;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.util.AppConfigReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Demo authentication service for the Event-over-HTTP endpoint.<p>
+ *
+ * The rest.yaml entry for "POST /api/event" declares
+ * {@code authentication: 'event.api.auth'}, so every incoming Event API request
+ * is delivered here first. This demo compares the caller's "authorization"
+ * header against a shared token that both peers resolve from the environment
+ * ({@code demo.peer.token=${DEMO_PEER_TOKEN:demo}} in application.properties) -
+ * never hard-code a real credential in source or config files.<p>
+ *
+ * Returning an EventEnvelope with a boolean body tells the REST automation
+ * engine to continue (true) or reject with HTTP-401 (false). Additional
+ * headers on the envelope become session info that rides to the target
+ * function as read-only headers - the "user" header in this demo.
+ * Replace this class with your own OAuth 2.0 bearer-token validation for
+ * production use.
+ */
+@PreLoad(route="event.api.auth", instances=10)
+public class EventApiAuth implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+    private static final Logger log = LoggerFactory.getLogger(EventApiAuth.class);
+
+    private static final String AUTHORIZATION = "authorization";
+    private static final String DEMO_TOKEN_KEY = "demo.peer.token";
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+        AppConfigReader config = AppConfigReader.getInstance();
+        String expected = config.getProperty(DEMO_TOKEN_KEY, "demo");
+        boolean authorized = expected.equals(input.getHeader(AUTHORIZATION));
+        log.info("Event API authorization {} {} = {}", input.getMethod(), input.getUrl(),
+                authorized? "PASS" : "FAIL");
+        return new EventEnvelope().setBody(authorized).setHeader("user", "demo");
+    }
+}

--- a/examples/lambda-example/src/main/resources/application.properties
+++ b/examples/lambda-example/src/main/resources/application.properties
@@ -49,3 +49,12 @@ closed.user.group=1
 # Uncomment this to test Event-over-HTTP
 #
 #yaml.event.over.http=classpath:/event-over-http.yaml
+
+#
+# Shared demo secret for the Event-over-HTTP authentication demo.
+# The "event.api.auth" service compares the caller's "authorization" header
+# against this value. Resolved from the DEMO_PEER_TOKEN environment variable
+# so no real credential is ever hard-coded ("demo" is the fallback for local
+# development only).
+#
+demo.peer.token=${DEMO_PEER_TOKEN:demo}

--- a/examples/lambda-example/src/main/resources/rest.yaml
+++ b/examples/lambda-example/src/main/resources/rest.yaml
@@ -55,6 +55,19 @@ rest:
     headers: header_1
     tracing: true
 
+  #
+  # Override the default "/api/event" endpoint to attach the demo authentication
+  # service (the EventApiAuth class). A calling party must present the shared
+  # demo token in the "authorization" header - see "demo.peer.token" in
+  # application.properties (resolved from the DEMO_PEER_TOKEN environment variable).
+  #
+  - service: "event.api.service"
+    methods: ['POST']
+    url: "/api/event"
+    timeout: 60s
+    authentication: 'event.api.auth'
+    tracing: true
+
   - service: "hello.download"
     methods: ['GET']
     url: "/api/hello/download"

--- a/examples/lambda-example/src/test/java/org/platformlambda/demo/EventApiAuthTest.java
+++ b/examples/lambda-example/src/test/java/org/platformlambda/demo/EventApiAuthTest.java
@@ -1,0 +1,79 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.demo;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.demo.common.TestBase;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * End-to-end coverage of the Event-over-HTTP authentication demo: rest.yaml
+ * overrides the default "/api/event" endpoint with the "event.api.auth"
+ * service, which validates the caller's "authorization" header against the
+ * shared demo token (demo.peer.token, resolved from DEMO_PEER_TOKEN).
+ */
+class EventApiAuthTest extends TestBase {
+
+    private String eventEndpoint() {
+        String port = AppConfigReader.getInstance().getProperty("rest.server.port", "8885");
+        return "http://127.0.0.1:" + port + "/api/event";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void acceptsTheSharedDemoToken() throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", "310", "TEST /api/event/auth");
+        Map<String, String> securityHeaders = Map.of("authorization", "demo");
+        EventEnvelope req = new EventEnvelope().setTo("hello.world").setBody(Map.of("hello", "auth"));
+        EventEnvelope response = po.request(req, 8000, securityHeaders, eventEndpoint(), true).get();
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("auth", map.getElement("body.hello"));
+        // session info injected by event.api.auth rides to the target function as a header
+        assertEquals("demo", map.getElement("headers.user"));
+    }
+
+    @Test
+    void rejectsAWrongToken() throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", "311", "TEST /api/event/auth");
+        Map<String, String> securityHeaders = Map.of("authorization", "let-me-in");
+        EventEnvelope req = new EventEnvelope().setTo("hello.world").setBody("x");
+        EventEnvelope response = po.request(req, 8000, securityHeaders, eventEndpoint(), true).get();
+        assertEquals(401, response.getStatus());
+        assertEquals("Unauthorized", response.getBody());
+    }
+
+    @Test
+    void rejectsAMissingToken() throws InterruptedException, ExecutionException {
+        PostOffice po = new PostOffice("unit.test", "312", "TEST /api/event/auth");
+        EventEnvelope req = new EventEnvelope().setTo("hello.world").setBody("x");
+        EventEnvelope response = po.request(req, 8000, Map.of(), eventEndpoint(), true).get();
+        assertEquals(401, response.getStatus());
+    }
+}

--- a/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
@@ -20,9 +20,9 @@ package org.platformlambda.core.services;
 
 import org.platformlambda.core.annotations.EventInterceptor;
 import org.platformlambda.core.annotations.PreLoad;
-import org.platformlambda.core.annotations.ZeroTracing;
 import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TraceInfo;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.EventEmitter;
@@ -38,8 +38,12 @@ import java.util.Map;
 /**
  * This is reserved for system use.
  * DO NOT use this directly in your application code.
+ * <p>
+ * This service is traced so the "/api/event" edge is visible in the span tree:
+ * its span parents onto the remote caller's span (carried by the inbound trace
+ * headers), the relayed local event carries this service's span so the target
+ * function parents onto it, and the HTTP response leg does the same.
  */
-@ZeroTracing
 @EventInterceptor
 @PreLoad(route=EventApiService.EVENT_API_SERVICE, instances=250)
 public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void> {
@@ -66,22 +70,28 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
             Map<String, String> sessionInfo = request.getSessionInfo();
             long timeout = Math.max(1000, util.str2long(request.getHeader(X_TTL)));
             boolean async = "true".equals(request.getHeader(X_ASYNC));
+            PostOffice po = new PostOffice(headers, instance);
+            // capture this service's span on the worker thread - the trace context is
+            // thread-keyed and torn down when the worker returns, so the async RPC
+            // callbacks below cannot look it up later
+            TraceInfo trace = po.getTrace();
+            String spanId = trace == null? null : trace.spanId;
             if (request.getBody() instanceof byte[] b) {
                 try {
-                    handleRequest(sessionInfo, headers, instance, b, input, timeout, async);
+                    handleRequest(sessionInfo, po, spanId, b, input, timeout, async);
                 } catch (Exception e) {
                     // the envelope could not be decoded, so its format is unknown -
                     // fall back to the classic compact format for the error reply
-                    sendError(input, EventEnvelope.Format.COMPACT, 400, e.getMessage());
+                    sendError(input, spanId, EventEnvelope.Format.COMPACT, 400, e.getMessage());
                 }
             } else {
-                sendError(input, EventEnvelope.Format.COMPACT, 500, "Invalid event-over-http data format");
+                sendError(input, spanId, EventEnvelope.Format.COMPACT, 500, "Invalid event-over-http data format");
             }
         }
         return null;
     }
 
-    private void handleRequest(Map<String, String> sessionInfo, Map<String, String> headers, int instance,
+    private void handleRequest(Map<String, String> sessionInfo, PostOffice po, String spanId,
                                byte[] requestBody, EventEnvelope input,
                                long timeout, boolean async) {
         EventEnvelope request = new EventEnvelope(requestBody);
@@ -92,11 +102,10 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                 EventEnvelope.Format.COMPACT : request.getWireFormat();
         // propagate session info if any
         sessionInfo.forEach(request::setHeader);
-        PostOffice po = new PostOffice(headers, instance);
         if (request.getTo() != null) {
             if (po.exists(request.getTo())) {
                 if (Platform.getInstance().isPrivate(request.getTo())) {
-                    sendError(input, format, 403, request.getTo() + PRIVATE_FUNCTION);
+                    sendError(input, spanId, format, 403, request.getTo() + PRIVATE_FUNCTION);
                 } else {
                     if (async) {
                         // Drop-n-forget
@@ -106,27 +115,29 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                         ackBody.put(DELIVERED, true);
                         ackBody.put(TIME, new Date());
                         EventEnvelope pending = new EventEnvelope().setStatus(202).setBody(ackBody);
-                        sendResponse(input, format, pending);
+                        sendResponse(input, spanId, format, pending);
                     } else {
-                        // RPC
+                        // RPC - po.asyncRequest stamps this service's span on the relayed
+                        // event (worker thread), so the target function parents onto it
                         po.asyncRequest(request, timeout)
-                                .onSuccess(result -> sendResponse(input, format, result))
-                                .onFailure(e -> sendError(input, format, 408, e.getMessage()));
+                                .onSuccess(result -> sendResponse(input, spanId, format, result))
+                                .onFailure(e -> sendError(input, spanId, format, 408, e.getMessage()));
                     }
                 }
             } else {
-                sendError(input, format, 404, ROUTE + request.getTo() + NOT_FOUND);
+                sendError(input, spanId, format, 404, ROUTE + request.getTo() + NOT_FOUND);
             }
         } else {
-            sendError(input, format, 400, MISSING_ROUTING_PATH);
+            sendError(input, spanId, format, 400, MISSING_ROUTING_PATH);
         }
     }
 
-    private void sendResponse(EventEnvelope input, EventEnvelope.Format format, EventEnvelope result) {
+    private void sendResponse(EventEnvelope input, String spanId, EventEnvelope.Format format, EventEnvelope result) {
         try {
             EventEnvelope response = new EventEnvelope().setTo(input.getReplyTo())
                     .setFrom(EVENT_API_SERVICE)
                     .setTrace(input.getTraceId(), input.getTracePath())
+                    .setSpanId(spanId)
                     .setCorrelationId(input.getCorrelationId())
                     .setHeader(CONTENT_TYPE, OCTET_STREAM)
                     .setBody(result.toBytes(format));
@@ -136,12 +147,13 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
         }
     }
 
-    private void sendError(EventEnvelope input, EventEnvelope.Format format, int status, String error) {
+    private void sendError(EventEnvelope input, String spanId, EventEnvelope.Format format, int status, String error) {
         try {
             EventEnvelope result = new EventEnvelope().setStatus(status).setBody(error);
             EventEnvelope response = new EventEnvelope().setTo(input.getReplyTo())
                     .setFrom(EVENT_API_SERVICE)
                     .setTrace(input.getTraceId(), input.getTracePath())
+                    .setSpanId(spanId)
                     .setCorrelationId(input.getCorrelationId())
                     .setHeader(CONTENT_TYPE, OCTET_STREAM)
                     .setStatus(status)

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
@@ -421,4 +421,70 @@ class EventHttpTest extends TestBase {
         MultiLevelMap map = new MultiLevelMap((Map<String, Object>) result.getBody());
         assertEquals("legacy", map.getElement("body"));
     }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void eventApiServiceIsAVisibleSpanInTheTrace() throws InterruptedException {
+        // Regression: the "/api/event" edge must connect to the span tree - the
+        // event.api.service span parents onto the remote caller's span (carried by the
+        // inbound trace headers), and the target function parents onto event.api.service.
+        // This is the reference behavior for other language implementations.
+        String traceForwarder = "distributed.trace.forwarder";
+        BlockingQueue<Map<String, Object>> records = new ArrayBlockingQueue<>(20);
+        Platform platform = Platform.getInstance();
+        String traceId = Utility.getInstance().getUuid();
+        String callerFunction = "event.api.span.caller";
+        LambdaFunction collector = (headers, input, instance) -> {
+            Map<String, Object> trace = (Map<String, Object>) input;
+            MultiLevelMap m = new MultiLevelMap(trace);
+            if (traceId.equals(m.getElement("trace.id"))) {
+                records.add(trace);
+            }
+            return null;
+        };
+        LambdaFunction caller = (headers, input, instance) -> {
+            // a traced function making a remote Event-over-HTTP RPC - its own span is
+            // the parent of the event.api.service span on the (loopback) remote side
+            PostOffice po = new PostOffice(headers, instance);
+            Map<String, String> securityHeaders = Map.of("Authorization", "demo");
+            EventEnvelope event = new EventEnvelope().setTo("hello.world").setBody(input);
+            return po.request(event, 8000, securityHeaders,
+                    "http://127.0.0.1:"+port+"/api/event", true).get().getBody();
+        };
+        platform.registerPrivate(traceForwarder, collector, 1);
+        platform.registerPrivate(callerFunction, caller, 1);
+        PostOffice po = new PostOffice("unit.test", traceId, "TEST /event/api/span");
+        po.asyncRequest(new EventEnvelope().setTo(callerFunction).setBody("start"), 8000)
+                .onSuccess(response -> assertEquals(200, response.getStatus()));
+        MultiLevelMap callerRecord = null;
+        MultiLevelMap eventApiRecord = null;
+        MultiLevelMap targetRecord = null;
+        long deadline = System.currentTimeMillis() + 10000;
+        while ((callerRecord == null || eventApiRecord == null || targetRecord == null)
+                && System.currentTimeMillis() < deadline) {
+            Map<String, Object> item = records.poll(2, TimeUnit.SECONDS);
+            if (item != null) {
+                MultiLevelMap m = new MultiLevelMap(item);
+                Object service = m.getElement("trace.service");
+                if (callerFunction.equals(service)) {
+                    callerRecord = m;
+                } else if ("event.api.service".equals(service)) {
+                    eventApiRecord = m;
+                } else if ("hello.world".equals(service)) {
+                    targetRecord = m;
+                }
+            }
+        }
+        platform.release(traceForwarder);
+        platform.release(callerFunction);
+        assertNotNull(callerRecord, "expect a trace record for the calling function");
+        assertNotNull(eventApiRecord, "expect a trace record for event.api.service");
+        assertNotNull(targetRecord, "expect a trace record for the target function");
+        assertEquals(callerRecord.getElement("trace.span_id"),
+                eventApiRecord.getElement("trace.parent_span_id"),
+                "event.api.service must parent onto the remote caller's span");
+        assertEquals(eventApiRecord.getElement("trace.span_id"),
+                targetRecord.getElement("trace.parent_span_id"),
+                "the target function must parent onto the event.api.service span");
+    }
 }


### PR DESCRIPTION
## What

**platform-core:** `event.api.service` is no longer zero-tracing. The `/api/event` edge is
now a visible span in the trace: its span parents onto the remote caller's span (carried by
the inbound trace headers), the relayed local event carries this service's span so the
target function parents onto it, and both response legs chain onto real spans (the span is
captured on the worker thread because the async RPC callbacks cannot read the thread-keyed
trace context later). New regression: `EventHttpTest.eventApiServiceIsAVisibleSpanInTheTrace`.

**Examples:** the declarative demo endpoint is renamed `/api/event/http/demo` →
`/api/event/http/declarative` (flow id `event-over-http-declarative`) for symmetry with its
programmatic twin, and the demo pair gains an authentication demo: the lambda-example
overrides the default `/api/event` entry with the `event.api.auth` service, which validates
the caller's `authorization` header against a shared secret resolved from the environment
(`demo.peer.token=${DEMO_PEER_TOKEN:demo}` on both peers — no hard-coded credential). The
composable-example presents the token declaratively (a `headers` block in
`event-over-http.yaml`) and programmatically (security headers on the request API), and
session info injected by the auth service rides to the target function — visible in the
echo as proof. Three new auth tests (accept / wrong / missing → 200/401/401).

**Docs:** the guide documents the rename and the new "Authentication: the event.api.auth
demo" section, and the interop test report is extended with the presentation-parity drive —
the normalized reference-signature method, the four-way empty-diff result, and a
"Learnings for future language ports" playbook.

## Why

A manual side-by-side review of all four interop direction logs — the way a DevSecOps
operator reads an aggregated stream — showed the `/api/event` REST edge connecting to no
span on the Java side. Field installations stay polyglot for a long time: both engines'
telemetry lands in one aggregation, so the two engines must present identically, with the
Java engine as the reference implementation. This PR makes the Java reference complete
(every record in the trace connects), and its live java-to-java run was distilled into the
normalized signature that the Rust port now replicates exactly (mercury PR pending, same
branch name) — verified live in all four directions with empty structural diffs.

The authentication demo closes the loop on the demo story: the zero-code walk-through now
also shows how to protect the Event API endpoint with an environment-based shared secret,
with authentication itself appearing in the trace as a real span.

## Verification

- platform-core 411, lambda-example 13, composable-example 5 — all green; strict docs build.
- Live two-app reference run: both patterns 200 with session proof, wrong token 401, and
  the full span chain verified (event.api.auth and event.api.service parent onto the remote
  caller's span; target and response legs chain onto event.api.service).
- Four-way interop verification (with the Rust parity branch): java-to-java, rust-to-rust,
  java-to-rust, rust-to-java all produce the identical normalized record set — empty diff,
  8 records declarative / 9 programmatic per direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>