### PR TITLE
fix(interop): clean envelope view, standards-first traceparent and the ce_traceparent interop report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    an intermediary (e.g. an API-gateway header allow-list) that strips the standard W3C header:
    outbound calls (async HTTP client, Event-over-HTTP, `simple.kafka.notification` and its
    secondary twin) stamp the same W3C value under **both** names, and inbound resolution (REST
-   automation, Kafka Flow Adapter) reads the custom name first — a well-formed value under it
-   wins, so an intermediary-injected standard `traceparent` cannot override the peer's context —
-   with the standard header as fallback for standards-compliant callers. Unlike the trace-id
+   automation, Kafka Flow Adapter) honors the **standard `traceparent` first** — the custom
+   name is read only when the standard header is absent, because a well-formed standard
+   traceparent means the caller already speaks W3C/OTel and a residual proprietary header is
+   safely ignored. Unlike the trace-id
    conflation workaround, the full W3C context (trace-id, parent span-id, flags) crosses the
    intermediary, so cross-application **span parenting** survives. Default behavior unchanged
    (`traceparent`). **The standard W3C/OpenTelemetry `traceparent` remains the project's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    with the standard header as fallback for standards-compliant callers. Unlike the trace-id
    conflation workaround, the full W3C context (trace-id, parent span-id, flags) crosses the
    intermediary, so cross-application **span parenting** survives. Default behavior unchanged
-   (`traceparent`); a renamed carrier is invisible to OpenTelemetry-compliant tooling, so keep
-   the default unless an unfixable intermediary forces the rename.
+   (`traceparent`). **The standard W3C/OpenTelemetry `traceparent` remains the project's
+   position** — the optional family is for backward compatibility with legacy systems only,
+   and departure from the standard is discouraged (a renamed carrier is invisible to
+   OTel-compliant tooling); treat a custom name as a temporary bridge and plan the migration
+   back to the standard header.
 
 ---
 ## Version 4.10.3, 7/23/2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## Unreleased
 
+### Fixed
+
+1. **The delivered envelope view is scrubbed of engine metadata (interop hygiene round).**
+   The pre-release `ce_traceparent` interop drive's four-combination matrix (see
+   `docs/test-reports/event-over-http-interop.md`) found that a peer-transported or
+   edge-merged `my_*` / `x-event-api` header could surface in a function's input
+   **envelope** header view (the injected input copy was already clean). The worker now
+   scrubs the five engine keys from the delivered envelope for non-interceptor functions —
+   whatever a peer transported can never masquerade as application data — while the legacy
+   `my_correlation_id` compat carrier remains honored into the injected view before the
+   scrub, and event interceptors keep raw transport fidelity. Two regressions added
+   (entry-side twins of the exit sanitization).
+2. **The programmatic Event-over-HTTP demo no longer copies its injected metadata onto the
+   outgoing event.** `EventOverHttpRpc` forwards business headers only — the injected
+   `my_*` view describes the local function's own context and is never transported.
+
 ### Added
 
 1. **Configurable traceparent header name (field request).** A new header-name family completes

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -501,7 +501,17 @@ HTTP header recognized (inbound, when no W3C `traceparent` is present) and emitt
 |------|---------|
 | `String` | `traceparent` |
 
