### PR TITLE
fix(core): registration conflict policy documented truthfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Fixed
+
+1. **Registration conflict policy documented truthfully (annotation-macro consistency
+   round, in lock-step with the Rust engine).** `Platform.register` / `registerPrivate`
+   javadoc claimed an `IllegalArgumentException` on duplicated registration; the actual
+   (and long-standing) behavior is a warn-and-reload — the existing function is released
+   and the new one takes its place. The javadoc now states the reload semantics. The
+   minigraph `PlaygroundLoader` also gains the same duplicate-name warning that
+   `SimplePluginLoader` already emits, so every registry reports duplicates consistently:
+   WARN + last-wins.
+
+---
 ## Version 4.10.6, 7/24/2026
 
 Code-quality patch release: resolves all 5 SonarQube findings reported by an enterprise

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -334,6 +334,31 @@
 
 ## Open Threads
 
+- [ ] (feature in flight — 2026-07-25) **Annotation → macro consistency arc (Eric's
+  initiative; design RATIFIED — see session 2026-07-25-235904 + the full spec at
+  draft-design-specs/annotation-macro-interop-design.md).** Goals: (1) Rust macro surface
+  reads like the Java annotation surface (decoupled; runtime classpath scan vs link-time
+  inventory is mechanics, not style); (2) the Rust port becomes the best-practice template
+  for future Python/Node ports. Verified ground truth: Java dogfoods its extension points
+  (47 @SimplePlugin built-ins, 2 @FetchFeature built-ins) while Rust hard-codes all of them
+  with zero production macro usage; #[fetch_feature] can't accept optional_service; conflict
+  semantics diverge AND Java itself is inconsistent (Platform.register javadoc claims
+  throws-on-duplicate but warn+reloads; PlaygroundLoader replaces silently). Ratified:
+  D1 convert Rust built-ins to declarative macros (explicit names where camelCase
+  derivation mismatches/keyword-collides; exact Java error-message parity); D2 ONE conflict
+  policy both engines (explicit register() > declarative; duplicate = WARN both sources +
+  last-wins; Java lock-step javadoc/log fixes); D3a fetch_feature + stacked
+  #[optional_service] (Java parity); D3b DEFERRED with Eric's principle: **plugins are
+  Event Script capabilities (flow vocabulary) — never conditionally on/off**; D4 (P2) port
+  yaml.preload.override to Rust; D5 (P2) registration-metadata contract spec page (real
+  schema; golden-JSON conformance per the wire-format precedent) + ADR pair; D6 DEFERRED
+  executionHint:blocking. Kafka annotations (@CloudConnector/@CloudService) ride the future
+  minimalist-kafka/sync-over-async port. Bonus fixes: two stale Rust docs (syntax.md
+  single-route claim; api-overview public/private claim). Branches:
+  feature/annotation-macro-consistency both repos (Java = javadoc+WARN lock-step; Rust =
+  the refinement round, delegated).
+  <!-- id: thread-annotation-macro-consistency | created: 2026-07-25 | last_used: 2026-07-25 | uses: 1 | tier: working | origin: 2026-07-25-235904 -->
+
 - [ ] (field support — 2026-07-25; v4.10.6 SHIPPED, field rescan pending) **v4.10.4 failed
   the field Sonar quality gate — 5 findings, fix reviewed + verified, MERGED as
   [PR #231](https://github.com/Accenture/mercury-composable/pull/231) (merge commit

--- a/memory/sessions/2026-07-25-235904.md
+++ b/memory/sessions/2026-07-25-235904.md
@@ -1,0 +1,78 @@
+# Session (2026-07-25T23:59:04.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Annotation → macro consistency arc STARTED (Eric's initiative, design RATIFIED).** Eric
+supplied two deliberately context-free external reviews (Desktop:
+annotation-macro-fidelity-report-2026-07-25.md, preload-interop-blueprint.md) and asked to
+(1) make the Rust macro surface read like the Java annotation surface (decoupled,
+consistent style despite runtime-scan vs link-time mechanics) and (2) refine the Rust port
+as the best-practice template for future Python/Node ports. Kafka-facing annotations
+(@CloudConnector/@CloudService) explicitly deferred to the future minimalist-kafka /
+sync-over-async port iteration.
+
+**Investigation (8-agent survey, both repos, all claims file:line-verified):** the fidelity
+report's core findings CONFIRMED — Java dogfoods its extension points (all 47 built-in
+mapping plugins are @SimplePlugin classes; both built-in fetch features are @FetchFeature)
+while Rust hard-codes all 46 plugins + 2 features and its #[simple_plugin]/#[fetch_feature]
+macros have zero production usage; #[fetch_feature] cannot even accept an optional_service
+(compile error); conflict semantics diverge (Rust features skip/first-wins vs Java
+last-wins). The context-free reviewers MISSED: (a) Rust marker stacking already mirrors
+Java (#[zero_tracing]/#[event_interceptor]/#[optional_service] stack below #[preload]);
+(b) yaml.preload.override — Java's config-driven rename/fan-out/instances surface — is
+unported and unknown to both reports; (c) Java itself is internally inconsistent on
+conflicts (Platform.register javadoc CLAIMS throws-on-duplicate but actually
+warn+reloads — a doc bug; PlaygroundLoader replaces silently); (d) Java's
+SimplePluginLoader does NOT honor @OptionalService (only the FetchFeature loader does);
+(e) the blueprint's "Rust macros silently broken for customSerializer/inputPojoClass" is
+REFUTED — those 4 @PreLoad fields are intentionally absent + structurally inapplicable
+(serde/TypedFunction; inputPojoClass exists to defeat JVM type erasure); one honest
+residual: Java flips snake/camel at runtime, Rust can't without recompile. Bonus: two
+stale Rust docs found (syntax.md "single route" claim — comma aliases work; api-overview
+"no public/private" claim — is_private + /api/event 403 exist).
+
+**Design (draft-design-specs/annotation-macro-interop-design.md; decisions RATIFIED by
+Eric 2026-07-25):**
+- D1 YES: convert all 46 Rust built-in plugins to #[simple_plugin(name="...")] fns + both
+  fetch features to #[fetch_feature] structs; delete builtin_registrations()/
+  register_builtins(); startup count assertion. Explicit names required where camelCase
+  derivation mismatches (plugin_get_first → "pluginGetFirst" wrong) or Rust keywords
+  collide (mod, etc.); exact Java error-message parity preserved (twin tests).
+- D2 YES: ONE conflict policy both engines — explicit register() > declarative; duplicates
+  = WARN naming both sources + last-wins reload (Java Platform's actual behavior).
+  Java lock-step fixes: Platform.register/registerPrivate javadoc lie corrected;
+  PlaygroundLoader duplicate put gains the WARN.
+- D3a YES: #[fetch_feature] accepts stacked #[optional_service] (reuse the platform
+  strip/fold pattern), FetchFeatureEntry.optional_service, loader evaluates via
+  util::feature::is_required — Java-parity (PlaygroundLoader gates via Feature.isRequired).
+- D3b DEFER, with Eric's design principle recorded: **plugins are part of the Event
+  Script capabilities (flow-language vocabulary) — they are never conditionally on/off**;
+  the macro's purpose is decoupling + loader discovery only. (Also the deeper rationale:
+  plugin names are compile-time-validated flow vocabulary at seq 3 before CompileFlows
+  seq 5 — conditional vocabulary would break flow portability.)
+- D4 YES (P2): port yaml.preload.override to Rust (boot-time transform over PreloadEntry
+  set between inventory iteration and registration).
+- D5 YES (P2): publish the registration-metadata contract (real schema replacing the
+  blueprint's placeholders) as a spec page in the Java repo (reference) + Rust adaptation;
+  golden-JSON conformance fixture (the envelope-wire-format golden-vector method); propose
+  ADR pair "registration metadata is a cross-language contract; carriers are per-language
+  idioms" (Java ADR-0009 / Rust ADR-0008).
+- D6 DEFER: executionHint:blocking (KernelThreadRunner analog) reserved in the contract,
+  unimplemented.
+- Ports insight for goal 2: Rust's free-fn plugin shape is the better template for
+  Python/Node than Java's class+interface (decorator-on-function is their idiom); the
+  portable part is the name-derivation rule.
+
+**Execution:** Java-side small lock-step fixes (javadoc + PlaygroundLoader warn) by
+Claude Code on branch feature/annotation-macro-consistency; Rust refinement round
+(D1/D2/D3a + stale docs) delegated to the Rust agent session on the same-named branch.
+
+## Memory References
+
+- referenced: conv-telemetry-presentation-parity (the lock-step/reference-implementation
+  contract extends to the macro surface), event-script-over-code, release-4-8-1-shipped
+  (flow-authoring conventions), thread-event-envelope-interop (golden-vector conformance
+  precedent, future-ports playbook)
+- created: thread-annotation-macro-consistency

--- a/memory/sessions/2026-07-25-235904.md
+++ b/memory/sessions/2026-07-25-235904.md
@@ -69,6 +69,32 @@ Eric 2026-07-25):**
 Claude Code on branch feature/annotation-macro-consistency; Rust refinement round
 (D1/D2/D3a + stale docs) delegated to the Rust agent session on the same-named branch.
 
