### PR TITLE
Protected metadata is injected and sanitized, never transported; response correlation-id echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **The HTTP response echoes the business correlation-id.** REST automation returns the
+   request's correlation-id (inbound or edge-generated) on the response under the
+   configured header name (default `X-Correlation-Id`), so an edge caller can correlate
+   without parsing the body. A response header of the same name set by the function takes
+   precedence.
+
+### Fixed
+
+1. **Protected metadata is never transported in the event.** The business correlation-id
+   now rides an engine-managed envelope tag instead of a `my_correlation_id` envelope
+   header, and the worker injects the `my_*` read-only keys into the function's input
+   header copy at delivery - so reserved metadata can no longer leak across the
+   Event-over-HTTP wire, into relayed events, or through flow header mappings. The
+   engine-internal `x-event-api` relay guard is likewise removed from the function's view.
+   A callee still honors the legacy header from a pre-4.10.2 peer (injected, then
+   stripped), but no longer sends it - business-cid continuity in mixed fleets requires
+   both sides on this version, the same upgrade-together posture as the wire format.
+
+---
 ## Version 4.10.1, 7/23/2026
 
 Patch release in lock-step with the Rust engine's v4.10.1: telemetry presentation parity.

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -485,7 +485,7 @@ Maximum stack-trace lines embedded in an `EventEnvelope` when an exception occur
 |------|---------|
 | `String` | `X-Correlation-Id` |
 
-HTTP header carrying the business correlation-id (enterprise-specific; case-insensitive on inbound). Captured at the edge and preserved end-to-end — exposed to flows as `model.cid` and to functions via `PostOffice.getMyCorrelationId()`. A fresh dash-less UUID is generated when the header is absent. Overridable per endpoint with `correlation.id.header` in a rest.yaml entry (impedance matching for a legacy caller).
+HTTP header carrying the business correlation-id (enterprise-specific; case-insensitive on inbound). Captured at the edge and preserved end-to-end — exposed to flows as `model.cid` and to functions via `PostOffice.getMyCorrelationId()`. A fresh dash-less UUID is generated when the header is absent, and the resolved value is **echoed on every HTTP response** under the same header name so an edge caller can correlate without parsing the body (a response header of the same name set by the function takes precedence). Overridable per endpoint with `correlation.id.header` in a rest.yaml entry (impedance matching for a legacy caller).
 
 ### `http.trace.id.header`
 

--- a/docs/guides/event-envelope-wire-format.md
+++ b/docs/guides/event-envelope-wire-format.md
@@ -151,7 +151,17 @@ them remain fully conformant.
 |------|----------|
 | map of str → str | optional |
 
-Routing metadata (e.g. `optional`, `json`, `broadcast`).
+Engine-managed metadata (e.g. `optional`, `json`, `broadcast`). Tags are never visible to a
+user function - the engine consumes them at delivery. Two tag names are reserved with
+cross-language semantics that a conforming implementation must honor:
+
+- **`rpc`** - marks an RPC request (value = timeout in ms). The serving engine suppresses the
+  worker-side trace record for an RPC-served execution; the caller's round-trip record is the
+  single record for that span.
+- **`my_cid`** - carries the business correlation-id across touch points and Event-over-HTTP
+  hops. Metadata is never transported as envelope headers; the receiving engine injects the
+  read-only `my_correlation_id` key into the function's input header copy from this tag at
+  delivery.
 
 ### `annotations`
 

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -149,6 +149,11 @@ You may also add environment variable or base configuration references to the ta
 > *Note*: The target function must declare itself as PUBLIC in the preload annotation. Otherwise, you will get
           a HTTP-403 exception.
 
