### PR TITLE
Release v4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.10.2, 7/23/2026
+
+Patch release in lock-step with the Rust engine's v4.10.2: the metadata contract and the
+RPC reply path. A composable function's three inputs are headers, body and instance - the
+headers are a copy of the envelope headers with read-only metadata injected by the worker
+at entry and sanitized at exit; metadata is never transported in the event itself. The
+`inbox.*` route namespace is confirmed to belong to applications (the Rust port aligned to
+the single reserved `temporary.inbox` route). Cross-language interop re-verified in all
+four direction combinations with the trace signature at empty diff - see the updated
+[Interop Test Report](https://accenture.github.io/mercury-composable/test-reports/event-over-http-interop/).
+Also ships three community-contributed collection plugins for Event Script.
 
 ### Added
 
-1. **The HTTP response echoes the business correlation-id.** REST automation returns the
+1. **Three collection plugins for Event Script data mapping (#220).** `isEmpty`
+   (Collection, Map, String or array), `getFirst` and `getLast` (non-empty List) join the
+   built-in simple plugins as the new `collection` category - documented in the syntax
+   guide's Built-in Plugins section.
+2. **The HTTP response echoes the business correlation-id (#221).** REST automation returns the
    request's correlation-id (inbound or edge-generated) on the response under the
    configured header name (default `X-Correlation-Id`), so an edge caller can correlate
    without parsing the body. A response header of the same name set by the function takes
@@ -20,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-1. **Protected metadata is never transported in the event.** The business correlation-id
+1. **Protected metadata is never transported in the event (#221).** The business correlation-id
    now rides an engine-managed envelope tag instead of a `my_correlation_id` envelope
    header, and the worker injects the `my_*` read-only keys into the function's input
    header copy at delivery - so reserved metadata can no longer leak across the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.1) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.2) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.1) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.2) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-22 | agent: Claude Code (2026-07-23-015717)
+- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-23-211728)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -320,6 +320,11 @@
   symmetric by construction. Reference signature procedure established 2026-07-23
   (normalized record set: service names, symbolic parent edges, round_trip vs exec-only kind,
   paths, one-record-per-span, no dangling parents, my_*-free response headers, context-gating).
+  **Scope extension (Eric, 2026-07-23): the Event Script surface is part of the cross-engine
+  contract** — flows are engine-portable YAML, so any new built-in simple plugin ships in
+  lock-step on both engines (with closely matching error messages — presentation parity extends
+  to error text), or flows stop being portable. Precedent: the #220 collection plugins mirrored
+  into the Rust v4.10.2.
   <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
 
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
@@ -365,16 +370,59 @@
 
 ## Open Threads
 