+**Round COMPLETE (three mid-round refinements ratified by Eric during review):**
+(1) **Positional #[simple_plugin("name")] grammar** added (mirrors #[fetch_feature]'s
+parse structure; name= stays as alias; no-arg keeps derivation), all 46 built-ins
+flipped — one visual grammar across both extension points; contract rule for
+Python/Node: "the string is the registered name; omit it to derive from the declaration".
+Root of the original asymmetry: Java @FetchFeature carries a required String value()
+(positional) while @SimplePlugin is a bare marker whose name lives in getName() — the
+Rust macro arg is the getName()-override analog. (2) **Order-insensitive marker
+stacking** — Eric: "Java does not require stack order of annotations"; #[zero_tracing]/
+#[event_interceptor] became real proc-macros using the #[optional_service]
+self-reattachment pattern, so markers stack above or below #[preload] exactly like Java;
+no-primary = compile error pointing at the inline equivalent. Contract rule: carriers
+must preserve Java's order-freedom — where a mechanism is order-sensitive by nature
+(Rust outside-in expansion; Python bottom-up decorators), the port owes the engineering
+to hide it. (3) **trybuild compile-fail guards** (Eric upgraded from P2 to this round):
+11 fixtures in 3 tests/ui suites hosted in the RUNTIME crates (no dev-dep cycles),
+covering every deliberate macro compile error incl. fetch_feature rejecting inline
+optional_service (the D3a boundary as an executable guard); repo pins no toolchain →
+.stderr files track stable, TRYBUILD=overwrite regeneration documented. Template lesson
+recorded: a crate using its own proc-macro needs `extern crate self as <name>`.
+
+**Final state:** Rust ONE commit `3737a784` (51 files, +1416/−162; workspace 265 passed,
+clippy 0, fmt clean — commit surface verified before push). Java `ac45d8ab`
+(platform-core 422 + minigraph 72 green). Remaining P2: yaml.preload.override port (D4),
+registration-metadata contract page + golden conformance fixture + ADR pair (D5).
+
 ## Memory References
 
 - referenced: conv-telemetry-presentation-parity (the lock-step/reference-implementation

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/start/PlaygroundLoader.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/start/PlaygroundLoader.java
@@ -69,6 +69,10 @@ public class PlaygroundLoader implements EntryPoint {
                     Class<?> featureClass = Class.forName(info.getName());
                     Object o = featureClass.getDeclaredConstructor().newInstance();
                     if (o instanceof FeatureRunner runner) {
+                        if (features.containsKey(feature.value())) {
+                            log.warn("Reloading FetchFeature {} - please check duplicated feature name",
+                                        feature.value());
+                        }
                         features.put(feature.value(), new FeatureDef(runner));
                         log.info("Class {} loaded as API fetcher feature {}", o.getClass().getName(), feature.value());
                     } else {

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -375,11 +375,14 @@ public class Platform {
     /**
      * Register a public lambda function with one or more concurrent instances.
      * Its routing path will be published to the global service registry.
+     * <p>
+     * Registering a route that already exists RELOADS it: the existing function is
+     * released and the new one takes its place, with a warning in the application log.
      *
      * @param route path
      * @param lambda function must be written in Java that implements the TypedLambdaFunction interface
      * @param instances for concurrent processing of events
-     * @throws IllegalArgumentException in case of duplicated registration
+     * @throws IllegalArgumentException in case of routing error
      */
     public void register(String route, TypedLambdaFunction<?, ?> lambda, int instances) {
         register(route, lambda, false, instances);
@@ -389,11 +392,14 @@ public class Platform {
      * Register a private lambda function with one or more concurrent instances.
      * Private function is only visible within a single execution unit.
      * Its routing path will not be published to the global service registry.
+     * <p>
+     * Registering a route that already exists RELOADS it: the existing function is
+     * released and the new one takes its place, with a warning in the application log.
      *
      * @param route path
      * @param lambda function must be written in Java that implements the TypedLambdaFunction interface
      * @param instances for concurrent processing of events
-     * @throws IllegalArgumentException in case of duplicated registration
+     * @throws IllegalArgumentException in case of routing error
      */
     public void registerPrivate(String route, TypedLambdaFunction<?, ?> lambda, int instances) {
         register(route, lambda, true, instances);


### PR DESCRIPTION
## What

The Java half of the annotation → macro consistency arc (lock-step with the Rust
engine's branch of the same name):

- `Platform.register` / `registerPrivate` javadoc corrected: it claimed an
  `IllegalArgumentException` on duplicated registration, while the long-standing
  behavior is warn-and-reload — the existing function is released and the new one
  takes its place. The javadoc now states the reload semantics.
- The minigraph `PlaygroundLoader` gains the same duplicate-name warning that
  `SimplePluginLoader` already emits, so every registry reports duplicates
  consistently: WARN + last-wins.

No behavior changes beyond the new warning line. platform-core 422 tests and
minigraph-playground-engine 72 tests green.

## Why

An external annotation-fidelity review (deliberately run without project context, then
verified line-by-line against both codebases) surfaced that the two engines' registration
conflict semantics diverged — and that Java itself was internally inconsistent, with the
Platform javadoc contradicting its own implementation. The ratified cross-engine rule is
one policy everywhere: explicit registration wins over declarative, and a duplicate name
is warned and reloaded (last-wins). This PR makes the Java reference say what it does;
the Rust PR makes its registries do the same.

Co-Authored-By: Claude Code <noreply@anthropic.com>