+> *Engine internals*: the relay stamps a reserved `x-event-api` header on the forwarded envelope as a
+> recursion guard (so the receiving engine does not re-relay the event through its own declarative map).
+> It is engine-internal — the worker removes it from a function's input header copy and filters it from
+> returned response headers, so application code never sees or emits it.
+
 The demo below is a complete working example of this service abstraction.
 
 ## Zero-code demo: composable-example to lambda-example {#zero-code-demo}

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -193,10 +193,16 @@ Propagation:
   plumbing invisible to application code; the business one is the durable, end-to-end identifier.
 - **Preserved in the flow** as `model.cid`, and exposed to every function task as the read-only
   `my_correlation_id` header (`PostOffice.getMyCorrelationId()`).
-- **Carried to any touch point.** Every `PostOffice` send/RPC/broadcast stamps `my_correlation_id` on the
-  outgoing event (the same way the trace context is carried), so the correlation-id follows the call graph
-  automatically — across in-memory calls, the cross-instance **event-over-HTTP** hop (it rides in the
-  serialized envelope and the peer target reads it via `getMyCorrelationId()`), and into downstream systems.
+- **Carried to any touch point.** Every `PostOffice` send/RPC/broadcast carries the business
+  correlation-id on an **engine-managed envelope tag** — never as an envelope header — so the
+  correlation-id follows the call graph automatically: across in-memory calls, the cross-instance
+  **event-over-HTTP** hop (the tag rides in the serialized envelope and the peer's engine injects
+  `my_correlation_id` at delivery for `getMyCorrelationId()`), and into downstream systems. Metadata is
+  never transported as envelope headers; the `my_*` keys exist only in the injected input-header copy.
+- **Echoed on the HTTP response.** REST automation returns the request's business correlation-id
+  (inbound or edge-generated) on the response under the configured header name (default
+  `X-Correlation-Id`), so an edge caller can correlate without parsing the body. A response header of
+  the same name set by the function takes precedence.
 - **Handed downstream.** `simple.kafka.notification` stamps it on the outbound Kafka message (under
   `kafka.correlation.id.header`), and `AsyncHttpClient` emits it as the configured HTTP header
   (`http.correlation.id.header`) on downstream calls — in both cases an explicitly set header (e.g. a flow

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -214,6 +214,67 @@ were symmetric with no additional work. Authentication verified in every directi
 (session proof in the echo; wrong or missing token → HTTP-401), response headers clean,
 and zero context blocks on untraced lines in either engine.
 
+## The metadata-hardening round (2026-07-23)
+
+A further manual four-direction review — after v4.10.1 — found two remaining issues: protected
+metadata visible to user functions and responses, and the business correlation-id missing from
+HTTP response headers. The trace signature was re-verified as an exact replica in all four
+directions **before** any fix, isolating the issues to pure header hygiene. The round produced
+a design ruling that is now the cross-engine contract:
+
+> **A composable function has exactly three inputs — headers, body and instance. The headers
+> are a COPY of the envelope headers with read-only metadata injected by the worker at entry
+> and sanitized at exit. Metadata is never transported in the event itself.**
+
+Root causes: the business correlation-id was the one metadata key transported as a real
+envelope header (the envelope has fields for trace id and path, but none for the business
+cid), so it leaked across the wire and into relayed events; the engine-internal `x-event-api`
+relay guard reached function views; and neither engine echoed the correlation-id on HTTP
+responses.
+
+**Fixes (both engines):** the business correlation-id rides an engine-managed envelope tag —
+`rpc` and `my_cid` are now documented reserved tag names in the
+[wire-format specification](../guides/event-envelope-wire-format.md) — with the worker
+injecting the four `my_*` read-only keys at delivery and sanitizing them (plus `x-event-api`)
+from returned envelopes at exit, covering the accidental-copy case; and REST automation echoes
+the request's business correlation-id on every HTTP response. This also closed a day-one
+injection asymmetry: the Rust callee now shows the identical `my_*` key set as Java, so the
+echo demos are replicas again.
+
+**The RPC reply path was aligned in the same round.** The Rust port had minted per-request
+pseudo-routes under an `inbox.` prefix — reserving the entire `inbox.*` namespace, which
+belongs to applications (workflow systems use routes like `inbox.approval` for human-approval
+staging). It now mirrors the Java design: one reserved private route `temporary.inbox` with a
+correlation-id-keyed pending registry, registered as an **essential service** at the highest
+startup priority (with the deliberate concurrency triple: HTTP client 500, temporary.inbox
+500, telemetry 1 — a singleton to preserve record ordering); the RPC marker is the reserved
+`rpc` tag; and the mesh-era `route@origin` syntax is never generated (inbound-tolerant only —
+instance addressing is a Kafka-service-mesh concern the port does not carry). A regression
+proves a user function registered as `inbox.approval` is reachable, RPC-able, and traced
+normally. The rework also surfaced a genuine pre-existing defect in the Rust HTTP client
+service (replying through the global platform instead of its own).
+
+### Regression re-test: the refactor is observably invisible
+
+The working hypothesis — that the rework would make interop more robust *and predictable* —
+was tested by re-running the full battery in both cross-language directions:
+
+| Check | Java → Rust | Rust → Java |
+|-------|-------------|-------------|
+| Functionality (both patterns) | pass | pass |
+| `X-Correlation-Id` response echo | pass | pass |
+| Generated-cid identity across the wire | pass | pass (one value end to end) |
+| Identical injected `my_*` key set | pass | pass |
+| `x-event-api` in any function view | absent | absent |
+| Authentication (session proof / 401) | pass | pass |
+| **Trace signature** | **empty diff** (8+9 records) | **empty diff** (8+9 records) |
+
+Same-language: Java full reactor and the Rust workspace suites green, with the rust-to-rust
+signature also an empty diff. The internals hardened — a static route table, one cid-keyed
+correlation concept local and remote, deterministic essential-service startup — while
+observable behavior stayed byte-for-byte unchanged, which is exactly what the empty diff is
+designed to prove.
+
 ## Learnings for future language ports
 
 This validation arc is the playbook for bringing the next language (e.g. Python) into the
@@ -240,3 +301,8 @@ family:
 6. **Live drives find what unit tests do not.** Every drive in this story surfaced real
    defects (timeout truncation, span misattribution, context leakage, an invisible relay
    edge) that per-repository test suites had not caught.
+7. **Reserve the minimum; inject the rest.** Engine metadata is injected into the function's
+   input copy at entry and sanitized at exit — never transported in the event — and the
+   engine reserves the smallest possible surface (one RPC listener route, two tag names).
+   Route namespaces and header space belong to applications; a port that borrows them for
+   engine plumbing will collide with real-world naming sooner or later.

--- a/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
@@ -966,9 +966,10 @@ public class TaskExecutor implements TypedLambdaFunction<EventEnvelope, Void> {
                                             .setBody(unwrapBodyIfWildcard(md))
                                             .setSpanId(parentSpanId);
             md.optionalHeaders.forEach(event::setHeader);
-            // expose the flow's business correlation-id (model.cid) as a read-only reserved header - stamped
-            // last so a mapped optional header named my_correlation_id cannot override the framework value
-            event.setHeader(MY_CORRELATION_ID, flowInstance.businessCorrelationId);
+            // carry the flow's business correlation-id (model.cid) on the engine-managed envelope tag -
+            // never as an envelope header - so the worker injects my_correlation_id at delivery and a
+            // mapped optional header cannot collide with the framework value
+            event.addTag(EventEmitter.BUSINESS_CID_TAG, flowInstance.businessCorrelationId);
             // execute task by sending event
             if (deferred > 0) {
                 po.sendLater(event, new Date(System.currentTimeMillis() + deferred));

--- a/system/platform-core/src/main/java/org/platformlambda/automation/models/AsyncContextHolder.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/models/AsyncContextHolder.java
@@ -30,6 +30,8 @@ public class AsyncContextHolder {
     public String resHeaderId;
     public String accept;
     public String method;
+    public String cidHeaderName;
+    public String businessCorrelationId;
 
     public AsyncContextHolder(HttpServerRequest request) {
         this.request = request;
@@ -59,6 +61,12 @@ public class AsyncContextHolder {
 
     public AsyncContextHolder setAccept(String accept) {
         this.accept = accept;
+        return this;
+    }
+
+    public AsyncContextHolder setCorrelation(String cidHeaderName, String businessCorrelationId) {
+        this.cidHeaderName = cidHeaderName;
+        this.businessCorrelationId = businessCorrelationId;
         return this;
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
@@ -77,6 +77,11 @@ public class AsyncHttpResponse implements TypedLambdaFunction<EventEnvelope, Voi
             if (holder != null) {
                 holder.touch();
                 HttpServerResponse response = holder.request.response();
+                // echo the request's business correlation-id (inbound or edge-generated) so the
+                // caller can correlate; a function-provided response header of the same name wins
+                if (holder.cidHeaderName != null && holder.businessCorrelationId != null) {
+                    response.putHeader(holder.cidHeaderName, holder.businessCorrelationId);
+                }
                 boolean isHeadMethod = HEAD.equals(holder.method);
                 var md = new HttpResMetadata();
                 md.contentType = isHeadMethod? "?" : null;

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -489,6 +489,8 @@ public class HttpRouter {
         }
         TraceContext trace = resolveTraceContext(request, route, req, uri,
                                                  cidHeaderName, generatedCid, businessCorrelationId);
+        // remember the resolved correlation-id so the response writer echoes it back to the caller
+        holder.setCorrelation(cidHeaderName, trace.businessCorrelationId());
         final HttpRequestEvent requestEvent = new HttpRequestEvent(requestId, route, authService,
                                                                     trace.traceId(), trace.tracePath());
         requestEvent.setParentSpanId(trace.parentSpanId());
@@ -887,9 +889,10 @@ public class HttpRouter {
             event.setTo(requestEvent.primary).setFrom(HTTP_REQUEST)
                     .setCorrelationId(requestEvent.requestId).setBody(requestEvent.httpRequest)
                     .setReplyTo(AsyncHttpClient.ASYNC_HTTP_RESPONSE + "@" + Platform.getInstance().getOrigin());
-            // expose the business correlation-id to the target function (and downstream via PostOffice)
+            // carry the business correlation-id on the engine-managed envelope tag (never a header);
+            // the worker injects my_correlation_id into the target function's input copy at delivery
             if (requestEvent.getBusinessCorrelationId() != null) {
-                event.setHeader(MY_CORRELATION_ID, requestEvent.getBusinessCorrelationId());
+                event.addTag(EventEmitter.BUSINESS_CID_TAG, requestEvent.getBusinessCorrelationId());
             }
             // enable distributed tracing if needed
             if (requestEvent.tracing) {
@@ -922,7 +925,7 @@ public class HttpRouter {
         EventEnvelope copy = new EventEnvelope().setTo(secondary).setFrom(HTTP_REQUEST)
                 .setBody(requestEvent.httpRequest);
         if (requestEvent.getBusinessCorrelationId() != null) {
-            copy.setHeader(MY_CORRELATION_ID, requestEvent.getBusinessCorrelationId());
+            copy.addTag(EventEmitter.BUSINESS_CID_TAG, requestEvent.getBusinessCorrelationId());
         }
         if (requestEvent.tracing) {
             copy.setTrace(requestEvent.traceId, requestEvent.tracePath);

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -50,6 +50,10 @@ public class EventEmitter {
     public static final String CLOUD_CONNECTOR = "cloud.connector";
     public static final String CLOUD_SERVICES = "cloud.services";
     public static final String RPC = "rpc";
+    // Engine-managed envelope tag carrying the business correlation-id across touch points and
+    // Event-over-HTTP hops. Metadata is never transported as envelope headers - the worker injects
+    // the my_correlation_id key into the function's input header copy from this tag at delivery.
+    public static final String BUSINESS_CID_TAG = "my_cid";
     private static final String MISSING_ROUTING_PATH = "Missing routing path";
     private static final String MISSING_EVENT = "Missing outgoing event";
     private static final long ASYNC_EVENT_HTTP_TIMEOUT = 60 * 1000L; // assume 60 seconds

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
@@ -713,10 +713,11 @@ public class PostOffice {
         if (event.getTracePath() == null) {
             event.setTracePath(myTracePath);
         }
-        // propagate the business correlation-id to the next touch point, readable via getMyCorrelationId
-        // carried as a read-only reserved header so it reaches any function, HTTP client, or Kafka producer
-        if (businessCorrelationId != null && event.getHeader(MY_CORRELATION_ID) == null) {
-            event.setHeader(MY_CORRELATION_ID, businessCorrelationId);
+        // propagate the business correlation-id to the next touch point, readable via getMyCorrelationId.
+        // It rides an engine-managed envelope tag - never an envelope header - and the worker injects
+        // it into the receiving function's input header copy at delivery.
+        if (businessCorrelationId != null && event.getTag(EventEmitter.BUSINESS_CID_TAG) == null) {
+            event.addTag(EventEmitter.BUSINESS_CID_TAG, businessCorrelationId);
         }
         // carry this function's spanId so the receiver can store it as its parentSpanId
         TraceInfo trace = getTrace();

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -73,6 +73,7 @@ public class WorkerHandler {
     private static final String MY_TRACE_ID = "my_trace_id";
     private static final String MY_TRACE_PATH = "my_trace_path";
     private static final String MY_CORRELATION_ID = "my_correlation_id";
+    private static final String X_EVENT_API = "x-event-api";
     private static final String X_STREAM_ID = "x-stream-id";
     private static final String X_TTL = "x-ttl";
     private static final String READY = "ready:";
@@ -203,14 +204,27 @@ public class WorkerHandler {
         final long begin = System.nanoTime();
         try {
             final Object body = prepareInputBody(event);
-            // Insert READ only metadata into function input headers
+            /*
+             * A user function receives a COPY of the envelope headers with read-only metadata
+             * injected at delivery time. Metadata is never transported in the event itself:
+             * engine-internal keys are removed from the copy, and the my_* keys below are
+             * derived from envelope fields, the business-cid tag and worker context.
+             */
             Map<String, String> parameters = new HashMap<>(event.getHeaders());
+            parameters.remove(X_EVENT_API);
+            // a legacy peer (pre-4.10.2) transported the business correlation-id as an envelope header
+            String legacyBusinessCid = parameters.remove(MY_CORRELATION_ID);
             parameters.put(MY_ROUTE, parentRoute);
             if (event.getTraceId() != null) {
                 parameters.put(MY_TRACE_ID, event.getTraceId());
             }
             if (event.getTracePath() != null) {
                 parameters.put(MY_TRACE_PATH, event.getTracePath());
+            }
+            String businessCid = event.getTag(EventEmitter.BUSINESS_CID_TAG) != null?
+                    event.getTag(EventEmitter.BUSINESS_CID_TAG) : legacyBusinessCid;
+            if (businessCid != null) {
+                parameters.put(MY_CORRELATION_ID, businessCid);
             }
             Object result = invokeFunction(f, parameters, body, event);
             md.diff = getExecTime(begin);
@@ -558,10 +572,12 @@ public class WorkerHandler {
     }
 
     private void copyResponseHeaders(Map<String, String> headers, EventEnvelope response) {
+        // exit-side sanitization, symmetric with the entry-side injection: the read-only
+        // metadata keys and engine-internal keys never leave a function as response headers
         for (Map.Entry<String, String> kv: headers.entrySet()) {
             String k = kv.getKey();
             if (!MY_ROUTE.equals(k) && !MY_TRACE_ID.equals(k) && !MY_TRACE_PATH.equals(k)
-                    && !MY_CORRELATION_ID.equals(k)) {
+                    && !MY_CORRELATION_ID.equals(k) && !X_EVENT_API.equals(k)) {
                 response.setHeader(k, kv.getValue());
             }
         }

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -190,6 +190,39 @@ class RestEndpointTest extends TestBase {
 
     @SuppressWarnings(value = "unchecked")
     @Test
+    void responseEchoesInboundCorrelationId() throws InterruptedException, ExecutionException {
+        // the edge echoes the request's business correlation-id on the HTTP response so the
+        // caller can correlate without parsing the body
+        var po = PostOffice.trackable("unit.test", "310", "GET /api/hello/world");
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/hello/world").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json");
+        req.setHeader("X-Correlation-Id", "cid-echo-0101");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        EventEnvelope response = po.eRequest(request, RPC_TIMEOUT).get();
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        assertEquals("cid-echo-0101", response.getHeader("x-correlation-id"));
+    }
+
+    @Test
+    void responseCarriesGeneratedCorrelationIdWhenAbsent() throws InterruptedException, ExecutionException {
+        // when the caller does not provide one, the edge generates a correlation-id and
+        // still returns it on the response
+        var po = PostOffice.trackable("unit.test", "311", "GET /api/hello/world");
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/hello/world").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        EventEnvelope response = po.eRequest(request, RPC_TIMEOUT).get();
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        String cid = response.getHeader("x-correlation-id");
+        assertNotNull(cid, "the generated correlation-id must be echoed on the response");
+        assertFalse(cid.isEmpty());
+    }
+
+    @Test
     void serviceTest() throws InterruptedException, ExecutionException {
         final int TTL_SECONDS = 7;
         var po = PostOffice.trackable("unit.test", "101", "/HELLO");
@@ -948,8 +981,8 @@ class RestEndpointTest extends TestBase {
         // HTTP head response may include custom headers and content-length
         assertEquals("HEAD request received", response.getHeader("X-Response"));
         assertEquals("100", response.getHeader("Content-Length"));
-        // the trace/correlation header is NOT echoed back to the caller (legacy echo-back removed)
-        assertNull(response.getHeader("X-Correlation-Id"));
+        // the business correlation-id IS echoed back to the caller; the trace header is not
+        assertEquals(traceId, response.getHeader("X-Correlation-Id"));
         assertNull(response.getHeader("X-Trace-Id"));
         // multiple "set-cookie" headers are consolidated into one composite value
         assertEquals("first=cookie|second=one", response.getHeader("set-cookie"));

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventHttpTest.java
@@ -89,7 +89,8 @@ class EventHttpTest extends TestBase {
     void eventOverHttpPropagatesTraceAndCorrelationId() throws InterruptedException {
         // The whole EventEnvelope is serialized into the HTTP body over the "event over HTTP" hop, so the
         // peer's target function continues the same trace (traceId exposed as my_trace_id) and receives the
-        // caller's business correlation-id (carried as the my_correlation_id reserved header by touch()).
+        // caller's business correlation-id (carried by the engine-managed envelope tag, injected as the
+        // my_correlation_id read-only key at delivery).
         final BlockingQueue<Map<String, String>> captured = new ArrayBlockingQueue<>(1);
         final String captureRoute = "event.http.trace.capture";
         TypedLambdaFunction<EventEnvelope, Object> capture = (headers, event, instance) -> {
@@ -420,6 +421,54 @@ class EventHttpTest extends TestBase {
         assertEquals(EventEnvelope.Format.COMPACT, result.getWireFormat());
         MultiLevelMap map = new MultiLevelMap((Map<String, Object>) result.getBody());
         assertEquals("legacy", map.getElement("body"));
+    }
+
+    @Test
+    void metadataIsNeverTransportedInTheEvent() throws InterruptedException {
+        // The my_* metadata keys are injected into the function's input header COPY at
+        // delivery - they must never exist as envelope headers. The business correlation-id
+        // crosses touch points (and the Event-over-HTTP wire) as an engine-managed tag.
+        final BlockingQueue<Map<String, String>> captured = new ArrayBlockingQueue<>(1);
+        final String captureRoute = "metadata.transport.capture";
+        TypedLambdaFunction<EventEnvelope, Object> capture = (headers, event, instance) -> {
+            Map<String, String> seen = new HashMap<>();
+            seen.put("injected_cid", headers.get("my_correlation_id"));
+            seen.put("injected_route", headers.get("my_route"));
+            seen.put("envelope_cid_header", event.getHeader("my_correlation_id"));
+            seen.put("envelope_event_api_header", event.getHeader("x-event-api"));
+            seen.put("delivered_event_api", headers.get("x-event-api"));
+            // engine metadata (routing target, tags) is not visible to a user function
+            seen.put("visible_tags", String.valueOf(event.getTags()));
+            captured.add(seen);
+            return null;
+        };
+        Platform.getInstance().register(captureRoute, capture, 1);
+        try {
+            String correlationId = "corr-" + Utility.getInstance().getUuid();
+            Map<String, String> callerContext = new HashMap<>();
+            callerContext.put("my_route", "unit.test");
+            callerContext.put("my_trace_id", "trace-" + Utility.getInstance().getUuid());
+            callerContext.put("my_trace_path", "TEST /metadata/transport");
+            callerContext.put("my_correlation_id", correlationId);
+            PostOffice po = PostOffice.trackable(callerContext, 1);
+            // remote hop through the loopback /api/event exercises the wire + relay too
+            Map<String, String> securityHeaders = Map.of("Authorization", "demo");
+            po.asyncRequest(new EventEnvelope().setTo(captureRoute).setBody("ping"), 5000,
+                    securityHeaders, "http://127.0.0.1:" + port + "/api/event", false);
+            Map<String, String> seen = captured.poll(10, TimeUnit.SECONDS);
+            assertNotNull(seen);
+            // injected metadata reaches the function's header copy
+            assertEquals(correlationId, seen.get("injected_cid"));
+            assertEquals(captureRoute, seen.get("injected_route"));
+            // but the envelope itself never carries metadata or engine-internal keys
+            assertNull(seen.get("envelope_cid_header"), "my_correlation_id must not be an envelope header");
+            assertNull(seen.get("delivered_event_api"), "x-event-api must not reach a user function");
+            // the tag channel is engine-managed - not even visible to the function's envelope view
+            // (the injected value above arriving intact across the wire proves the tag carried it)
+            assertEquals("{}", seen.get("visible_tags"));
+        } finally {
+            Platform.getInstance().release(captureRoute);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
@@ -1019,6 +1019,43 @@ class PostOfficeTest extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void accidentalMetadataEchoIsSanitizedAtExit() throws InterruptedException, ExecutionException {
+        // Eric's scenario: a function accidentally copies its input headers - including the
+        // injected read-only metadata - onto a returned EventEnvelope. The exit-side
+        // sanitization must filter the protected keys while keeping ordinary headers.
+        String echoAllHeaders = "echo.all.headers";
+        LambdaFunction f = (headers, input, instance) -> {
+            EventEnvelope result = new EventEnvelope().setBody("ok");
+            headers.forEach(result::setHeader);         // the accidental copy
+            result.setHeader("x-event-api", "spoofed"); // deliberate engine-internal key
+            return result;
+        };
+        Platform.getInstance().registerPrivate(echoAllHeaders, f, 1);
+        try {
+            Map<String, String> ctx = new HashMap<>();
+            ctx.put("my_route", "unit.test");
+            ctx.put("my_trace_id", "trace-sanitize-1");
+            ctx.put("my_trace_path", "TEST /exit/sanitization");
+            ctx.put("my_correlation_id", "cid-sanitize-1");
+            PostOffice po = PostOffice.trackable(ctx, 1);
+            EventEnvelope req = new EventEnvelope().setTo(echoAllHeaders)
+                    .setBody("x").setHeader("hello", "world");
+            EventEnvelope reply = po.request(req, 8000).get();
+            assertEquals("ok", reply.getBody());
+            // ordinary headers survive
+            assertEquals("world", reply.getHeader("hello"));
+            // protected metadata and engine-internal keys are filtered out at exit
+            assertNull(reply.getHeader("my_route"));
+            assertNull(reply.getHeader("my_trace_id"));
+            assertNull(reply.getHeader("my_trace_path"));
+            assertNull(reply.getHeader("my_correlation_id"));
+            assertNull(reply.getHeader("x-event-api"));
+        } finally {
+            Platform.getInstance().release(echoAllHeaders);
+        }
+    }
+
+    @Test
     void rpcTelemetryCarriesSpanLineage() throws InterruptedException {
         // Regression: the RPC trace record (the one with round_trip) must chain like a
         // worker-emitted record - span_id is the callee's own span (carried on the RPC


### PR DESCRIPTION
## What

The design ruling from the latest interop review, now the cross-engine contract: a
composable function has exactly three inputs — headers, body and instance. The headers are
a COPY of the envelope headers with read-only metadata injected by the WorkerHandler at
entry and sanitized at exit. **Metadata is never transported in the event itself.**

- The business correlation-id moves from a `my_correlation_id` envelope header to an
  engine-managed envelope tag (`my_cid`, riding the existing wire `tags` field — no
  wire-spec or golden-vector change), converted at all three stamping sites
  (`PostOffice.touch()`, the flow engine's task dispatch, `HttpRouter`).
- The worker injects the four `my_*` read-only keys into the function's input header copy
  at delivery (honoring, then stripping, the legacy header from pre-fix peers) and removes
  the engine-internal `x-event-api` relay guard; exit-side sanitization filters the same
  keys from returned envelopes — symmetric, and covering the synchronous, deferred and
  Mono response paths, including the accidental-copy case.
- REST automation echoes the request's business correlation-id (inbound or edge-generated)
  on every HTTP response under the configured header name (default `X-Correlation-Id`); a
  function-set response header of the same name wins.
- Docs: the wire-format specification now documents `rpc` and `my_cid` as reserved tag
  names with cross-language semantics; reserved-names, configuration-reference and the
  Event-over-HTTP guide updated; the interop test report gains "The metadata-hardening
  round" section and learning #7 ("Reserve the minimum; inject the rest").

## Why

A manual side-by-side interop review found protected metadata leaking to user functions
and responses, and no correlation-id on HTTP responses. The root cause was structural: the
business correlation-id was the one metadata key transported as a real envelope header, so
it leaked across the Event-over-HTTP wire, into relayed events, and through flow header
mappings. Moving it to the engine tag channel — invisible to user functions by existing
design — and making injection/sanitization symmetric enforces clean boundary demarcation:
route namespaces and header space belong to applications; the engine reserves the smallest
possible surface. The response echo restores edge correlation with business-cid semantics.

The Rust counterpart PR (same branch name) mirrors this and additionally aligns its RPC
reply path to the single reserved `temporary.inbox` route, freeing the `inbox.*` namespace.

## Verification

- Full reactor BUILD SUCCESS; platform-core 415 green with four new regressions
  (metadata-never-transported over the wire, accidental-echo-sanitized-at-exit, response
  echo inbound + generated).
- Live two-app verification plus full cross-language re-test in both directions: response
  echo, end-to-end cid identity across the wire, identical injected `my_*` key set,
  `x-event-api` absent, auth intact — and the trace signature at empty diff throughout.

**Compatibility:** a fixed callee honors the legacy `my_correlation_id` header from
pre-fix peers but no longer sends it — business-cid continuity in mixed fleets requires
both sides upgraded, the same posture as the wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>