### PR TITLE
Fix/otel scope version + refactor: eliminate version literals outside the poms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mercury-composable — Claude Code
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.6) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury`) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mercury-composable — Gemini CLI
 
-Event-driven Java framework (Maven reactor, `com.accenture.mercury` v4.10.6) — self-contained functions wired by YAML event flows.
+Event-driven Java framework (Maven reactor, `com.accenture.mercury`) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Read [`AGENTS.md`](./AGENTS.md)
 first** — it is the hub: it carries the memory protocol and what to read under `memory/`.

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +44,6 @@ public class OtelForwarderContext {
     private static final Logger log = LoggerFactory.getLogger(OtelForwarderContext.class);
 
     public static final String INSTRUMENTATION_NAME = "org.platformlambda.opentelemetry-forwarder";
-    // OTLP instrumentation-scope version — keep in step with the module/release version.
-    private static final String VERSION = "4.9.2";
     private static final String SERVICE_NAME_KEY = "service.name";
 
     private final boolean enabled;
@@ -56,7 +55,12 @@ public class OtelForwarderContext {
         this.enabled = enabled;
         this.exporter = exporter;
         this.resource = Resource.create(Attributes.builder().put(SERVICE_NAME_KEY, serviceName).build());
-        this.scope = InstrumentationScopeInfo.builder(INSTRUMENTATION_NAME).setVersion(VERSION).build();
+        // The instrumentation-scope version is resolved at runtime from the running application
+        // (jar manifest, else the info.app.version parameter), so it can never go stale the way
+        // a hard-coded constant did across releases.
+        var util = Utility.getInstance();
+        this.scope = InstrumentationScopeInfo.builder(INSTRUMENTATION_NAME)
+                                             .setVersion(util.getVersion()).build();
     }
 
     public boolean isEnabled() {

--- a/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/OpenTelemetryForwarderTest.java
+++ b/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/OpenTelemetryForwarderTest.java
@@ -21,6 +21,7 @@ package org.platformlambda.opentelemetry;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.Test;
+import org.platformlambda.core.util.Utility;
 import org.platformlambda.opentelemetry.support.OtelForwarderContext;
 
 import java.util.HashMap;
@@ -62,6 +63,21 @@ class OpenTelemetryForwarderTest {
     void contextReportsEnabledFlag() {
         assertTrue(new OtelForwarderContext(true, InMemorySpanExporter.create(), "x").isEnabled());
         assertFalse(new OtelForwarderContext(false, null, "x").isEnabled());
+    }
+
+    @Test
+    void instrumentationScopeVersionTracksTheRunningApplication() {
+        // the scope version is resolved at runtime (jar manifest, else info.app.version) instead of
+        // a hard-coded constant, so it can never go stale across releases - this pins the contract
+        InMemorySpanExporter mem = InMemorySpanExporter.create();
+        new OtelForwarderContext(true, mem, "x").forward(dataset());
+        List<SpanData> spans = mem.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+        var scope = spans.getFirst().getInstrumentationScopeInfo();
+        assertEquals(OtelForwarderContext.INSTRUMENTATION_NAME, scope.getName());
+        assertEquals(Utility.getInstance().getVersion(), scope.getVersion());
+        assertNotNull(scope.getVersion());
+        assertFalse(scope.getVersion().isBlank());
     }
 
     @Test

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -13,7 +13,7 @@ readers to it (docs/README references were removed 2026-07-20).
 
 **Type:** Multi-module framework / SDK (Maven reactor)
 **Primary language:** Java 21 (one Kotlin example module)
-**Coordinates:** `com.accenture.mercury:parent-mercury` (currently `4.10.6`)
+**Coordinates:** `com.accenture.mercury:parent-mercury` (version: root `pom.xml` is the source of truth)
 **Build:** Maven 3.9.7+ — `pom.xml` source of truth for the version
 **Upstream:** github.com/Accenture/mercury-composable · docs: accenture.github.io/mercury-composable
 

--- a/memory/sessions/2026-07-24-154543.md
+++ b/memory/sessions/2026-07-24-154543.md
@@ -172,11 +172,22 @@ lagged — resumed on retry); (2) EMU accounts cannot create PRs via API AT ALL 
 createPullRequest AND REST pulls both 403) — the web UI is the only PR-creation path;
 prepared PR bodies as /tmp files + pbcopy for fast web-form paste.
 
+**Also: OtelForwarderContext hard-coded VERSION removed (Eric's enhancement, branch
+fix/otel-scope-version).** The instrumentation-scope version is now resolved at runtime via
+Utility.getVersion() (app jar manifest → info.app.version → "1.0.0") instead of a constant
+that release sweeps never touched — closing the wart first flagged at v4.6.1 (constant then
+read 4.5.0; it sat at 4.9.2 while the codebase reached 4.10.5). Clarification recorded:
+util.getVersion() returns the HOST APPLICATION's version (not platform-core's) — for in-repo
+apps it equals the reactor version; for field apps it reports their app version, matching
+/info's identity semantics. New regression instrumentationScopeVersionTracksTheRunningApplication
+pins the contract (asserts equality with util.getVersion(), no literal). Module 23/23 green.
+
 ## Memory References
 
 - referenced: thread-field-trace-propagation-4-6-3, field-trace-propagation-4-6-3-diagnosis,
   conv-telemetry-presentation-parity, release-4-8-0-shipped (header-precedence facts),
-  release-4-8-2-shipped (impedance-matching pattern)
+  release-4-8-2-shipped (impedance-matching pattern), release-4.6.1-security-patch (the
+  original VERSION-constant flag, now resolved)
 - created: thread-traceparent-header-config, thread-release-4-10-4, thread-release-4-10-5
 
 Co-Authored-By: Claude Code <noreply@anthropic.com>


### PR DESCRIPTION
## What

Two commits removing every framework-version literal that lived outside the Maven poms:

1. **OtelForwarderContext resolves the instrumentation-scope version at runtime.** The
   hard-coded `VERSION` constant is removed; the constructor now builds the OTLP
   instrumentation scope with `Utility.getInstance().getVersion()` (the running
   application's jar manifest `Implementation-Version`, else the `info.app.version`
   parameter). A new regression —
   `instrumentationScopeVersionTracksTheRunningApplication` — pins the contract by
   asserting the exported span's scope version equals the runtime value rather than any
   literal. Module suite 23/23 green.
2. **CLAUDE.md / GEMINI.md / memory/instructions.md no longer carry the version.** The
   repo-meta line reads the coordinates without a version, and instructions.md points at
   the root pom as the source of truth.

## Why

Version literals outside the poms drift. The release sweep only touches pom.xml files,
so the OTel scope constant was flagged reading `4.5.0` back at v4.6.1, was manually
corrected to `4.9.2`, and had silently drifted again while the codebase reached 4.10.6 —
a hard-coded version is stale by construction. Resolving it at runtime makes the scope
version follow the running application forever, and removing the markdown literals
shrinks the release-sweep surface to exactly the 32 poms — nothing left to forget.

Co-Authored-By: Claude Code <noreply@anthropic.com>