### PR TITLE
feat(observability): configurable traceparent header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **Configurable traceparent header name (field request).** A new header-name family completes
+   the observability impedance-matching surface: `http.traceparent.header`,
+   `kafka.traceparent.header` and `secondary.kafka.traceparent.header` (secondary falls back to
+   primary, then to the standard `traceparent`), plus per-entry overrides — `traceparent.header`
+   in a rest.yaml endpoint and in a kafka-flow-adapter.yaml consumer binding. An escape hatch for
+   an intermediary (e.g. an API-gateway header allow-list) that strips the standard W3C header:
+   outbound calls (async HTTP client, Event-over-HTTP, `simple.kafka.notification` and its
+   secondary twin) stamp the same W3C value under **both** names, and inbound resolution (REST
+   automation, Kafka Flow Adapter) reads the custom name first — a well-formed value under it
+   wins, so an intermediary-injected standard `traceparent` cannot override the peer's context —
+   with the standard header as fallback for standards-compliant callers. Unlike the trace-id
+   conflation workaround, the full W3C context (trace-id, parent span-id, flags) crosses the
+   intermediary, so cross-application **span parenting** survives. Default behavior unchanged
+   (`traceparent`); a renamed carrier is invisible to OpenTelemetry-compliant tooling, so keep
+   the default unless an unfixable intermediary forces the rename.
+
+---
 ## Version 4.10.3, 7/23/2026
 
 Patch release for field deployment, in lock-step with the Rust engine's v4.10.3. No engine

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -495,6 +495,14 @@ HTTP header carrying the business correlation-id (enterprise-specific; case-inse
 
 HTTP header recognized (inbound, when no W3C `traceparent` is present) and emitted (outbound by the async HTTP client) as the trace-id. A well-formed `traceparent` always takes precedence inbound. Overridable per endpoint with `trace.id.header` in a rest.yaml entry.
 
+### `http.traceparent.header`
+
+| Type | Default |
+|------|---------|
+| `String` | `traceparent` |
+
+HTTP header name carrying the **W3C trace context** (the full `traceparent` value: trace-id, parent span-id and flags). An **escape hatch** for an intermediary — typically an API gateway with a header allow-list — that strips the standard `traceparent` header and cannot be fixed promptly. When customized, outbound HTTP calls (the async HTTP client and Event-over-HTTP) stamp the same W3C value under **both** names, and inbound resolution reads the custom name first (a well-formed value under it wins, so an intermediary-injected standard `traceparent` cannot override the peer's context) with the standard header as fallback. Overridable per endpoint with `traceparent.header` in a rest.yaml entry. **Caution:** a renamed traceparent is invisible to standards-compliant tooling (OpenTelemetry SDKs, service meshes, APM agents) — keep the default unless an unfixable intermediary forces the rename, and configure both ends alike.
+
 ### `kafka.correlation.id.header`
 
 | Type | Default |
@@ -510,6 +518,14 @@ Kafka message header carrying the business correlation-id (no cross-vendor stand
 | `String` | — |
 
 Optional Kafka message header for the trace-id. Inbound: a fallback trace-id source when the upstream sends no W3C `traceparent` (which always takes precedence). Outbound: `simple.kafka.notification` stamps the current trace-id under this name alongside `traceparent`, for legacy downstream consumers. Unset = traceparent-only behavior (unchanged). Overridable per binding with `trace.id.header` in a kafka-flow-adapter.yaml entry.
+
+### `kafka.traceparent.header`
+
+| Type | Default |
+|------|---------|
+| `String` | `traceparent` |
+
+Kafka message header name carrying the **W3C trace context** — the Kafka twin of `http.traceparent.header`, for middleware or an upstream convention that carries the W3C value under its own header name. When customized, `simple.kafka.notification` stamps the same value under **both** names, and the Kafka Flow Adapter reads the custom name first (a well-formed value under it wins) with the standard `traceparent` as fallback. Overridable per binding with `traceparent.header` in a kafka-flow-adapter.yaml entry.
 
 ### `kafka.health.timeout`
 
@@ -1037,13 +1053,13 @@ Time-to-live for an entry in the in-memory (platform `ManagedCache`) cache of sc
 
 [twin-kafka](twin-kafka.md#health): tunables for `secondary.kafka.health`, the secondary cluster's twin of `kafka.health`. A bridge lists both: `mandatory.health.dependencies=kafka.health, secondary.kafka.health`.
 
-### `secondary.kafka.correlation.id.header` / `secondary.kafka.trace.id.header`
+### `secondary.kafka.correlation.id.header` / `secondary.kafka.trace.id.header` / `secondary.kafka.traceparent.header`
 
 | Type | Default |
 |------|---------|
 | `String` | fall back to the `kafka.*` globals |
 
-[twin-kafka](twin-kafka.md): outbound header names on the secondary cluster when the two clusters follow different conventions.
+[twin-kafka](twin-kafka.md): outbound header names on the secondary cluster when the two clusters follow different conventions. Each key falls back to its primary `kafka.*` setting when unset (`secondary.kafka.traceparent.header` → `kafka.traceparent.header` → `traceparent`).
 
 The Kafka **connection and security** settings (`bootstrap.servers`, `security.protocol`, `sasl.*`, `ssl.*`,
 `acks`, `auto.offset.reset`) live in the `kafka-producer.properties` / `kafka-consumer.properties` template

--- a/docs/guides/event-envelope-reference.md
+++ b/docs/guides/event-envelope-reference.md
@@ -948,7 +948,7 @@ in user code when operating at the HTTP boundary:
 | `X-Stream-Id` | Stream ID for Flux streaming responses |
 | `X-TTL` | Time-to-live for Flux stream consumers |
 | `X-Trace-Id` | Distributed trace identifier (default header name; configurable via `http.trace.id.header`) |
-| `traceparent` | W3C Trace Context (trace ID + parent span ID); takes precedence over `X-Trace-Id` inbound |
+| `traceparent` | W3C Trace Context (trace ID + parent span ID); takes precedence over `X-Trace-Id` inbound (default header name; configurable via `http.traceparent.header`) |
 | `X-Correlation-Id` | Business correlation-id (default header name; configurable via `http.correlation.id.header`) |
 | `X-Flow-Id` | Active flow ID |
 | `X-App-Instance` | Target application instance for Event-over-HTTP |

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -92,6 +92,7 @@ consumer:
 | `max-poll-records` | no | Override the delivery mode's default poll batch size (1 for manual-commit, 500 for auto-commit). |
 | `correlation.id.header` | no | Per-binding override of the global `kafka.correlation.id.header` (default `cid`) — impedance matching for an upstream that publishes its own correlation-id header name (e.g. `X-Correlation-ID`). |
 | `trace.id.header` | no | Per-binding override of the global `kafka.trace.id.header` — a fallback trace-id source for an upstream that does not send a W3C `traceparent` (which always takes precedence). |
+| `traceparent.header` | no | Per-binding override of the global `kafka.traceparent.header` (default `traceparent`) — the header carrying the **full W3C trace context** for an upstream that uses its own name. A well-formed value under the custom name wins; the standard `traceparent` remains a fallback. |
 
 The file is read by `ConfigReader`, so **every value supports `${ENV_VAR:default}` substitution** — e.g.
 `group: '${KAFKA_CONSUMER_GROUP:sales-order-group}'`. A malformed entry (missing `topic`/`topic-pattern`/

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -119,16 +119,19 @@ Global defaults in `application.properties`:
 |:----|:--------|:-----------------|
 | `http.trace.id.header` | `X-Trace-Id` | REST automation inbound (when no `traceparent` is present) and the async HTTP client outbound |
 | `http.correlation.id.header` | `X-Correlation-Id` | HTTP edge capture inbound; async HTTP client outbound |
+| `http.traceparent.header` | `traceparent` | The header carrying the full W3C trace context; REST automation inbound (custom name first, standard fallback) and HTTP client / Event-over-HTTP outbound (stamped under **both** names) |
 | `kafka.trace.id.header` | *(unset)* | Kafka Flow Adapter inbound fallback; `simple.kafka.notification` outbound, stamped alongside `traceparent` |
 | `kafka.correlation.id.header` | `cid` | Kafka Flow Adapter inbound; `simple.kafka.notification` outbound |
+| `kafka.traceparent.header` | `traceparent` | Kafka twin of `http.traceparent.header`: adapter inbound (custom name first, standard fallback); notification outbound (stamped under **both** names) |
 
 Per-entry overrides, for a single application that faces callers with different conventions:
 
-- a **rest.yaml** endpoint entry accepts `trace.id.header` / `correlation.id.header`;
-- a **kafka-flow-adapter.yaml** consumer binding accepts the same two keys
+- a **rest.yaml** endpoint entry accepts `trace.id.header` / `correlation.id.header` / `traceparent.header`;
+- a **kafka-flow-adapter.yaml** consumer binding accepts the same three keys
   ([Minimalist Kafka](minimalist-kafka.md#adapter-yaml));
-- [twin-kafka](twin-kafka.md) adds `secondary.kafka.trace.id.header` / `secondary.kafka.correlation.id.header`
-  globals when the second Kafka cluster follows its own convention.
+- [twin-kafka](twin-kafka.md) adds `secondary.kafka.trace.id.header` / `secondary.kafka.correlation.id.header` /
+  `secondary.kafka.traceparent.header` globals when the second Kafka cluster follows its own convention
+  (each falls back to its primary `kafka.*` setting when unset).
 
 **Precedence:** per-entry override > `application.properties` global > built-in default. A well-formed W3C
 `traceparent` **always** takes precedence for the trace id, whatever the header naming — so adopting these
@@ -142,6 +145,17 @@ overrides never breaks OpenTelemetry-compliant callers. The full key reference l
 > the inbound `traceparent` when present, otherwise a single generated id — so the outgoing
 > `traceparent` and the shared header always carry the same trace id. Prefer migrating the gateway to
 > pass `traceparent` (and `X-Trace-Id`), then retiring the conflation.
+
+> **A renamed traceparent beats conflation for the gateway case.** The conflation above carries only
+> the trace **id**, so spans in different applications can be stitched by id but not **parented** across
+> the hop. Renaming the traceparent carrier (`http.traceparent.header=X-Trace-Context`) moves the *full*
+> W3C context — trace-id, parent span-id and flags — through the gateway under an allow-listed name, so
+> cross-application span parenting survives. Outbound calls stamp the same value under both the custom
+> and the standard name; inbound, a well-formed value under the custom name wins (an intermediary that
+> injects its own fresh `traceparent` cannot break the caller's chain) and the standard header remains a
+> fallback for standards-compliant callers. **The trade-off:** a renamed traceparent is invisible to
+> OpenTelemetry SDKs, service meshes and APM agents — treat it as an escape hatch for an intermediary
+> you cannot fix, configure both ends alike, and prefer fixing the gateway allow-list.
 
 ```yaml
 # rest.yaml - one endpoint serves a legacy caller that sends its own header names

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -152,6 +152,10 @@ emitted outbound:
   **takes precedence** over `X-Trace-Id`: the trace ID segment becomes the Mercury trace ID and the parent
   span ID is adopted, so the trace continues from the upstream caller (span lineage across HTTP boundaries).
   On outbound the system emits `traceparent` built from this hop's own span, alongside `X-Trace-Id`.
+  The carrier **name** is configurable via `http.traceparent.header` / `kafka.traceparent.header`
+  (default `traceparent`) - an escape hatch for an intermediary that strips the standard header: the same
+  W3C value then travels under **both** names, and a well-formed value under the custom name wins inbound
+  (see [Observability](observability.md#impedance-config)).
 
 The framework does **not** echo the trace ID (or the correlation-id) back to the HTTP client.
 

--- a/docs/guides/rest-automation/ai-agent-guide.md
+++ b/docs/guides/rest-automation/ai-agent-guide.md
@@ -86,9 +86,11 @@ rest:
 ```
 
 A traced endpoint serving a legacy caller that uses its own trace/correlation header names
-(per-endpoint impedance matching — the optional `trace.id.header` / `correlation.id.header`
-keys override the global `http.trace.id.header` / `http.correlation.id.header` names for
-this entry only; a well-formed W3C `traceparent` still takes precedence for the trace-id):
+(per-endpoint impedance matching — the optional `trace.id.header` / `correlation.id.header` /
+`traceparent.header` keys override the global `http.trace.id.header` / `http.correlation.id.header` /
+`http.traceparent.header` names for this entry only; a well-formed W3C `traceparent` still takes
+precedence for the trace-id, and a well-formed value under a custom `traceparent.header` name wins
+with the standard `traceparent` as fallback):
 
 ```yaml
 rest:

--- a/docs/guides/rest-automation/rest-automation.json
+++ b/docs/guides/rest-automation/rest-automation.json
@@ -22,6 +22,7 @@
     { "field": "tracing", "required": false, "meaning": "true/false (default false) - enable distributed tracing" },
     { "field": "trace.id.header", "required": false, "meaning": "per-endpoint override of the global http.trace.id.header (default X-Trace-Id) - header name (quoted string) for a caller with its own trace-id header convention; a well-formed W3C traceparent still takes precedence" },
     { "field": "correlation.id.header", "required": false, "meaning": "per-endpoint override of the global http.correlation.id.header (default X-Correlation-Id) - header name (quoted string) for a caller with its own business correlation-id header convention" },
+    { "field": "traceparent.header", "required": false, "meaning": "per-endpoint override of the global http.traceparent.header (default traceparent) - header name (quoted string) carrying the full W3C trace context, for an intermediary that strips the standard name; a well-formed value under the custom name wins, standard traceparent remains a fallback" },
     { "field": "trust_all_cert", "required": false, "meaning": "true/false - HTTPS relay only" },
     { "field": "url_rewrite", "required": false, "meaning": "list of exactly two strings [from, to] - HTTP(S) relay only" }
   ],

--- a/docs/guides/rest-automation/rest-grammar.md
+++ b/docs/guides/rest-automation/rest-grammar.md
@@ -50,6 +50,7 @@ related:
 | `tracing` | no | `true`/`false` (default false) — enable distributed tracing |
 | `trace.id.header` | no | per-endpoint override of the global `http.trace.id.header` (default `X-Trace-Id`) — impedance matching for a caller that sends its own trace-id header name; a well-formed W3C `traceparent` still takes precedence |
 | `correlation.id.header` | no | per-endpoint override of the global `http.correlation.id.header` (default `X-Correlation-Id`) — impedance matching for a caller that sends its own business correlation-id header name |
+| `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for an intermediary that strips the standard name; a well-formed value under the custom name wins, with the standard `traceparent` as fallback |
 | `trust_all_cert` | no | `true`/`false` — **HTTPS relay only** |
 | `url_rewrite` | no | a list of **exactly two** strings `[from, to]` — **HTTP(S) relay only** |
 

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -51,7 +51,7 @@ cluster's schema-id cache is isolated (Confluent global ids are only unique with
 | Producer template | `kafka-producer.properties` | `secondary-kafka-producer.properties` |
 | Consumer template | `kafka-consumer.properties` | `secondary-kafka-consumer.properties` |
 | Schema Registry (optional) | `schema.registry.url` + `schema-registry.properties` | `secondary.schema.registry.url` + `secondary-schema-registry.properties` |
-| Outbound header names | `kafka.correlation.id.header` / `kafka.trace.id.header` | `secondary.kafka.correlation.id.header` / `secondary.kafka.trace.id.header` (fall back to the globals) |
+| Outbound header names | `kafka.correlation.id.header` / `kafka.trace.id.header` / `kafka.traceparent.header` | `secondary.kafka.correlation.id.header` / `secondary.kafka.trace.id.header` / `secondary.kafka.traceparent.header` (fall back to the globals) |
 
 All secondary templates follow the same mechanics as the primary ones: loaded from the bundled
 classpath template by default, `${ENV_VAR:default}` substitution, and OAuth token endpoint URLs
@@ -162,12 +162,13 @@ crossing the two emulated clusters with trace/correlation continuity — see the
 | `secondary.kafka.health.startup.grace` | falls back to `kafka.health.startup.grace` (`30s`) | Start-up grace for `secondary.kafka.health` (placeholder healthy status while the client warms up). |
 | `secondary.kafka.correlation.id.header` | falls back to `kafka.correlation.id.header` (`cid`) | Outbound correlation-id header on the secondary cluster. |
 | `secondary.kafka.trace.id.header` | falls back to `kafka.trace.id.header` (unset) | Optional outbound trace-id header on the secondary cluster. |
+| `secondary.kafka.traceparent.header` | falls back to `kafka.traceparent.header` (`traceparent`) | Header name carrying the full W3C trace context on the secondary cluster; when customized, the notification stamps the same value under both this and the standard name. |
 
 The retry/dead-letter tuning keys (`kafka.dlq.timeout.ms`, `kafka.flow.max.retries`,
 `kafka.flow.retry.backoff.ms`) are application-level policy shared by both adapters. Per-binding
 options in the secondary adapter YAML are identical to the [primary's](minimalist-kafka.md#adapter-yaml) -
-including `schema.enabled`, `dlq-topic`, and the `trace.id.header` / `correlation.id.header`
-impedance-matching overrides.
+including `schema.enabled`, `dlq-topic`, and the `trace.id.header` / `correlation.id.header` /
+`traceparent.header` impedance-matching overrides.
 
 ## Health check {#health}
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-23 | agent: Claude Code (2026-07-24-023859)
+- **last_session:** 2026-07-24 | agent: Claude Code (2026-07-24-154543)
 - **last_review:** 2026-07-13 | through 2026-07-13-001009.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -48,7 +48,7 @@
   keys/fields/methods as per-entry sections (heading + Type/Default mini-table + prose), not wide
   tables — same pattern as the Rust port, so the two sites stay structurally aligned. CI installs
   `mkdocs-material` in `.github/workflows/docs.yml`.
-  <!-- id: docs-site-material-theme | created: 2026-07-20 | last_used: 2026-07-20 | uses: 1 | tier: working | origin: 2026-07-20-222709 -->
+  <!-- id: docs-site-material-theme | created: 2026-07-20 | last_used: 2026-07-21 | uses: 2 | tier: archive-candidate | origin: 2026-07-20-222709 -->
 
 ## Architectural Invariants
 
@@ -87,7 +87,7 @@
   **Durable lessons:** field screenshots' naming conventions are client-identifiable — paraphrase
   generically in fixtures/commits/PRs; a flow needs ≥1 `end` task (a `sink` only terminates a side
   branch). See [[release-4-8-2-shipped]] for the prior cycle.
-  <!-- id: release-4-8-3-shipped | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-170933 -->
+  <!-- id: release-4-8-3-shipped | created: 2026-07-13 | last_used: 2026-07-21 | uses: 9 | tier: active | origin: 2026-07-13-170933 -->
 
 - **Field trace-propagation report on 4.6.3 diagnosed (2026-07-13): not a framework bug.** A field team
   saw the traceId stop propagating between application endpoints after upgrading 4.4.11 → 4.6.3. Root
@@ -104,7 +104,7 @@
   hops) + new regression test `traceContinuesAcrossApplicationToApplicationHttpCall`
   (branch `test/trace-continuity-http-hop`, `DownstreamCaller` fixture + `/api/chain/probe`) proving
   traced app-to-app HTTP continuity over the real HTTP stack — a previously untested contract.
-  <!-- id: field-trace-propagation-4-6-3-diagnosis | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-142021 -->
+  <!-- id: field-trace-propagation-4-6-3-diagnosis | created: 2026-07-13 | last_used: 2026-07-22 | uses: 3 | tier: active | origin: 2026-07-13-142021 -->
 
 - **Snyk gate rejected v4.8.2 in the field (2026-07-13) — remediated and MERGED (PR #168, merge
   commit `e21be449`, 30 poms; ships in v4.8.3; the team trials v4.7.1 for the trace fix meanwhile —
@@ -146,7 +146,7 @@
   version is a substring of a dependency version (classgraph 4.8.184 contains "4.8.1"), the perl
   sweep needs a digit lookahead `(?!\d)` — not every bump is naturally safe.
   See [[release-4-8-1-shipped]] for the prior cycle's facts.
-  <!-- id: release-4-8-2-shipped | created: 2026-07-12 | last_used: 2026-07-12 | uses: 1 | tier: active | origin: 2026-07-13-014037 -->
+  <!-- id: release-4-8-2-shipped | created: 2026-07-12 | last_used: 2026-07-21 | uses: 3 | tier: archive-candidate | origin: 2026-07-13-014037 -->
 
 - **Release 4.8.1 — SHIPPED 2026-07-11 (tag `v4.8.1` on merge commit `3d226c5b`; PRs #159-#161).**
   Maintenance release: dependency security updates (Jackson 2.22.1 closed dependabot/28; log4j2/
@@ -170,7 +170,7 @@
   (platform-core otherwise content-negotiates from the request's accept header). (6) **No version
   strings in pom comments** — the release sweep mangled a historical "retired 4.8.0" note; history
   belongs in the CHANGELOG. See [[release-4-8-0-shipped]] for the twin-kafka architecture facts.
-  <!-- id: release-4-8-1-shipped | created: 2026-07-11 | last_used: 2026-07-13 | uses: 1 | tier: active | origin: 2026-07-12-002326 -->
+  <!-- id: release-4-8-1-shipped | created: 2026-07-11 | last_used: 2026-07-23 | uses: 6 | tier: active | origin: 2026-07-12-002326 -->
 
 - **Release 4.8.0 — SHIPPED 2026-07-10 (tag `v4.8.0` on merge commit `5d9fda45`; PRs #153-#157).**
   Feature release: **twin-kafka** (dual Kafka cluster bridging), configurable trace-id headers with
@@ -196,7 +196,7 @@
   from `model.cid` (engine-seeded), never from the raw record header; CompileFlows rejects data
   mappings that overwrite reserved model keys (cid/instance/flow/ttl). See [[release-4-7-0-shipped]]
   for the release-bump surface and prior caveats.
-  <!-- id: release-4-8-0-shipped | created: 2026-07-10 | last_used: 2026-07-13 | uses: 1 | tier: active | origin: 2026-07-11-031930 -->
+  <!-- id: release-4-8-0-shipped | created: 2026-07-10 | last_used: 2026-07-14 | uses: 6 | tier: archive-candidate | origin: 2026-07-11-031930 -->
 
 - **Release 4.7.0 — SHIPPED 2026-07-08 (tag `v4.7.0` on merge commit `e41a20b7`; PRs #146 feature +
   #147 bump).** Feature release: **MiniGraph `graph.task` skill** — a Task node invokes any composable
@@ -260,7 +260,7 @@
   in a library jar, because classpath shadowing across jars is classloader-order-dependent. Companion fixes
   in the same branch: eager `LogContextConfig` init in `AppStarter.reConfigLogger` (kills the "Recursive call
   to appender" warning) and RPC `round_trip` telemetry now carrying span_id/parent_span_id (inbox family).
-  <!-- id: log-context-on-by-default | created: 2026-07-22 | last_used: 2026-07-22 | uses: 1 | tier: working | origin: 2026-07-22-234845 -->
+  <!-- id: log-context-on-by-default | created: 2026-07-22 | last_used: 2026-07-23 | uses: 3 | tier: active | origin: 2026-07-22-234845 -->
 
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker
   returns.** `EventEmitter.traces` is keyed by `Thread.currentThread().threadId()+instance+route`, and
@@ -325,7 +325,7 @@
   lock-step on both engines (with closely matching error messages — presentation parity extends
   to error text), or flows stop being portable. Precedent: the #220 collection plugins mirrored
   into the Rust v4.10.2.
-  <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-145132 -->
+  <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-24 | uses: 2 | tier: active | origin: 2026-07-23-145132 -->
 
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
@@ -340,7 +340,7 @@
   invocation). Shared non-thread-safe resources inside a multi-worker function are guarded by a
   `ReentrantLock`, not by dropping to one worker (kafka.health precedent: 5 workers, lock-confined
   KafkaConsumer).
-  <!-- id: conv-instance-count-pattern | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-221521 -->
+  <!-- id: conv-instance-count-pattern | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: archive-candidate | origin: 2026-07-13-221521 -->
 - **Test config injection: use the EXACT config key as a System property, never a `${VAR}` reference
   set in `@BeforeAll`** (2026-07-14, from the second field Jenkins twin-kafka failure). Three facts
   interact: (1) `AppConfigReader` resolves `${VAR}` references ONCE when the singleton first loads;
@@ -357,7 +357,7 @@
   — PR #178's deadline extension treated a symptom of this very bug. Relates
   [[conv-instance-count-pattern]] (the health-check tests that shifted the class order arrived with
   kafka.health/secondary.kafka.health).
-  <!-- id: test-config-injection-exact-key | created: 2026-07-14 | last_used: 2026-07-14 | uses: 1 | tier: working | origin: 2026-07-14-173816 -->
+  <!-- id: test-config-injection-exact-key | created: 2026-07-14 | last_used: 2026-07-14 | uses: 3 | tier: archive-candidate | origin: 2026-07-14-173816 -->
 
 ## Blueprint  *(gap from Current State → Vision; `(blueprint)` threads serve `vision-mercury-composable`)*
 
@@ -370,6 +370,31 @@
 
 ## Open Threads
 
+- [ ] (feature in flight — 2026-07-24) **Configurable traceparent header name (field request).**
+  Field wants `http.traceparent.header` / `kafka.traceparent.header` /
+  `secondary.kafka.traceparent.header` (secondary → primary fallback) alongside the existing
+  trace-id/correlation-id families. Assessment AGREED (design-clean, unlike the rejected
+  `legacy.trace.id` conflation flag: renames the CARRIER, not the semantics — full W3C context
+  crosses a header-stripping gateway, so cross-app span parenting survives; fixes the known
+  limitation in [[thread-field-trace-propagation-4-6-3]]). Eric ratified the 3 design points
+  2026-07-24: (2) inbound = configured name wins when well-formed (sidecar-injected standard
+  traceparent cannot override the peer's context), standard header as fallback; (3) outbound =
+  stamp BOTH names (the "alongside" precedent); (4) per-entry overrides included
+  (rest.yaml + kafka-flow-adapter.yaml `traceparent.header`) for a symmetric surface. Default
+  stays `traceparent`; docs carry the standards-deviation warning (renamed carrier invisible to
+  OTel/Istio/APM). Java reference IMPLEMENTED on `feature/configurable-traceparent-header`:
+  platform-core (HttpRouter class-load static + per-entry, dual stamp in AsyncHttpClient +
+  EventEmitter setTraceHeaders helper), minimalist-kafka (notification dual stamp +
+  isPropagatableHeader exclusion, consumer custom-first parse, per-binding key), twin-kafka
+  (secondaryOrGlobal). Tests: platform-core 420 green (5 new; suite runs WITH the global custom
+  name active = additive proof), minimalist-kafka 101 (5 new incl. wire-level dual-stamp e2e),
+  twin-kafka 9 (wire-level secondary→primary fallback assert). Docs: config-reference 3 new
+  keys, observability table + "renamed traceparent beats conflation" note, rest-grammar +
+  rest-automation.json + ai-agent-guide, minimalist/twin-kafka guides, reserved-names,
+  CHANGELOG Unreleased. Remaining: full reactor gate, Rust lock-step mirror
+  ([[conv-telemetry-presentation-parity]] — identical keys/precedence/log text), PR + release.
+  <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-154543 -->
+
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.3 SHIPPED AND PUBLISHED in
   lock-step (both repos) — field-deployment roll-up.** Releases are immutable (Eric), so the
   post-4.10.2 fixes shipped as a new patch for the field pipeline: demo clean-echo
@@ -381,7 +406,7 @@
   concurrent build on the same tree). Rust: PR #176, tag on merge `b3804a67`, CI green
   (252 tests). Fourth lock-step release of the arc: 4.10.0 interop → 4.10.1 presentation
   parity → 4.10.2 boundary demarcation → 4.10.3 field roll-up.
-  <!-- id: thread-release-4-10-3 | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-24-023859 -->
+  <!-- id: thread-release-4-10-3 | created: 2026-07-23 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-023859 -->
 
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.2 SHIPPED AND PUBLISHED in
   lock-step (both repos).** Java: PR #222, tag `v4.10.2` on `61ddb772`, published. Rust:
@@ -432,7 +457,7 @@
   invisible, validating Eric's robustness hypothesis). **BOTH PRs MERGED 2026-07-23: Java #221
   (merge `a25d95d5`) + Rust #171 (merge `f86fbec2`), CI green both.** Remaining: the v4.10.2
   lock-step releases ([[thread-release-4-10-2]]). Relates [[conv-telemetry-presentation-parity]].
-  <!-- id: thread-metadata-injection-hardening | created: 2026-07-23 | last_used: 2026-07-23 | uses: 1 | tier: working | origin: 2026-07-23-211728 -->
+  <!-- id: thread-metadata-injection-hardening | created: 2026-07-23 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-23-211728 -->
 
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.1 SHIPPED via the normal
   flow (Java repo)** — tag `v4.10.1` on merge commit `9ae666df` (PR #218, CI green + local
@@ -474,7 +499,7 @@
   instructions.md coordinates), CHANGELOG dated 7/22/2026. **PR #216 merged (`af21e6f6`, CI
   green); tag `v4.10.0` pushed on the merge commit; release notes delivered.** Close when the
   GitHub release is published.
-  <!-- id: thread-release-4-10-0 | created: 2026-07-22 | last_used: 2026-07-22 | uses: 1 | tier: working | origin: 2026-07-23-015717 -->
+  <!-- id: thread-release-4-10-0 | created: 2026-07-22 | last_used: 2026-07-23 | uses: 1 | tier: active | origin: 2026-07-23-015717 -->
 
 - [x] (design — 2026-07-21; COMPLETED 2026-07-22 with the v4.10.0 release) **Common event
   envelope wire format for cross-language interop (Event over HTTP with the Rust port).** Design DRAFTED at
@@ -537,7 +562,7 @@
   ([[thread-release-4-10-0]]) — this thread is COMPLETE: design → implementation → parity →
   live interop → release, both engines in lock-step.** → serves `vision-mercury-composable`
   (polyglot deployment)
-  <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-215951 -->
+  <!-- id: thread-event-envelope-interop | created: 2026-07-21 | last_used: 2026-07-23 | uses: 5 | tier: active | origin: 2026-07-21-215951 -->
 
 - [ ] (field support — 2026-07-21) **v4.9.1 REJECTED by the field Sonar quality gate; remediation
   MERGED (PR #210, `7110561c`), v4.9.2 release in flight for the field rescan.** 19 issues
@@ -559,7 +584,7 @@
   day: dependabot HIGH alert #29 (js-yaml 4.2.0, dev-only transitive in the playground webapp
   lockfile) remediated via PR #209 (`902da23f`, lockfile-only bump to 4.3.0) — landed one commit
   after the release tag; no artifact impact.
-  <!-- id: thread-release-4-9-1 | created: 2026-07-21 | last_used: 2026-07-21 | uses: 1 | tier: working | origin: 2026-07-21-012842 -->
+  <!-- id: thread-release-4-9-1 | created: 2026-07-21 | last_used: 2026-07-21 | uses: 2 | tier: archive-candidate | origin: 2026-07-21-012842 -->
 
 - [x] (release in flight — 2026-07-14; CLOSED same day) **v4.8.6 SHIPPED via the normal flow** —
   tag `v4.8.6` on merge commit `19916875` (PR #185, CI green), release text delivered. Purpose:
@@ -572,7 +597,7 @@
   tag `v4.8.5` on merge commit `a1cc1dec` (PR #182, CI green), release text delivered. Carries
   #178-#181: conflated-header one-id fix (validated live) + field pipeline build reliability
   (twin-kafka test-order root cause + env-leakage hardening).
-  <!-- id: thread-release-4-8-5 | created: 2026-07-14 | last_used: 2026-07-14 | uses: 1 | tier: working | origin: 2026-07-14-183626 -->
+  <!-- id: thread-release-4-8-5 | created: 2026-07-14 | last_used: 2026-07-14 | uses: 1 | tier: archive-candidate | origin: 2026-07-14-183626 -->
 
 
 - [x] (release in flight — 2026-07-13; CLOSED same day) **v4.8.4 SHIPPED via the normal flow** —
@@ -580,14 +605,14 @@
   (secondary.kafka.health, 5 health-check workers, Minimalist Kafka guide rename). Eric's ruling
   retained for the record: the 4.8.3 deferred-tag flow was SPECIFIC to the Snyk rejection; normal
   releases tag immediately on merge.
-  <!-- id: thread-release-4-8-4-tag-deferred | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-230916 -->
+  <!-- id: thread-release-4-8-4-tag-deferred | created: 2026-07-13 | last_used: 2026-07-21 | uses: 3 | tier: archive-candidate | origin: 2026-07-13-230916 -->
 
 
 - [x] (release in flight — 2026-07-13; CLOSED same day) **v4.8.3 bumped for field pipeline test; TAG
   DEFERRED.** The deferred-tag flow completed: field pipeline PASSED (Snyk + Sonar), the touch-up
   round landed (#172-#175), and `v4.8.3` was tagged on merge commit `6696a76f` with release text
   delivered. Closure recorded in [[release-4-8-3-shipped]].
-  <!-- id: thread-release-4-8-3-tag-deferred | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-142021 -->
+  <!-- id: thread-release-4-8-3-tag-deferred | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: archive-candidate | origin: 2026-07-13-142021 -->
 
 - [ ] (field support — 2026-07-13; ROOT CAUSE FOUND via Eric's devops screen share) **Trace-propagation
   report: the internal API gateway strips `traceparent` AND `X-Trace-Id` (neither on its allow-list);
@@ -626,7 +651,7 @@
   hello.world span parented directly onto the traceparent's span id across the HTTP hop. Field runs this conflation short-term; gateway team has been ASKED (2026-07-14) to
   allow-list traceparent + X-Trace-Id at the gateway/Istio — Eric updates after the devops team
   tests in the cloud dev environment.
-  <!-- id: thread-field-trace-propagation-4-6-3 | created: 2026-07-13 | last_used: 2026-07-13 | uses: 1 | tier: working | origin: 2026-07-13-142021 -->
+  <!-- id: thread-field-trace-propagation-4-6-3 | created: 2026-07-13 | last_used: 2026-07-14 | uses: 5 | tier: working | origin: 2026-07-13-142021 -->
 
 - [ ] (P0–P5 code-complete — Claude Code, 2026-07-05, branch `feature/elastic-queue-file-fifo`; remaining = field canary → P4 retire-BDB) **Replace
   ElasticQueue's Berkeley DB spill tier with a portable file-backed segmented FIFO.** Full detail + rationale
@@ -712,7 +737,7 @@
   checks?), and should it reuse or diverge from `event-script-engine`'s own `validInput`/`validOutput`
   validation (already confirmed to diverge in places — minigraph's per-skill namespace rules, e.g. fetcher
   input/output/dictionary, don't match event-script's).
-  <!-- id: thread-compilegraph-syntax-validation | created: 2026-07-02 | last_used: 2026-07-02 | uses: 1 | tier: working | origin: 2026-07-02-004606 -->
+  <!-- id: thread-compilegraph-syntax-validation | created: 2026-07-02 | last_used: 2026-07-22 | uses: 2 | tier: working | origin: 2026-07-02-004606 -->
 
 - [ ] (planned — backlog, no ETA, no CVE driver) **Upgrade `kafka.version` (4.2.0 → 4.3.x) across the 24
   pom.xml files that pin it.** Deliberately deferred alongside the `confluent.version` 8.2.0→8.3.0 bump — see
@@ -767,7 +792,7 @@
   - **Surface the machine-readable catalogs in `llms.txt`** (the DSL `*.json` files) as first-class entries, and add
     "build & test an app" + "author an extension" entries so an agent doesn't discover them only by reading prose.
   → serves `vision-mercury-composable`.
-  <!-- id: thread-docs-improvement-backlog | created: 2026-06-24 | last_used: 2026-06-24 | uses: 1 | tier: working -->
+  <!-- id: thread-docs-improvement-backlog | created: 2026-06-24 | last_used: 2026-07-20 | uses: 4 | tier: working -->
 - [ ] (next iteration — Eric, 2026-06-24; **design + implement**) **Cross-pod request-response via Redis
   Pub/Sub RPC + Kafka.** A distributed sync-over-async pattern (an advanced opt-in use case, cf.
   `kafka-mesh-opt-in`): `REST sync request-response → Composable service (POD-1) → Redis Pub/Sub RPC + Kafka

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -1,0 +1,66 @@
+# Session (2026-07-24T15:45:43.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Configurable traceparent header name — field request assessed, designed, and Java reference
+implemented (branch `feature/configurable-traceparent-header`).** The field asked for
+`http.traceparent.header` / `kafka.traceparent.header` / `secondary.kafka.traceparent.header`
+(secondary falling back to primary) alongside the existing trace-id/correlation-id families.
+
+**Assessment (agreed by Eric):** this is the design-clean generalization of the 2026-07-13 field
+gateway saga. Unlike the rejected `legacy.trace.id` conflation flag, it renames the CARRIER, not
+the semantics — the full W3C context (trace-id, parent span-id, flags) crosses a header-stripping
+gateway under an allow-listed name, so cross-application SPAN PARENTING survives (the one thing
+the trace-id conflation could never provide). The requested secondary→primary fallback matched
+the existing `secondaryOrGlobal` convention exactly (verified in SecondaryKafkaNotification).
+
+**Design points ratified by Eric (2026-07-24):**
+1. Default stays `traceparent`; the config is an escape hatch; docs carry the standards-deviation
+   warning (a renamed carrier is invisible to OTel SDKs / service meshes / APM agents).
+2. Inbound: a well-formed value under the CONFIGURED name wins (a sidecar-injected standard
+   traceparent must not override the peer's context); the standard header remains a fallback so
+   standards-compliant callers keep working.
+3. Outbound: stamp the SAME W3C value under BOTH names (the kafka.trace.id.header "alongside"
+   precedent).
+4. Per-entry overrides included for a symmetric surface: `traceparent.header` in a rest.yaml
+   endpoint and a kafka-flow-adapter.yaml consumer binding.
+
+**Implementation (small, well-bounded — `W3cTrace.TRACEPARENT` had ~6 read/write sites):**
+- platform-core: HttpRouter (class-load static default so client-only apps resolve the name +
+  re-read/logged in initialize(); `parseInboundTraceparent` with per-entry > global > standard
+  fallback), RouteInfo/RoutingEntry per-entry key, AsyncHttpClient dual stamp, EventEmitter's two
+  event-over-HTTP sites deduplicated into a `setTraceHeaders` helper with the dual stamp.
+- minimalist-kafka: SimpleKafkaNotification dual stamp + `traceparentHeader()` protected accessor
+  (twin-kafka seam) + isPropagatableHeader excludes the custom name (an inbound custom-named
+  traceparent must not relay verbatim — stale span); KafkaFlowConsumer custom-first parse;
+  KafkaConsumerBinding/KafkaFlowAdapter per-binding `traceparent.header`.
+- twin-kafka: SecondaryKafkaNotification `secondaryOrGlobal("secondary.kafka.traceparent.header",
+  "kafka.traceparent.header", "traceparent")`.
+
+**Verification:** platform-core 420 tests green — 5 new (custom name carries context; custom wins
+over injected standard; standard fallback; per-entry beats global; outbound dual stamp via new
+EchoChainCaller fixture) and the ENTIRE suite runs with `http.traceparent.header=X-Trace-Context`
+active, proving the feature is additive. minimalist-kafka 101 green — 5 new (wire-level dual-stamp
+e2e through embedded Kafka + custom-name-wins e2e + 3 per-binding unit tests via the invokeFlow
+seam). twin-kafka 9 green — wire-level assert that an UNSET secondary key falls back to the primary
+setting (only `kafka.traceparent.header` set in test props; the secondary record carries it).
+Full reactor BUILD SUCCESS 4:58.
+
+**Docs:** configuration-reference (3 new per-key sections), observability (impedance table + the
+"renamed traceparent beats conflation" guidance note), rest-grammar + rest-automation.json
+(machine-readable catalog) + ai-agent-guide, minimalist-kafka + twin-kafka guides,
+reserved-names-and-headers, event-envelope-reference, CHANGELOG Unreleased.
+
+**Next:** Rust lock-step mirror (identical keys, precedence, log text — the Event Script /
+presentation-parity contract), then PR + release per Eric's gating.
+
+## Memory References
+
+- referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,
+  conv-telemetry-presentation-parity, release-4-8-0-shipped (header-precedence facts),
+  release-4-8-2-shipped (impedance-matching pattern)
+- created: thread-traceparent-header-config
+
+Co-Authored-By: Claude Code <noreply@anthropic.com>

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaConsumerBinding.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaConsumerBinding.java
@@ -38,6 +38,7 @@ public final class KafkaConsumerBinding {
     private final Integer maxPollRecords;
     private final String traceIdHeader;
     private final String correlationIdHeader;
+    private final String traceparentHeader;
 
     private KafkaConsumerBinding(Builder b) {
         this.topicOrPattern = b.topicOrPattern;
@@ -51,6 +52,7 @@ public final class KafkaConsumerBinding {
         this.maxPollRecords = b.maxPollRecords;
         this.traceIdHeader = b.traceIdHeader;
         this.correlationIdHeader = b.correlationIdHeader;
+        this.traceparentHeader = b.traceparentHeader;
     }
 
     /** Literal topic name, or the regex pattern text when {@link #isPattern()} is true. */
@@ -112,6 +114,16 @@ public final class KafkaConsumerBinding {
         return correlationIdHeader;
     }
 
+    /**
+     * Per-binding inbound traceparent header override ({@code traceparent.header}), or {@code null} to
+     * use the global {@code kafka.traceparent.header} (default {@code traceparent}). Impedance matching
+     * for an upstream that carries W3C trace context under its own header name - a well-formed value
+     * under the effective name wins, with the standard {@code traceparent} as fallback.
+     */
+    public String traceparentHeader() {
+        return traceparentHeader;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -129,6 +141,7 @@ public final class KafkaConsumerBinding {
         private Integer maxPollRecords;
         private String traceIdHeader;
         private String correlationIdHeader;
+        private String traceparentHeader;
 
         private Builder() {
         }
@@ -187,6 +200,11 @@ public final class KafkaConsumerBinding {
 
         public Builder correlationIdHeader(String correlationIdHeader) {
             this.correlationIdHeader = correlationIdHeader;
+            return this;
+        }
+
+        public Builder traceparentHeader(String traceparentHeader) {
+            this.traceparentHeader = traceparentHeader;
             return this;
         }
 

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
@@ -108,10 +108,11 @@ public class KafkaFlowAdapter implements AutoCloseable {
     private static final String SCHEMA = "schema";
     private static final String SCHEMA_ENABLED_FLAT = "schema.enabled";
     private static final String ENABLED = "enabled";
-    // Optional per-binding overrides of the global kafka.trace.id.header / kafka.correlation.id.header,
-    // for impedance matching with an upstream that uses its own header convention.
+    // Optional per-binding overrides of the global kafka.trace.id.header / kafka.correlation.id.header
+    // / kafka.traceparent.header, for impedance matching with an upstream that uses its own header convention.
     private static final String TRACE_ID_HEADER_FLAT = "trace.id.header";
     private static final String CORRELATION_ID_HEADER_FLAT = "correlation.id.header";
+    private static final String TRACEPARENT_HEADER_FLAT = "traceparent.header";
     private static final String DLQ_TOPIC = "dlq-topic";
     private static final String AUTO_COMMIT = "auto-commit";
     private static final String MAX_POLL_RECORDS = "max-poll-records";
@@ -184,7 +185,8 @@ public class KafkaFlowAdapter implements AutoCloseable {
                 .flowId(flowId).groupId(groupId).partition(partition).schemaEnabled(schemaEnabled)
                 .dlqTopic(dlqTopic).autoCommit(autoCommit).maxPollRecords(maxPollRecords)
                 .traceIdHeader(nestedText(entry, TRACE_ID_HEADER_FLAT))
-                .correlationIdHeader(nestedText(entry, CORRELATION_ID_HEADER_FLAT));
+                .correlationIdHeader(nestedText(entry, CORRELATION_ID_HEADER_FLAT))
+                .traceparentHeader(nestedText(entry, TRACEPARENT_HEADER_FLAT));
         KafkaConsumerBinding binding = (topicPattern != null ? builder.topicPattern(topicPattern)
                 : builder.topic(topic)).build();
         logBinding(label, binding);
@@ -238,7 +240,7 @@ public class KafkaFlowAdapter implements AutoCloseable {
 
     /** Log a one-line summary of a resolved consumer binding. */
     private void logBinding(String label, KafkaConsumerBinding binding) {
-        log.info("Kafka flow adapter binding: {} -> flow '{}' (consumer group '{}'{}{}{}{}{}{})",
+        log.info("Kafka flow adapter binding: {} -> flow '{}' (consumer group '{}'{}{}{}{}{}{}{})",
                 label, binding.flowId(), binding.groupId(),
                 binding.partition() != null ? ", pinned to partition " + binding.partition() : "",
                 binding.schemaEnabled() ? ", schema decode on" : "",
@@ -246,7 +248,9 @@ public class KafkaFlowAdapter implements AutoCloseable {
                 binding.autoCommit() ? ", auto-commit on" : "",
                 binding.traceIdHeader() != null ? ", trace-id header '" + binding.traceIdHeader() + "'" : "",
                 binding.correlationIdHeader() != null
-                        ? ", correlation-id header '" + binding.correlationIdHeader() + "'" : "");
+                        ? ", correlation-id header '" + binding.correlationIdHeader() + "'" : "",
+                binding.traceparentHeader() != null
+                        ? ", traceparent header '" + binding.traceparentHeader() + "'" : "");
     }
 
     /**

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -126,6 +126,11 @@ public class KafkaFlowConsumer implements AutoCloseable {
     // does not send a W3C traceparent. A well-formed traceparent always takes precedence.
     private static final String GLOBAL_TRACE_ID_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.trace.id.header");
+    // Global inbound traceparent header name (default "traceparent"): impedance matching for an upstream
+    // that carries W3C trace context under its own header name. A well-formed value under the effective
+    // name wins; the standard header remains a fallback.
+    private static final String GLOBAL_TRACEPARENT_HEADER = AppConfigReader.getInstance()
+            .getProperty("kafka.traceparent.header", W3cTrace.TRACEPARENT);
 
     private final Consumer<String, byte[]> consumer;
     private final KafkaConsumerBinding binding;
@@ -144,6 +149,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
     // Effective inbound header names: per-binding override first, then the application.properties global.
     private final String correlationIdHeader;
     private final String traceIdHeader;
+    private final String traceparentHeader;
     private final ExecutorService loop;
 
     private volatile boolean running;
@@ -160,6 +166,8 @@ public class KafkaFlowConsumer implements AutoCloseable {
         this.correlationIdHeader = binding.correlationIdHeader() != null
                 ? binding.correlationIdHeader() : GLOBAL_CORRELATION_ID_HEADER;
         this.traceIdHeader = binding.traceIdHeader() != null ? binding.traceIdHeader() : GLOBAL_TRACE_ID_HEADER;
+        this.traceparentHeader = binding.traceparentHeader() != null
+                ? binding.traceparentHeader() : GLOBAL_TRACEPARENT_HEADER;
         this.loop = Executors.newSingleThreadExecutor(runnable -> {
             Thread thread = new Thread(runnable, "kafka-flow-" + binding.topicOrPattern());
             thread.setDaemon(true);
@@ -232,12 +240,26 @@ public class KafkaFlowConsumer implements AutoCloseable {
         }
         @SuppressWarnings("unchecked")
         Map<String, String> headers = (Map<String, String>) dataset.get(HEADER);
-        String[] trace = W3cTrace.parse(headers.get(W3cTrace.TRACEPARENT));
+        String[] trace = parseInboundTraceparent(headers);
         // trace-id precedence: W3C traceparent > configured trace-id header (legacy upstream) > fresh UUID
         String traceId = trace.length > 0 ? trace[0] : traceIdFromHeaderOrNew(headers);
         String tracePath = "KAFKA /" + consumerRecord.topic();
         EventEnvelope forward = toFlowRequest(dataset, headers, trace, traceId, tracePath);
         return deliver(consumerRecord, forward, traceId, tracePath);
+    }
+
+    /**
+     * Parse the inbound W3C trace context from the effective traceparent header name (per-binding
+     * 'traceparent.header', else the global kafka.traceparent.header, default "traceparent"). A
+     * well-formed value under the custom name wins; the standard header remains a fallback so a
+     * standards-compliant upstream still propagates.
+     */
+    private String[] parseInboundTraceparent(Map<String, String> headers) {
+        String[] parsed = W3cTrace.parse(headers.get(traceparentHeader));
+        if (parsed.length == 0 && !W3cTrace.TRACEPARENT.equalsIgnoreCase(traceparentHeader)) {
+            parsed = W3cTrace.parse(headers.get(W3cTrace.TRACEPARENT));
+        }
+        return parsed;
     }
 
     /** The inbound trace-id from the effective trace-id header when configured, else a fresh UUID. */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
@@ -91,6 +91,11 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
     // proprietary trace-id header instead of parsing traceparent.
     private static final String TRACE_ID_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.trace.id.header");
+    // Configurable traceparent header name (default "traceparent"): when customized, the W3C trace
+    // context is stamped under BOTH names, for an intermediary or downstream convention that does not
+    // handle the standard header.
+    private static final String TRACEPARENT_HEADER = AppConfigReader.getInstance()
+            .getProperty("kafka.traceparent.header", W3cTrace.TRACEPARENT);
 
     // one Encoder per worker instance (an instance is single-flight) -> owner-confined Confluent serializers.
     private final ConcurrentMap<Integer, SchemaCodec.Encoder> encoders = new ConcurrentHashMap<>();
@@ -113,6 +118,11 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
     /** The optional outbound trace-id header name (default from kafka.trace.id.header), or null. */
     protected String traceIdHeader() {
         return TRACE_ID_HEADER;
+    }
+
+    /** The traceparent header name (default "traceparent", from kafka.traceparent.header). */
+    protected String traceparentHeader() {
+        return TRACEPARENT_HEADER;
     }
 
     /** The registry-url application property named in error messages (for accurate diagnostics). */
@@ -146,6 +156,12 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
         String traceparent = currentTraceparent(new PostOffice(headers, instance));
         if (traceparent != null) {
             kafkaHeaders.put(W3cTrace.TRACEPARENT, traceparent.getBytes(StandardCharsets.UTF_8));
+            // when a custom traceparent header name is configured, stamp the same value under that
+            // name too, for an intermediary or downstream convention that does not handle the standard
+            String customTraceparent = traceparentHeader();
+            if (!W3cTrace.TRACEPARENT.equalsIgnoreCase(customTraceparent)) {
+                kafkaHeaders.put(customTraceparent, traceparent.getBytes(StandardCharsets.UTF_8));
+            }
         }
         // when the trace-id header is configured, also stamp the trace-id under that name for legacy
         // downstream consumers; an explicitly mapped value wins over the flow's trace-id (my_trace_id).
@@ -193,9 +209,10 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
 
     /**
      * Whether an event header is forwarded verbatim as a Kafka header. Excludes routing/encoding directives
-     * (topic/partition/subject/version), the inbound traceparent (replaced with this hop's own span), the
-     * correlation-id and configured trace-id headers (stamped explicitly from the resolved values), and the
-     * framework's read-only reserved headers (my_route / my_trace_id / my_trace_path / my_correlation_id).
+     * (topic/partition/subject/version), the inbound traceparent under the standard or configured name
+     * (replaced with this hop's own span), the correlation-id and configured trace-id headers (stamped
+     * explicitly from the resolved values), and the framework's read-only reserved headers
+     * (my_route / my_trace_id / my_trace_path / my_correlation_id).
      */
     private boolean isPropagatableHeader(String key) {
         return !KafkaHeaders.TOPIC.equals(key)
@@ -203,6 +220,7 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<byte[], Mono
                 && !KafkaHeaders.SUBJECT.equals(key)
                 && !KafkaHeaders.VERSION.equals(key)
                 && !W3cTrace.TRACEPARENT.equals(key)
+                && !traceparentHeader().equals(key)
                 && !correlationIdHeader().equals(key)
                 && !key.equals(traceIdHeader())
                 && !MY_ROUTE.equals(key)

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Standalone end-to-end proof of the minimalist-kafka building blocks (no Redis, no REST):
@@ -144,6 +145,51 @@ class KafkaFlowAdapterTest {
                 "business cid surfaced to the task as model.cid / getMyCorrelationId() through the flow engine");
         assertEquals("{\"hello\":\"kafka\"}", received.get("body"), "body round-tripped through Kafka");
         assertEquals(TRACE_ID, received.get("traceId"), "trace-id stayed continuous across the Kafka hop");
+    }
+
+    @Test
+    void notificationStampsTraceContextUnderBothNames() throws Exception {
+        KafkaSinkTask.RECEIVED.clear();
+        // kafka.traceparent.header=x-kafka-trace in this test suite: the notification stamps the SAME
+        // W3C value under both the standard "traceparent" and the custom name, so the context survives
+        // middleware that mishandles the standard header while compliant consumers keep working
+        String cid = Utility.getInstance().getUuid();
+        PostOffice po = PostOffice.trackable("unit.test", TRACE_ID, "TEST /dual/stamp");
+        po.send(new EventEnvelope().setTo("simple.kafka.notification")
+                .setHeader(KafkaHeaders.TOPIC, TOPIC)
+                .setHeader(KafkaHeaders.CORRELATION_ID, cid)
+                .setBody("{\"hello\":\"dual\"}".getBytes(StandardCharsets.UTF_8))
+                .setTraceId(TRACE_ID).setTracePath("TEST /dual/stamp"));
+
+        Map<String, Object> received = KafkaSinkTask.RECEIVED.poll(25, TimeUnit.SECONDS);
+        assertNotNull(received, "the sink flow should receive the message");
+        String standard = (String) received.get("traceparent");
+        assertNotNull(standard, "the standard traceparent header is stamped");
+        assertTrue(standard.contains(TRACE_ID), "the stamped traceparent continues the caller's trace");
+        assertEquals(standard, received.get("customTraceparent"),
+                "the same W3C value must be stamped under the custom kafka.traceparent.header name");
+    }
+
+    @Test
+    void adapterAdoptsTraceContextFromCustomHeaderName() throws Exception {
+        KafkaSinkTask.RECEIVED.clear();
+        // inbound impedance matching: an upstream carries W3C trace context ONLY under the custom
+        // name (middleware stripped the standard header); the adapter adopts it - and when an
+        // intermediary injects its own standard traceparent, the custom name still wins
+        String customTraceId = "aaaa2222333344445555666677778888";
+        String injectedTraceId = "bbbb2222333344445555666677778888";
+        Map<String, byte[]> recordHeaders = new HashMap<>();
+        recordHeaders.put("x-kafka-trace",
+                W3cTrace.format(customTraceId, "aaaabbbbccccdddd").getBytes(StandardCharsets.UTF_8));
+        recordHeaders.put(W3cTrace.TRACEPARENT,
+                W3cTrace.format(injectedTraceId, "ddddccccbbbbaaaa").getBytes(StandardCharsets.UTF_8));
+        KafkaRuntime.publisher().publishSync(TOPIC, null, recordHeaders,
+                "{\"hello\":\"custom\"}".getBytes(StandardCharsets.UTF_8), 10000);
+
+        Map<String, Object> received = KafkaSinkTask.RECEIVED.poll(25, TimeUnit.SECONDS);
+        assertNotNull(received, "the sink flow should receive the message");
+        assertEquals(customTraceId, received.get("traceId"),
+                "a well-formed value under the custom traceparent name wins over the standard header");
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
@@ -276,6 +276,81 @@ class KafkaFlowConsumerTest {
     }
 
     @Test
+    void perBindingTraceparentOverrideAdoptsCustomHeaderName() {
+        // the binding's 'traceparent.header' override reads the W3C trace context from a custom name
+        EventEnvelope[] captured = new EventEnvelope[1];
+        RetryPolicy policy = new RetryPolicy(0, 0, null);
+        KafkaConsumerBinding custom = binding().traceparentHeader("X-Bridge-Trace").build();
+        KafkaFlowConsumer consumer = new KafkaFlowConsumer(null, custom, 1000, policy, null) {
+            @Override
+            EventEnvelope invokeFlow(EventEnvelope forward, String traceId, String tracePath) {
+                captured[0] = forward;
+                return new EventEnvelope().setStatus(200);
+            }
+        };
+        ConsumerRecord<String, byte[]> r = new ConsumerRecord<>("orders", 0, 7L, "k", "payload".getBytes(UTF_8));
+        r.headers().add("X-Bridge-Trace",
+                "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".getBytes(UTF_8));
+
+        consumer.routeToFlow(r);
+
+        assertEquals("0af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
+                "trace-id adopted from the custom traceparent header name");
+        assertEquals("b7ad6b7169203331", captured[0].getSpanId(),
+                "the flow chains onto the upstream span carried under the custom name");
+    }
+
+    @Test
+    void customTraceparentNameWinsOverStandardHeader() {
+        // an intermediary may inject its own standard traceparent; the deliberately configured
+        // custom name must not be overridden by it
+        EventEnvelope[] captured = new EventEnvelope[1];
+        RetryPolicy policy = new RetryPolicy(0, 0, null);
+        KafkaConsumerBinding custom = binding().traceparentHeader("X-Bridge-Trace").build();
+        KafkaFlowConsumer consumer = new KafkaFlowConsumer(null, custom, 1000, policy, null) {
+            @Override
+            EventEnvelope invokeFlow(EventEnvelope forward, String traceId, String tracePath) {
+                captured[0] = forward;
+                return new EventEnvelope().setStatus(200);
+            }
+        };
+        ConsumerRecord<String, byte[]> r = new ConsumerRecord<>("orders", 0, 7L, "k", "payload".getBytes(UTF_8));
+        r.headers().add("X-Bridge-Trace",
+                "00-1af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".getBytes(UTF_8));
+        r.headers().add("traceparent",
+                "00-2af7651916cd43dd8448eb211c80319c-c7ad6b7169203332-01".getBytes(UTF_8));
+
+        consumer.routeToFlow(r);
+
+        assertEquals("1af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
+                "a well-formed value under the custom traceparent name wins over the standard header");
+    }
+
+    @Test
+    void standardTraceparentRemainsFallbackUnderCustomName() {
+        // a standards-compliant upstream that only sends the standard header still propagates,
+        // even though the binding is configured with a custom traceparent name
+        EventEnvelope[] captured = new EventEnvelope[1];
+        RetryPolicy policy = new RetryPolicy(0, 0, null);
+        KafkaConsumerBinding custom = binding().traceparentHeader("X-Bridge-Trace").build();
+        KafkaFlowConsumer consumer = new KafkaFlowConsumer(null, custom, 1000, policy, null) {
+            @Override
+            EventEnvelope invokeFlow(EventEnvelope forward, String traceId, String tracePath) {
+                captured[0] = forward;
+                return new EventEnvelope().setStatus(200);
+            }
+        };
+        ConsumerRecord<String, byte[]> r = new ConsumerRecord<>("orders", 0, 7L, "k", "payload".getBytes(UTF_8));
+        r.headers().add("traceparent",
+                "00-3af7651916cd43dd8448eb211c80319c-d7ad6b7169203333-01".getBytes(UTF_8));
+
+        consumer.routeToFlow(r);
+
+        assertEquals("3af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
+                "the standard traceparent remains a fallback when the custom name is absent");
+    }
+
+    @Test
     void subscribesWithPatternWhenConfigured() {
         MockConsumer<String, byte[]> mock = new MockConsumer<>("earliest");
         mock.updatePartitions("orders-1", List.of(new PartitionInfo("orders-1", 0, null, new Node[0], new Node[0])));

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaSinkTask.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaSinkTask.java
@@ -46,6 +46,9 @@ public class KafkaSinkTask implements TypedLambdaFunction<byte[], Map<String, Ob
         // inbound Kafka cid as the flow's correlation-id, which survives the RPC hop as this header)
         entry.put("myCid", po.getMyCorrelationId());
         entry.put("traceId", po.getTraceId());
+        // raw trace headers from the Kafka record (mapped by the flow) - for the dual-stamp assertion
+        entry.put("traceparent", headers.get("traceparent"));
+        entry.put("customTraceparent", headers.get("x-kafka-trace"));
         entry.put("body", new String(input, StandardCharsets.UTF_8));
         RECEIVED.add(entry);
         return Map.of("status", "received");

--- a/system/minimalist-kafka/src/test/resources/application.properties
+++ b/system/minimalist-kafka/src/test/resources/application.properties
@@ -29,3 +29,8 @@ schema.registry.cache.ttl=1h
 # (dlq-topic in kafka-flow-adapter.yaml), not a global setting.
 kafka.flow.max.retries=3
 kafka.flow.retry.backoff.ms=500
+# Custom traceparent header name (escape hatch for middleware that mishandles the standard W3C
+# "traceparent"): the notification stamps the trace context under BOTH names and the adapter reads
+# the custom name first with the standard header as fallback. Set here so the whole test suite runs
+# with the feature active, proving it is additive.
+kafka.traceparent.header=x-kafka-trace

--- a/system/minimalist-kafka/src/test/resources/flows/kafka-sink-flow.yml
+++ b/system/minimalist-kafka/src/test/resources/flows/kafka-sink-flow.yml
@@ -26,6 +26,10 @@ tasks:
       - 'model.cid -> header.cid'
       # model.cid is seeded by the adapter from the configured 'kafka.correlation.id.header';
       # to read an additional raw header, add e.g. 'input.header.ce-id -> header.ce-id'
+      # raw trace headers surfaced so the test can assert the notification's dual traceparent stamp
+      # (standard 'traceparent' plus the custom 'kafka.traceparent.header' name)
+      - 'input.header.traceparent -> header.traceparent'
+      - 'input.header.x-kafka-trace -> header.x-kafka-trace'
     process: 'kafka.test.sink'
     output:
       - 'result -> output.body'

--- a/system/platform-core/src/main/java/org/platformlambda/automation/config/RoutingEntry.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/config/RoutingEntry.java
@@ -46,8 +46,10 @@ public class RoutingEntry {
     private static final String UPLOAD = "upload";
     private static final String TRACING = "tracing";
     // optional per-endpoint overrides of the global http.trace.id.header / http.correlation.id.header
+    // / http.traceparent.header
     private static final String TRACE_ID_HEADER = "trace.id.header";
     private static final String CORRELATION_ID_HEADER = "correlation.id.header";
+    private static final String TRACEPARENT_HEADER = "traceparent.header";
     private static final String SERVICE = "service";
     private static final String FLOW = "flow";
     private static final String METHODS = "methods";
@@ -509,6 +511,7 @@ public class RoutingEntry {
         // nested maps, so the composite paths below resolve them correctly
         info.traceIdHeader = config.getProperty(REST+"["+idx+"]."+TRACE_ID_HEADER);
         info.correlationIdHeader = config.getProperty(REST+"["+idx+"]."+CORRELATION_ID_HEADER);
+        info.traceparentHeader = config.getProperty(REST+"["+idx+"]."+TRACEPARENT_HEADER);
         // drop query string when parsing URL
         if (url.contains("?")) {
             url = url.substring(0, url.indexOf('?'));

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -340,6 +340,13 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         String traceparent = W3cTrace.format(traceId, spanId);
         if (traceparent != null) {
             http.set(W3cTrace.TRACEPARENT, traceparent);
+            // when a custom traceparent header name is configured (http.traceparent.header), stamp the
+            // same value under that name too, so the W3C trace context survives an intermediary that
+            // strips the standard header
+            String customTraceparent = HttpRouter.getTraceparentHeader();
+            if (!W3cTrace.TRACEPARENT.equalsIgnoreCase(customTraceparent)) {
+                http.set(customTraceparent, traceparent);
+            }
         }
         // propagate the business correlation-id downstream (unless the caller set the header explicitly)
         String businessCorrelationId = po.getMyCorrelationId();

--- a/system/platform-core/src/main/java/org/platformlambda/automation/models/RouteInfo.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/models/RouteInfo.java
@@ -40,10 +40,11 @@ public class RouteInfo {
     public String flowId;
     public boolean trustAllCert = false;
     public List<String> urlRewrite;
-    // optional per-endpoint overrides of http.trace.id.header / http.correlation.id.header,
-    // for impedance matching with an upstream that uses its own header convention
+    // optional per-endpoint overrides of http.trace.id.header / http.correlation.id.header /
+    // http.traceparent.header, for impedance matching with an upstream that uses its own header convention
     public String traceIdHeader;
     public String correlationIdHeader;
+    public String traceparentHeader;
 
     public String getAuthService(String headerKey) {
         return getAuthService(headerKey, "*");

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -110,6 +110,13 @@ public class HttpRouter {
     private static String traceIdHeader = DEFAULT_TRACE_ID_HEADER;
     // Configurable HTTP correlation-id header (enterprise-specific); default X-Correlation-Id.
     private static String businessCorrelationIdHeader;
+    // Configurable traceparent header name (http.traceparent.header): an escape hatch for an
+    // intermediary (e.g. an API gateway) that strips the standard W3C "traceparent" header. When
+    // customized, the same W3C-format value travels under BOTH names on outbound calls, and inbound
+    // resolution reads the custom name first with the standard header as fallback. Read at class-load
+    // so a client-only application (no rest-automation server) resolves the same name.
+    private static String traceparentHeader = AppConfigReader.getInstance()
+            .getProperty("http.traceparent.header", W3cTrace.TRACEPARENT);
     // Read-only reserved header exposing the business correlation-id to the target function.
     // Package-private so the HttpAuth handler (same package) can stamp it on the post-auth forward.
     static final String MY_CORRELATION_ID = "my_correlation_id";
@@ -131,6 +138,8 @@ public class HttpRouter {
                 log.info("Correlation-id HTTP header is '{}'", businessCorrelationIdHeader);
                 traceIdHeader = config.getProperty("http.trace.id.header", DEFAULT_TRACE_ID_HEADER);
                 log.info("Trace-id HTTP header is '{}'", traceIdHeader);
+                traceparentHeader = config.getProperty("http.traceparent.header", W3cTrace.TRACEPARENT);
+                log.info("Traceparent HTTP header is '{}'", traceparentHeader);
                 String folder = config.getProperty("spring.web.resources.static-locations",
                         config.getProperty("static.html.folder", "classpath:/public"));
                 if (folder.endsWith("/")) {
@@ -175,6 +184,17 @@ public class HttpRouter {
      */
     public static String getTraceIdHeader() {
         return traceIdHeader;
+    }
+
+    /**
+     * The traceparent header name (default "traceparent", configurable via http.traceparent.header).
+     * When customized, outbound HTTP calls stamp the W3C trace context under this name in addition
+     * to the standard header, so the context survives an intermediary that strips "traceparent".
+     *
+     * @return the traceparent header name
+     */
+    public static String getTraceparentHeader() {
+        return traceparentHeader;
     }
 
     public ConcurrentMap<String, AsyncContextHolder> getContexts() {
@@ -562,7 +582,7 @@ public class HttpRouter {
         }
         // W3C trace context: continue an upstream trace and adopt the caller's span as our parent
         String parentSpanId = null;
-        String[] traceParent = W3cTrace.parse(request.getHeader(W3cTrace.TRACEPARENT));
+        String[] traceParent = parseInboundTraceparent(request, route);
         if (traceParent.length > 0) {
             traceId = traceParent[0];
             parentSpanId = traceParent[1];
@@ -573,6 +593,26 @@ public class HttpRouter {
             req.setHeader(cidHeaderName, traceId);
         }
         return new TraceContext(traceId, tracePath, parentSpanId, businessCorrelationId);
+    }
+
+    /**
+     * Parse the inbound W3C trace context from the effective traceparent header name (per-endpoint
+     * 'traceparent.header' in rest.yaml, else the global http.traceparent.header, default "traceparent").
+     * A well-formed value under the custom name wins - an intermediary may inject its own standard
+     * traceparent, which must not override the peer's context - while the standard header remains a
+     * fallback so standards-compliant callers still propagate.
+     *
+     * @param request HTTP
+     * @param route the assigned route
+     * @return a 2-element array of {trace-id, parent-span-id}, or an empty array when absent/invalid
+     */
+    private String[] parseInboundTraceparent(HttpServerRequest request, AssignedRoute route) {
+        String name = route.info.traceparentHeader != null ? route.info.traceparentHeader : traceparentHeader;
+        String[] parsed = W3cTrace.parse(request.getHeader(name));
+        if (parsed.length == 0 && !W3cTrace.TRACEPARENT.equalsIgnoreCase(name)) {
+            parsed = W3cTrace.parse(request.getHeader(W3cTrace.TRACEPARENT));
+        }
+        return parsed;
     }
 
     private void handlePayload(HttpServerRequest request, AssignedRoute route,

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -23,6 +23,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import org.platformlambda.automation.http.AsyncHttpClient;
+import org.platformlambda.automation.services.HttpRouter;
 import org.platformlambda.core.models.*;
 import org.platformlambda.core.services.TemporaryInbox;
 import org.platformlambda.core.util.AppConfigReader;
@@ -872,15 +873,7 @@ public class EventEmitter {
                 }
             }
         }
-        // propagate trace context: X-Trace-Id plus W3C "traceparent" (traceId + spanId) if available
-        String eventTraceId = event.getTraceId();
-        if (eventTraceId != null) {
-            req.setHeader(X_TRACE_ID, eventTraceId);
-            String traceParent = W3cTrace.format(eventTraceId, event.getSpanId());
-            if (traceParent != null) {
-                req.setHeader(W3cTrace.TRACEPARENT, traceParent);
-            }
-        }
+        setTraceHeaders(req, event);
         req.setUrl(url.getPath());
         req.setTargetHost(getTargetFromUrl(url));
         byte[] b = event.toBytes(httpEventFormat(headers));
@@ -897,6 +890,30 @@ public class EventEmitter {
             request.setTracePath(event.getTracePath());
         }
         return Future.future(promise -> submitAsyncRequest(promise, request, timeout));
+    }
+
+    /**
+     * Propagate the trace context of an event-over-HTTP call: X-Trace-Id plus the W3C "traceparent"
+     * (traceId + spanId) if available. When a custom traceparent header name is configured
+     * (http.traceparent.header), the same value is stamped under that name too, so the trace context
+     * survives an intermediary that strips the standard header.
+     *
+     * @param req the HTTP request to the peer's /api/event endpoint
+     * @param event the outgoing event carrying the current trace context
+     */
+    private void setTraceHeaders(AsyncHttpRequest req, EventEnvelope event) {
+        String eventTraceId = event.getTraceId();
+        if (eventTraceId != null) {
+            req.setHeader(X_TRACE_ID, eventTraceId);
+            String traceParent = W3cTrace.format(eventTraceId, event.getSpanId());
+            if (traceParent != null) {
+                req.setHeader(W3cTrace.TRACEPARENT, traceParent);
+                String customTraceparent = HttpRouter.getTraceparentHeader();
+                if (!W3cTrace.TRACEPARENT.equalsIgnoreCase(customTraceparent)) {
+                    req.setHeader(customTraceparent, traceParent);
+                }
+            }
+        }
     }
 
     private void submitAsyncRequest(Promise<EventEnvelope> promise, EventEnvelope request, long timeout) {
@@ -1011,15 +1028,7 @@ public class EventEmitter {
                 }
             }
         }
-        // propagate trace context: X-Trace-Id plus W3C "traceparent" (traceId + spanId) if available
-        String eventTraceId = event.getTraceId();
-        if (eventTraceId != null) {
-            req.setHeader(X_TRACE_ID, eventTraceId);
-            String traceParent = W3cTrace.format(eventTraceId, event.getSpanId());
-            if (traceParent != null) {
-                req.setHeader(W3cTrace.TRACEPARENT, traceParent);
-            }
-        }
+        setTraceHeaders(req, event);
         req.setUrl(url.getPath());
         req.setTargetHost(getTargetFromUrl(url));
         byte[] b = event.toBytes(httpEventFormat(headers));

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -164,6 +164,121 @@ class RestEndpointTest extends TestBase {
         assertEquals(w3cTraceId, probe.get("cid"));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void customTraceparentHeaderNameCarriesTheTraceContext() throws InterruptedException {
+        // http.traceparent.header=X-Trace-Context in this test suite: an intermediary that strips
+        // the standard W3C "traceparent" can still deliver the trace context under the custom name
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String w3cTraceId = "1af92f3577b34da6a3ce929d0e0e4701";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/legacy/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json")
+                .setHeader("X-Trace-Context", "00-" + w3cTraceId + "-00f067aa0ba902b7-01");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals(w3cTraceId, probe.get("traceId"),
+                "the endpoint adopted the W3C trace context carried under the custom header name");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void customTraceparentNameWinsOverInjectedStandardHeader() throws InterruptedException {
+        // an intermediary (e.g. a service-mesh sidecar) may inject its OWN standard traceparent;
+        // the peer's context under the deliberately configured custom name must not be overridden
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String peerTraceId = "2af92f3577b34da6a3ce929d0e0e4702";
+        String injectedTraceId = "3af92f3577b34da6a3ce929d0e0e4703";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/legacy/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json")
+                .setHeader("X-Trace-Context", "00-" + peerTraceId + "-00f067aa0ba902b7-01")
+                .setHeader("traceparent", "00-" + injectedTraceId + "-00f067aa0ba902b8-01");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals(peerTraceId, probe.get("traceId"),
+                "a well-formed value under the custom traceparent name wins over the standard header");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void standardTraceparentRemainsFallbackUnderCustomName() throws InterruptedException {
+        // a standards-compliant caller that only sends the standard header still propagates,
+        // even though this application is configured with a custom traceparent name
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String w3cTraceId = "4af92f3577b34da6a3ce929d0e0e4704";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/legacy/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json")
+                .setHeader("traceparent", "00-" + w3cTraceId + "-00f067aa0ba902b7-01");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals(w3cTraceId, probe.get("traceId"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void perEndpointTraceparentOverrideBeatsGlobalName() throws InterruptedException {
+        // /api/renamed/traceparent/probe declares 'traceparent.header: X-Endpoint-Trace' in rest.yaml,
+        // which replaces the global custom name (X-Trace-Context) for that endpoint
+        final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
+        String endpointTraceId = "5af92f3577b34da6a3ce929d0e0e4705";
+        String globalNameTraceId = "6af92f3577b34da6a3ce929d0e0e4706";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setUrl("/api/renamed/traceparent/probe").setTargetHost("http://127.0.0.1:" + port);
+        req.setHeader("accept", "application/json")
+                .setHeader("X-Endpoint-Trace", "00-" + endpointTraceId + "-00f067aa0ba902b7-01")
+                .setHeader("X-Trace-Context", "00-" + globalNameTraceId + "-00f067aa0ba902b8-01");
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
+        po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
+        EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
+        assert response != null;
+        Map<String, Object> probe = (Map<String, Object>) response.getBody();
+        assertEquals(endpointTraceId, probe.get("traceId"),
+                "the per-endpoint traceparent.header override takes precedence over the global name");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void asyncHttpClientStampsTraceContextUnderBothNames() throws InterruptedException, ExecutionException {
+        // outbound: with http.traceparent.header configured, AsyncHttpClient stamps the SAME W3C value
+        // under both the standard "traceparent" and the custom name, so the context survives an
+        // intermediary that strips the standard header while compliant hops keep working
+        String w3cTraceId = "7af92f3577b34da6a3ce929d0e0e4707";
+        String traceparent = "00-" + w3cTraceId + "-00f067aa0ba902b7-01";
+        EventEmitter po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setHeader("accept", "application/json").setHeader("traceparent", traceparent);
+        req.setUrl("/api/echo/chain").setQueryParameter("port", String.valueOf(port));
+        req.setTargetHost("http://127.0.0.1:" + port);
+        EventEnvelope response = po.asyncRequest(new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST)
+                .setBody(req), RPC_TIMEOUT).toCompletionStage().toCompletableFuture().get();
+        assert response != null;
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        MultiLevelMap map = new MultiLevelMap((Map<String, Object>) response.getBody());
+        String stamped = (String) map.getElement("headers.traceparent");
+        assertNotNull(stamped, "the traced caller stamped the standard traceparent on the outgoing hop");
+        assertTrue(stamped.startsWith("00-" + w3cTraceId + "-"),
+                "the stamped traceparent continues the caller's trace");
+        assertEquals(stamped, map.getElement("headers.x-trace-context"),
+                "the same W3C value must be stamped under the custom traceparent header name");
+    }
+
     @Test
     void optionsMethodTest() throws InterruptedException {
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/EchoChainCaller.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/EchoChainCaller.java
@@ -1,0 +1,50 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+
+/**
+ * A traced function that calls the "/api/hello/world" echo endpoint through the "async.http.request"
+ * HTTP client and returns the echo's view of the request it received. Because the echo reflects the
+ * raw HTTP headers, a test can assert exactly what AsyncHttpClient stamped on the outgoing call -
+ * e.g. that the W3C trace context travels under BOTH the standard "traceparent" and a custom
+ * http.traceparent.header name.
+ */
+@PreLoad(route = "echo.chain.caller", instances = 10)
+public class EchoChainCaller implements TypedLambdaFunction<AsyncHttpRequest, Object> {
+    private static final long RPC_TIMEOUT = 10000;
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) throws Exception {
+        var po = new PostOffice(headers, instance);
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET").setHeader("accept", "application/json");
+        req.setUrl("/api/hello/world").setTargetHost("http://127.0.0.1:" + input.getQueryParameter("port"));
+        EventEnvelope res = po.eRequest(new EventEnvelope().setTo("async.http.request").setBody(req),
+                                        RPC_TIMEOUT).get();
+        return res.getBody();
+    }
+}

--- a/system/platform-core/src/test/resources/application.properties
+++ b/system/platform-core/src/test/resources/application.properties
@@ -109,6 +109,14 @@ show.env.variables=PATH, NON_EXIST
 show.application.properties=rest.automation, snake.case.serialization
 
 #
+# Custom traceparent header name (escape hatch for an intermediary that strips the standard
+# W3C "traceparent"): outbound calls stamp the trace context under BOTH names, and inbound
+# resolution reads the custom name first with the standard header as fallback. Set here so
+# the whole test suite runs with the feature active, proving it is additive.
+#
+http.traceparent.header=X-Trace-Context
+
+#
 # stack trace transport size in EventEnvelope
 # - the maximum number of lines in a stack trace
 #

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -69,12 +69,30 @@ rest:
     trace.id.header: "X-Shared-Id"
     correlation.id.header: "X-Shared-Id"
 
+  # Per-endpoint traceparent header-name override: this endpoint reads the W3C trace context from
+  # 'X-Endpoint-Trace', taking precedence over the global http.traceparent.header (X-Trace-Context
+  # in this test suite) and the standard 'traceparent' (which remains a fallback when absent).
+  - service: "header.probe"
+    methods: ['GET']
+    url: "/api/renamed/traceparent/probe"
+    timeout: 10s
+    tracing: true
+    traceparent.header: "X-Endpoint-Trace"
+
   # Simulates application A in an application-to-application HTTP call: this traced endpoint's
   # function calls /api/legacy/probe ("application B") through async.http.request, so tests can
   # assert that one distributed trace continues across the HTTP hop between the two.
   - service: "downstream.caller"
     methods: ['GET']
     url: "/api/chain/probe"
+    timeout: 15s
+    tracing: true
+
+  # A traced caller whose downstream target is the /api/hello/world echo, so tests can inspect
+  # the raw headers AsyncHttpClient stamped on the outgoing hop (e.g. the custom traceparent name).
+  - service: "echo.chain.caller"
+    methods: ['GET']
+    url: "/api/echo/chain"
     timeout: 15s
     tracing: true
 

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaNotification.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaNotification.java
@@ -21,6 +21,7 @@ package org.platformlambda.twin.kafka;
 import org.platformlambda.core.annotations.KernelThreadRunner;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.W3cTrace;
 import org.platformlambda.mini.kafka.KafkaRequestPublisher;
 import org.platformlambda.mini.kafka.SimpleKafkaNotification;
 import org.platformlambda.mini.kafka.schema.SchemaCodec;
@@ -31,10 +32,11 @@ import org.platformlambda.mini.kafka.schema.SchemaCodec;
  * the SECOND Kafka cluster through {@link SecondaryKafkaRuntime}. A flow task bridges two clusters by
  * consuming from one adapter and publishing through the other cluster's notification function.
  *
- * <p>Outbound header names may be tuned per cluster: {@code secondary.kafka.correlation.id.header}
- * and {@code secondary.kafka.trace.id.header} override the shared globals
- * ({@code kafka.correlation.id.header}, default {@code cid} / {@code kafka.trace.id.header}, unset)
- * when the two clusters follow different conventions.</p>
+ * <p>Outbound header names may be tuned per cluster: {@code secondary.kafka.correlation.id.header},
+ * {@code secondary.kafka.trace.id.header} and {@code secondary.kafka.traceparent.header} override the
+ * shared globals ({@code kafka.correlation.id.header}, default {@code cid} /
+ * {@code kafka.trace.id.header}, unset / {@code kafka.traceparent.header}, default
+ * {@code traceparent}) when the two clusters follow different conventions.</p>
  *
  * <p>Same threading model as the base class: {@code @KernelThreadRunner} with a small single-flight
  * worker pool (see {@link SimpleKafkaNotification} for the full rationale).</p>
@@ -48,6 +50,8 @@ public class SecondaryKafkaNotification extends SimpleKafkaNotification {
             secondaryOrGlobal("secondary.kafka.correlation.id.header", "kafka.correlation.id.header", "cid");
     private static final String TRACE_ID_HEADER =
             secondaryOrGlobal("secondary.kafka.trace.id.header", "kafka.trace.id.header", null);
+    private static final String TRACEPARENT_HEADER = secondaryOrGlobal(
+            "secondary.kafka.traceparent.header", "kafka.traceparent.header", W3cTrace.TRACEPARENT);
 
     /** The secondary-cluster key when set, else the global key, else the hard default (may be null). */
     private static String secondaryOrGlobal(String secondaryKey, String globalKey, String hardDefault) {
@@ -77,6 +81,11 @@ public class SecondaryKafkaNotification extends SimpleKafkaNotification {
     @Override
     protected String traceIdHeader() {
         return TRACE_ID_HEADER;
+    }
+
+    @Override
+    protected String traceparentHeader() {
+        return TRACEPARENT_HEADER;
     }
 
     @Override

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/TwinKafkaBridgeTest.java
@@ -265,6 +265,9 @@ class TwinKafkaBridgeTest {
                 "trace-id stamped under the SECONDARY override name");
         assertTrue(String.valueOf(headerValue(rec, "traceparent")).contains(TRACE_B),
                 "W3C traceparent is stamped alongside the legacy trace-id header");
+        assertEquals(headerValue(rec, "traceparent"), headerValue(rec, "X-Global-Traceparent"),
+                "secondary.kafka.traceparent.header is unset, so the secondary notification falls back "
+                        + "to the primary kafka.traceparent.header and stamps the same W3C value under it");
         assertNull(headerValue(rec, "cid"),
                 "the global default name is not used when the secondary override is set");
     }

--- a/system/twin-kafka/src/test/resources/application.properties
+++ b/system/twin-kafka/src/test/resources/application.properties
@@ -37,3 +37,6 @@ secondary.schema.registry.cache.ttl=1h
 # records, and the secondary adapter bindings read the same names back from cluster B.
 secondary.kafka.correlation.id.header=X-Secondary-Cid
 secondary.kafka.trace.id.header=X-Secondary-Trace
+# Custom traceparent header name: set ONLY the primary key (no secondary.kafka.traceparent.header),
+# so the test proves the secondary notification falls back to the primary setting.
+kafka.traceparent.header=X-Global-Traceparent


### PR DESCRIPTION
## What

A new observability header-name family completing the impedance-matching surface:
`http.traceparent.header`, `kafka.traceparent.header` and
`secondary.kafka.traceparent.header` (secondary falls back to primary, then to the
standard `traceparent`), plus per-entry `traceparent.header` overrides in a rest.yaml
endpoint and a kafka-flow-adapter.yaml consumer binding — precedence: per-entry >
global > built-in default.

Semantics: outbound calls (async HTTP client, Event-over-HTTP, the Kafka notification
functions) stamp the same W3C value under **both** the standard and the custom name;
inbound resolution (REST automation, Kafka Flow Adapter) reads the custom name first —
a well-formed value under it wins, so an intermediary-injected standard `traceparent`
cannot override the peer's context — with the standard header as fallback for
standards-compliant callers. Default behavior is unchanged (`traceparent`).

Verification: full reactor green. platform-core's entire 420-test suite runs with a
custom global name active (proving the feature is additive), plus five new regressions
(custom-name adoption, custom-wins-over-injected-standard, standard fallback,
per-entry-beats-global, outbound dual stamp shown on raw echoed headers).
minimalist-kafka adds a wire-level dual-stamp e2e through embedded Kafka; twin-kafka
proves on the wire that an unset secondary key falls back to the primary setting.
Docs: configuration-reference, observability, REST grammar + machine-readable catalog,
both Kafka guides, reserved-names, CHANGELOG.

## Why

A field installation's API gateway strips the standard W3C `traceparent` from its
header allow-list, breaking cross-application trace propagation. The earlier
config-only remedy — conflating the trace-id into `X-Correlation-Id` — carries only
the trace **id**, so spans could be stitched by id but never **parented** across the
hop. Renaming the traceparent **carrier** moves the full W3C context (trace-id, parent
span-id, flags) through the gateway under an allow-listed name, so span lineage
survives end to end — while the dual stamp and standard-header fallback keep every
standards-compliant participant working unchanged. It is an escape hatch, documented
as such: a renamed carrier is invisible to OpenTelemetry-compliant tooling, so the
default stays `traceparent` and the guidance remains to fix the gateway allow-list.

Ships in lock-step with the Rust engine's mirror (same branch name), keeping the
configuration surface and telemetry behavior engine-portable.

Co-Authored-By: Claude Code <noreply@anthropic.com>