### PR TITLE
The demo echo displays the clean envelope-header view

### DIFF
--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -257,8 +257,8 @@ tasks:
       "body": { "hello": "world" },
       "headers": {
         "x-flow-id": "event-over-http-declarative",
-        "my_trace_id": "51fb9a95cb6b47169dd83771283aebc2",
-        "my_trace_path": "POST /api/event/http/declarative",
+        "X-Correlation-Id": "51fb9a95cb6b47169dd83771283aebc2",
+        "user": "demo",
         "...": "..."
       },
       "instance": 4,
@@ -267,7 +267,12 @@ tasks:
     ```
 
     The `origin` identifies the application instance that actually executed the function —
-    the lambda-example, not the app you called.
+    the lambda-example, not the app you called. The echoed `headers` map is the clean
+    envelope-header view (`input.getHeaders()` on the `EventEnvelope`): the engine never
+    transports its read-only `my_*` metadata in the event, so none appears here — the
+    function reads that metadata from its injected input headers instead (the
+    `PostOffice` bootstrap). The `user` entry is session info added by the authentication
+    demo shown below.
 
 5. Look at both applications' logs: the trace context propagated across the HTTP hop
    automatically. Both apps log telemetry under the **same trace id**, the
@@ -298,8 +303,7 @@ curl -s -X POST -H "content-type: application/json" \
 The response has the same echo shape, and the trace continues across the hop the same way.
 This is why the echo function registers **two route names**: the programmatic endpoint calls
 the primary route `hello.world`, the declarative endpoint calls the alias
-`hello.declarative` — against a Java callee, the echoed `my_route` header shows which route
-(and therefore which pattern) served the call.
+`hello.declarative`.
 Choose declarative when the target address is deployment configuration (the usual case);
 choose programmatic when the code must compute or vary the target at runtime.
 

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -65,7 +65,9 @@ Rust at [PR #167](https://github.com/Accenture/mercury/pull/167).
   application instance that actually executed the function — in the other language.
 - Java callee: the echoed `my_route` header discriminates the pattern —
   `hello.declarative` (declarative) vs `hello.world` (programmatic) — demonstrating why
-  the echo function registers two route names.
+  the echo function registers two route names. (The demo echo has since been changed to
+  display the clean envelope-header view, so the injected metadata no longer appears in
+  its output; the two route names remain.)
 
 ## Results — trace continuity
 

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/HelloWorld.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/HelloWorld.java
@@ -19,9 +19,8 @@
 package org.platformlambda.services;
 
 import org.platformlambda.core.annotations.PreLoad;
-import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.EventEnvelope;
-import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.Utility;
@@ -55,20 +54,24 @@ import java.util.Map;
  * The default settings are "peer.demo.host=127.0.0.1" and "peer.demo.port={$rest.server.port}"
  */
 @PreLoad(route="hello.world, hello.declarative", instances=10, isPrivate = false)
-public class HelloWorld implements LambdaFunction {
+public class HelloWorld implements TypedLambdaFunction<EventEnvelope, Map<String, Object>> {
     private static final Logger log = LoggerFactory.getLogger(HelloWorld.class);
 
     @Override
-    public Object handleEvent(Map<String, String> headers, Object input, int instance) throws AppException {
+    public Map<String, Object> handleEvent(Map<String, String> headers, EventEnvelope input, int instance) {
         var po = new PostOffice(headers, instance);
         log.info("echo #{} got a request", instance);
-        if (input instanceof Map<?, ?> map && map.get("sleep_ms") != null) {
+        if (input.getBody() instanceof Map<?, ?> map && map.get("sleep_ms") != null) {
             long ms = Utility.getInstance().str2long(String.valueOf(map.get("sleep_ms")));
             Utility.getInstance().sleep(Math.min(ms, 10000));
         }
         Map<String, Object> result = new HashMap<>();
-        result.put("body", input);
-        result.put("headers", headers);
+        // echo back the input payload
+        result.put("body", input.getBody());
+        // Note that 'headers' = input.getHeaders() plus metadata for tracing
+        // (metadata: my_route, my_trace_id, my_trace_path and my_correlation_id).
+        // Since we want to echo back the original request headers, we use the input.getHeaders() method.
+        result.put("headers", input.getHeaders());
         result.put("instance", instance);
         result.put("origin", Platform.getInstance().getOrigin());
         // forward event to hello.pojo so we can see the span-id of "hello.world" propagated to "hello.pojo"

--- a/examples/lambda-example/src/test/java/org/platformlambda/demo/HelloWorldTest.java
+++ b/examples/lambda-example/src/test/java/org/platformlambda/demo/HelloWorldTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HelloWorldTest extends TestBase {
 
@@ -53,6 +54,20 @@ class HelloWorldTest extends TestBase {
         assertEquals(address, map.getElement("body.address"));
         assertEquals(telephone, map.getElement("body.telephone"));
         assertEquals(util.date2str(pojo.time), map.getElement("body.time"));
+    }
+
+    @Test
+    void sleepMsDelaysTheEcho() throws InterruptedException, ExecutionException {
+        // regression: the optional sleep_ms body key must actually delay the reply
+        // (it reads the envelope BODY - a silent no-op here once broke the timeout drives)
+        PostOffice po = new PostOffice("unit.test", "12346", "POST /api/hello/world");
+        EventEnvelope request = new EventEnvelope().setTo("hello.world")
+                .setBody(Map.of("sleep_ms", 1200));
+        long begin = System.currentTimeMillis();
+        EventEnvelope response = po.request(request, 8000).get();
+        long elapsed = System.currentTimeMillis() - begin;
+        assertEquals(200, response.getStatus());
+        assertTrue(elapsed >= 1100, "sleep_ms must delay the echo, elapsed=" + elapsed);
     }
 
     private static class DemoPoJo {

--- a/memory/sessions/2026-07-24-023859.md
+++ b/memory/sessions/2026-07-24-023859.md
@@ -1,0 +1,39 @@
+# Session (2026-07-24T02:38:59.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Demo clean-echo fix (Eric's 4th interop round) — review + corrections, both repos.** Eric's
+round found all four interop combinations identically displaying the injected my_* metadata in
+the echo response body. Analysis (confirmed by Eric): NOT an engine defect — the demo echo
+copied its injected input-header view into its result payload; the engine must not rewrite
+application payloads. Eric fixed the demos himself: the echo now consumes the EventEnvelope
+(TypedLambdaFunction<EventEnvelope,...> / input.headers() in Rust) and echoes the CLEAN
+envelope-header view — turning the demo into a live proof that metadata never rides the wire.
+He also removed the dead MY_CORRELATION_ID constant in TaskExecutor and set hello-flow's
+log.format=json for side-by-side parity.
+
+**Review found 5 side effects, all fixed at Eric's direction:** (1) REAL: sleep_ms was
+silently dead (`input instanceof Map` with input now EventEnvelope — always false; compiled,
+no test covered it) → `input.getBody() instanceof Map` + NEW regression
+`sleepMsDelaysTheEcho`; (2) three unused imports in HelloWorld (incl. an accidental SamplePoJo
+auto-import); (3) TaskExecutor's orphaned constant comment; (4) docs contradiction — the guide's
+my_route pattern-discriminator claim is retired (echo no longer displays injected metadata);
+sample responses updated to the clean shape in BOTH guides, with an explanation paragraph;
+the historical my_route claim in both test-report copies annotated (rename-note precedent);
+(5) Rust comment nits (Java naming in Rust file; hello_world in hello-flow's yml example).
+
+**Durable lesson:** demo/echo functions should display `input.getHeaders()` (the clean
+envelope view), not the injected params map — the injected view is for PostOffice
+bootstrapping, and echoing it into payloads re-exposes metadata as application data.
+
+Verification: lambda-example 14/14 (new regression), event-script 179/179, strict docs build
+clean, both Rust examples green.
+
+## Memory References
+
+- referenced: thread-metadata-injection-hardening, conv-telemetry-presentation-parity
+- created: (none — demo-level; lesson recorded here)
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
@@ -75,8 +75,6 @@ public class TaskExecutor implements TypedLambdaFunction<EventEnvelope, Void> {
     private static final String OUTPUT_BODY = "output.body";
     private static final String OUTPUT_HEADER = "output.header";
     private static final String MODEL = "model";
-    // Read-only reserved header exposing the flow's correlation-id (model.cid) to every function task.
-    private static final String MY_CORRELATION_ID = "my_correlation_id";
     private static final String RESULT = "result";
     private static final String DATA_TYPE = "datatype";
     private static final String HEADER = "header";


### PR DESCRIPTION
## What

The demo echo (`HelloWorld` in the lambda-example) now consumes the `EventEnvelope`
(`TypedLambdaFunction<EventEnvelope, Map<String, Object>>`) and echoes
`input.getHeaders()` — the clean envelope-header view — instead of the injected
input-header params map. Review corrections riding the fix: `sleep_ms` repaired (it tested
the input as a Map, which became dead code once the input type changed) with a new
regression test asserting the actual delay; unused imports removed; the now-dead
`MY_CORRELATION_ID` constant's orphaned comment removed in TaskExecutor; the Event over
HTTP guide's sample response updated to the clean-echo shape with an explanation, the
`my_route` pattern-discriminator claim retired, and the historical claim in the interop
test report annotated.

## Why

A four-direction interop review showed all combinations identically displaying the
injected `my_*` metadata in the echo response body. This was not an engine defect — the
engine's injection/sanitization contract held everywhere — but a demo-code choice: the
echo copied its injected input view (meant for PostOffice bootstrapping) into its result
payload, re-exposing read-only metadata as application data. With the fix, the demo
becomes a live proof of the boundary contract: the echoed headers show that metadata never
rides the wire, in either engine. The Rust counterpart PR carries the identical mirror.

## Verification

- lambda-example 14/14 (including the new `sleepMsDelaysTheEcho` regression — the feature
  had silently died and nothing caught it), event-script-engine 179/179, strict docs
  build clean.
- All four interop combinations re-run manually after the fix: clean echoes everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>