### PR TITLE
chore(release): version 4.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.10.6, 7/24/2026
+
+Code-quality patch release: resolves all 5 SonarQube findings reported by an enterprise
+quality-gate scan of v4.10.4 (2 MEDIUM, 3 HIGH). Every change is behavior-preserving; no
+functional changes.
+
+### Changed
+
+1. **Prose comments reworded so they no longer pattern-match as commented-out code (#231).**
+   `HttpRouter.java` and `KafkaFlowConsumer.java` each carried a comment ending in a stray
+   trailing semicolon — a copy-edit leftover that Sonar's heuristic (java:S125) mistakes
+   for a disabled line of code. Both reworded as plain sentences; no code changed.
+2. **Cognitive complexity reduced by extracting focused helpers (#231).**
+   `InboxBase.recordTrace` (17→15, split into `getTraceMetrics` + `setTraceStatus` with an
+   early-return guard clause), `AsyncHttpResponse.handleEvent` (17→15, guard-clause early
+   returns replacing nested `if` blocks, plus an extracted `setBusinessCorrelationIdHeader`),
+   and `AsyncHttpClient.updateHttpHeaders` (16→15, split into five single-purpose helpers:
+   `setContentLengthHeader`, `applyRequestAndSessionHeaders`, `applyTraceHeaders`,
+   `applyBusinessCorrelationId`, `setCookies`). Regression-verified: full reactor build
+   green, plus a live Java-to-Java Event-over-HTTP interop drive (both the declarative and
+   programmatic calling patterns) confirming distributed-trace span propagation and
+   business correlation-id echo are unchanged — zero duplicate spans, zero dangling
+   `parent_span_id`s across 17 span records.
+
+---
 ## Version 4.10.5, 7/24/2026
 
 Security patch in lock-step with the Rust engine's v4.10.5.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.5) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.6) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.5) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.6) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -334,23 +334,26 @@
 
 ## Open Threads
 
-- [ ] (field support — 2026-07-25; PR open) **v4.10.4 failed the field Sonar quality gate —
-  5 findings, fix reviewed + verified, [PR #231](https://github.com/Accenture/mercury-composable/pull/231)
-  open on `feature/sonar-quality-fixes`.** GitHub Copilot authored the fix (commit
-  `ac36ec4f`); Claude Code independently reviewed all 5 diffs line-by-line and verified.
-  Findings: 2× S125 (commented-out code — both were prose comments ending in a stray
-  semicolon, which Sonar's heuristic mistakes for commented-out code, in `HttpRouter.java`
-  and `KafkaFlowConsumer.java`) + 3× S3776 (Cognitive Complexity >15 in
-  `InboxBase.recordTrace`, `AsyncHttpResponse.handleEvent`, `AsyncHttpClient.updateHttpHeaders`
-  — fixed via helper-method extraction / guard-clause early returns, confirmed
-  behavior-preserving). **Verification:** full reactor `mvn clean install` (29 modules)
-  BUILD SUCCESS; live Java-to-Java Event-over-HTTP interop drive (composable-example ⇄
-  lambda-example, both declarative + programmatic patterns) as a targeted regression test
-  of the three refactored trace/cid-propagation classes — 17 span records, zero
-  duplicates, zero dangling `parent_span_id`s, correct cross-process span parenting in
-  both patterns (programmatic pattern's non-adoption of a foreign span confirmed
-  consistent with the I2 fix behavior in [[thread-event-envelope-interop]]). Close when
-  merged, tagged, and the field rescan passes (precedent:
+- [ ] (field support — 2026-07-25; PR MERGED, release pending) **v4.10.4 failed the field
+  Sonar quality gate — 5 findings, fix reviewed + verified, MERGED to main as
+  [PR #231](https://github.com/Accenture/mercury-composable/pull/231) (merge commit
+  `c7d05d83`, CI green: Build & Unit Tests 7m1s + memory + verify all pass).** GitHub
+  Copilot authored the fix (commit `ac36ec4f`); Claude Code independently reviewed all 5
+  diffs line-by-line and verified. Findings: 2× S125 (commented-out code — both were prose
+  comments ending in a stray semicolon, which Sonar's heuristic mistakes for
+  commented-out code, in `HttpRouter.java` and `KafkaFlowConsumer.java`) + 3× S3776
+  (Cognitive Complexity >15 in `InboxBase.recordTrace`, `AsyncHttpResponse.handleEvent`,
+  `AsyncHttpClient.updateHttpHeaders` — fixed via helper-method extraction / guard-clause
+  early returns, confirmed behavior-preserving). **Verification:** full reactor
+  `mvn clean install` (29 modules) BUILD SUCCESS; live Java-to-Java Event-over-HTTP
+  interop drive (composable-example ⇄ lambda-example, both declarative + programmatic
+  patterns) as a targeted regression test of the three refactored trace/cid-propagation
+  classes — 17 span records, zero duplicates, zero dangling `parent_span_id`s, correct
+  cross-process span parenting in both patterns (programmatic pattern's non-adoption of a
+  foreign span confirmed consistent with the I2 fix behavior in
+  [[thread-event-envelope-interop]]). **Remaining:** no release/tag yet — this fix ships
+  whenever the next patch version is cut; close this thread when a version is tagged and
+  the field rescan confirms the gate passes (precedent:
   [[thread-sonar-4-9-1-field-rejection]]).
   <!-- id: thread-sonar-4-10-4-field-rejection | created: 2026-07-25 | last_used: 2026-07-25 | uses: 1 | tier: working | origin: 2026-07-25-005125 -->
 

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -13,7 +13,7 @@ readers to it (docs/README references were removed 2026-07-20).
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.5`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.6`)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-25-005125.md
+++ b/memory/sessions/2026-07-25-005125.md
@@ -49,6 +49,20 @@ pure-logic extraction.
 from v4.10.4 field scan", body drafted by Claude Code (What/Why/Test-plan, dual
 Co-Authored-By: GitHub Copilot + Claude Code).
 
+**Also (same working session): PR #231 MERGED** to main by Eric via the GitHub UI,
+merge commit `c7d05d83` — CI confirmed green before merge (Build & Unit Tests 7m1s +
+memory ×2 + verify, all pass). No version tag cut yet; `thread-sonar-4-10-4-field-rejection`
+stays open until a release ships this fix and the field rescan confirms the gate passes.
+
+**Also (same working session): v4.10.6 release prep started** on branch
+`chore/release-4.10.6` (Eric's instruction) to ship the PR #231 fix. Version sweep 32
+poms + `CLAUDE.md`/`GEMINI.md`/`memory/instructions.md` coordinates (4.10.5→4.10.6, digit
+lookahead confirmed safe — no `4.10.5x` substring collision found); CHANGELOG entry
+following the v4.9.2 pure-Sonar-remediation precedent structure. Full reactor
+`mvn clean install` (29 modules) BUILD SUCCESS on the bumped version (4m51s). Commit
+`0e1660f5` on the release branch; not yet pushed, PR not yet opened — awaiting Eric's
+go-ahead per the established gate (Eric opens PRs via the GitHub UI).
+
 ## Memory References
 
 - Referenced: [[thread-event-envelope-interop]] (I2 fix precedent used to interpret the

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.10.5</version>
+    <version>4.10.6</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.10.5</version>
+            <version>4.10.6</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version bump 4.10.5 → 4.10.6 to ship [PR #231](https://github.com/Accenture/mercury-composable/pull/231)'s SonarQube quality-gate remediation (2× S125 commented-out-code, 3× S3776 cognitive-complexity findings — all behavior-preserving refactors, no functional change). Sweep: 32 `pom.xml` files, `CLAUDE.md`, `GEMINI.md`, `memory/instructions.md` coordinates, plus a `CHANGELOG.md` entry.

## Why

v4.10.4 failed the field DevSecOps Sonar quality gate (0 blocker/critical/major across the whole codebase, not just new code). The fix already merged to `main` via #231; this patch release ships it to the field for rescan.

## Test plan

- [x] Full reactor `mvn clean install` (29 modules) — **BUILD SUCCESS** on the bumped version (4m51s), all tests green.
- [x] Version-string sweep verified complete (32/32 poms) with no `4.10.5x`-style substring collision.
- [x] The underlying fix was already regression-tested in #231 via a live Java-to-Java Event-over-HTTP interop drive (both declarative and programmatic calling patterns) — 17 span records, zero duplicate spans, zero dangling `parent_span_id`s, confirming distributed-trace and business correlation-id propagation are unchanged by the refactored code.

Co-Authored-By: Claude Code <noreply@anthropic.com>