### PR TITLE
feat: add isEmpty logical operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.10.1, 7/23/2026
+
+### Added
+
+1. **`isEmpty` logical operator**. Added support for checking empty collections, maps, strings, and arrays.
+
+---
 ## Version 4.10.0, 7/22/2026
 
 Feature release: cross-language Event-over-HTTP interoperability with the official

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Version 4.10.1, 7/23/2026
+## Version 4.10.2, 7/23/2026
 
 ### Added
 
 1. **`isEmpty` logical operator**. Added support for checking empty collections, maps, strings, and arrays.
+
+---
+## Version 4.10.1, 7/23/2026
+
+Patch release in lock-step with the Rust engine's v4.10.1: telemetry presentation parity.
+Polyglot installations aggregate both engines' telemetry and logs in front of the same
+DevSecOps team, so the two engines' output must be structurally identical. The Java engine
+is the reference implementation - this release makes its trace complete (the "/api/event"
+edge is now a visible span), and the two engines' logs are verified as exact structural
+replicas in all four direction combinations - see the updated
+[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/),
+which now also serves as the playbook for future language ports.
+
+### Added
+
+1. **Event-over-HTTP authentication demo (#217).** The lambda-example overrides the default
+   `/api/event` endpoint with a demo authentication service (`event.api.auth`) that
+   validates the caller's `authorization` header against a shared secret resolved from the
+   environment (`demo.peer.token=${DEMO_PEER_TOKEN:demo}` on both peers - no hard-coded
+   credential). The composable-example presents the token declaratively (a `headers` block
+   in `event-over-http.yaml`) and programmatically (the request API's security headers),
+   and session info injected by the auth service rides to the target function.
+
+### Changed
+
+1. **The declarative demo endpoint is renamed for symmetry with its programmatic twin (#217):**
+   `/api/event/http/demo` → `/api/event/http/declarative` and flow id
+   `event-over-http-demo` → `event-over-http-declarative` in the composable-example.
+
+### Fixed
+
+1. **The "/api/event" edge is now a visible span in the trace (#217).** `event.api.service` was
+   zero-tracing, so the target function of a remote call parented onto a span from another
+   application with nothing in between, and the HTTP response leg floated with no parent.
+   The service is now traced: its span parents onto the remote caller's span, the target
+   function parents onto it, and the response leg chains onto it as well. This is the
+   reference behavior for other language implementations.
 
 ---
 ## Version 4.10.0, 7/22/2026

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/IsEmptyOperator.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/logical/IsEmptyOperator.java
@@ -1,0 +1,46 @@
+package com.accenture.services.plugins.logical;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Map;
+
+@SimplePlugin
+public class IsEmptyOperator implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "isEmpty";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        if (input == null || input.length != 1) {
+            throw new IllegalArgumentException(
+                    "One input is required to check if value is empty");
+        }
+
+        Object value = input[0];
+
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Input cannot be null to check if value is empty");
+        }
+
+        return switch (value) {
+            case Collection<?> collection -> collection.isEmpty();
+            case Map<?, ?> map -> map.isEmpty();
+            case CharSequence text -> text.isEmpty();
+            default -> {
+                if (value.getClass().isArray()) {
+                    yield Array.getLength(value) == 0;
+                }
+
+                throw new IllegalArgumentException(
+                        "Unsupported input type to check if value is empty: " + value.getClass().getName());
+            }
+        };
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginLoaderTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginLoaderTest.java
@@ -106,7 +106,12 @@ public class SimplePluginLoaderTest {
                 Arguments.of(new UniqueSet(), new Object[]{List.of("a", "b", "a", "c", "b")}),
                 Arguments.of(new UpdateListOfMap(), new Object[]{
                         List.of(Map.of("world", 1), Map.of("world", 2)),
-                        Map.of("more", List.of("X", "Y"))})
+                        Map.of("more", List.of("X", "Y"))}),
+                Arguments.of(new IsEmptyOperator(), new Object[]{List.of()}),
+                Arguments.of(new IsEmptyOperator(), new Object[]{List.of("foo")}),
+                Arguments.of(new IsEmptyOperator(), new Object[]{Map.of()}),
+                Arguments.of(new IsEmptyOperator(), new Object[]{""}),
+                Arguments.of(new IsEmptyOperator(), new Object[]{new String[]{}})
         );
     }
 

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/logical/IsEmptyOperatorTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/logical/IsEmptyOperatorTest.java
@@ -1,0 +1,62 @@
+package com.accenture.services.plugins.logical;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IsEmptyOperatorTest {
+
+    private final IsEmptyOperator operator = new IsEmptyOperator();
+
+    static Stream<Arguments> emptyValues() {
+        return Stream.of(
+                Arguments.of(List.of(), true),
+                Arguments.of(List.of("foo"), false),
+                Arguments.of(Map.of(), true),
+                Arguments.of(Map.of("k", "v"), false),
+                Arguments.of("", true),
+                Arguments.of("hello", false),
+                Arguments.of(new String[]{}, true),
+                Arguments.of(new String[]{"hello"}, false),
+                Arguments.of(new int[]{}, true),
+                Arguments.of(new int[]{1, 2, 3}, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyValues")
+    void shouldCheckIfValueIsEmpty(Object input, boolean expected) {
+        assertEquals(expected, operator.calculate(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidInputs")
+    void shouldThrowExceptionForInvalidInput(Object[] input, String expectedMessage) {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> operator.calculate(input));
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    static Stream<Arguments> invalidInputs() {
+        return Stream.of(
+                Arguments.of(
+                        new Object[]{},
+                        "One input is required to check if value is empty"),
+                Arguments.of(
+                        new Object[]{"a", "b"},
+                        "One input is required to check if value is empty"),
+                Arguments.of(
+                        new Object[]{null},
+                        "Input cannot be null to check if value is empty"),
+                Arguments.of(
+                        new Object[]{123},
+                        "Unsupported input type to check if value is empty: java.lang.Integer"));
+    }
+}


### PR DESCRIPTION
## Summary
Added a new `isEmpty` logical operator.

## Why
Provides a reusable way to check whether common value types are empty without requiring custom expressions or additional handling.

## Supported values
- Collections
- Maps
- Character sequences
- Arrays

---
Co-Authored-By: "ChatGPT"

