### PR TITLE
feat(docs): the registration-metadata contract + golden conformance vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## Unreleased
 
+### Added
+
+1. **Registration Metadata Contract (annotation-macro consistency arc, P2).** A new
+   reference page — `docs/guides/registration-metadata-contract.md` — fixes the
+   cross-language contract behind `@PreLoad` and its family: one canonical metadata model
+   with fixed semantics (boot-time resolution, optional-service grammar, order-free marker
+   stacking, one conflict policy, extension-point naming rules, the boot sequence and
+   loud-failure discovery), carried by per-language idioms. Conformance is proven by
+   **golden vectors shared verbatim** between engine repositories
+   (`registration-vectors/core.json`, `plugin.json`, `feature.json`) with a conformance
+   test per kind — the same golden-vector method that guards the event envelope wire
+   format. Formalized as ADR-0009.
+
 ### Fixed
 
 1. **Registration conflict policy documented truthfully (annotation-macro consistency

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -22,6 +22,61 @@ in that ADR's own *Rationale* section.
 
 ---
 
+## ADR-0009 — Registration metadata is a cross-language contract; carriers are per-language idioms {#adr-0009}
+**Status:** Accepted · **Date:** 2026-07-26T01:40:00.000Z · **Serves:** vision-mercury-composable · **Formalizes:** registration-metadata-contract
+<!-- id: adr-0009 | status: accepted -->
+
+**Abstract.** Declarative registration — `@PreLoad` and its family (entry points, websocket
+services, Event Script plugins, graph fetch features) — is governed by **one canonical
+metadata model with fixed semantics**, specified in
+`docs/guides/registration-metadata-contract.md` and proven by **golden vectors shared
+verbatim** between engine repositories. How each language *carries* the metadata is an
+idiom — Java annotations discovered by runtime classpath scan, Rust attribute macros
+collected by link-time inventory, Python/Node decorators discovered by explicit
+package/module walks — but the model and its semantics are the contract: attach at
+definition / resolve at boot (`envInstances`); the `OptionalService` condition grammar;
+order-free marker stacking; one conflict policy (explicit wins over declarative;
+duplicates WARN + last-wins); extension-point naming (an explicit positional name, or
+derivation from the declaration such that idiomatic declarations in every language yield
+the same registered name); plugins are Event Script capabilities (flow vocabulary) and are
+never conditionally gated, while features honor gating; the boot sequence
+(discover → register → override → resolve → validate → route table); explicit
+loud-failure discovery; and misuse as a first-class, tested error surface.
+
+**Rationale.** The Rust port's first annotation pass proved that porting the *mechanism*
+without fixing the *semantics* produces drift invisible to any single repository: built-ins
+bypassing the extension points they exemplify, conflict policies diverging (skip-first-wins
+vs last-wins), gating support absent where the reference has it, and an attribute
+stack-order requirement Java never had. Each was individually small; together they meant a
+developer — or an AI agent — could not transfer knowledge between engines, and every future
+port would re-diverge independently. The same problem was already solved once for the wire
+format (ADR-referenced spec + golden vectors, v4.10.0): fixing the contract in a
+language-neutral artifact with executable conformance is what made the four-way interop
+matrix provable. This ADR applies that method to the declaration surface. The maintainer's
+two governing directives are part of the decision: developers must see **consistent,
+decoupled** registration in every language, and the Rust port is the **best-practice
+template** for the Python and Node ports.
+
+**Alternatives.** (a) *Per-port judgment calls documented in each repo* — rejected: that is
+the drift this ADR eliminates; N-of-1 documentation cannot be conformance-tested.
+(b) *A shared runtime registry service* (as the original external blueprint's open item
+suggested for multi-process parity) — rejected: registration is process-local by design in
+a self-contained composable application; cross-process discovery is the service mesh's
+concern and stays opt-in. (c) *Exporting the full live registry for byte comparison* —
+rejected in favor of a fixed fixture set: engines legitimately differ in framework
+built-ins (no Spring in Rust, no Kafka mesh), so whole-registry comparison would pin
+incidental surface, not contract.
+
+**Consequences.** New ports implement the carrier idiomatically, then pass the three
+golden-vector suites (`registration-vectors/core.json`, `plugin.json`, `feature.json`)
+before their declaration surface is considered done; every capability field a port cannot
+honor is documented as N/A where developers would meet it, never silently dropped. The
+engines accept a small ongoing cost: vector files are maintained verbatim in every
+repository, and semantic changes to registration must update the contract page, the
+vectors, and all engines in lock-step — which is precisely the point.
+
+---
+
 ## ADR-0008 — Synchronous AI-companion endpoint: in-band command outcome + live tee {#adr-0008}
 **Status:** Accepted · **Date:** 2026-07-18T18:13:53.000Z · **Serves:** vision-mercury-composable
 <!-- id: adr-0008 | status: accepted -->

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -954,6 +954,14 @@ Arguments can be model variables, constant types, or nested plugin calls.
 | `f:substring(str, start, end)` | Substring range | `f:substring(model.text, int(0), int(5)) -> head` |
 | `f:length(a)` | Length of string or list | `f:length(model.items) -> count` |
 
+> **Cross-engine note (portable flows):** string length and substring indexes count
+> UTF-16 code units in this Java engine (`String.length()` — a JVM legacy) and **Unicode
+> scalar values** in the Rust engine and future ports (the
+> [contract rule](registration-metadata-contract.md#capabilities)). Identical for all
+> Basic-Multilingual-Plane text — English, Chinese, JSON keys, typical enterprise
+> payloads; only supplementary-plane characters (e.g. emoji) differ: 2 code units here,
+> 1 scalar value in the ports.
+
 ### Collection operations
 
 | Function | Description | Example |

--- a/docs/guides/registration-metadata-contract.md
+++ b/docs/guides/registration-metadata-contract.md
@@ -1,0 +1,181 @@
+---
+title: Registration Metadata Contract
+summary: The cross-language contract behind @PreLoad and its family - one metadata model with fixed semantics, carried by per-language idioms (Java annotations, Rust macros, future Python/Node decorators) and proven by shared golden vectors.
+layer: reference
+audience: [developer, ai-agent, porter]
+keywords: [annotations, macros, decorators, preload, registration, interop, port, conformance]
+---
+
+# Registration Metadata Contract
+
+> **At a glance** — Functions, entry points, websocket services, Event Script plugins and
+> graph fetch features all register **declaratively**: metadata attached at the definition
+> site, discovered and resolved by the engine at boot. This page fixes the metadata model
+> and its semantics **across languages**. How each language attaches the metadata —
+> a Java annotation, a Rust attribute macro, a Python or TypeScript decorator — is an
+> idiom; everything else on this page is the contract, and the
+> [golden vectors](#conformance) prove an engine honors it.
+
+The Java engine is the reference implementation; the
+[Annotations Reference](annotations-reference.md) documents its carrier surface in full.
+The Rust engine implements this contract today (its
+[Macros Reference](https://accenture.github.io/mercury/guides/macros-reference/) is the
+carrier twin of the annotations page). Python and Node.js ports implement it next.
+
+## One model, many carriers {#model}
+
+The same declaration in the four languages:
+
+```java
+// Java - runtime classpath scan
+@PreLoad(route = "hello.world", instances = 10)
+public class HelloWorld implements TypedLambdaFunction<Map<String, Object>, Object> { ... }
+```
+
+```rust
+// Rust - link-time inventory
+#[preload(route = "hello.world", instances = 10, typed)]
+struct HelloWorld;   // + impl TypedFunction<I, O>
+```
+
+```python
+# Python (future) - decorator + explicit package walk
+@pre_load(route="hello.world", instances=10)
+class HelloWorld(TypedLambdaFunction): ...
+```
+
+```typescript
+// Node/TypeScript (future) - decorator + explicit module glob
+@PreLoad({ route: "hello.world", instances: 10 })
+class HelloWorld implements TypedLambdaFunction<EventEnvelope, unknown> { ... }
+```
+
+The discovery mechanics differ by necessity — only the JVM scans a classpath at runtime —
+but the developer-visible style, the metadata model and the boot-time semantics must not.
+
+## The canonical metadata model {#schema}
+
+Every registration resolves to one canonical record. Wire form for tooling and
+conformance: JSON, camelCase keys, enums as strings (never ordinals).
+
+```json
+{
+  "kind": "function | websocket | entrypoint-before | entrypoint-main | plugin | feature",
+  "routes": ["array of route names - function kind; comma-separated aliases in the carrier"],
+  "name": "string - websocket / plugin / feature kinds",
+  "namespace": "string - websocket kind, default \"ws\"",
+  "sequence": "integer - entrypoint kinds, default 10 (0 is framework-reserved)",
+  "declaredInstances": "integer, default 1",
+  "envInstances": "string configuration KEY, default \"\" - carried for audit",
+  "resolvedInstances": "integer - the boot-resolved effective value, clamped 1..1000",
+  "isPrivate": "boolean, default true",
+  "zeroTracing": "boolean marker, default false",
+  "eventInterceptor": "boolean marker, default false",
+  "optionalService": "string | null - an OR-list of key, !key, key=value conditions"
+}
+```
+
+### Capability fields (per-language applicability) {#capabilities}
+
+Some Java `@PreLoad` fields are capabilities of a runtime family, not universal contract:
+
+| Field | Java | Rust | Python / Node guidance |
+|---|---|---|---|
+| `customSerializer` | runtime ObjectMapper swap per route | **N/A** — serde is the single compile-time serializer; per-type attributes cover the use cases | applicable — both have runtime serialization hooks; carry as a type-name string |
+| `inputPojoClass` | defeats JVM type erasure; enables `List<PoJo>` | **N/A** — `TypedFunction<I, O>` is monomorphized; `body_as::<Vec<T>>()` carries the element type | Python: type hints suffice; Node: applicable as a class reference |
+| `inputStrategy` / `outputStrategy` | SNAKE / CAMEL / DEFAULT, flippable at runtime (`snake.case.serialization`) | **N/A at runtime** — `#[serde(rename_all)]` fixes case at compile time (the one genuine capability difference) | applicable — runtime case mapping is natural in both |
+| `executionHint` (reserved) | `@KernelThreadRunner` → kernel thread pool | reserved, unimplemented — every function is a tokio task; revisit if a field workload needs `spawn_blocking` | Python: relevant (GIL / thread pool); Node: worker_threads — design when porting |
+
+A port documents each N/A explicitly (the Rust docs' `!!! note "Rust port"` convention);
+silence is not a disposition.
+
+## Fixed semantics — every port MUST {#semantics}
+
+1. **Attach at definition, resolve at boot.** `envInstances` names a configuration KEY
+   (which may itself hold `${ENV_VAR:default}`); the value is read at framework boot —
+   never at decoration, macro-expansion or import time. A numeric value wins; anything
+   else falls back to `declaredInstances`. Effective instances clamp to 1..1000.
+2. **Optional-service grammar** is exactly the Java `Feature` evaluator: comma-separated
+   conditions are OR-ed; `!` negates; `key=value` matches case-insensitively; a bare
+   `key` means `key=true`; no annotation means always required. Evaluated at boot against
+   the application configuration; a false condition skips registration with a
+   "Skip optional" log line.
+3. **Marker stacking is order-free.** `@ZeroTracing` / `@EventInterceptor` /
+   `@OptionalService` combine with the primary annotation in any order, as Java
+   annotations always have. Where a language's mechanism is order-sensitive by nature
+   (Rust attribute macros expand outside-in; Python decorators apply bottom-up), the port
+   owes the engineering to hide it — the Rust engine's markers re-attach themselves so
+   either order works.
+4. **One conflict policy.** Explicit programmatic registration wins over declarative
+   (it runs later and replaces). Within any registry, a duplicate name is a WARNING
+   ("Reloading ... please check duplicated ... name") and the later registration wins —
+   never a silent replace, never an error. Registration order among declaratively
+   discovered items is not guaranteed (classpath scan order, link order, import order);
+   do not rely on it.
+5. **Extension-point naming.** A plugin or feature name is the positional string on the
+   carrier — `@FetchFeature("log-request-headers")`, `#[simple_plugin("getFirst")]`,
+   `@simple_plugin("getFirst")`. For plugins only, omitting the name derives it from the
+   declaration: Java lowercases the first letter of the class simple name; Rust
+   camelCases the snake_case fn name — **idiomatic declarations in every language yield
+   the same registered name**. Plugins are Event Script capabilities (flow vocabulary):
+   they take no optional-service gating and are never conditionally on/off. Features are
+   runtime behaviors: they honor optional-service gating.
+6. **Boot sequence**: discover → register → **override** (`yaml.preload.override`:
+   configuration-driven route rename / fan-out / instance re-tuning, applied to the
+   collected function set before registration) → resolve (`envInstances`) → validate
+   (route uniqueness warnings, non-empty registries where built-ins are expected) →
+   route table. Lifecycle anchors: plugins load before flow compilation; features load
+   before graph execution; entry points run in ascending sequence with 0 reserved for
+   the framework.
+7. **Discovery is explicit and fails loudly.** Java: classpath scan over the base
+   packages plus `web.component.scan` (free). Rust: link-time `inventory` collection —
+   plus a startup assertion on expected built-in counts, because a crate that is never
+   linked contributes nothing, silently. Python: a package walk (`pkgutil.walk_packages`)
+   importing every module under the services packages **before** resolution — an
+   unimported module's decorator never runs. Node: a directory glob + dynamic `import()`
+   with the same failure mode. Both future ports must fail loudly on an empty registry
+   that should not be empty.
+8. **Misuse is a first-class contract.** Invalid declarations fail at the earliest
+   possible stage with a helpful message — unknown parameters name the valid set, a
+   marker without a primary points at the correct form. Where the failure is
+   compile-time (Rust), compile-fail tests guard the messages (`trybuild`); where it is
+   import/boot-time (Java, Python, Node), unit tests do.
+
+## Conformance — the golden vectors {#conformance}
+
+The contract is proven the same way the
+[event envelope wire format](event-envelope-wire-format.md) is: **golden vectors shared
+verbatim between repositories**. Three files, one per metadata-rich kind:
+
+| Vectors file | Kind | Java module | Rust crate |
+|---|---|---|---|
+| `registration-vectors/core.json` | function | platform-core | platform-core |
+| `registration-vectors/plugin.json` | plugin | event-script-engine | event-script |
+| `registration-vectors/feature.json` | feature | minigraph-playground-engine | knowledge-graph |
+
+Each engine declares the same small fixture set through **its own carrier** (annotation /
+macro / decorator), boots, and asserts that the resolved registrations match the golden
+entries exactly — including boot-time `envInstances` resolution against the vectors'
+`assumedConfig`, marker effects, name derivation, and the **absence** of every `gatedOut`
+fixture. A new port passes the contract when all three vector suites pass against files
+byte-identical to these.
+
+The websocket and entry-point kinds carry little metadata beyond a name/namespace or a
+sequence; they are pinned by each engine's own registration tests rather than shared
+vectors.
+
+## Porting order (the playbook) {#porting}
+
+For a new language port, in order: (1) implement the carrier + local registry + boot
+resolver for the function kind; (2) pass `core.json`; (3) add the extension points and
+pass `plugin.json` / `feature.json`; (4) document every capability-field disposition and
+intentionally unported carrier; (5) adopt the discovery-failure assertions. The
+[future-ports playbook](../test-reports/event-over-http-interop.md) covers the runtime
+side (wire format, telemetry parity) — this page covers the declaration side; together
+they are the port-acceptance bar.
+
+## See also
+
+- [Annotations Reference](annotations-reference.md) — the Java carrier surface (source of truth)
+- [Event Envelope Wire Format](event-envelope-wire-format.md) — the sibling contract + golden-vector precedent
+- ADR-0009 in `docs/arch-decisions/ADR.md` — the decision record behind this contract

--- a/docs/guides/registration-metadata-contract.md
+++ b/docs/guides/registration-metadata-contract.md
@@ -85,9 +85,14 @@ Some Java `@PreLoad` fields are capabilities of a runtime family, not universal 
 | `inputPojoClass` | defeats JVM type erasure; enables `List<PoJo>` | **N/A** — `TypedFunction<I, O>` is monomorphized; `body_as::<Vec<T>>()` carries the element type | Python: type hints suffice; Node: applicable as a class reference |
 | `inputStrategy` / `outputStrategy` | SNAKE / CAMEL / DEFAULT, flippable at runtime (`snake.case.serialization`) | **N/A at runtime** — `#[serde(rename_all)]` fixes case at compile time (the one genuine capability difference) | applicable — runtime case mapping is natural in both |
 | `executionHint` (reserved) | `@KernelThreadRunner` → kernel thread pool | reserved, unimplemented — every function is a tokio task; revisit if a field workload needs `spawn_blocking` | Python: relevant (GIL / thread pool); Node: worker_threads — design when porting |
+| string length/index semantics (plugin catalog: `length`, `substring`) | UTF-16 code units (`String.length()` — JVM legacy, retained) | **Unicode scalar values** (`chars()`) — the ports rule | Python `len()` and Go `RuneCountInString` are scalar-native; Node uses `[...str].length`, NOT the UTF-16 `.length` — never retrofit the JVM legacy |
 
 A port documents each N/A explicitly (the Rust docs' `!!! note "Rust port"` convention);
-silence is not a disposition.
+silence is not a disposition. The string-semantics row is a **bounded, deliberate
+divergence** (maintainer ruling, 2026-07-26): identical for all Basic-Multilingual-Plane
+text — English, Chinese, JSON keys, typical enterprise payloads — and differing only for
+supplementary-plane characters (emoji, historical scripts), which Java counts as 2 code
+units and every port counts as 1 scalar value.
 
 ## Fixed semantics — every port MUST {#semantics}
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -283,6 +283,19 @@
   <!-- id: event-script-over-code | created: 2026-06-27 | last_used: 2026-06-27 | uses: 1 | tier: core -->
 ## Conventions
 
+- **Registration metadata is a cross-language contract; carriers are per-language idioms.
+  (ADR-0009)** One canonical model + fixed semantics for @PreLoad and family (boot-time
+  envInstances resolution; OptionalService OR/!/= grammar; order-free marker stacking; one
+  conflict policy — explicit > declarative, duplicates WARN + last-wins; extension-point
+  naming: explicit positional name or same-name derivation from idiomatic declarations;
+  plugins = flow vocabulary never gated, features honor gating; discover → register →
+  override → resolve → validate → route table; loud-failure discovery; misuse is a tested
+  error surface). Spec: docs/guides/registration-metadata-contract.md. Conformance:
+  golden vectors shared verbatim (registration-vectors/{core,plugin,feature}.json) — the
+  wire-format golden-vector method applied to the declaration surface. New ports pass the
+  three vector suites before their declaration surface is done.
+  <!-- id: registration-metadata-contract | created: 2026-07-26 | last_used: 2026-07-26 | uses: 1 | tier: working | origin: 2026-07-25-235904 -->
+
 - **Telemetry/log presentation parity across language engines is a field requirement (Eric,
   2026-07-23).** Rationale: even after the Rust engine is accepted into the field, installations
   will be POLYGLOT for a long time — DevSecOps teams see both engines' telemetry and logs in one

--- a/memory/sessions/2026-07-25-235904.md
+++ b/memory/sessions/2026-07-25-235904.md
@@ -95,6 +95,28 @@ clippy 0, fmt clean — commit surface verified before push). Java `ac45d8ab`
 (platform-core 422 + minigraph 72 green). Remaining P2: yaml.preload.override port (D4),
 registration-metadata contract page + golden conformance fixture + ADR pair (D5).
 
+**P1 MERGED both repos (Java #234 squash 265f295d; Rust #181) — P2 STARTED at Eric's
+direction (branch feature/registration-metadata-contract both repos).** D4 delegated to
+the Rust agent (yaml.preload.override port with Java's exact merge/application semantics).
+D5 Java reference half BUILT by Claude Code: (1) three golden-vector files —
+registration-vectors/{core,plugin,feature}.json in platform-core / event-script-engine /
+minigraph test resources, to be shared VERBATIM with every engine repo (the wire-format
+golden-vector method applied to the declaration surface); (2) seven conformance fixtures
+declared through the real Java carriers (VectorAliasFunction with comma aliases +
+envInstances; VectorMarkedFunction with stacked @ZeroTracing @EventInterceptor
+@OptionalService; VectorGatedOutFunction gated out; VectorEcho explicit plugin name;
+VectorDerived derived name; VectorFeature gated in; VectorFeatureOff gated out);
+(3) three RegistrationVectorsTest conformance suites — all green (hit and fixed the
+documented Gson Integer→Long map gotcha with util.str2int, per conv-serialization-gotchas;
+also cleared a stale ecj-compiled class in event-script target/ via clean build);
+(4) the spec page docs/guides/registration-metadata-contract.md (canonical model,
+capability matrix incl. executionHint reserved, 8 fixed semantics, conformance section,
+porting playbook) + mkdocs nav; (5) ADR-0009 "Registration metadata is a cross-language
+contract; carriers are per-language idioms" (formalizes: registration-metadata-contract
+Key Decision fact added to continuity with the (ADR-0009) tag); (6) CHANGELOG Unreleased
+Added entry. Next: hand the Rust agent the D5 half (verbatim vectors + adapted spec page +
+3 conformance suites + ADR-0008) once D4 lands.
+
 ## Memory References
 
 - referenced: conv-telemetry-presentation-parity (the lock-step/reference-implementation

--- a/memory/sessions/2026-07-25-235904.md
+++ b/memory/sessions/2026-07-25-235904.md
@@ -117,10 +117,24 @@ Key Decision fact added to continuity with the (ADR-0009) tag); (6) CHANGELOG Un
 Added entry. Next: hand the Rust agent the D5 half (verbatim vectors + adapted spec page +
 3 conformance suites + ADR-0008) once D4 lands.
 
+**Also (Eric's ruling, 2026-07-26): string plugins use Unicode SCALAR VALUES, not Java's
+UTF-16 — the JVM legacy is never retrofitted onto modern ports.** Found TWO retrofit sites
+in Rust (length + substring, the F20 parity round); the substring one was already leaky
+(surrogate-split → U+FFFD; Rust can't hold unpaired surrogates, so exact parity was
+structurally impossible). Precise semantic: code points, NOT UTF-8 bytes (你好 must be 2,
+never 6 — bytes would break the CJK case). Bounded divergence: BMP text identical
+(English/Chinese/JSON); supplementary-plane chars (emoji) = 2 in Java, 1 in ports. Ports
+rule in the contract capability matrix (Node steered to [...str].length, not its UTF-16
+.length); Java code UNCHANGED (documented legacy); cross-engine note added beside the
+f:length/f:substring entries in flow-schema-reference. Rust reverted with emoji + CJK
+test evidence, error messages verbatim-unchanged; supersession recorded at decision level
+(no live fact carried F20); anti-re-retrofit guard fact added in the Rust memory.
+
 ## Memory References
 
 - referenced: conv-telemetry-presentation-parity (the lock-step/reference-implementation
   contract extends to the macro surface), event-script-over-code, release-4-8-1-shipped
   (flow-authoring conventions), thread-event-envelope-interop (golden-vector conformance
-  precedent, future-ports playbook)
-- created: thread-annotation-macro-consistency
+  precedent, future-ports playbook), conv-serialization-gotchas (the Gson Integer→Long
+  gotcha hit by the conformance test)
+- created: thread-annotation-macro-consistency, registration-metadata-contract (ADR-0009)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
     - Configuration Reference: guides/configuration-reference.md
     - Event Envelope Reference: guides/event-envelope-reference.md
     - Event Envelope Wire Format: guides/event-envelope-wire-format.md
+    - Registration Metadata Contract: guides/registration-metadata-contract.md
     - Interop Test Report (Java ⇄ Rust): test-reports/event-over-http-interop.md
     - Reserved Names & Headers: guides/reserved-names-and-headers.md
     - Actuators & HTTP Client: guides/actuators-and-http-client.md

--- a/system/event-script-engine/src/test/java/com/accenture/automation/RegistrationVectorsTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/RegistrationVectorsTest.java
@@ -1,0 +1,66 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.automation;
+
+import com.accenture.setup.TestBase;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.serializers.SimpleMapper;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Registration-metadata conformance for the PLUGIN kind: the golden vectors in
+ * registration-vectors/plugin.json are shared verbatim with every engine repository. The name
+ * rules are the contract - VectorEcho registers under its EXPLICIT name and VectorDerived under
+ * the name DERIVED from its declaration, and idiomatic declarations in every language must yield
+ * the same registered names. See docs/guides/registration-metadata-contract.md.
+ */
+class RegistrationVectorsTest extends TestBase {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void pluginKindMatchesGoldenVectors() {
+        Utility util = Utility.getInstance();
+        InputStream in = this.getClass().getResourceAsStream("/registration-vectors/plugin.json");
+        assertNotNull(in, "golden vectors file must exist");
+        Map<String, Object> vectors = SimpleMapper.getInstance().getMapper()
+                .readValue(util.stream2str(in), Map.class);
+        List<Map<String, Object>> entries =
+                (List<Map<String, Object>>) new MultiLevelMap(vectors).getElement("entries");
+        assertEquals(2, entries.size(), "vector entry count");
+        for (Map<String, Object> expected : entries) {
+            String name = (String) expected.get("name");
+            assertTrue(SimplePluginLoader.containsSimplePlugin(name),
+                    name + " must be registered under exactly this name");
+        }
+        // the two fixtures pin both halves of the naming rule
+        assertEquals("vectorEcho", SimplePluginLoader.getSimplePluginByName("vectorEcho").getName(),
+                "explicit name wins");
+        assertEquals("vectorDerived", SimplePluginLoader.getSimplePluginByName("vectorDerived").getName(),
+                "derived name: Java lowercases the first letter of the class simple name");
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/service/VectorDerived.java
+++ b/system/event-script-engine/src/test/java/com/accenture/service/VectorDerived.java
@@ -1,0 +1,37 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.service;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/plugin.json):
+ * the DERIVED plugin name - Java lowercases the first letter of this class's simple name and the
+ * Rust carrier camelCases "fn vector_derived", so idiomatic declarations in both languages
+ * register the same "vectorDerived".
+ */
+@SimplePlugin
+public class VectorDerived implements PluginFunction {
+
+    @Override
+    public Object calculate(Object... input) {
+        return input == null ? 0 : input.length;
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/service/VectorEcho.java
+++ b/system/event-script-engine/src/test/java/com/accenture/service/VectorEcho.java
@@ -1,0 +1,44 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.service;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/plugin.json):
+ * the EXPLICIT plugin name wins over derivation - the Java carrier overrides getName(), the Rust
+ * carrier writes the positional string, and both register the same "vectorEcho".
+ */
+@SimplePlugin
+public class VectorEcho implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "vectorEcho";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        if (input == null || input.length != 1) {
+            throw new IllegalArgumentException("One input is required to echo");
+        }
+        return input[0];
+    }
+}

--- a/system/event-script-engine/src/test/resources/registration-vectors/plugin.json
+++ b/system/event-script-engine/src/test/resources/registration-vectors/plugin.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "description": "Golden registration-metadata vectors for the PLUGIN kind (Event Script f: functions). The name rules ARE the contract: an explicit name declared on the carrier wins; without one, the name derives from the declaration - Java lowercases the first letter of the class simple name, Rust camelCases the snake_case fn name, so idiomatic declarations in every language yield the SAME registered name. Plugins are Event Script capabilities (flow vocabulary): they carry no optional-service gating and are never conditionally on/off.",
+  "assumedConfig": {},
+  "entries": [
+    { "kind": "plugin", "name": "vectorDerived" },
+    { "kind": "plugin", "name": "vectorEcho" }
+  ]
+}

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/RegistrationVectorsTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/RegistrationVectorsTest.java
@@ -1,0 +1,77 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.features;
+
+import com.accenture.minigraph.start.PlaygroundLoader;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.serializers.SimpleMapper;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Registration-metadata conformance for the FEATURE kind: the golden vectors in
+ * registration-vectors/feature.json are shared verbatim with every engine repository. Feature
+ * names are explicit on the carrier and features honor optional-service gating - the gated-out
+ * fixture must be absent from the registry. See docs/guides/registration-metadata-contract.md.
+ */
+class RegistrationVectorsTest {
+
+    @BeforeAll
+    static void setup() {
+        AutoStart.main(new String[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void featureKindMatchesGoldenVectors() {
+        Utility util = Utility.getInstance();
+        InputStream in = this.getClass().getResourceAsStream("/registration-vectors/feature.json");
+        assertNotNull(in, "golden vectors file must exist");
+        Map<String, Object> vectors = SimpleMapper.getInstance().getMapper()
+                .readValue(util.stream2str(in), Map.class);
+        MultiLevelMap map = new MultiLevelMap(vectors);
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) map.getElement("entries");
+        assertEquals(1, entries.size(), "vector entry count");
+        for (Map<String, Object> expected : entries) {
+            String name = (String) expected.get("name");
+            assertNotNull(PlaygroundLoader.getFeature(name), name + " must be registered");
+        }
+        // the fixture's declared condition matches the vectors
+        OptionalService condition = VectorFeature.class.getAnnotation(OptionalService.class);
+        assertNotNull(condition);
+        assertEquals(entries.getFirst().get("optionalService"), condition.value());
+        // gated-out fixtures must never register
+        List<String> gatedOut = (List<String>) map.getElement("gatedOut");
+        for (String name : gatedOut) {
+            assertNull(PlaygroundLoader.getFeature(name),
+                    name + " carries a false optional-service condition and must not register");
+        }
+    }
+}

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/VectorFeature.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/VectorFeature.java
@@ -1,0 +1,47 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.features;
+
+import com.accenture.minigraph.annotations.FetchFeature;
+import com.accenture.minigraph.common.FeatureRunner;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.util.MultiLevelMap;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/feature.json):
+ * a fetch feature with an @OptionalService condition that evaluates true under the assumed
+ * configuration, so the feature registers.
+ */
+@FetchFeature("vector-feature")
+@OptionalService("vector.feature.on")
+public class VectorFeature implements FeatureRunner {
+
+    @Override
+    public boolean runBefore() {
+        return true;
+    }
+
+    @Override
+    public void execute(AsyncHttpRequest request, EventEnvelope response, MultiLevelMap stateMachine,
+                        String nodeName) {
+        // conformance fixture - no behavior required
+    }
+}

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/VectorFeatureOff.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/features/VectorFeatureOff.java
@@ -1,0 +1,47 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.features;
+
+import com.accenture.minigraph.annotations.FetchFeature;
+import com.accenture.minigraph.common.FeatureRunner;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.util.MultiLevelMap;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/feature.json):
+ * the negated @OptionalService condition evaluates FALSE under the assumed configuration, so this
+ * feature must never register - the golden vectors list it under "gatedOut".
+ */
+@FetchFeature("vector-feature-off")
+@OptionalService("!vector.feature.on")
+public class VectorFeatureOff implements FeatureRunner {
+
+    @Override
+    public boolean runBefore() {
+        return false;
+    }
+
+    @Override
+    public void execute(AsyncHttpRequest request, EventEnvelope response, MultiLevelMap stateMachine,
+                        String nodeName) {
+        // conformance fixture - no behavior required
+    }
+}

--- a/system/minigraph-playground-engine/src/test/resources/application.properties
+++ b/system/minigraph-playground-engine/src/test/resources/application.properties
@@ -88,3 +88,6 @@ graph.model.automation=classpath:/graphs.yaml
 # app.env={$ENV_NAME}
 #
 app.env=dev
+
+# registration-metadata conformance vectors (registration-vectors/feature.json assumedConfig)
+vector.feature.on=true

--- a/system/minigraph-playground-engine/src/test/resources/registration-vectors/feature.json
+++ b/system/minigraph-playground-engine/src/test/resources/registration-vectors/feature.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "description": "Golden registration-metadata vectors for the FEATURE kind (graph.api.fetcher features). Feature names are explicit on the carrier, and features honor optional-service gating - a feature whose condition evaluates false at boot is skipped and must be absent from the registry.",
+  "assumedConfig": {
+    "vector.feature.on": "true"
+  },
+  "entries": [
+    { "kind": "feature", "name": "vector-feature", "optionalService": "vector.feature.on" }
+  ],
+  "gatedOut": ["vector-feature-off"]
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/RegistrationVectorsTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/RegistrationVectorsTest.java
@@ -1,0 +1,112 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.annotations.ZeroTracing;
+import org.platformlambda.core.mock.VectorAliasFunction;
+import org.platformlambda.core.mock.VectorMarkedFunction;
+import org.platformlambda.core.serializers.SimpleMapper;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.ServiceDef;
+import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Registration-metadata conformance for the FUNCTION kind: the golden vectors in
+ * registration-vectors/core.json are shared verbatim with every engine repository. Each engine
+ * declares the same fixture set through its own carrier (here: Java annotations on the
+ * VectorAliasFunction / VectorMarkedFunction / VectorGatedOutFunction mocks) and must resolve to
+ * exactly the golden entries at boot - declared metadata, boot-time env resolution, marker
+ * stacking, optional-service gating and privacy all pinned in one place.
+ * See docs/guides/registration-metadata-contract.md.
+ */
+class RegistrationVectorsTest extends TestBase {
+
+    private static final Map<String, Class<?>> FIXTURES = Map.of(
+            "vector.alias.one", VectorAliasFunction.class,
+            "vector.marked", VectorMarkedFunction.class);
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void functionKindMatchesGoldenVectors() {
+        Utility util = Utility.getInstance();
+        InputStream in = this.getClass().getResourceAsStream("/registration-vectors/core.json");
+        assertNotNull(in, "golden vectors file must exist");
+        Map<String, Object> vectors = SimpleMapper.getInstance().getMapper()
+                .readValue(util.stream2str(in), Map.class);
+        MultiLevelMap map = new MultiLevelMap(vectors);
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) map.getElement("entries");
+        assertEquals(FIXTURES.size(), entries.size(), "vector entry count");
+        Platform platform = Platform.getInstance();
+        for (Map<String, Object> expected : entries) {
+            List<String> routes = (List<String>) expected.get("routes");
+            String primary = routes.getFirst();
+            Class<?> cls = FIXTURES.get(primary);
+            assertNotNull(cls, "a fixture class must exist for " + primary);
+            PreLoad annotation = cls.getAnnotation(PreLoad.class);
+            // declared metadata matches the vectors
+            List<String> declaredRoutes = util.split(annotation.route(), ", ").stream().sorted().toList();
+            assertEquals(routes, declaredRoutes, primary + ": routes");
+            // JSON integers surface as Long through the customized Gson - normalize before comparing
+            assertEquals(util.str2int(String.valueOf(expected.get("declaredInstances"))),
+                    annotation.instances(), primary + ": declaredInstances");
+            assertEquals(expected.get("envInstances"), annotation.envInstances(), primary + ": envInstances");
+            assertEquals(expected.get("isPrivate"), annotation.isPrivate(), primary + ": isPrivate");
+            OptionalService condition = cls.getAnnotation(OptionalService.class);
+            assertEquals(expected.get("optionalService"), condition == null? null : condition.value(),
+                    primary + ": optionalService");
+            assertEquals(expected.get("zeroTracing"), cls.getAnnotation(ZeroTracing.class) != null,
+                    primary + ": zeroTracing");
+            assertEquals(expected.get("eventInterceptor"), cls.getAnnotation(EventInterceptor.class) != null,
+                    primary + ": eventInterceptor");
+            // resolved registration matches the vectors, for every alias
+            for (String route : routes) {
+                assertTrue(platform.hasRoute(route), route + " must be registered");
+                ServiceDef def = platform.getLocalRoutingTable().get(route);
+                assertNotNull(def, route + " must be in the routing table");
+                assertEquals(util.str2int(String.valueOf(expected.get("resolvedInstances"))),
+                        def.getConcurrency(), route + ": resolvedInstances (envInstances resolved at boot)");
+                assertEquals(expected.get("isPrivate"), def.isPrivate(), route + ": isPrivate resolved");
+                assertEquals(expected.get("zeroTracing"), !def.isTrackable(), route + ": zeroTracing resolved");
+                assertEquals(expected.get("eventInterceptor"), def.isInterceptor(),
+                        route + ": eventInterceptor resolved");
+            }
+        }
+        // gated-out fixtures must never register
+        List<String> gatedOut = (List<String>) map.getElement("gatedOut");
+        for (String route : gatedOut) {
+            assertFalse(platform.hasRoute(route),
+                    route + " carries a false optional-service condition and must not register");
+        }
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorAliasFunction.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorAliasFunction.java
@@ -1,0 +1,39 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/core.json):
+ * comma-separated route aliases plus an envInstances key resolved from configuration at boot.
+ * The same fixture is declared in every engine's own carrier and must resolve to the identical
+ * golden vector entry.
+ */
+@PreLoad(route = "vector.alias.one, vector.alias.two", instances = 5, envInstances = "vector.instances")
+public class VectorAliasFunction implements TypedLambdaFunction<Map<String, Object>, Object> {
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        return input;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorGatedOutFunction.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorGatedOutFunction.java
@@ -1,0 +1,41 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/core.json):
+ * the negated @OptionalService condition evaluates FALSE under the assumed configuration
+ * (vector.feature.on=true), so this function must never be registered - the golden vectors
+ * list its route under "gatedOut".
+ */
+@PreLoad(route = "vector.gated.out")
+@OptionalService("!vector.feature.on")
+public class VectorGatedOutFunction implements TypedLambdaFunction<Map<String, Object>, Object> {
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        return input;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorMarkedFunction.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/mock/VectorMarkedFunction.java
@@ -1,0 +1,47 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core.mock;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.annotations.OptionalService;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.annotations.ZeroTracing;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * Registration-metadata conformance fixture (see test resource registration-vectors/core.json):
+ * the marker annotations (@ZeroTracing, @EventInterceptor) stack with @PreLoad in any order -
+ * exactly the order-freedom every carrier must preserve - and the @OptionalService condition
+ * evaluates true under the assumed configuration, so this function registers.
+ */
+@PreLoad(route = "vector.marked")
+@ZeroTracing
+@EventInterceptor
+@OptionalService("vector.feature.on")
+public class VectorMarkedFunction implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope input, int instance) {
+        // an interceptor's return value is ignored by the engine
+        return null;
+    }
+}

--- a/system/platform-core/src/test/resources/application.properties
+++ b/system/platform-core/src/test/resources/application.properties
@@ -138,3 +138,7 @@ skip.rpc.tracing=
 # (default is false)
 #
 serializer.null.transport=true
+
+# registration-metadata conformance vectors (registration-vectors/core.json assumedConfig)
+vector.instances=25
+vector.feature.on=true

--- a/system/platform-core/src/test/resources/registration-vectors/core.json
+++ b/system/platform-core/src/test/resources/registration-vectors/core.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "description": "Golden registration-metadata vectors for the FUNCTION kind. Shared verbatim between engine repositories: each engine declares the same fixture set through its own carrier (Java annotations / Rust macros / future Python-Node decorators) and must resolve to exactly these entries at boot. Canonical form: keys sorted alphabetically, entries sorted by first route. assumedConfig lists the configuration the conformance test must provide.",
+  "assumedConfig": {
+    "vector.feature.on": "true",
+    "vector.instances": "25"
+  },
+  "entries": [
+    {
+      "declaredInstances": 5,
+      "envInstances": "vector.instances",
+      "eventInterceptor": false,
+      "isPrivate": true,
+      "kind": "function",
+      "optionalService": null,
+      "resolvedInstances": 25,
+      "routes": ["vector.alias.one", "vector.alias.two"],
+      "zeroTracing": false
+    },
+    {
+      "declaredInstances": 1,
+      "envInstances": "",
+      "eventInterceptor": true,
+      "isPrivate": true,
+      "kind": "function",
+      "optionalService": "vector.feature.on",
+      "resolvedInstances": 1,
+      "routes": ["vector.marked"],
+      "zeroTracing": true
+    }
+  ],
+  "gatedOut": ["vector.gated.out"]
+}


### PR DESCRIPTION
## What

P2 of the annotation → macro consistency arc — the reference half of the cross-language
registration contract (lock-step with the Rust engine's branch of the same name):

1. **The Registration Metadata Contract**
   (`docs/guides/registration-metadata-contract.md`, formalized as **ADR-0009**): one
   canonical metadata model with fixed semantics for `@PreLoad` and its family — boot-time
   `envInstances` resolution, the `@OptionalService` grammar, order-free marker stacking,
   one conflict policy (explicit wins over declarative; duplicates WARN + last-wins),
   extension-point naming rules (an explicit positional name, or derivation such that
   idiomatic declarations in every language yield the same registered name), the boot
   sequence including the `yaml.preload.override` step, loud-failure discovery, and
   misuse as a tested error surface. Carriers — Java annotations, Rust macros, future
   Python/Node decorators — are per-language idioms; everything else is contract.
2. **Golden conformance vectors, shared verbatim between engine repositories**
   (`registration-vectors/core.json`, `plugin.json`, `feature.json`) with a fixture set
   declared through the real Java carriers and one conformance test per kind — the same
   golden-vector method that guards the event envelope wire format, applied to the
   declaration surface. Suites green: platform-core 423, event-script-engine 180,
   minigraph 73.
3. **String-semantics ruling recorded** (maintainer, 2026-07-26): the plugin catalog's
   string length/index semantics are **Unicode scalar values** in every port; the Java
   engine's UTF-16 code units (`String.length()`) are a JVM legacy retained here and
   never retrofitted onto modern languages. Identical for all BMP text (English, Chinese,
   JSON); only supplementary-plane characters differ. Recorded in the contract's
   capability matrix (with per-language guidance, incl. steering Node to
   `[...str].length`) and as a cross-engine note beside `f:length`/`f:substring` in the
   flow-schema reference. No Java code change.

## Why

The P1 round proved that porting registration *mechanisms* without fixing the *semantics*
produces drift invisible to any single repository — and that the cure is the one already
proven for the wire format: a language-neutral contract with executable conformance. This
PR makes the declaration surface provable the same way, so the Python and Node ports
inherit written, tested rules — name grammar, order-freedom, conflict policy, gating,
string semantics — instead of re-deriving them and re-diverging. The golden vectors are
the acceptance bar: a new port's declaration surface is done when the three suites pass
against byte-identical files.

Co-Authored-By: Claude Code <noreply@anthropic.com>