-- [ ] (release in flight — 2026-07-23) **v4.10.1 release prep on `chore/release-4.10.1`
-  (Java repo).** Patch release in lock-step with the Rust engine's v4.10.1 (its branch
+- [ ] (release in flight — 2026-07-23) **v4.10.2 release prep on `chore/release-4.10.2` (Java).**
+  Patch release in lock-step with Rust: metadata contract (#221), temporary.inbox alignment
+  (Rust #171), + PR #220 (team-contributed collection plugins isEmpty/getFirst/getLast —
+  REVIEWED by Claude Code at Eric's request: correct + convention-consistent; polish commit
+  `a38bb181` added license headers ×6 + syntax-guide Collection docs; CHANGELOG entry deferred
+  to release prep to avoid branch conflict; formal GitHub review API blocked for EMU accounts —
+  review delivered in-session). Sweep 4.10.1→4.10.2 done; CHANGELOG dated 7/23/2026 with the
+  boundary-demarcation summary. Close when tagged + published both repos.
+  <!-- id: thread-release-4-10-2 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-211728 -->
+
+- [ ] (in flight — 2026-07-23) **Metadata injection/sanitization hardening (Eric's 3rd interop
+  round).** Design ruling: function inputs = headers/body/instance; headers = envelope-header
+  COPY + metadata INJECTED at entry, SANITIZED at exit; metadata NEVER transported in the event.
+  Java reference DONE on `feature/metadata-injection-hardening` (1 commit, NOT pushed): business
+  cid → engine tag `my_cid` (EventEmitter.BUSINESS_CID_TAG; tags wire field, no spec change;
+  three stamping sites converted), worker entry injection (4 my_* keys + legacy-header compat +
+  x-event-api strip), symmetric exit filter (copyResponseHeaders + x-event-api), HTTP response
+  X-Correlation-Id echo (AsyncContextHolder + AsyncHttpResponse; function-set header wins).
+  Full reactor green; platform-core 415 (4 new regressions); live verification passed (cid echo
+  inbound+generated; function view: 4 injected my_*, business cid intact, no x-event-api).
+  Tracing signature UNCHANGED (all four directions re-verified against the reference before the
+  fix). **Rust mirror COMPLETE (`794fb287`, 249 tests green) and four-way re-verification
+  PASSED with the extended invariants** — identical injected my_* key set on both callees,
+  end-to-end cid identity across the language boundary (response header == callee-injected
+  my_correlation_id), x-event-api absent everywhere, span signature empty-diff in all four
+  combinations. **+ Second item (Eric): Rust RPC-reply design gap — the "inbox." prefix
+  pseudo-routes reserve the whole inbox.* namespace (collides with workflow-app route names
+  like inbox.approval); Rust session aligning to Java's single reserved private route
+  `temporary.inbox` (@ZeroTracing @EventInterceptor, 500 instances, cid-keyed registry,
+  composite cid-seq split) as a 2nd commit on the same branch; CRITICAL sub-item: the Rust
+  one-record-per-span suppression gate keyed off the "inbox." prefix must re-key (prefer the
+  rpc tag, Java's real mechanism).** **Rust 2nd commit DONE (`698de3c4`, 250 tests; gate
+  re-keyed to the rpc TAG; essential sequencing + @origin never-emit per Eric's hints; found a
+  genuine AsyncHttpClientService global-platform bug) and the INTEROP RE-TEST PASSED in full**
+  (cross-language both directions: functionality, auth, cid echo + generated-identity, my_*
+  parity, x-event-api-free, signature empty-diff ×2×2 — the inbox refactor is observably
+  invisible, validating Eric's robustness hypothesis). **BOTH PRs MERGED 2026-07-23: Java #221
+  (merge `a25d95d5`) + Rust #171 (merge `f86fbec2`), CI green both.** Remaining: the v4.10.2
+  lock-step releases ([[thread-release-4-10-2]]). Relates [[conv-telemetry-presentation-parity]].
+  <!-- id: thread-metadata-injection-hardening | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-211728 -->
+
+- [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.1 SHIPPED via the normal
+  flow (Java repo)** — tag `v4.10.1` on merge commit `9ae666df` (PR #218, CI green + local
+  full reactor), release notes delivered, release published. Rust shipped in lock-step the
+  same day (tag on `2c4e4066`, PR #170). Patch release in lock-step with the Rust engine's v4.10.1 (its branch
   `chore/release-4.10.1`, commit `44658df5`, pushed): telemetry presentation parity. Content:
   PR #217 (/api/event visible span, declarative rename, event.api.auth demo, interop report
   parity outcome + future-ports playbook). Sweep done (32 poms + CLAUDE/GEMINI +
   instructions.md), CHANGELOG dated 7/23/2026. Close when tagged + release published.
   <!-- id: thread-release-4-10-1 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
 
-- [ ] (in flight — 2026-07-23) **Post-4.10.0 telemetry presentation parity + auth demo (Eric's
-  manual-test findings).** Java reference branch `feature/event-api-span-and-auth` (2 commits,
+- [x] (in flight — 2026-07-23; COMPLETE same day) **Post-4.10.0 telemetry presentation parity +
+  auth demo (Eric's manual-test findings).** Java reference branch `feature/event-api-span-and-auth` (2 commits,
   NOT pushed): /api/event edge is now a visible span (EventApiService no longer @ZeroTracing;
   worker-thread span capture for async callbacks; regression eventApiServiceIsAVisibleSpanInThe
   Trace), demo→declarative rename, event.api.auth demo (${DEMO_PEER_TOKEN:demo} env secret,
@@ -385,8 +433,10 @@
   reference signature** (/tmp/java-to-java-reference-signature.md; per-pattern 8+9 records).
   **UPDATE: both PRs MERGED 2026-07-23** — Java #217 (merge `d3c2f853`, CI green 6m29s) and
   Rust #169 (merge `ecec21c5`, CI green); both repos' docs carry the extended interop test
-  report (parity drive + four-way empty-diff + future-ports playbook). Remaining: the two
-  v4.10.1 releases (both branches in flight). Relates [[conv-telemetry-presentation-parity]].
+  report (parity drive + four-way empty-diff + future-ports playbook). **COMPLETE: both
+  v4.10.1 releases published 2026-07-23 ([[thread-release-4-10-1]]) — the parity arc closed
+  end to end: reference implementation → refactor → four-way empty diff → lock-step release.**
+  Relates [[conv-telemetry-presentation-parity]].
   <!-- id: thread-telemetry-parity-auth | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
 
 - [x] (release in flight — 2026-07-22; CLOSED same day) **v4.10.0 SHIPPED via the normal flow** —

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -13,7 +13,7 @@ readers to it (docs/README references were removed 2026-07-20).
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.1`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.2`)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-23-145132.md
+++ b/memory/sessions/2026-07-23-145132.md
@@ -91,6 +91,10 @@ delivered); Java `chore/release-4.10.1` (sweep 4.10.0→4.10.1 across 32 poms + 
 instructions.md, CHANGELOG dated 7/23/2026 leading with the presentation-parity story, full
 reactor gate run before push).
 
+**Final: BOTH v4.10.1 RELEASES PUBLISHED (2026-07-23)** — Java tag on `9ae666df` (PR #218),
+Rust tag on `2c4e4066` (PR #170), lock-step same day. thread-release-4-10-1 and
+thread-telemetry-parity-auth both closed. The parity arc is complete end to end.
+
 ## Memory References
 
 - referenced: trace-thread-keyed-mono-gotcha (drove the worker-thread span capture),

--- a/memory/sessions/2026-07-23-211728.md
+++ b/memory/sessions/2026-07-23-211728.md
@@ -1,0 +1,125 @@
+# Session (2026-07-23T21:17:28.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Metadata injection/sanitization hardening (Eric's third interop round findings) — Java
+reference on branch `feature/metadata-injection-hardening`** (1 commit, not pushed). Eric's
+round found two remaining bugs: (1) protected metadata leaked to user functions and responses,
+(2) X-Correlation-Id missing from HTTP response headers. Tracing correctness verified FIRST:
+all four direction logs still match the reference signature exactly (8 records, all edges,
+auth spans) — the issues were purely header hygiene.
+
+**Eric's design ruling (now the cross-engine contract):** a composable function has exactly
+3 inputs — headers, body, instance; headers = a COPY of the envelope headers with read-only
+metadata INJECTED by the WorkerHandler at entry and SANITIZED at exit; **metadata is never
+transported in the event itself.** The root defect: `my_correlation_id` was the one metadata
+key transported as a real envelope header (touch(), TaskExecutor task dispatch, HttpRouter) —
+because the envelope lacks a business-cid field — so it leaked across the wire; `x-event-api`
+(relay guard) also reached function views.
+
+**Implementation:**
+- Business cid now rides an engine-managed envelope tag (`EventEmitter.BUSINESS_CID_TAG` =
+  "my_cid", existing `tags` wire field — no wire-spec/vector change; tags are already invisible
+  to functions). All three stamping sites converted.
+- WorkerHandler entry: injects my_route/my_trace_id/my_trace_path (worker context + envelope
+  FIELDS) and my_correlation_id (tag; legacy pre-4.10.2 header honored then stripped); removes
+  x-event-api from the copy.
+- WorkerHandler exit: `copyResponseHeaders` (single funnel covering sync + deferred + Mono
+  paths) filters the four my_* + now x-event-api — symmetric with entry. Eric's explicit
+  scenario ("function accidentally copies headers with protected metadata as return headers")
+  encoded as regression `accidentalMetadataEchoIsSanitizedAtExit`.
+- Bug 2: HttpRouter remembers the ingress-resolved cid (header name + value) on the
+  AsyncContextHolder; AsyncHttpResponse stamps it on every response (function-set header wins).
+  The old "legacy echo-back removed" HEAD-test assertion inverted per Eric's ruling.
+- **Empirical discovery recorded:** the local bus delivery already scrubs `to` and `tags` from
+  the function's envelope view (why the RPC tag never leaked) — the tag channel is invisible to
+  user code by existing design.
+
+**Verification:** full reactor BUILD SUCCESS; platform-core 415 green (4 new regressions:
+metadata-never-transported, accidental-echo-sanitized, response echo ×2); live two-app run:
+X-Correlation-Id echoed (inbound cid-eric-0001 + generated case, same value end-to-end
+response header == injected my_correlation_id), function view shows the four injected my_*
+with business cid intact across the wire, x-event-api gone.
+
+**Compat note (CHANGELOG):** fixed callee honors the legacy my_correlation_id header from
+pre-4.10.2 peers but no longer sends it — upgrade-together posture for business-cid
+continuity in mixed fleets.
+
+Rust session briefed to mirror (same branch name): tag transport, all-four-key injection
+(Rust previously injected none — parity for the echo demos), symmetric exit sanitization,
+response cid echo + ingress cid stamping, mirrored regressions, extended four-way acceptance
+invariants.
+
+**Update (same session): Rust mirror COMPLETE + cross-language verification PASSED.** Rust
+branch `feature/metadata-injection-hardening` (`794fb287`, not pushed): tags wire field added
+(byte-identical vectors), my_cid tag, all-four-key injection (previously none), symmetric exit
+sanitization, response cid echo + ingress stamping; 249 tests green. My independent
+cross-language drives (both directions, both patterns): X-Correlation-Id echoed
+(inbound + generated), END-TO-END CID IDENTITY across the language boundary (response header ==
+callee-injected my_correlation_id, e.g. a1a77591 J→R / adde1042 R→J), identical injected my_*
+key set on both callees, x-event-api absent everywhere, span signature EMPTY DIFF in all four
+combinations. Both branches ready to push.
+
+**Design rationale articulated by Eric (record for the ledger):** the /api/event endpoint and
+the private/public distinction in @PreLoad (Rust: the preload macro) exist for CLEAN BOUNDARY
+DEMARCATION — cloud native in nature. Three concentric boundaries, each policed by the engine:
+(1) function boundary — inputs are exactly headers/body/instance, metadata injected at entry
+and sanitized at exit; (2) application boundary — functions private by default, isPrivate=false
+is a deliberate act of publishing; (3) network boundary — /api/event is the single door for
+events (one auth point, one wire contract, one visible trace edge). Engine internals
+(temporary.inbox, tags, my_* metadata, x-event-api) never cross the boundary they belong to.
+Also explains the @origin ruling: instance-addressed routing is a mesh-era concern; cloud-native
+default is any-instance-behind-the-door. Rationale connects [[functions-decoupled-routes]],
+[[kafka-mesh-opt-in]], [[thread-metadata-injection-hardening]].
+
+**Update (same session): temporary.inbox alignment COMPLETE + interop re-test PASSED.** Rust
+2nd commit `698de3c4` (same branch): one reserved private route `temporary.inbox` (cid-keyed
+registry, composite cid-seq split, 500 instances, zero-traced by EXACT name — inbox.* namespace
+freed, regression `inbox_namespace_belongs_to_applications` proves a user route inbox.approval
+is reachable AND traced), essential-service sequencing (Eric's hint: Java EssentialServiceLoader
+@BeforeApplication(sequence=0), concurrency triple 500/500/1 — telemetry singleton preserves
+ordering), suppression gate re-keyed to the reserved `rpc` envelope TAG (Java's real mechanism),
+@origin never emitted / parse-tolerant (Eric's mesh-era ruling), + a genuine pre-existing bug
+found (AsyncHttpClientService replied through the global platform). 250 tests green.
+**Interop re-test (Eric's directive): both cross-language directions, full battery — ALL PASS:**
+functionality both patterns, auth 401 negative, X-Correlation-Id echo (inbound per-pattern ids +
+generated-cid IDENTITY MATCH across the wire), identical injected my_* set, x-event-api absent,
+span signature EMPTY DIFF (8/8 + 9/9 both directions). Eric's robustness hypothesis validated:
+internals hardened, observable behavior byte-for-byte unchanged. Both branches ready to push
+(Java 1 commit, Rust 2 commits).
+
+**Final (same session): docs round complete in both repos.** Java: interop report gained "The
+metadata-hardening round" section (design ruling as cross-engine contract, temporary.inbox/
+namespace story, re-test table, learning #7 "Reserve the minimum; inject the rest") + wire spec
+now documents reserved tag names (rpc, my_cid) + config-reference response-echo + x-event-api
+engine-internals note — all folded into the single branch commit (`bbd64589`, 16 files). Rust:
+3rd commit `652e33d1` — report mirrored byte-identically (reverse-substitution diff empty),
+reserved-tags section in its EventEnvelope reference + reserved-names + guide, AND fixed stale
+claims ("deliberately not byte-compatible with Java", "tags/annotations do not exist here") left
+over from pre-interop days. BOTH BRANCHES COMPLETE AND READY TO PUSH: Java 1 commit, Rust 3.
+
+**Update (same session): PRs merged + PR #220 review + v4.10.2 prep.** Java #221 (`a25d95d5`)
+and Rust #171 (`f86fbec2`) merged, CI green. Then reviewed team PR #220 (three collection
+plugins: isEmpty/getFirst/getLast) at Eric's request — verdict: correct, convention-consistent
+(strict null rejection matches the isNull/notNull house design; Java 21 idioms; comprehensive
+parameterized tests). Polish commit `a38bb181`: Apache headers ×6 files + syntax-guide
+"Collection" Built-in Plugins docs; CHANGELOG deferred to release prep (branch predates #221's
+Unreleased section — conflict avoidance; the team's own reverted CHANGELOG commit suggests they
+hit this). NOTE: GitHub review/comment APIs are BLOCKED for this EMU account (Unauthorized on
+addPullRequestReview/addComment) — reviews must be delivered in-session; Eric clicks approve.
+Local test-run gotcha recorded: ~/.m2 carried hardened artifacts under the released 4.10.1
+version (the hardening branch reuses the version number until the release bump), so the PR
+branch's tests need platform-core rebuilt from ITS tree — the 1-failure was environment skew,
+not a PR defect. #220 merged (`df8280d4`); v4.10.2 prep: sweep + CHANGELOG dated, full reactor
+gate running.
+
+## Memory References
+
+- referenced: conv-telemetry-presentation-parity (drives the identical-injection requirement),
+  thread-telemetry-parity-auth, business-vs-internal-correlation-id-terminology (archive),
+  trace-thread-keyed-mono-gotcha
+- created: (thread below in continuity)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.10.1</version>
+    <version>4.10.2</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version bump 4.10.1 → 4.10.2 across the 32 module poms and version references, and the
CHANGELOG dated for release. The 4.10.2 content merged ahead of this branch:

- **Protected metadata is injected and sanitized, never transported (#221)** — the
  business correlation-id rides an engine-managed envelope tag; the worker injects the
  four `my_*` read-only keys into a function's input header copy at entry and sanitizes
  them (plus the engine-internal `x-event-api`) at exit; `rpc` and `my_cid` are documented
  reserved tag names in the wire-format specification.
- **The HTTP response echoes the business correlation-id (#221)** — inbound or
  edge-generated, under the configured header name (default `X-Correlation-Id`).
- **Three collection plugins for Event Script (#220)** — `isEmpty`, `getFirst`, `getLast`,
  community-contributed, forming the new `collection` plugin category (license headers and
  Built-in Plugins documentation added during review).

## Why

Patch release in lock-step with the Rust engine's v4.10.2, completing the
boundary-demarcation contract from this week's interop reviews: a composable function's
three inputs are headers, body and instance — the headers are a copy with read-only
metadata injected at entry and sanitized at exit, and metadata is never transported in
the event itself. The Rust counterpart additionally aligns its RPC reply path to the
single reserved `temporary.inbox` route (the `inbox.*` namespace belongs to applications)
and mirrors the collection plugins so Event Script flows remain engine-portable.
Cross-language interop re-verified in all four direction combinations with the trace
signature at empty diff — recorded in the updated Interop Test Report on both docs sites.

## Verification

- Full reactor build + test at 4.10.2: BUILD SUCCESS (all modules, 5:08).
- Version sweep verified: zero residual 4.10.1 references outside historical records.
- Content PRs #220 and #221 individually CI-green before merge; four-way interop
  re-verification passed after the metadata and reply-path changes.

**Compatibility note:** applications upgrading from ≤4.10.1 — a fixed callee honors the
legacy `my_correlation_id` header from older peers but no longer sends it; business-cid
continuity in mixed fleets requires both sides on 4.10.2 (upgrade-together, as with the
wire format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>