### PR TITLE
fix: resolve Sonar S125/S3776 findings from v4.10.4 field scan

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-24 | agent: GitHub Copilot (2026-07-24-232712)
+- **last_session:** 2026-07-25 | agent: Claude Code (2026-07-25-005125)
 - **last_review:** 2026-07-24 | through 2026-07-24-154543.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -333,6 +333,26 @@
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-06-21 | uses: 1 | tier: working -->
 
 ## Open Threads
+
+- [ ] (field support — 2026-07-25; PR open) **v4.10.4 failed the field Sonar quality gate —
+  5 findings, fix reviewed + verified, [PR #231](https://github.com/Accenture/mercury-composable/pull/231)
+  open on `feature/sonar-quality-fixes`.** GitHub Copilot authored the fix (commit
+  `ac36ec4f`); Claude Code independently reviewed all 5 diffs line-by-line and verified.
+  Findings: 2× S125 (commented-out code — both were prose comments ending in a stray
+  semicolon, which Sonar's heuristic mistakes for commented-out code, in `HttpRouter.java`
+  and `KafkaFlowConsumer.java`) + 3× S3776 (Cognitive Complexity >15 in
+  `InboxBase.recordTrace`, `AsyncHttpResponse.handleEvent`, `AsyncHttpClient.updateHttpHeaders`
+  — fixed via helper-method extraction / guard-clause early returns, confirmed
+  behavior-preserving). **Verification:** full reactor `mvn clean install` (29 modules)
+  BUILD SUCCESS; live Java-to-Java Event-over-HTTP interop drive (composable-example ⇄
+  lambda-example, both declarative + programmatic patterns) as a targeted regression test
+  of the three refactored trace/cid-propagation classes — 17 span records, zero
+  duplicates, zero dangling `parent_span_id`s, correct cross-process span parenting in
+  both patterns (programmatic pattern's non-adoption of a foreign span confirmed
+  consistent with the I2 fix behavior in [[thread-event-envelope-interop]]). Close when
+  merged, tagged, and the field rescan passes (precedent:
+  [[thread-sonar-4-9-1-field-rejection]]).
+  <!-- id: thread-sonar-4-10-4-field-rejection | created: 2026-07-25 | last_used: 2026-07-25 | uses: 1 | tier: working | origin: 2026-07-25-005125 -->
 
 - [x] (release in flight — 2026-07-24; CLOSED same day) **v4.10.5 security patch SHIPPED
   AND PUBLISHED in lock-step (both repos) — react-router CVE remediation.** Dependabot #16

--- a/memory/sessions/2026-07-25-005125.md
+++ b/memory/sessions/2026-07-25-005125.md
@@ -1,0 +1,62 @@
+# Session (2026-07-25T00:51:25Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**v4.10.4 failed the field Sonar quality gate — 5 findings, fix reviewed + verified,
+[PR #231](https://github.com/Accenture/mercury-composable/pull/231) opened.**
+GitHub Copilot authored the fix on `feature/sonar-quality-fixes` (commit `ac36ec4f`,
+Co-Authored-By trailer already on the commit); this session's job was independent
+review + verification, not authorship. Findings: 2× S125 (commented-out code — both were
+innocuous comments ending in a stray semicolon, which Sonar's heuristic mistakes for
+commented-out code) and 3× S3776 (Cognitive Complexity over 15) in `InboxBase.recordTrace`,
+`AsyncHttpResponse.handleEvent`, and `AsyncHttpClient.updateHttpHeaders` — all three fixed
+by extracting single-purpose helper methods / guard-clause early returns, verified
+line-by-line to be behavior-preserving (same branches, same field/map mutation order).
+
+**Verification performed:**
+1. `mvn clean install` full reactor (29 modules) — **BUILD SUCCESS**, all tests green
+   (~4m43s).
+2. **Live Java-to-Java Event-over-HTTP interop drive** (composable-example port 8100 ⇄
+   lambda-example port 8085, both the declarative and programmatic calling patterns) as a
+   targeted regression test of the three refactored classes — `AsyncHttpClient`,
+   `AsyncHttpResponse`, `InboxBase` sit directly in the trace/business-cid propagation
+   path exercised by this drive, so a wrong-order extraction would have shown up here
+   even if unit tests (which mock `po`/`http`) missed it. Result: both patterns returned
+   HTTP 200 with the correct cross-app `origin` (proving the call genuinely crossed
+   processes, not a local echo); span-level analysis of both traces (17 span records
+   total, extracted from the JSON-lines application logs) found **zero duplicate spans**
+   and **zero dangling `parent_span_id`s** — every parent resolved to a real span across
+   the combined caller+callee logs. Confirmed the declarative pattern's response callback
+   parents onto the callee's own function span (`InboxBase.spanIdFromResponder` adopts
+   because reply.getFrom() matches the exact requested route), while the programmatic
+   pattern's response callback parents onto the caller's own RPC task span rather than a
+   foreign one — correctly reflecting the **I2 fix behavior** already recorded in
+   [[thread-event-envelope-interop]] (adopt the responder's span only when the reply comes
+   from the requested route itself, never a relay through `event.api.service`). Business
+   correlation-id (`X-Correlation-Id`) echoed correctly on both responses.
+
+**Assessment offered on scope**: recommended running the interop drive specifically
+because `AsyncHttpClient.updateHttpHeaders`'s extraction reorders trace/cid-header
+application into five helpers — the single place where a wrong extraction order could
+silently drop a header, and the one refactor not fully exercised by mocked unit tests.
+The two S125 comment fixes and the `InboxBase`/`AsyncHttpResponse` refactors needed no
+live check — existing unit-test coverage over those methods already regression-guards
+pure-logic extraction.
+
+**PR opened by Eric via GitHub UI**: #231, title "fix: resolve Sonar S125/S3776 findings
+from v4.10.4 field scan", body drafted by Claude Code (What/Why/Test-plan, dual
+Co-Authored-By: GitHub Copilot + Claude Code).
+
+## Memory References
+
+- Referenced: [[thread-event-envelope-interop]] (I2 fix precedent used to interpret the
+  programmatic-pattern span-parenting behavior), [[functions-decoupled-routes]] (context
+  for reading the refactored classes), [[thread-sonar-4-9-1-field-rejection]] (prior-cycle
+  precedent for the field-Sonar-rejection → remediation → re-scan pattern this session
+  follows).
+- No new facts created — this was a review/verification task, not a decision or design
+  change. PR #231 tracking is left as a lightweight open thread below rather than a full
+  Key Decision, since it will fold into a normal release-shipped entry (matching the
+  `thread-release-4-x-x` pattern) once merged and tagged.

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -127,8 +127,8 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private static final String GLOBAL_TRACE_ID_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.trace.id.header");
     // Global inbound traceparent header name (default "traceparent"): impedance matching for an upstream