-HTTP header name carrying the **W3C trace context** (the full `traceparent` value: trace-id, parent span-id and flags). An **escape hatch** for an intermediary — typically an API gateway with a header allow-list — that strips the standard `traceparent` header and cannot be fixed promptly. When customized, outbound HTTP calls (the async HTTP client and Event-over-HTTP) stamp the same W3C value under **both** names, and inbound resolution reads the custom name first (a well-formed value under it wins, so an intermediary-injected standard `traceparent` cannot override the peer's context) with the standard header as fallback. Overridable per endpoint with `traceparent.header` in a rest.yaml entry. **Caution:** a renamed traceparent is invisible to standards-compliant tooling (OpenTelemetry SDKs, service meshes, APM agents) — keep the default unless an unfixable intermediary forces the rename, and configure both ends alike.
+HTTP header name carrying the **W3C trace context** (the full `traceparent` value: trace-id, parent span-id and flags). When customized, outbound HTTP calls (the async HTTP client and Event-over-HTTP) stamp the same W3C value under **both** names, and inbound resolution reads the custom name first (a well-formed value under it wins, so an intermediary-injected standard `traceparent` cannot override the peer's context) with the standard header as fallback. Overridable per endpoint with `traceparent.header` in a rest.yaml entry.
+
+> **Our position: use the standard.** `traceparent` is the W3C Trace Context header that
+> OpenTelemetry and the wider observability ecosystem interoperate on, and the framework
+> implements it as the default with zero configuration. This optional setting exists for
+> **backward compatibility with legacy systems only** — an intermediary (typically an API
+> gateway with a header allow-list) or an upstream convention that cannot be fixed promptly.
+> **Departure from the standard is discouraged:** a renamed carrier is invisible to
+> standards-compliant tooling (OpenTelemetry SDKs, service meshes, APM agents) and every
+> participant must be configured alike. Treat a custom name as a temporary bridge, and plan
+> the migration back to the standard header (e.g. fixing the gateway allow-list).
 
 ### `kafka.correlation.id.header`
 
@@ -525,7 +535,7 @@ Optional Kafka message header for the trace-id. Inbound: a fallback trace-id sou
 |------|---------|
 | `String` | `traceparent` |
 
-Kafka message header name carrying the **W3C trace context** — the Kafka twin of `http.traceparent.header`, for middleware or an upstream convention that carries the W3C value under its own header name. When customized, `simple.kafka.notification` stamps the same value under **both** names, and the Kafka Flow Adapter reads the custom name first (a well-formed value under it wins) with the standard `traceparent` as fallback. Overridable per binding with `traceparent.header` in a kafka-flow-adapter.yaml entry.
+Kafka message header name carrying the **W3C trace context** — the Kafka twin of `http.traceparent.header`, for **backward compatibility with legacy middleware or an upstream convention only** (see the standards position under `http.traceparent.header` — departure from the standard `traceparent` name is discouraged). When customized, `simple.kafka.notification` stamps the same value under **both** names, and the Kafka Flow Adapter reads the custom name first (a well-formed value under it wins) with the standard `traceparent` as fallback. Overridable per binding with `traceparent.header` in a kafka-flow-adapter.yaml entry.
 
 ### `kafka.health.timeout`
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -501,7 +501,7 @@ HTTP header recognized (inbound, when no W3C `traceparent` is present) and emitt
 |------|---------|
 | `String` | `traceparent` |
 
-HTTP header name carrying the **W3C trace context** (the full `traceparent` value: trace-id, parent span-id and flags). When customized, outbound HTTP calls (the async HTTP client and Event-over-HTTP) stamp the same W3C value under **both** names, and inbound resolution reads the custom name first (a well-formed value under it wins, so an intermediary-injected standard `traceparent` cannot override the peer's context) with the standard header as fallback. Overridable per endpoint with `traceparent.header` in a rest.yaml entry.
+HTTP header name carrying the **W3C trace context** (the full `traceparent` value: trace-id, parent span-id and flags). When customized, outbound HTTP calls (the async HTTP client and Event-over-HTTP) stamp the same W3C value under **both** names. Inbound, the **standard `traceparent` always wins** — the custom name is read only when the standard header is absent: a well-formed standard traceparent means the caller already speaks W3C/OTel, so a proprietary header alongside it is residual and safely ignored. Overridable per endpoint with `traceparent.header` in a rest.yaml entry.
 
 > **Our position: use the standard.** `traceparent` is the W3C Trace Context header that
 > OpenTelemetry and the wider observability ecosystem interoperate on, and the framework
@@ -535,7 +535,7 @@ Optional Kafka message header for the trace-id. Inbound: a fallback trace-id sou
 |------|---------|
 | `String` | `traceparent` |
 
-Kafka message header name carrying the **W3C trace context** — the Kafka twin of `http.traceparent.header`, for **backward compatibility with legacy middleware or an upstream convention only** (see the standards position under `http.traceparent.header` — departure from the standard `traceparent` name is discouraged). When customized, `simple.kafka.notification` stamps the same value under **both** names, and the Kafka Flow Adapter reads the custom name first (a well-formed value under it wins) with the standard `traceparent` as fallback. Overridable per binding with `traceparent.header` in a kafka-flow-adapter.yaml entry.
+Kafka message header name carrying the **W3C trace context** — the Kafka twin of `http.traceparent.header`, for **backward compatibility with legacy middleware or an upstream convention only** (see the standards position under `http.traceparent.header` — departure from the standard `traceparent` name is discouraged). When customized, `simple.kafka.notification` stamps the same value under **both** names, and the Kafka Flow Adapter honors the **standard `traceparent` first** — the custom name is read only when the standard header is absent. Overridable per binding with `traceparent.header` in a kafka-flow-adapter.yaml entry.
 
 ### `kafka.health.timeout`
 

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -151,7 +151,8 @@ You may also add environment variable or base configuration references to the ta
 
 > *Engine internals*: the relay stamps a reserved `x-event-api` header on the forwarded envelope as a
 > recursion guard (so the receiving engine does not re-relay the event through its own declarative map).
-> It is engine-internal — the worker removes it from a function's input header copy and filters it from
+> It is engine-internal — the worker removes it (together with any transported `my_*` key) from a
+> function's input header copy *and* from the delivered envelope's own header view, and filters it from
 > returned response headers, so application code never sees or emits it.
 
 The demo below is a complete working example of this service abstraction.

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -92,7 +92,7 @@ consumer:
 | `max-poll-records` | no | Override the delivery mode's default poll batch size (1 for manual-commit, 500 for auto-commit). |
 | `correlation.id.header` | no | Per-binding override of the global `kafka.correlation.id.header` (default `cid`) — impedance matching for an upstream that publishes its own correlation-id header name (e.g. `X-Correlation-ID`). |
 | `trace.id.header` | no | Per-binding override of the global `kafka.trace.id.header` — a fallback trace-id source for an upstream that does not send a W3C `traceparent` (which always takes precedence). |
-| `traceparent.header` | no | Per-binding override of the global `kafka.traceparent.header` (default `traceparent`) — the header carrying the **full W3C trace context** for an upstream that uses its own name. A well-formed value under the custom name wins; the standard `traceparent` remains a fallback. |
+| `traceparent.header` | no | Per-binding override of the global `kafka.traceparent.header` (default `traceparent`) — the header carrying the **full W3C trace context**, for **backward compatibility with a legacy upstream only** (departure from the W3C/OTel standard is discouraged). A well-formed value under the custom name wins; the standard `traceparent` remains a fallback. |
 
 The file is read by `ConfigReader`, so **every value supports `${ENV_VAR:default}` substitution** — e.g.
 `group: '${KAFKA_CONSUMER_GROUP:sales-order-group}'`. A malformed entry (missing `topic`/`topic-pattern`/

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -92,7 +92,7 @@ consumer:
 | `max-poll-records` | no | Override the delivery mode's default poll batch size (1 for manual-commit, 500 for auto-commit). |
 | `correlation.id.header` | no | Per-binding override of the global `kafka.correlation.id.header` (default `cid`) — impedance matching for an upstream that publishes its own correlation-id header name (e.g. `X-Correlation-ID`). |
 | `trace.id.header` | no | Per-binding override of the global `kafka.trace.id.header` — a fallback trace-id source for an upstream that does not send a W3C `traceparent` (which always takes precedence). |
-| `traceparent.header` | no | Per-binding override of the global `kafka.traceparent.header` (default `traceparent`) — the header carrying the **full W3C trace context**, for **backward compatibility with a legacy upstream only** (departure from the W3C/OTel standard is discouraged). A well-formed value under the custom name wins; the standard `traceparent` remains a fallback. |
+| `traceparent.header` | no | Per-binding override of the global `kafka.traceparent.header` (default `traceparent`) — the header carrying the **full W3C trace context**, for **backward compatibility with a legacy upstream only** (departure from the W3C/OTel standard is discouraged). The standard `traceparent` always wins; the custom name is read only when the standard is absent. |
 
 The file is read by `ConfigReader`, so **every value supports `${ENV_VAR:default}` substitution** — e.g.
 `group: '${KAFKA_CONSUMER_GROUP:sales-order-group}'`. A malformed entry (missing `topic`/`topic-pattern`/

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -119,10 +119,10 @@ Global defaults in `application.properties`:
 |:----|:--------|:-----------------|
 | `http.trace.id.header` | `X-Trace-Id` | REST automation inbound (when no `traceparent` is present) and the async HTTP client outbound |
 | `http.correlation.id.header` | `X-Correlation-Id` | HTTP edge capture inbound; async HTTP client outbound |
-| `http.traceparent.header` | `traceparent` | The header carrying the full W3C trace context; REST automation inbound (custom name first, standard fallback) and HTTP client / Event-over-HTTP outbound (stamped under **both** names) |
+| `http.traceparent.header` | `traceparent` | The header carrying the full W3C trace context; REST automation inbound (standard `traceparent` first, custom name only when the standard is absent) and HTTP client / Event-over-HTTP outbound (stamped under **both** names) |
 | `kafka.trace.id.header` | *(unset)* | Kafka Flow Adapter inbound fallback; `simple.kafka.notification` outbound, stamped alongside `traceparent` |
 | `kafka.correlation.id.header` | `cid` | Kafka Flow Adapter inbound; `simple.kafka.notification` outbound |
-| `kafka.traceparent.header` | `traceparent` | Kafka twin of `http.traceparent.header`: adapter inbound (custom name first, standard fallback); notification outbound (stamped under **both** names) |
+| `kafka.traceparent.header` | `traceparent` | Kafka twin of `http.traceparent.header`: adapter inbound (standard first, custom name only when the standard is absent); notification outbound (stamped under **both** names) |
 
 Per-entry overrides, for a single application that faces callers with different conventions:
 
@@ -160,10 +160,10 @@ overrides never breaks OpenTelemetry-compliant callers. The full key reference l
 > (`http.traceparent.header=X-Trace-Context`) moves the *full* W3C context — trace-id, parent
 > span-id and flags — through the gateway under an allow-listed name, so cross-application span
 > parenting survives. Outbound calls stamp the same value under both the custom and the
-> standard name; inbound, a well-formed value under the custom name wins (an intermediary that
-> injects its own fresh `traceparent` cannot break the caller's chain) and the standard header
-> remains a fallback for standards-compliant callers. The durable fix is always the gateway
-> allow-list — retire the custom name once it lands.
+> standard name; inbound, the **standard `traceparent` always wins** and the custom name is
+> read only when the standard is absent — a well-formed standard traceparent means the caller
+> already speaks W3C/OTel, so a residual proprietary header alongside it is safely ignored.
+> The durable fix is always the gateway allow-list — retire the custom name once it lands.
 
 ```yaml
 # rest.yaml - one endpoint serves a legacy caller that sends its own header names

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -146,16 +146,24 @@ overrides never breaks OpenTelemetry-compliant callers. The full key reference l
 > `traceparent` and the shared header always carry the same trace id. Prefer migrating the gateway to
 > pass `traceparent` (and `X-Trace-Id`), then retiring the conflation.
 
-> **A renamed traceparent beats conflation for the gateway case.** The conflation above carries only
-> the trace **id**, so spans in different applications can be stitched by id but not **parented** across
-> the hop. Renaming the traceparent carrier (`http.traceparent.header=X-Trace-Context`) moves the *full*
-> W3C context — trace-id, parent span-id and flags — through the gateway under an allow-listed name, so
-> cross-application span parenting survives. Outbound calls stamp the same value under both the custom
-> and the standard name; inbound, a well-formed value under the custom name wins (an intermediary that
-> injects its own fresh `traceparent` cannot break the caller's chain) and the standard header remains a
-> fallback for standards-compliant callers. **The trade-off:** a renamed traceparent is invisible to
-> OpenTelemetry SDKs, service meshes and APM agents — treat it as an escape hatch for an intermediary
-> you cannot fix, configure both ends alike, and prefer fixing the gateway allow-list.
+> **The standard W3C `traceparent` is our position — use it.** It is the header OpenTelemetry
+> and the wider observability ecosystem interoperate on, and the framework implements it as the
+> default with zero configuration. The optional `traceparent.header` family below exists for
+> **backward compatibility with legacy systems only**; departure from the standard is
+> discouraged, because a renamed carrier is invisible to OpenTelemetry SDKs, service meshes and
+> APM agents, and every participant must be configured alike. Treat a custom name as a
+> temporary bridge and plan the migration back to the standard header.
+>
+> Within that constraint, **a renamed traceparent beats conflation for the gateway case.** The
+> conflation above carries only the trace **id**, so spans in different applications can be
+> stitched by id but not **parented** across the hop. Renaming the traceparent carrier
+> (`http.traceparent.header=X-Trace-Context`) moves the *full* W3C context — trace-id, parent
+> span-id and flags — through the gateway under an allow-listed name, so cross-application span
+> parenting survives. Outbound calls stamp the same value under both the custom and the
+> standard name; inbound, a well-formed value under the custom name wins (an intermediary that
+> injects its own fresh `traceparent` cannot break the caller's chain) and the standard header
+> remains a fallback for standards-compliant callers. The durable fix is always the gateway
+> allow-list — retire the custom name once it lands.
 
 ```yaml
 # rest.yaml - one endpoint serves a legacy caller that sends its own header names

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -154,9 +154,11 @@ emitted outbound:
   On outbound the system emits `traceparent` built from this hop's own span, alongside `X-Trace-Id`.
   The carrier **name** is configurable via `http.traceparent.header` / `kafka.traceparent.header`
   (default `traceparent`) - for **backward compatibility with legacy systems only**, e.g. an intermediary
-  that strips the standard header: the same W3C value then travels under **both** names, and a well-formed
-  value under the custom name wins inbound. Departure from the W3C/OpenTelemetry standard is discouraged -
-  treat a custom name as a temporary bridge (see [Observability](observability.md#impedance-config)).
+  that strips the standard header: the same W3C value then travels under **both** names. Inbound, the
+  standard `traceparent` always wins; the custom name is read only when the standard is absent (its
+  presence means the caller already upgraded to the standard - a residual proprietary value is safely
+  ignored). Departure from the W3C/OpenTelemetry standard is discouraged - treat a custom name as a
+  temporary bridge (see [Observability](observability.md#impedance-config)).
 
 The framework does **not** echo the trace ID (or the correlation-id) back to the HTTP client.
 

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -153,9 +153,10 @@ emitted outbound:
   span ID is adopted, so the trace continues from the upstream caller (span lineage across HTTP boundaries).
   On outbound the system emits `traceparent` built from this hop's own span, alongside `X-Trace-Id`.
   The carrier **name** is configurable via `http.traceparent.header` / `kafka.traceparent.header`
-  (default `traceparent`) - an escape hatch for an intermediary that strips the standard header: the same
-  W3C value then travels under **both** names, and a well-formed value under the custom name wins inbound
-  (see [Observability](observability.md#impedance-config)).
+  (default `traceparent`) - for **backward compatibility with legacy systems only**, e.g. an intermediary
+  that strips the standard header: the same W3C value then travels under **both** names, and a well-formed
+  value under the custom name wins inbound. Departure from the W3C/OpenTelemetry standard is discouraged -
+  treat a custom name as a temporary bridge (see [Observability](observability.md#impedance-config)).
 
 The framework does **not** echo the trace ID (or the correlation-id) back to the HTTP client.
 

--- a/docs/guides/rest-automation/ai-agent-guide.md
+++ b/docs/guides/rest-automation/ai-agent-guide.md
@@ -88,11 +88,10 @@ rest:
 A traced endpoint serving a legacy caller that uses its own trace/correlation header names
 (per-endpoint impedance matching — the optional `trace.id.header` / `correlation.id.header` /
 `traceparent.header` keys override the global `http.trace.id.header` / `http.correlation.id.header` /
-`http.traceparent.header` names for this entry only; a well-formed W3C `traceparent` still takes
-precedence for the trace-id, and a well-formed value under a custom `traceparent.header` name wins
-with the standard `traceparent` as fallback. These overrides are for backward compatibility with
-legacy systems only — the standard W3C/OTel `traceparent` needs no configuration and departing
-from it is discouraged):
+`http.traceparent.header` names for this entry only; the standard W3C `traceparent` always takes
+precedence, and a custom `traceparent.header` name is read only when the standard header is
+absent. These overrides are for backward compatibility with legacy systems only — the standard
+W3C/OTel `traceparent` needs no configuration and departing from it is discouraged):
 
 ```yaml
 rest:

--- a/docs/guides/rest-automation/ai-agent-guide.md
+++ b/docs/guides/rest-automation/ai-agent-guide.md
@@ -90,7 +90,9 @@ A traced endpoint serving a legacy caller that uses its own trace/correlation he
 `traceparent.header` keys override the global `http.trace.id.header` / `http.correlation.id.header` /
 `http.traceparent.header` names for this entry only; a well-formed W3C `traceparent` still takes
 precedence for the trace-id, and a well-formed value under a custom `traceparent.header` name wins
-with the standard `traceparent` as fallback):
+with the standard `traceparent` as fallback. These overrides are for backward compatibility with
+legacy systems only — the standard W3C/OTel `traceparent` needs no configuration and departing
+from it is discouraged):
 
 ```yaml
 rest:

--- a/docs/guides/rest-automation/rest-automation.json
+++ b/docs/guides/rest-automation/rest-automation.json
@@ -22,7 +22,7 @@
     { "field": "tracing", "required": false, "meaning": "true/false (default false) - enable distributed tracing" },
     { "field": "trace.id.header", "required": false, "meaning": "per-endpoint override of the global http.trace.id.header (default X-Trace-Id) - header name (quoted string) for a caller with its own trace-id header convention; a well-formed W3C traceparent still takes precedence" },
     { "field": "correlation.id.header", "required": false, "meaning": "per-endpoint override of the global http.correlation.id.header (default X-Correlation-Id) - header name (quoted string) for a caller with its own business correlation-id header convention" },
-    { "field": "traceparent.header", "required": false, "meaning": "per-endpoint override of the global http.traceparent.header (default traceparent) - header name (quoted string) carrying the full W3C trace context, for an intermediary that strips the standard name; a well-formed value under the custom name wins, standard traceparent remains a fallback" },
+    { "field": "traceparent.header", "required": false, "meaning": "per-endpoint override of the global http.traceparent.header (default traceparent) - header name (quoted string) carrying the full W3C trace context, for backward compatibility with a legacy intermediary ONLY (departure from the W3C/OTel standard is discouraged); a well-formed value under the custom name wins, standard traceparent remains a fallback" },
     { "field": "trust_all_cert", "required": false, "meaning": "true/false - HTTPS relay only" },
     { "field": "url_rewrite", "required": false, "meaning": "list of exactly two strings [from, to] - HTTP(S) relay only" }
   ],

--- a/docs/guides/rest-automation/rest-automation.json
+++ b/docs/guides/rest-automation/rest-automation.json
@@ -22,7 +22,7 @@
     { "field": "tracing", "required": false, "meaning": "true/false (default false) - enable distributed tracing" },
     { "field": "trace.id.header", "required": false, "meaning": "per-endpoint override of the global http.trace.id.header (default X-Trace-Id) - header name (quoted string) for a caller with its own trace-id header convention; a well-formed W3C traceparent still takes precedence" },
     { "field": "correlation.id.header", "required": false, "meaning": "per-endpoint override of the global http.correlation.id.header (default X-Correlation-Id) - header name (quoted string) for a caller with its own business correlation-id header convention" },
-    { "field": "traceparent.header", "required": false, "meaning": "per-endpoint override of the global http.traceparent.header (default traceparent) - header name (quoted string) carrying the full W3C trace context, for backward compatibility with a legacy intermediary ONLY (departure from the W3C/OTel standard is discouraged); a well-formed value under the custom name wins, standard traceparent remains a fallback" },
+    { "field": "traceparent.header", "required": false, "meaning": "per-endpoint override of the global http.traceparent.header (default traceparent) - header name (quoted string) carrying the full W3C trace context, for backward compatibility with a legacy intermediary ONLY (departure from the W3C/OTel standard is discouraged); the standard traceparent always wins, the custom name is read only when the standard is absent" },
     { "field": "trust_all_cert", "required": false, "meaning": "true/false - HTTPS relay only" },
     { "field": "url_rewrite", "required": false, "meaning": "list of exactly two strings [from, to] - HTTP(S) relay only" }
   ],

--- a/docs/guides/rest-automation/rest-grammar.md
+++ b/docs/guides/rest-automation/rest-grammar.md
@@ -50,7 +50,7 @@ related:
 | `tracing` | no | `true`/`false` (default false) — enable distributed tracing |
 | `trace.id.header` | no | per-endpoint override of the global `http.trace.id.header` (default `X-Trace-Id`) — impedance matching for a caller that sends its own trace-id header name; a well-formed W3C `traceparent` still takes precedence |
 | `correlation.id.header` | no | per-endpoint override of the global `http.correlation.id.header` (default `X-Correlation-Id`) — impedance matching for a caller that sends its own business correlation-id header name |
-| `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for **backward compatibility with a legacy intermediary only** (departure from the W3C/OTel standard is discouraged); a well-formed value under the custom name wins, with the standard `traceparent` as fallback |
+| `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for **backward compatibility with a legacy intermediary only** (departure from the W3C/OTel standard is discouraged); the standard `traceparent` always wins, and the custom name is read only when the standard is absent |
 | `trust_all_cert` | no | `true`/`false` — **HTTPS relay only** |
 | `url_rewrite` | no | a list of **exactly two** strings `[from, to]` — **HTTP(S) relay only** |
 

--- a/docs/guides/rest-automation/rest-grammar.md
+++ b/docs/guides/rest-automation/rest-grammar.md
@@ -50,7 +50,7 @@ related:
 | `tracing` | no | `true`/`false` (default false) — enable distributed tracing |
 | `trace.id.header` | no | per-endpoint override of the global `http.trace.id.header` (default `X-Trace-Id`) — impedance matching for a caller that sends its own trace-id header name; a well-formed W3C `traceparent` still takes precedence |
 | `correlation.id.header` | no | per-endpoint override of the global `http.correlation.id.header` (default `X-Correlation-Id`) — impedance matching for a caller that sends its own business correlation-id header name |
-| `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for an intermediary that strips the standard name; a well-formed value under the custom name wins, with the standard `traceparent` as fallback |
+| `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for **backward compatibility with a legacy intermediary only** (departure from the W3C/OTel standard is discouraged); a well-formed value under the custom name wins, with the standard `traceparent` as fallback |
 | `trust_all_cert` | no | `true`/`false` — **HTTPS relay only** |
 | `url_rewrite` | no | a list of **exactly two** strings `[from, to]` — **HTTP(S) relay only** |
 

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -162,7 +162,7 @@ crossing the two emulated clusters with trace/correlation continuity — see the
 | `secondary.kafka.health.startup.grace` | falls back to `kafka.health.startup.grace` (`30s`) | Start-up grace for `secondary.kafka.health` (placeholder healthy status while the client warms up). |
 | `secondary.kafka.correlation.id.header` | falls back to `kafka.correlation.id.header` (`cid`) | Outbound correlation-id header on the secondary cluster. |
 | `secondary.kafka.trace.id.header` | falls back to `kafka.trace.id.header` (unset) | Optional outbound trace-id header on the secondary cluster. |
-| `secondary.kafka.traceparent.header` | falls back to `kafka.traceparent.header` (`traceparent`) | Header name carrying the full W3C trace context on the secondary cluster; when customized, the notification stamps the same value under both this and the standard name. |
+| `secondary.kafka.traceparent.header` | falls back to `kafka.traceparent.header` (`traceparent`) | Header name carrying the full W3C trace context on the secondary cluster — for backward compatibility with a legacy convention only (prefer the standard `traceparent`); when customized, the notification stamps the same value under both this and the standard name. |
 
 The retry/dead-letter tuning keys (`kafka.dlq.timeout.ms`, `kafka.flow.max.retries`,
 `kafka.flow.retry.backoff.ms`) are application-level policy shared by both adapters. Per-binding

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -277,6 +277,68 @@ correlation concept local and remote, deterministic essential-service startup �
 observable behavior stayed byte-for-byte unchanged, which is exactly what the empty diff is
 designed to prove.
 
+## The configurable-traceparent round (2026-07-24)
+
+A field installation's API gateway strips the standard W3C `traceparent` from its header
+allow-list, so both engines gained a configurable traceparent **carrier name** —
+`http.traceparent.header` (Java adds the `kafka.*` / `secondary.kafka.*` twins), with per-entry
+overrides — shipped in lock-step (Java PR #227, Rust PR #177). Before release, this round
+validated the feature live across the language boundary with the custom name `ce_traceparent`,
+every application launched with `-Dhttp.traceparent.header=ce_traceparent` (the Rust port
+honors the same `-D` override syntax).
+
+The drive deliberately simulated the field scenario: the client supplied the W3C value **only
+under `ce_traceparent`** — the standard header never sent — so any trace continuity observed
+had to come from the custom carrier.
+
+### Results — the feature is correct and symmetric
+
+| Check | java→rust | rust→java |
+|-------|-----------|-----------|
+| Functionality (declarative + programmatic) | pass | pass |
+| Edge adopts trace context from `ce_traceparent` alone | pass | pass |
+| Caller's REST span parents onto the client's span | pass | pass |
+| Callee `/api/event` spans parent onto the caller's span | pass | pass |
+| Declarative reply-span asymmetry preserved cross-language | pass | pass |
+| Authentication (`event.api.auth`) | pass | pass |
+| `X-Correlation-Id` response echo | pass | pass |
+
+Wire-level captures (a header-dumping listener standing in for the peer) confirmed the **dual
+stamp** on both engines' outbound `/api/event` calls: `traceparent` and `ce_traceparent`
+carrying the identical W3C value, alongside the trace-id header. A four-combination echo
+matrix (java→java, java→rust, rust→rust, rust→java, both patterns, all eight runs under the
+custom name) confirmed the feature introduces no cross-engine differences: every echoed
+`ce_traceparent` and trace behavior was symmetric.
+
+### Findings — pre-existing surfaces exposed by the matrix (not caused by the feature)
+
+The deeper matrix inspection surfaced header-hygiene asymmetries that predate this feature:
+
+1. **Both programmatic demo tasks transport their injected metadata.** Java's
+   `EventOverHttpRpc` (`headers.forEach(req::setHeader)`) and the Rust twin (its `set_header`
+   loop) copy the function's **injected** header view — including the four `my_*` keys — onto
+   the outgoing envelope: the accidental-copy anti-pattern of learning #7, on the request side.
+2. **The two engines sanitize different subsets at the receiving `/api/event` door.** With
+   inbound `my_*` on the wire, a Java callee delivers `my_correlation_id` (the legacy-cid
+   compat carrier) but strips `my_route`/`my_trace_id`/`my_trace_path`; a Rust callee strips
+   `my_correlation_id` and `x-event-api` but delivers the other three. On the declarative
+   path, `x-event-api: callback` is visible in a Java callee's envelope view, absent in a
+   Rust callee's.
+3. **Wire hygiene nits.** The Rust HTTP client emits each trace header twice (same value);
+   it stamps `x-correlation-id` on the `/api/event` request where Java carries the business
+   cid only in the envelope tag; Java sends `accept` and `x-small-payload-as-bytes` where
+   Rust does not; and the Rust port does not log the resolved traceparent header name at
+   startup (Java: `Traceparent HTTP header is 'ce_traceparent'`).
+
+### Verdict
+
+The configurable traceparent carrier works end to end in both directions: with the standard
+header never supplied, the custom name alone carried the full W3C context — trace identity
+**and** span parenting — through both engines' edges, app-to-app hops, and `/api/event`
+doors. The feature is release-ready. The findings above are queued as a follow-up hygiene
+round: fix the two demo tasks, align the inbound `/api/event` metadata sanitization, and
+polish the wire/logging nits.
+
 ## Learnings for future language ports
 
 This validation arc is the playbook for bringing the next language (e.g. Python) into the

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -373,6 +373,17 @@ header set from both engines' clients, and cross-language span parenting held in
 directions. Gates: Java full reactor green (422 platform-core tests, 2 new); Rust workspace
 260 passed (3 new), clippy 0, fmt clean.
 
+**Post-round refinement — inbound precedence finalized before release.** In line with the
+standards position, the inbound rule was flipped from the drive's original
+custom-name-first semantics: the **standard `traceparent` always wins**, and the custom
+name is read only when the standard header is absent. Rationale: a well-formed standard
+traceparent means the legacy system already upgraded to the W3C/OTel standard, so a
+proprietary header alongside it is residual and safely ignored. This also makes the family
+self-consistent — the `trace.id.header` fallback already yields to the standard. Both
+engines flipped in lock-step with their precedence regressions inverted, and note that the
+drive's ce_traceparent-only scenario (the gateway simulation) is unaffected: the custom
+name remains the carrier whenever the standard header does not survive the intermediary.
+
 ## Learnings for future language ports
 
 This validation arc is the playbook for bringing the next language (e.g. Python) into the

--- a/docs/test-reports/event-over-http-interop.md
+++ b/docs/test-reports/event-over-http-interop.md
@@ -335,9 +335,43 @@ The deeper matrix inspection surfaced header-hygiene asymmetries that predate th
 The configurable traceparent carrier works end to end in both directions: with the standard
 header never supplied, the custom name alone carried the full W3C context — trace identity
 **and** span parenting — through both engines' edges, app-to-app hops, and `/api/event`
-doors. The feature is release-ready. The findings above are queued as a follow-up hygiene
-round: fix the two demo tasks, align the inbound `/api/event` metadata sanitization, and
-polish the wire/logging nits.
+doors. The feature is release-ready. The findings above were fixed in the hygiene round
+below.
+
+### Resolution — the hygiene round (2026-07-24, ships in v4.10.4)
+
+All findings were fixed in lock-step and the matrix re-run:
+
+1. **The delivered envelope view is scrubbed on both engines.** The worker removes the five
+   engine keys (`my_route`, `my_trace_id`, `my_trace_path`, `my_correlation_id`,
+   `x-event-api`) from the delivered envelope's own headers for non-interceptor functions —
+   whatever a peer transported or a local edge merged can never masquerade as application
+   data. The legacy `my_correlation_id` compat carrier remains honored into the injected
+   view before the scrub, and event interceptors keep raw transport fidelity (on the Rust
+   port this also *restored* interceptor fidelity that its earlier partial scrub had
+   violated). Entry-side regression twins added on both engines. The investigation settled
+   the attribution: the Rust port never injected metadata into the envelope view — the
+   matrix leaks were pure transport (both programmatic demos' header-copy loops) plus, on
+   the Java side, the declarative relay guard and the auth session-info merge reaching the
+   envelope view.
+2. **Both programmatic demo tasks forward business headers only** — the injected `my_*`
+   view describes the local function's own context and is never transported.
+3. **Wire hygiene aligned to the Java reference.** The Rust client now stamps each trace
+   header exactly once, no longer adds `x-correlation-id` to the event-over-HTTP transport
+   leg (the business cid rides the envelope tag), sends `accept` and
+   `x-small-payload-as-bytes` like Java, and logs the resolved
+   `Correlation-id / Trace-id / Traceparent HTTP header` names at startup.
+4. **The endpoint timeout rides the request dataset as `x-ttl` on both engines.** Java's
+   REST ingress represents the route timeout as the request's `x-ttl` header (caller-sent
+   value wins), so a flow's `input.header` view carries it; the Rust ingress now does the
+   same — with a regression pinning both the default and the caller-wins precedence.
+
+**Final verification:** the four-combination matrix re-ran with both fixed engines under
+`ce_traceparent` — **all eight echoes are identical** after normalizing volatile fields
+(same header set, same values including `x-ttl` milliseconds), wire captures show the same
+header set from both engines' clients, and cross-language span parenting held in both
+directions. Gates: Java full reactor green (422 platform-core tests, 2 new); Rust workspace
+260 passed (3 new), clippy 0, fmt clean.
 
 ## Learnings for future language ports
 

--- a/examples/composable-example/src/main/java/com/accenture/demo/tasks/EventOverHttpRpc.java
+++ b/examples/composable-example/src/main/java/com/accenture/demo/tasks/EventOverHttpRpc.java
@@ -26,6 +26,7 @@ import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.AppConfigReader;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Demonstrates the PROGRAMMATIC Event-over-HTTP pattern - the counterpart of the
@@ -49,6 +50,11 @@ public class EventOverHttpRpc implements LambdaFunction {
     private static final String PEER_HOST = "peer.demo.host";
     private static final String PEER_PORT = "peer.demo.port";
     private static final String DEMO_TOKEN_KEY = "demo.peer.token";
+    // The engine injects these read-only metadata keys into this function's input header copy.
+    // They describe THIS function's own context and are never transported in an event - so they
+    // must not be copied onto the outgoing request (metadata is injected, not forwarded).
+    private static final Set<String> INJECTED_METADATA =
+            Set.of("my_route", "my_trace_id", "my_trace_path", "my_correlation_id");
 
     @Override
     public Object handleEvent(Map<String, String> headers, Object input, int instance) throws Exception {
@@ -62,7 +68,12 @@ public class EventOverHttpRpc implements LambdaFunction {
         // variable) as a security header on the HTTP request
         Map<String, String> securityHeaders = Map.of("authorization", config.getProperty(DEMO_TOKEN_KEY, "demo"));
         EventEnvelope req = new EventEnvelope().setTo(HELLO_WORLD).setBody(input);
-        headers.forEach(req::setHeader);
+        // forward the business headers only - the injected my_* view stays local
+        headers.forEach((k, v) -> {
+            if (!INJECTED_METADATA.contains(k)) {
+                req.setHeader(k, v);
+            }
+        });
         EventEnvelope response = po.request(req, 10000, securityHeaders, eventEndpoint, true).get();
         if (response.getStatus() != 200) {
             throw new AppException(response.getStatus(), String.valueOf(response.getError()));

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -401,7 +401,18 @@
   anti-pattern, request side); the engines sanitize different subsets at the /api/event door
   (Java delivers my_correlation_id / strips route+trace keys, Rust the inverse + strips
   x-event-api); Rust wire nits (duplicate trace headers, x-correlation-id on /api/event,
-  missing traceparent-name startup log). Remaining: release (Eric gates; feature = minor bump).
+  missing traceparent-name startup log). **Hygiene round COMPLETE 2026-07-24 (Eric directed;
+  ships in v4.10.4):** both engines scrub the 5 engine keys from the delivered ENVELOPE view
+  (non-interceptor; legacy my_correlation_id honored-then-scrubbed; interceptors keep raw
+  fidelity — the Rust fix also RESTORED interceptor fidelity its partial scrub violated);
+  both demos forward business headers only; Rust wire aligned to the Java reference (single
+  stamps, no x-correlation-id on the event-over-HTTP leg, accept + x-small-payload-as-bytes,
+  startup header-name log lines); x-ttl ingress alignment (Java represents the route timeout
+  as the request's x-ttl header, caller-sent wins — AsyncHttpRequest.setTimeoutSeconds; Rust
+  ingress now mirrors). **Final matrix: ALL EIGHT ECHOES IDENTICAL after normalization** —
+  report Resolution subsection in both repos. Java branch fix/interop-header-hygiene
+  (stacked on the report branch); Rust same-name branch (33fba853 + 7e22af9a, 260 tests).
+  Remaining: v4.10.4 release prep both repos (Eric gates).
   <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-154543 -->
 
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.3 SHIPPED AND PUBLISHED in

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -412,6 +412,12 @@
   ingress now mirrors). **Final matrix: ALL EIGHT ECHOES IDENTICAL after normalization** —
   report Resolution subsection in both repos. Java branch fix/interop-header-hygiene
   (stacked on the report branch); Rust same-name branch (33fba853 + 7e22af9a, 260 tests).
+  **Standards position stated in all docs (Eric's ruling): W3C/OTel traceparent is the
+  position; traceparent.header = backward compat with legacy systems ONLY; departure
+  discouraged. Final ruling (SUPERSEDES design point 2): inbound precedence = STANDARD
+  traceparent always wins, custom name read only when standard absent (presence of the
+  standard means the legacy system already upgraded; proprietary value is residual). Both
+  engines flipped in lock-step, regressions inverted, report carries the refinement note.**
   Remaining: v4.10.4 release prep both repos (Eric gates).
   <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-154543 -->
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -391,8 +391,17 @@
   twin-kafka 9 (wire-level secondary→primary fallback assert). Docs: config-reference 3 new
   keys, observability table + "renamed traceparent beats conflation" note, rest-grammar +
   rest-automation.json + ai-agent-guide, minimalist/twin-kafka guides, reserved-names,
-  CHANGELOG Unreleased. Remaining: full reactor gate, Rust lock-step mirror
-  ([[conv-telemetry-presentation-parity]] — identical keys/precedence/log text), PR + release.
+  CHANGELOG Unreleased. **BOTH PRs MERGED 2026-07-24 (Java #227 merge `47e948ef`, CI 7m40s;
+  Rust #177 merge `e99013cb`, 257 tests) and the pre-release ce_traceparent interop drive
+  PASSED in full** (gateway simulation: W3C value supplied ONLY under the custom name; edge
+  adoption + cross-language span parenting both directions; wire-level dual stamp both
+  engines; report round appended to docs/test-reports/event-over-http-interop.md in both
+  repos). **Findings queued for a follow-up hygiene round (pre-existing, not the feature):**
+  both programmatic demo tasks transport their injected my_* view (accidental-copy
+  anti-pattern, request side); the engines sanitize different subsets at the /api/event door
+  (Java delivers my_correlation_id / strips route+trace keys, Rust the inverse + strips
+  x-event-api); Rust wire nits (duplicate trace headers, x-correlation-id on /api/event,
+  missing traceparent-name startup log). Remaining: release (Eric gates; feature = minor bump).
   <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: working | origin: 2026-07-24-154543 -->
 
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.3 SHIPPED AND PUBLISHED in

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -79,6 +79,25 @@ x-event-api which Java delivers on the declarative path);
 (Java carries cid only in the envelope tag), Java sends accept + x-small-payload-as-bytes,
 and Rust misses the startup log line for the resolved traceparent name.
 
+**Update (same session): hygiene round IMPLEMENTED at Eric's direction (target v4.10.4).**
+Java reference on `fix/interop-header-hygiene` (branched from the report branch — one PR
+carries report + fixes): (1) WorkerHandler scrubs the 5 engine keys (4 my_* + x-event-api)
+from the delivered ENVELOPE view for non-interceptor functions — safe because each delivery
+deserializes its own copy (WorkerDispatcher); interceptors keep raw fidelity for the
+x-event-api relay guard; legacy my_correlation_id still honored-then-scrubbed. (2)
+EventOverHttpRpc demo forwards business headers only (INJECTED_METADATA filter). New probe
+CleanEnvelopeEcho + 2 regressions (entry-side twins of accidentalMetadataEchoIsSanitizedAtExit):
+transportedMetadataIsScrubbedFromTheDeliveredEnvelopeView,
+legacyCorrelationIdHeaderIsHonoredThenScrubbed. platform-core 422 green; composable-example
+5/5; live j2j re-run: both patterns' echoes now clean AND identical (only x-flow-id differs) —
+reality matches the guide's documented samples. Rust mirror delegated (same invariant + demo
+filter + 4 wire nits). Investigation note: Java's envelope view previously showed
+my_correlation_id via the auth session-info merge (EventApiService merges sessionInfo into
+the dispatched envelope; HttpAuth stamps my_correlation_id post-auth) and x-event-api via the
+declarative relay guard — both now scrubbed at worker delivery. Residual noted: Java
+transports an x-ttl envelope header on the caller path where Rust does not (matrix shape
+nit, deferred).
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -56,6 +56,29 @@ reserved-names-and-headers, event-envelope-reference, CHANGELOG Unreleased.
 **Next:** Rust lock-step mirror (identical keys, precedence, log text — the Event Script /
 presentation-parity contract), then PR + release per Eric's gating.
 
+**Update (same session): both PRs MERGED (Java #227 CI 7m40s green; Rust #177, 257 tests) and
+the pre-release ce_traceparent INTEROP DRIVE PASSED in full.** Eric's requested drive: both
+engines' demo apps launched with `-Dhttp.traceparent.header=ce_traceparent` (the Rust port
+honors Java's -D override syntax via its overrides registry). The gateway scenario was
+simulated by supplying the W3C value ONLY under ce_traceparent — never the standard header.
+Both directions, both patterns: edge adoption from the custom name alone, cross-language span
+parenting (curl span → caller REST span → callee /api/event spans, verified by span-id in both
+telemetry logs), dual stamp on the wire (header-dump listener: traceparent + ce_traceparent
+identical values, both engines), auth + cid echo intact. Four-combination echo matrix
+symmetric for the feature. **Report filed: new round appended to
+docs/test-reports/event-over-http-interop.md in BOTH repos (byte-identical section).**
+
+**Findings (pre-existing, NOT the feature — queued as a follow-up hygiene round):**
+(1) BOTH programmatic demo tasks copy their injected header view onto the outgoing envelope
+(Java `headers.forEach(req::setHeader)`, Rust `set_header` loop) → the caller's my_* metadata
+is transported — learning #7's accidental-copy anti-pattern on the request side;
+(2) the engines sanitize DIFFERENT subsets at the receiving /api/event door (Java delivers
+my_correlation_id, strips my_route/my_trace_id/my_trace_path; Rust the inverse, plus strips
+x-event-api which Java delivers on the declarative path);
+(3) wire nits — Rust emits each trace header twice, stamps x-correlation-id on /api/event
+(Java carries cid only in the envelope tag), Java sends accept + x-small-payload-as-bytes,
+and Rust misses the startup log line for the resolved traceparent name.
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -98,6 +98,21 @@ declarative relay guard — both now scrubbed at worker delivery. Residual noted
 transports an x-ttl envelope header on the caller path where Rust does not (matrix shape
 nit, deferred).
 
+**Final update: hygiene round COMPLETE — the four-combination matrix is an EXACT REPLICA.**
+Rust mirror landed (2 commits on its fix/interop-header-hygiene: `33fba853` scrub + wire
+hygiene, `7e22af9a` x-ttl ingress alignment; 260 tests, clippy 0). Attribution settled: the
+Rust engine never injected metadata into the envelope view — the leaks were pure transport
+(both demos) + Java's relay guard/session-info reaching the envelope view. The x-ttl residual
+was aligned too (Java's AsyncHttpRequest.setTimeoutSeconds represents the route timeout AS
+the x-ttl request header, caller-sent wins — Rust ingress now mirrors, with a
+caller-precedence regression its own suite forced). Independent verification: final matrix —
+**ALL EIGHT ECHOES IDENTICAL** after normalization (incl. raw x-ttl 15000 both engines); Rust
+wire capture = exact Java header set; cross-language span parenting intact both directions;
+Java full reactor 5:13 green. Report Resolution subsection appended in both repos
+(byte-identical). Durable lesson: the engines' parity method (normalize + diff against the
+j2j reference) turned four echo shapes into ONE — the same method that proved the trace
+signature now proves the header surface.
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -122,6 +122,17 @@ in both repos: config-reference blockquote (primary statement), observability wa
 admonition, reserved-names, REST grammar/per-entry docs + machine-readable catalog, Kafka
 guides (Java), HTTP-client guide (Rust), CHANGELOG entries.
 
+**And (Eric's final ruling, 2026-07-24, SUPERSEDES the ratified design point 2): inbound
+precedence FLIPPED — the standard traceparent always wins; the custom name is read only when
+the standard is absent.** Rationale: a well-formed standard OTel traceparent means the legacy
+system already upgraded — a proprietary header alongside it is residual and safely ignored.
+Also makes the family self-consistent (trace.id.header already yields to the standard). Java:
+HttpRouter + KafkaFlowConsumer parseInboundTraceparent flipped (standard first, custom
+fallback); precedence regressions inverted (standardTraceparentWinsOverCustomHeaderName ×2 +
+a new e2e both-present case); all docs flipped; report carries a "Post-round refinement" note
+(the ce_traceparent-only gateway simulation is unaffected — the custom name remains the
+carrier when the standard doesn't survive the intermediary). Rust mirror delegated.
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -113,6 +113,15 @@ Java full reactor 5:13 green. Report Resolution subsection appended in both repo
 j2j reference) turned four echo shapes into ONE — the same method that proved the trace
 signature now proves the header surface.
 
+**Also (Eric's ruling, 2026-07-24): the docs now state the STANDARDS POSITION** — the W3C/
+OpenTelemetry `traceparent` is the project's position (zero-config default); the optional
+`traceparent.header` family is for BACKWARD COMPATIBILITY WITH LEGACY SYSTEMS ONLY; departure
+from the standard is DISCOURAGED (renamed carrier invisible to OTel tooling; every participant
+must be configured alike; treat as a temporary bridge, migrate back to the standard). Stated
+in both repos: config-reference blockquote (primary statement), observability warning
+admonition, reserved-names, REST grammar/per-entry docs + machine-readable catalog, Kafka
+guides (Java), HTTP-client guide (Rust), CHANGELOG entries.
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaConsumerBinding.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaConsumerBinding.java
@@ -117,8 +117,8 @@ public final class KafkaConsumerBinding {
     /**
      * Per-binding inbound traceparent header override ({@code traceparent.header}), or {@code null} to
      * use the global {@code kafka.traceparent.header} (default {@code traceparent}). Impedance matching
-     * for an upstream that carries W3C trace context under its own header name - a well-formed value
-     * under the effective name wins, with the standard {@code traceparent} as fallback.
+     * for an upstream that carries W3C trace context under its own header name - the standard
+     * {@code traceparent} always wins, and the custom name is read only when the standard is absent.
      */
     public String traceparentHeader() {
         return traceparentHeader;

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -127,8 +127,8 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private static final String GLOBAL_TRACE_ID_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.trace.id.header");
     // Global inbound traceparent header name (default "traceparent"): impedance matching for an upstream
-    // that carries W3C trace context under its own header name. A well-formed value under the effective
-    // name wins; the standard header remains a fallback.
+    // that carries W3C trace context under its own header name. The standard traceparent always wins;
+    // the custom name is read only when the standard header is absent.
     private static final String GLOBAL_TRACEPARENT_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.traceparent.header", W3cTrace.TRACEPARENT);
 
@@ -249,15 +249,16 @@ public class KafkaFlowConsumer implements AutoCloseable {
     }
 
     /**
-     * Parse the inbound W3C trace context from the effective traceparent header name (per-binding
-     * 'traceparent.header', else the global kafka.traceparent.header, default "traceparent"). A
-     * well-formed value under the custom name wins; the standard header remains a fallback so a
-     * standards-compliant upstream still propagates.
+     * Parse the inbound W3C trace context. The standard "traceparent" header always wins; the
+     * effective custom name (per-binding 'traceparent.header', else the global
+     * kafka.traceparent.header) is read only when the standard header is absent or malformed.
+     * Rationale: a well-formed standard traceparent means the upstream already speaks the
+     * W3C/OpenTelemetry standard - a proprietary header alongside it is residual and safely ignored.
      */
     private String[] parseInboundTraceparent(Map<String, String> headers) {
-        String[] parsed = W3cTrace.parse(headers.get(traceparentHeader));
+        String[] parsed = W3cTrace.parse(headers.get(W3cTrace.TRACEPARENT));
         if (parsed.length == 0 && !W3cTrace.TRACEPARENT.equalsIgnoreCase(traceparentHeader)) {
-            parsed = W3cTrace.parse(headers.get(W3cTrace.TRACEPARENT));
+            parsed = W3cTrace.parse(headers.get(traceparentHeader));
         }
         return parsed;
     }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
@@ -174,22 +174,39 @@ class KafkaFlowAdapterTest {
     void adapterAdoptsTraceContextFromCustomHeaderName() throws Exception {
         KafkaSinkTask.RECEIVED.clear();
         // inbound impedance matching: an upstream carries W3C trace context ONLY under the custom
-        // name (middleware stripped the standard header); the adapter adopts it - and when an
-        // intermediary injects its own standard traceparent, the custom name still wins
+        // name (legacy middleware stripped the standard header); the adapter falls back to it
         String customTraceId = "aaaa2222333344445555666677778888";
-        String injectedTraceId = "bbbb2222333344445555666677778888";
         Map<String, byte[]> recordHeaders = new HashMap<>();
         recordHeaders.put("x-kafka-trace",
                 W3cTrace.format(customTraceId, "aaaabbbbccccdddd").getBytes(StandardCharsets.UTF_8));
-        recordHeaders.put(W3cTrace.TRACEPARENT,
-                W3cTrace.format(injectedTraceId, "ddddccccbbbbaaaa").getBytes(StandardCharsets.UTF_8));
         KafkaRuntime.publisher().publishSync(TOPIC, null, recordHeaders,
                 "{\"hello\":\"custom\"}".getBytes(StandardCharsets.UTF_8), 10000);
 
         Map<String, Object> received = KafkaSinkTask.RECEIVED.poll(25, TimeUnit.SECONDS);
         assertNotNull(received, "the sink flow should receive the message");
         assertEquals(customTraceId, received.get("traceId"),
-                "a well-formed value under the custom traceparent name wins over the standard header");
+                "the custom traceparent name delivers the context when the standard header is absent");
+    }
+
+    @Test
+    void standardTraceparentWinsOverCustomHeaderName() throws Exception {
+        KafkaSinkTask.RECEIVED.clear();
+        // the standards position: a well-formed standard traceparent means the upstream already
+        // speaks W3C/OTel - a residual proprietary header alongside it is safely ignored
+        String residualTraceId = "aaaa3333444455556666777788889999";
+        String standardTraceId = "bbbb3333444455556666777788889999";
+        Map<String, byte[]> recordHeaders = new HashMap<>();
+        recordHeaders.put("x-kafka-trace",
+                W3cTrace.format(residualTraceId, "aaaabbbbccccdddd").getBytes(StandardCharsets.UTF_8));
+        recordHeaders.put(W3cTrace.TRACEPARENT,
+                W3cTrace.format(standardTraceId, "ddddccccbbbbaaaa").getBytes(StandardCharsets.UTF_8));
+        KafkaRuntime.publisher().publishSync(TOPIC, null, recordHeaders,
+                "{\"hello\":\"standard\"}".getBytes(StandardCharsets.UTF_8), 10000);
+
+        Map<String, Object> received = KafkaSinkTask.RECEIVED.poll(25, TimeUnit.SECONDS);
+        assertNotNull(received, "the sink flow should receive the message");
+        assertEquals(standardTraceId, received.get("traceId"),
+                "the standard W3C traceparent wins; the custom name is a fallback only");
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
@@ -277,7 +277,8 @@ class KafkaFlowConsumerTest {
 
     @Test
     void perBindingTraceparentOverrideAdoptsCustomHeaderName() {
-        // the binding's 'traceparent.header' override reads the W3C trace context from a custom name
+        // the binding's 'traceparent.header' override reads the W3C trace context from a custom
+        // name when the standard traceparent is absent (the custom name is a fallback only)
         EventEnvelope[] captured = new EventEnvelope[1];
         RetryPolicy policy = new RetryPolicy(0, 0, null);
         KafkaConsumerBinding custom = binding().traceparentHeader("X-Bridge-Trace").build();
@@ -301,9 +302,9 @@ class KafkaFlowConsumerTest {
     }
 
     @Test
-    void customTraceparentNameWinsOverStandardHeader() {
-        // an intermediary may inject its own standard traceparent; the deliberately configured
-        // custom name must not be overridden by it
+    void standardTraceparentWinsOverCustomHeaderName() {
+        // the standards position: a well-formed standard traceparent means the upstream already
+        // speaks W3C/OTel - a proprietary header alongside it is residual and safely ignored
         EventEnvelope[] captured = new EventEnvelope[1];
         RetryPolicy policy = new RetryPolicy(0, 0, null);
         KafkaConsumerBinding custom = binding().traceparentHeader("X-Bridge-Trace").build();
@@ -322,13 +323,13 @@ class KafkaFlowConsumerTest {
 
         consumer.routeToFlow(r);
 
-        assertEquals("1af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
-                "a well-formed value under the custom traceparent name wins over the standard header");
+        assertEquals("2af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
+                "the standard W3C traceparent wins; the custom name is a fallback only");
     }
 
     @Test
-    void standardTraceparentRemainsFallbackUnderCustomName() {
-        // a standards-compliant upstream that only sends the standard header still propagates,
+    void standardTraceparentIsAuthoritativeUnderCustomName() {
+        // a standards-compliant upstream that only sends the standard header propagates normally,
         // even though the binding is configured with a custom traceparent name
         EventEnvelope[] captured = new EventEnvelope[1];
         RetryPolicy policy = new RetryPolicy(0, 0, null);
@@ -347,7 +348,7 @@ class KafkaFlowConsumerTest {
         consumer.routeToFlow(r);
 
         assertEquals("3af7651916cd43dd8448eb211c80319c", captured[0].getTraceId(),
-                "the standard traceparent remains a fallback when the custom name is absent");
+                "the standard traceparent is authoritative whatever custom name is configured");
     }
 
     @Test

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -596,21 +596,23 @@ public class HttpRouter {
     }
 
     /**
-     * Parse the inbound W3C trace context from the effective traceparent header name (per-endpoint
-     * 'traceparent.header' in rest.yaml, else the global http.traceparent.header, default "traceparent").
-     * A well-formed value under the custom name wins - an intermediary may inject its own standard
-     * traceparent, which must not override the peer's context - while the standard header remains a
-     * fallback so standards-compliant callers still propagate.
+     * Parse the inbound W3C trace context. The standard "traceparent" header always wins; the
+     * custom name (per-endpoint 'traceparent.header' in rest.yaml, else the global
+     * http.traceparent.header) is read only when the standard header is absent or malformed.
+     * Rationale: a well-formed standard traceparent means the caller already speaks the
+     * W3C/OpenTelemetry standard - a proprietary header alongside it is residual and safely ignored.
      *
      * @param request HTTP
      * @param route the assigned route
      * @return a 2-element array of {trace-id, parent-span-id}, or an empty array when absent/invalid
      */
     private String[] parseInboundTraceparent(HttpServerRequest request, AssignedRoute route) {
-        String name = route.info.traceparentHeader != null ? route.info.traceparentHeader : traceparentHeader;
-        String[] parsed = W3cTrace.parse(request.getHeader(name));
-        if (parsed.length == 0 && !W3cTrace.TRACEPARENT.equalsIgnoreCase(name)) {
-            parsed = W3cTrace.parse(request.getHeader(W3cTrace.TRACEPARENT));
+        String[] parsed = W3cTrace.parse(request.getHeader(W3cTrace.TRACEPARENT));
+        if (parsed.length == 0) {
+            String name = route.info.traceparentHeader != null ? route.info.traceparentHeader : traceparentHeader;
+            if (!W3cTrace.TRACEPARENT.equalsIgnoreCase(name)) {
+                parsed = W3cTrace.parse(request.getHeader(name));
+            }
         }
         return parsed;
     }

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -226,6 +226,19 @@ public class WorkerHandler {
             if (businessCid != null) {
                 parameters.put(MY_CORRELATION_ID, businessCid);
             }
+            /*
+             * The delivered envelope view is scrubbed of the same engine keys: a peer that
+             * transported my_* headers (e.g. a function that copied its injected input view onto an
+             * outgoing event) or an edge that merged them must never surface engine metadata as
+             * application data. Safe to mutate - each delivery deserializes its own envelope copy
+             * (WorkerDispatcher). Event interceptors are exempt: they relay raw envelopes and need
+             * transport fidelity (e.g. the x-event-api relay guard).
+             */
+            if (!interceptor) {
+                event.getHeaders().keySet()
+                        .removeIf(k -> X_EVENT_API.equals(k) || MY_ROUTE.equals(k) || MY_TRACE_ID.equals(k)
+                                || MY_TRACE_PATH.equals(k) || MY_CORRELATION_ID.equals(k));
+            }
             Object result = invokeFunction(f, parameters, body, event);
             md.diff = getExecTime(begin);
             String replyTo = event.getReplyTo();

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RestEndpointTest.java
@@ -167,8 +167,8 @@ class RestEndpointTest extends TestBase {
     @SuppressWarnings("unchecked")
     @Test
     void customTraceparentHeaderNameCarriesTheTraceContext() throws InterruptedException {
-        // http.traceparent.header=X-Trace-Context in this test suite: an intermediary that strips
-        // the standard W3C "traceparent" can still deliver the trace context under the custom name
+        // http.traceparent.header=X-Trace-Context in this test suite: when the standard W3C
+        // "traceparent" is absent (an intermediary stripped it), the custom name delivers the context
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
         String w3cTraceId = "1af92f3577b34da6a3ce929d0e0e4701";
         EventEmitter po = EventEmitter.getInstance();
@@ -188,31 +188,31 @@ class RestEndpointTest extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
-    void customTraceparentNameWinsOverInjectedStandardHeader() throws InterruptedException {
-        // an intermediary (e.g. a service-mesh sidecar) may inject its OWN standard traceparent;
-        // the peer's context under the deliberately configured custom name must not be overridden
+    void standardTraceparentWinsOverCustomHeaderName() throws InterruptedException {
+        // the standards position: a well-formed standard traceparent means the caller already
+        // speaks W3C/OTel - a proprietary header alongside it is residual and safely ignored
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
-        String peerTraceId = "2af92f3577b34da6a3ce929d0e0e4702";
-        String injectedTraceId = "3af92f3577b34da6a3ce929d0e0e4703";
+        String residualTraceId = "2af92f3577b34da6a3ce929d0e0e4702";
+        String standardTraceId = "3af92f3577b34da6a3ce929d0e0e4703";
         EventEmitter po = EventEmitter.getInstance();
         AsyncHttpRequest req = new AsyncHttpRequest();
         req.setMethod("GET").setUrl("/api/legacy/probe").setTargetHost("http://127.0.0.1:" + port);
         req.setHeader("accept", "application/json")
-                .setHeader("X-Trace-Context", "00-" + peerTraceId + "-00f067aa0ba902b7-01")
-                .setHeader("traceparent", "00-" + injectedTraceId + "-00f067aa0ba902b8-01");
+                .setHeader("X-Trace-Context", "00-" + residualTraceId + "-00f067aa0ba902b7-01")
+                .setHeader("traceparent", "00-" + standardTraceId + "-00f067aa0ba902b8-01");
         EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req);
         po.asyncRequest(request, RPC_TIMEOUT).onSuccess(bench::add);
         EventEnvelope response = bench.poll(10, TimeUnit.SECONDS);
         assert response != null;
         Map<String, Object> probe = (Map<String, Object>) response.getBody();
-        assertEquals(peerTraceId, probe.get("traceId"),
-                "a well-formed value under the custom traceparent name wins over the standard header");
+        assertEquals(standardTraceId, probe.get("traceId"),
+                "the standard W3C traceparent wins; the custom name is a fallback only");
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    void standardTraceparentRemainsFallbackUnderCustomName() throws InterruptedException {
-        // a standards-compliant caller that only sends the standard header still propagates,
+    void standardTraceparentIsAuthoritativeUnderCustomName() throws InterruptedException {
+        // a standards-compliant caller that only sends the standard header propagates normally,
         // even though this application is configured with a custom traceparent name
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
         String w3cTraceId = "4af92f3577b34da6a3ce929d0e0e4704";
@@ -233,7 +233,8 @@ class RestEndpointTest extends TestBase {
     @Test
     void perEndpointTraceparentOverrideBeatsGlobalName() throws InterruptedException {
         // /api/renamed/traceparent/probe declares 'traceparent.header: X-Endpoint-Trace' in rest.yaml,
-        // which replaces the global custom name (X-Trace-Context) for that endpoint
+        // which replaces the global custom name (X-Trace-Context) for that endpoint. The standard
+        // traceparent is absent here, so the effective custom name is the fallback source.
         final BlockingQueue<EventEnvelope> bench = new ArrayBlockingQueue<>(1);
         String endpointTraceId = "5af92f3577b34da6a3ce929d0e0e4705";
         String globalNameTraceId = "6af92f3577b34da6a3ce929d0e0e4706";

--- a/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
@@ -1055,6 +1055,61 @@ class PostOfficeTest extends TestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void transportedMetadataIsScrubbedFromTheDeliveredEnvelopeView() throws InterruptedException, ExecutionException {
+        // The entry-side twin of the exit sanitization above: a peer transports the engine's
+        // reserved keys as ordinary envelope headers (e.g. a function that copied its injected
+        // input view onto an outgoing event, or a spoofing caller). The worker must scrub them
+        // from the delivered envelope view - a function's input envelope never surfaces engine
+        // metadata as application data - while ordinary headers survive and the injected view
+        // still carries the real context.
+        Map<String, String> ctx = new HashMap<>();
+        ctx.put("my_route", "unit.test");
+        ctx.put("my_trace_id", "trace-entry-scrub-1");
+        ctx.put("my_trace_path", "TEST /entry/scrub");
+        PostOffice po = PostOffice.trackable(ctx, 1);
+        EventEnvelope req = new EventEnvelope().setTo("clean.envelope.echo")
+                .setBody("x").setHeader("hello", "clean")
+                .setHeader("my_route", "spoofed.route")
+                .setHeader("my_trace_id", "spoofed-trace")
+                .setHeader("my_trace_path", "SPOOF /path")
+                .setHeader("x-event-api", "spoofed");
+        EventEnvelope reply = po.request(req, 8000).get();
+        assertInstanceOf(Map.class, reply.getBody());
+        Map<String, Object> result = (Map<String, Object>) reply.getBody();
+        Map<String, String> envelopeView = (Map<String, String>) result.get("envelope_headers");
+        // ordinary headers survive in the envelope view
+        assertEquals("clean", envelopeView.get("hello"));
+        // the transported engine keys are scrubbed from the delivered envelope
+        assertFalse(envelopeView.containsKey("my_route"));
+        assertFalse(envelopeView.containsKey("my_trace_id"));
+        assertFalse(envelopeView.containsKey("my_trace_path"));
+        assertFalse(envelopeView.containsKey("my_correlation_id"));
+        assertFalse(envelopeView.containsKey("x-event-api"));
+        // the injected view is unaffected: real context, not the spoofed values
+        assertEquals("clean.envelope.echo", result.get("injected_route"));
+    }
+
+    @Test
+    void legacyCorrelationIdHeaderIsHonoredThenScrubbed() throws InterruptedException, ExecutionException {
+        // a pre-4.10.2 peer transports the business correlation-id as the my_correlation_id
+        // envelope header (no my_cid tag): the worker must still honor it - the function reads
+        // it via getMyCorrelationId() - while the delivered envelope view stays clean
+        EventEnvelope req = new EventEnvelope().setTo("clean.envelope.echo")
+                .setBody("x").setHeader("my_correlation_id", "legacy-cid-0042");
+        EventEnvelope reply = EventEmitter.getInstance().request(req, 8000).get();
+        assertInstanceOf(Map.class, reply.getBody());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) reply.getBody();
+        assertEquals("legacy-cid-0042", result.get("injected_cid"),
+                "the legacy header is honored into the injected view");
+        @SuppressWarnings("unchecked")
+        Map<String, String> envelopeView = (Map<String, String>) result.get("envelope_headers");
+        assertFalse(envelopeView.containsKey("my_correlation_id"),
+                "the legacy carrier is scrubbed from the delivered envelope view");
+    }
+
     @Test
     void rpcTelemetryCarriesSpanLineage() throws InterruptedException {
         // Regression: the RPC trace record (the one with round_trip) must chain like a

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/CleanEnvelopeEcho.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/CleanEnvelopeEcho.java
@@ -1,0 +1,48 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test probe for the worker's envelope-view sanitization: an EventEnvelope-typed function that
+ * reports both of its header views - the delivered envelope's own headers (which must never
+ * contain the engine's my_* / x-event-api keys, whatever a peer transported) and its injected
+ * input copy (where the my_* metadata legitimately lives) - so a test can assert the boundary
+ * between transported data and injected metadata.
+ */
+@PreLoad(route = "clean.envelope.echo", instances = 10)
+public class CleanEnvelopeEcho implements TypedLambdaFunction<EventEnvelope, Object> {
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, EventEnvelope input, int instance) {
+        var po = new PostOffice(headers, instance);
+        Map<String, Object> result = new HashMap<>();
+        result.put("envelope_headers", input.getHeaders());
+        result.put("injected_cid", po.getMyCorrelationId());
+        result.put("injected_route", po.getRoute());
+        return result;
+    }
+}

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -69,9 +69,9 @@ rest:
     trace.id.header: "X-Shared-Id"
     correlation.id.header: "X-Shared-Id"
 
-  # Per-endpoint traceparent header-name override: this endpoint reads the W3C trace context from
-  # 'X-Endpoint-Trace', taking precedence over the global http.traceparent.header (X-Trace-Context
-  # in this test suite) and the standard 'traceparent' (which remains a fallback when absent).
+  # Per-endpoint traceparent header-name override: when the standard 'traceparent' is absent
+  # (it always wins when present), this endpoint falls back to 'X-Endpoint-Trace' - the per-entry
+  # name replaces the global http.traceparent.header (X-Trace-Context in this test suite).
   - service: "header.probe"
     methods: ['GET']
     url: "/api/renamed/traceparent/probe"


### PR DESCRIPTION
## What

The complete pre-release validation and hygiene arc for v4.10.4, in lock-step with the
Rust engine:

1. **Interop test report — the ce_traceparent round.** The configurable traceparent
   carrier was validated live across the language boundary with
   `-Dhttp.traceparent.header=ce_traceparent` on both engines' demo apps, simulating the
   field gateway by supplying the W3C value ONLY under the custom name: edge adoption,
   cross-language span parenting in both directions, wire-level dual stamping, auth and
   correlation-id echo all pass (new round + resolution in
   `docs/test-reports/event-over-http-interop.md`, byte-identical in both repos).
2. **The delivered envelope view is scrubbed of engine metadata.** The round's
   four-combination matrix found that a peer-transported or edge-merged `my_*` /
   `x-event-api` header could surface in a function's input ENVELOPE header view (the
   injected copy was already clean). The worker now scrubs the five engine keys from the
   delivered envelope for non-interceptor functions; the legacy `my_correlation_id`
   compat carrier remains honored into the injected view first, and event interceptors
   keep raw transport fidelity. Entry-side regression twins added.
3. **The programmatic demo forwards business headers only** — `EventOverHttpRpc` no
   longer copies its injected `my_*` view onto the outgoing event.
4. **Standards-first traceparent, stated and enforced.** The docs now state the project's
   position: the W3C/OpenTelemetry `traceparent` is the default and the recommendation;
   the optional `traceparent.header` family is for backward compatibility with legacy
   systems only, and departure from the standard is discouraged. Inbound precedence is
   finalized accordingly: **the standard `traceparent` always wins** — the custom name is
   read only when the standard header is absent, because a well-formed standard
   traceparent means the caller already upgraded and a residual proprietary header is
   safely ignored (this also matches the `trace.id.header` family, which already yields
   to the standard).

Verification: full reactor green; platform-core 422 tests, minimalist-kafka 102 (with the
inverted precedence regressions); final four-combination matrix with both fixed engines —
**all eight echoes identical** after normalizing volatile fields, including the `x-ttl`
value both engines now stamp at REST ingress.

## Why

Polyglot field installations put both engines' logs and payload shapes in front of one
DevSecOps team, so the cross-engine contract is exact structural parity — and the metadata
contract says a composable function's inputs never surface engine internals as application
data. The ce_traceparent drive proved the new feature correct, and its matrix caught the
last places where the two engines' function-visible surfaces diverged. Fixing them closes
the boundary-demarcation story ("inject at entry, sanitize at exit, never transport") on
the last remaining surface — the envelope view itself — while the standards-first
precedence keeps the escape hatch subordinate to the W3C/OTel standard it exists to bridge
back to.

Ships in lock-step with the Rust engine's branch of the same name; both repos' reports
carry the identical validation record.

Co-Authored-By: Claude Code <noreply@anthropic.com>