### PR TITLE
Release v4.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.10.1, 7/23/2026
+
+Patch release in lock-step with the Rust engine's v4.10.1: telemetry presentation parity.
+Polyglot installations aggregate both engines' telemetry and logs in front of the same
+DevSecOps team, so the two engines' output must be structurally identical. The Java engine
+is the reference implementation - this release makes its trace complete (the "/api/event"
+edge is now a visible span), and the two engines' logs are verified as exact structural
+replicas in all four direction combinations - see the updated
+[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/),
+which now also serves as the playbook for future language ports.
 
 ### Added
 
-1. **Event-over-HTTP authentication demo.** The lambda-example overrides the default
+1. **Event-over-HTTP authentication demo (#217).** The lambda-example overrides the default
    `/api/event` endpoint with a demo authentication service (`event.api.auth`) that
    validates the caller's `authorization` header against a shared secret resolved from the
    environment (`demo.peer.token=${DEMO_PEER_TOKEN:demo}` on both peers - no hard-coded
@@ -22,13 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin:**
+1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin (#217):**
    `/api/event/http/demo` → `/api/event/http/declarative` and flow id
    `event-over-http-demo` → `event-over-http-declarative` in the composable-example.
 
 ### Fixed
 
-1. **The "/api/event" edge is now a visible span in the trace.** `event.api.service` was
+1. **The "/api/event" edge is now a visible span in the trace (#217).** `event.api.service` was
    zero-tracing, so the target function of a remote call parented onto a span from another
    application with nothing in between, and the HTTP response leg floated with no parent.
    The service is now traced: its span parents onto the remote caller's span, the target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.1) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.0) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.1) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -310,6 +310,18 @@
   <!-- id: event-script-over-code | created: 2026-06-27 | last_used: 2026-06-27 | uses: 1 | tier: core -->
 ## Conventions
 
+- **Telemetry/log presentation parity across language engines is a field requirement (Eric,
+  2026-07-23).** Rationale: even after the Rust engine is accepted into the field, installations
+  will be POLYGLOT for a long time — DevSecOps teams see both engines' telemetry and logs in one
+  aggregation, and any presentation difference (record shapes, span topology, context-block
+  gating, header hygiene) is a support burden they will flag. Operating rule: the Java engine is
+  the REFERENCE implementation; a same-language interop run (java-to-java vs rust-to-rust) must
+  be an exact structural replica after normalizing volatile fields — then cross-language runs are
+  symmetric by construction. Reference signature procedure established 2026-07-23
+  (normalized record set: service names, symbolic parent edges, round_trip vs exec-only kind,
+  paths, one-record-per-span, no dangling parents, my_*-free response headers, context-gating).
+  <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
+
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
   <!-- id: conv-add-capability | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
@@ -352,6 +364,30 @@
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-06-21 | uses: 1 | tier: working -->
 
 ## Open Threads
+
+- [ ] (release in flight — 2026-07-23) **v4.10.1 release prep on `chore/release-4.10.1`
+  (Java repo).** Patch release in lock-step with the Rust engine's v4.10.1 (its branch
+  `chore/release-4.10.1`, commit `44658df5`, pushed): telemetry presentation parity. Content:
+  PR #217 (/api/event visible span, declarative rename, event.api.auth demo, interop report
+  parity outcome + future-ports playbook). Sweep done (32 poms + CLAUDE/GEMINI +
+  instructions.md), CHANGELOG dated 7/23/2026. Close when tagged + release published.
+  <!-- id: thread-release-4-10-1 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
+
+- [ ] (in flight — 2026-07-23) **Post-4.10.0 telemetry presentation parity + auth demo (Eric's
+  manual-test findings).** Java reference branch `feature/event-api-span-and-auth` (2 commits,
+  NOT pushed): /api/event edge is now a visible span (EventApiService no longer @ZeroTracing;
+  worker-thread span capture for async callbacks; regression eventApiServiceIsAVisibleSpanInThe
+  Trace), demo→declarative rename, event.api.auth demo (${DEMO_PEER_TOKEN:demo} env secret,
+  session-info proof, 3 tests). Rust branch of the same name (2 commits, NOT pushed): callback-
+  dispatch refactor + async.http.response service, request-scoped context gating, my_* strip,
+  rename+auth mirror (session-info forwarding implemented). **Four-way verification COMPLETE:
+  java-to-java, rust-to-rust, java-to-rust, rust-to-java all EMPTY DIFF against the normalized
+  reference signature** (/tmp/java-to-java-reference-signature.md; per-pattern 8+9 records).
+  **UPDATE: both PRs MERGED 2026-07-23** — Java #217 (merge `d3c2f853`, CI green 6m29s) and
+  Rust #169 (merge `ecec21c5`, CI green); both repos' docs carry the extended interop test
+  report (parity drive + four-way empty-diff + future-ports playbook). Remaining: the two
+  v4.10.1 releases (both branches in flight). Relates [[conv-telemetry-presentation-parity]].
+  <!-- id: thread-telemetry-parity-auth | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
 
 - [x] (release in flight — 2026-07-22; CLOSED same day) **v4.10.0 SHIPPED via the normal flow** —
   tag `v4.10.0` on merge commit `af21e6f6` (PR #216, CI green + local full reactor), release

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -13,7 +13,7 @@ readers to it (docs/README references were removed 2026-07-20).
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.0`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.1`)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-23-145132.md
+++ b/memory/sessions/2026-07-23-145132.md
@@ -1,0 +1,101 @@
+# Session (2026-07-23T14:51:32.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Post-4.10.0 interop loose ends (Eric's manual test findings) — Java reference implementation
+work on branch `feature/event-api-span-and-auth`** (from main; not yet pushed). Eric tested all
+four interop directions manually (his .txt logs on Desktop) and found: a Java telemetry bug
+(/api/event edge connects to no span), several Rust bugs (redundant app-log-context on logs
+without trace context, my_* metadata leaked to response headers, missing first-leg span), plus
+two enhancements (demo→declarative rename; event-over-http authentication). Directive: fix Java
+FIRST and make it the reference implementation for Rust.
+
+**1. /api/event is now a visible span (commit 1 on the branch).** Root cause: `EventApiService`
+was `@ZeroTracing` — the relay was invisible, the target function parented onto the remote
+caller's span directly, and the response leg floated. Fix: the service is now traced (the
+traced-@EventInterceptor precedent is EventScriptManager); its span parents onto the remote
+caller's span from the inbound trace headers; `po.asyncRequest` on the worker thread stamps its
+span onto the relayed event (touch() overwrites span unconditionally when a trace exists) so the
+target parents onto it; sendResponse/sendError carry a span captured ON THE WORKER THREAD
+(the thread-keyed-trace gotcha — async callbacks cannot look it up later). New regression
+`EventHttpTest.eventApiServiceIsAVisibleSpanInTheTrace` (caller → event.api.service → target
+chain asserted). platform-core 411 green.
+
+**2. Rename + auth demo (commit 2).** `/api/event/http/demo` → `/api/event/http/declarative`,
+flow id `event-over-http-declarative` (rest.yaml, flows.yaml, flow file, test, guide, javadoc;
+the historical interop test report annotated, not rewritten). Auth demo per Eric's spec:
+lambda-example `EventApiAuth` (route `event.api.auth`, contract = EventEnvelope with boolean
+body + session headers, modeled on the platform-core test mock) validates `authorization`
+against `demo.peer.token=${DEMO_PEER_TOKEN:demo}` (env secret — no hard-coded credential;
+Snyk-safe: the ${VAR:default} placeholder carries no high-entropy literal); rest.yaml override
+of the default /api/event with `authentication: 'event.api.auth'`; composable-example presents
+the token declaratively (event-over-http.yaml headers) AND programmatically (security headers
+in EventOverHttpRpc). 3 new lambda-example tests (accept/wrong/missing → 200/401/401);
+lambda-example 13 green, composable-example 5 green. Guide gains "Authentication: the
+event.api.auth demo" section.
+
+**3. Live Java-to-Java reference run (jars at 4.10.0 + branch changes):** both endpoints 200
+with `user: demo` session proof; wrong token → 401. REFERENCE SPAN TOPOLOGY (for Rust parity),
+declarative trace: caller http.flow.adapter (root) → callee event.api.auth (parent = caller
+span, round_trip) + event.api.service (parent = caller span) → hello.declarative (parent =
+event.api.service) → hello.pojo; callee async.http.response parents onto event.api.service
+(no longer floating); caller async.http.response parents onto the callee's function span.
+Programmatic identical through v1.event.over.http.rpc. Caller HTTP response headers verified
+CLEAN of my_* metadata (the baseline for the Rust leak fix).
+
+Next: Rust session briefed with the reference topology + Eric's Rust bug list (log-context
+gating on logs without trace context, zero-tracing telemetry function, /api/event propagation
+alignment, my_* response-header leak, missing first-leg http.flow.adapter span, rename + auth
+mirror).
+
+**Refined goal (Eric): the rust-to-rust interop log must be an exact structural replica of
+java-to-java** — then cross-language symmetry follows naturally. Encoded as a machine-checkable
+normalized signature at `/tmp/java-to-java-reference-signature.md` (8 records declarative /
+9 programmatic; service names, symbolic parent edges, round_trip vs exec-only kind, paths;
+one-record-per-span + no-dangling-parent invariants; response-header cleanliness; log-context
+gating rules; volatile fields exempt). Notable deliberate cross-pattern asymmetry preserved:
+caller async.http.response parents onto the CALLEE function span (declarative) vs the local
+v1.event.over.http.rpc task span (programmatic). Rust session re-briefed mid-flight with the
+empty-diff acceptance procedure.
+
+**FOUR-WAY SYMMETRY VERIFIED (same session).** The Rust session completed its batch (branch
+`feature/event-api-span-and-auth` in ~/sandbox/mercury, 2 commits, 245 tests green): callback
+dispatch refactor for endpoint services + new async.http.response service (the structural fix
+Eric predicted), request-scoped context gating (the bug was a constants-without-bracket fallback
++ zero-traced brackets rendering), my_* strip at the REST boundary (leak not reproducible on
+current main but the protection point is now explicit), rename + auth mirror (rest.yaml
+`authentication:` support existed; SESSION-INFO forwarding was the missing half, now
+implemented), and its rust-to-rust drive produced an EMPTY DIFF against the reference signature.
+I then independently verified the CROSS-LANGUAGE directions live with a normalized diff script
+(scratchpad sigdiff.py): **java-to-rust EMPTY DIFF (8/8 + 9/9) and rust-to-java EMPTY DIFF
+(8/8 + 9/9)** — plus auth cross-language both ways (user:demo session proof; 401 negatives),
+zero my_* response headers, zero context blocks on telemetry lines. All four direction
+combinations now emit the identical normalized record set — Eric's replica goal achieved.
+The Rust repo recorded the parity invariant as a CORE invariant (inv-telemetry-presentation-
+parity). Both feature branches are LOCAL (not pushed), awaiting Eric's word.
+
+**Also (same session):** the interop test report now records the symmetry outcome per Eric —
+extended with "The presentation-parity drive (2026-07-23)" (rationale block quote, normalized
+signature tables, refactoring-not-patching, four-way empty-diff table) and a "Learnings for
+future language ports" playbook section (Python named). Committed on the Java branch (3rd
+commit) and DEPOSITED byte-identically (links adapted) into the Rust port's docs by the Rust
+session (`7f41ac56`, its branch's 3rd commit) with mirrored nav + See-also — the two sites carry
+the same permanent record, as the learning artifact for future ports.
+
+**Update (same session): BOTH PARITY PRs MERGED** — Java #217 (`d3c2f853`, CI green ×
+full reactor 6m29s) and Rust #169 (`ecec21c5`). **v4.10.1 releases in flight in lock-step:**
+Rust `chore/release-4.10.1` (`44658df5`, prepared by the Rust session, pushed, PR text
+delivered); Java `chore/release-4.10.1` (sweep 4.10.0→4.10.1 across 32 poms + CLAUDE/GEMINI +
+instructions.md, CHANGELOG dated 7/23/2026 leading with the presentation-parity story, full
+reactor gate run before push).
+
+## Memory References
+
+- referenced: trace-thread-keyed-mono-gotcha (drove the worker-thread span capture),
+  event-script-over-code, conv-add-capability, log-context-on-by-default,
+  client-naming-in-screenshots (Eric's Desktop logs are internal test output — no client data)
+- created: (thread to be added when the arc completes — Java half done, Rust half in flight)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.10.0</version>
+    <version>4.10.1</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.0</version>
+            <version>4.10.1</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version bump 4.10.0 → 4.10.1 across the 32 module poms and version references, and the
CHANGELOG dated for release. The 4.10.1 content merged ahead of this branch in #217:

- **The `/api/event` edge is a visible span in the trace** — `event.api.service` is no
  longer zero-tracing; its span parents onto the remote caller's span, the target function
  parents onto it, and both response legs chain onto real spans.
- **Declarative demo endpoint renamed** `/api/event/http/demo` →
  `/api/event/http/declarative` for symmetry with its programmatic twin.
- **Event-over-HTTP authentication demo** — `event.api.auth` validates a shared secret
  resolved from the `DEMO_PEER_TOKEN` environment variable, presented declaratively and
  programmatically by the composable-example, with session info riding to the target
  function as proof.
- **Interop test report extended** with the presentation-parity drive: the normalized
  reference-signature method, the four-way empty-diff result, and the learnings playbook
  for future language ports.

## Why

Patch release in lock-step with the Rust engine's v4.10.1 (mercury PR #170): telemetry
presentation parity. Polyglot installations aggregate both engines' telemetry and logs in
front of the same DevSecOps team, so the two engines' output must be structurally
identical. The Java engine is the reference implementation — this release completes its
trace (every record connects), and the two engines' logs are verified as exact structural
replicas in all four direction combinations, with the validation arc preserved on both
docs sites as the playbook for future ports.

## Verification

- Full reactor build + test at 4.10.1: BUILD SUCCESS (all 28 modules, 5:00).
- Version sweep verified: zero residual 4.10.0 references outside historical records.
- Content PR #217 was CI-green before merge; four-way interop symmetry verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>