-    // that carries W3C trace context under its own header name. The standard traceparent always wins;
-    // the custom name is read only when the standard header is absent.
+    // that carries W3C trace context under its own header name. The standard traceparent always wins
+    // and the custom name is read only when the standard header is absent.
     private static final String GLOBAL_TRACEPARENT_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.traceparent.header", W3cTrace.TRACEPARENT);
 

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -311,21 +311,34 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
     private void updateHttpHeaders(PostOffice po, AsyncHttpRequest request, HttpHeaders http, String spanId) {
         // set user-agent for this HTTP client
         http.set(USER_AGENT, USER_AGENT_NAME);
+        setContentLengthHeader(request, http);
+        applyRequestAndSessionHeaders(request, http);
+        applyTraceHeaders(po, http, spanId);
+        applyBusinessCorrelationId(po, request, http);
+        setCookies(request, http);
+    }
+
+    private void setContentLengthHeader(AsyncHttpRequest request, HttpHeaders http) {
         // set content-length, including zero, if needed
         var method = request.getMethod();
         if (request.isContentLengthDefined() && request.getStreamRoutes().isEmpty() &&
                 (POST.equals(method) || PUT.equals(method) || PATCH.equals(method))) {
             http.set(CONTENT_LENGTH, request.getContentLength());
         }
+    }
+
+    private void applyRequestAndSessionHeaders(AsyncHttpRequest request, HttpHeaders http) {
         Map<String, String> reqHeaders = request.getHeaders();
         // convert authentication session info into HTTP request headers
-        Map<String, String> sessionInfo = request.getSessionInfo();
-        reqHeaders.putAll(sessionInfo);
+        reqHeaders.putAll(request.getSessionInfo());
         for (Map.Entry<String, String> kv: reqHeaders.entrySet()) {
             if (permittedHttpHeader(kv.getKey())) {
                 http.set(kv.getKey(), kv.getValue());
             }
         }
+    }
+
+    private void applyTraceHeaders(PostOffice po, HttpHeaders http, String spanId) {
         // Trace headers (X-Trace-Id / W3C "traceparent") copied from the request above are left intact when
         // this call is not being traced: an explicitly developer-set trace header is an intentional act (e.g.
         // handing a trace context to a 3rd-party system, or forwarding an upstream trace) and must propagate.
@@ -348,6 +361,9 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                 http.set(customTraceparent, traceparent);
             }
         }
+    }
+
+    private void applyBusinessCorrelationId(PostOffice po, AsyncHttpRequest request, HttpHeaders http) {
         // propagate the business correlation-id downstream (unless the caller set the header explicitly)
         String businessCorrelationId = po.getMyCorrelationId();
         if (businessCorrelationId != null) {
@@ -356,6 +372,9 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                 http.set(cidHeader, businessCorrelationId);
             }
         }
+    }
+
+    private void setCookies(AsyncHttpRequest request, HttpHeaders http) {
         // set cookies if any
         Map<String, String> cookies  = request.getCookies();
         StringBuilder sb = new StringBuilder();

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
@@ -72,33 +72,39 @@ public class AsyncHttpResponse implements TypedLambdaFunction<EventEnvelope, Voi
     @Override
     public Void handleEvent(Map<String, String> headers, EventEnvelope event, int instance) {
         String requestId = event.getCorrelationId();
-        if (requestId != null) {
-            AsyncContextHolder holder = contexts.get(requestId);
-            if (holder != null) {
-                holder.touch();
-                HttpServerResponse response = holder.request.response();
-                // echo the request's business correlation-id (inbound or edge-generated) so the
-                // caller can correlate; a function-provided response header of the same name wins
-                if (holder.cidHeaderName != null && holder.businessCorrelationId != null) {
-                    response.putHeader(holder.cidHeaderName, holder.businessCorrelationId);
-                }
-                boolean isHeadMethod = HEAD.equals(holder.method);
-                var md = new HttpResMetadata();
-                md.contentType = isHeadMethod? "?" : null;
-                updateHeadersAndContentType(response, holder, event, md, isHeadMethod);
-                // is this an exception?
-                if (handleException(requestId, holder, event)) {
-                    return null;
-                }
-                // Except HEAD method, HTTP response may have a body
-                if (!isHeadMethod && handleContent(requestId, response, event, holder, md)) {
-                    return null;
-                }
-                HttpRouter.closeContext(requestId);
-                response.end();
-            }
+        if (requestId == null) {
+            return null;
         }
+        AsyncContextHolder holder = contexts.get(requestId);
+        if (holder == null) {
+            return null;
+        }
+        holder.touch();
+        HttpServerResponse response = holder.request.response();
+        setBusinessCorrelationIdHeader(response, holder);
+        boolean isHeadMethod = HEAD.equals(holder.method);
+        var md = new HttpResMetadata();
+        md.contentType = isHeadMethod? "?" : null;
+        updateHeadersAndContentType(response, holder, event, md, isHeadMethod);
+        // is this an exception?
+        if (handleException(requestId, holder, event)) {
+            return null;
+        }
+        // Except HEAD method, HTTP response may have a body
+        if (!isHeadMethod && handleContent(requestId, response, event, holder, md)) {
+            return null;
+        }
+        HttpRouter.closeContext(requestId);
+        response.end();
         return null;
+    }
+
+    private void setBusinessCorrelationIdHeader(HttpServerResponse response, AsyncContextHolder holder) {
+        // echo the request's business correlation-id (inbound or edge-generated) so the
+        // caller can correlate; a function-provided response header of the same name wins
+        if (holder.cidHeaderName != null && holder.businessCorrelationId != null) {
+            response.putHeader(holder.cidHeaderName, holder.businessCorrelationId);
+        }
     }
 
     private long getReadTimeout(String timeoutOverride, long contextTimeout) {

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -931,7 +931,7 @@ public class HttpRouter {
             event.setTo(requestEvent.primary).setFrom(HTTP_REQUEST)
                     .setCorrelationId(requestEvent.requestId).setBody(requestEvent.httpRequest)
                     .setReplyTo(AsyncHttpClient.ASYNC_HTTP_RESPONSE + "@" + Platform.getInstance().getOrigin());
-            // carry the business correlation-id on the engine-managed envelope tag (never a header);
+            // Business correlation-id is carried on the engine-managed envelope tag, never as a header.
             // the worker injects my_correlation_id into the target function's input copy at delivery
             if (requestEvent.getBusinessCorrelationId() != null) {
                 event.addTag(EventEmitter.BUSINESS_CID_TAG, requestEvent.getBusinessCorrelationId());

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/InboxBase.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/InboxBase.java
@@ -73,47 +73,57 @@ public abstract class InboxBase {
 
     protected void recordTrace(InboxMetadata md) {
         var service = trimOrigin(md.to);
-        if (!getSkipTracing().contains(service)) {
-            try {
-                Map<String, Object> payload = new HashMap<>();
-                Map<String, Object> metrics = new HashMap<>();
-                metrics.put("origin", Platform.getInstance().getOrigin());
-                metrics.put("id", md.traceId);
-                metrics.put("service", service);
-                if (md.from != null) {
-                    metrics.put("from", trimOrigin(md.from));
-                }
-                // span lineage of the RPC: span_id is the responder's own span (present only
-                // for a direct RPC - see spanIdFromResponder) and parent_span_id is the
-                // caller's span carried on the outbound request, so the round-trip record
-                // chains like any worker-emitted trace record
-                if (md.spanId != null) {
-                    metrics.put("span_id", md.spanId);
-                }
-                if (md.parentSpanId != null) {
-                    metrics.put("parent_span_id", md.parentSpanId);
-                }
-                metrics.put("exec_time", md.execTime);
-                metrics.put("round_trip", md.roundTrip);
-                metrics.put("start", md.start);
-                metrics.put("path", md.tracePath);
-                payload.put("trace", metrics);
-                if (!md.annotations.isEmpty()) {
-                    payload.put(ANNOTATIONS, md.annotations);
-                }
-                metrics.put("status", md.status);
-                if (md.status >= 400) {
-                    metrics.put("success", false);
-                    // for data privacy, only shown error message from recognized standard error dataset format
-                    metrics.put("exception", md.error instanceof String message? message : "***");
-                } else {
-                    metrics.put("success", true);
-                }
-                EventEnvelope dt = new EventEnvelope().setTo(Telemetry.DISTRIBUTED_TRACING);
-                EventEmitter.getInstance().send(dt.setBody(payload));
-            } catch (Exception e) {
-                log.error("Unable to send to {}", Telemetry.DISTRIBUTED_TRACING, e);
+        if (getSkipTracing().contains(service)) {
+            return;
+        }
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            Map<String, Object> metrics = getTraceMetrics(md, service);
+            payload.put("trace", metrics);
+            if (!md.annotations.isEmpty()) {
+                payload.put(ANNOTATIONS, md.annotations);
             }
+            setTraceStatus(md, metrics);
+            EventEnvelope dt = new EventEnvelope().setTo(Telemetry.DISTRIBUTED_TRACING);
+            EventEmitter.getInstance().send(dt.setBody(payload));
+        } catch (Exception e) {
+            log.error("Unable to send to {}", Telemetry.DISTRIBUTED_TRACING, e);
+        }
+    }
+
+    private Map<String, Object> getTraceMetrics(InboxMetadata md, String service) {
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put("origin", Platform.getInstance().getOrigin());
+        metrics.put("id", md.traceId);
+        metrics.put("service", service);
+        if (md.from != null) {
+            metrics.put("from", trimOrigin(md.from));
+        }
+        // span lineage of the RPC: span_id is the responder's own span (present only
+        // for a direct RPC - see spanIdFromResponder) and parent_span_id is the
+        // caller's span carried on the outbound request, so the round-trip record
+        // chains like any worker-emitted trace record
+        if (md.spanId != null) {
+            metrics.put("span_id", md.spanId);
+        }
+        if (md.parentSpanId != null) {
+            metrics.put("parent_span_id", md.parentSpanId);
+        }
+        metrics.put("exec_time", md.execTime);
+        metrics.put("round_trip", md.roundTrip);
+        metrics.put("start", md.start);
+        metrics.put("path", md.tracePath);
+        return metrics;
+    }
+
+    private void setTraceStatus(InboxMetadata md, Map<String, Object> metrics) {
+        metrics.put("status", md.status);
+        if (md.status >= 400) {
+            metrics.put("success", false);
+            // for data privacy, only shown error message from recognized standard error dataset format
+            metrics.put("exception", md.error instanceof String message? message : "***");
+        } else {
+            metrics.put("success", true);
         }
     }
 


### PR DESCRIPTION
## What

Fixes 5 SonarQube findings from the v4.10.4 field quality-gate scan, all behavior-preserving refactors:

- **S125 (commented-out code), 2 findings** — two comments ended with a stray semicolon (a leftover from editing), which Sonar's heuristic flags as commented-out code:
  - `HttpRouter.java:934` — reworded as a plain sentence.
  - `KafkaFlowConsumer.java:130` — joined the two comment lines with "and", dropping the semicolon.
- **S3776 (Cognitive Complexity), 3 findings** — extracted helper methods to bring each method back under the threshold of 15:
  - `InboxBase.recordTrace` (17→15) — split into `getTraceMetrics` + `setTraceStatus`, with an early-return guard clause replacing the wrapping `if`.
  - `AsyncHttpResponse.handleEvent` (17→15) — guard-clause pattern for the two null checks (inverted + early return) plus an extracted `setBusinessCorrelationIdHeader` helper.
  - `AsyncHttpClient.updateHttpHeaders` (16→15) — split into five single-purpose helpers (`setContentLengthHeader`, `applyRequestAndSessionHeaders`, `applyTraceHeaders`, `applyBusinessCorrelationId`, `setCookies`).

No functional changes — same branches, same field names, same map/header contents; only structure changed.

## Why

The field DevSecOps Sonar gate holds the whole codebase (not just new code) to 0 blocker/critical/major, and these 5 issues surfaced in the v4.10.4 scan. Fixing them now keeps the next field rescan clean without carrying quality debt into future releases.

## Test plan

- [x] `mvn clean install` — full reactor (29 modules), **BUILD SUCCESS**, all tests green.
- [x] Reviewed every diff hunk line-by-line to confirm each extraction preserves control flow, map/field mutation order, and early-return semantics exactly.
- [x] Live Java-to-Java interop drive (composable-example ⇄ lambda-example, both the declarative and programmatic Event-over-HTTP patterns) to regression-test the refactored `AsyncHttpClient`/`AsyncHttpResponse`/`InboxBase` trace and business correlation-id paths under real cross-process traffic:
  - Both patterns returned HTTP 200 with the correct cross-app `origin`, confirming the call genuinely crossed processes.
  - Span-level analysis of both traces: 17 span records total, **zero duplicates**, **zero dangling `parent_span_id`s** (every parent resolves to a real span in the combined logs), and correct cross-process span parenting in both directions.
  - Business correlation-id (`X-Correlation-Id`) echoed correctly on both responses.

Co-Authored-By: GitHub Copilot <noreply@github.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>