### PR TITLE
Ops-tunable worker instances: one actuator family knob + truthful worker.instances docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    test per kind — the same golden-vector method that guards the event envelope wire
    format. Formalized as ADR-0009.
 
+### Changed
+
+1. **Actuator worker instances: rule-of-thumb default + operations knob.** The actuator
+   family (`actuator.services` and its aliases serving `/info`, `/info/routes`,
+   `/info/lib`, `/env`, `/health`, `/livenessprobe`) now defaults to **5** worker
+   instances (was 30) and is tunable at deployment time via the new
+   `worker.instances.actuator.services` parameter — one knob for the whole family,
+   following the same `envInstances` convention as `no.op` and the Event Script
+   built-ins. Declared instance counts are rules of thumb; the knob is what lets an
+   operations team tune concurrency in QA and Perf environments before promoting to
+   Production. The lambda-example `event.api.auth` demo likewise moves to 30 instances
+   (a real deployment verifies bearer tokens against an OAuth 2.0 security authority —
+   an I/O-bound call) with `worker.instances.event.api.auth`, modeling the same
+   practice.
+
 ### Fixed
 
 1. **Registration conflict policy documented truthfully (annotation-macro consistency
@@ -33,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    minigraph `PlaygroundLoader` also gains the same duplicate-name warning that
    `SimplePluginLoader` already emits, so every registry reports duplicates consistently:
    WARN + last-wins.
+
+2. **`worker.instances.<route>` documented truthfully.** The configuration reference
+   claimed the pattern overrides the instance count of *any* registered route; it
+   actually applies only to functions whose `@PreLoad` declares the key via
+   `envInstances` (overriding an arbitrary function's count is `yaml.preload.override`'s
+   job). The page now states the real mechanism and adds the previously undocumented
+   `worker.instances.http.flow.adapter` key.
 
 ---
 ## Version 4.10.6, 7/24/2026

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -357,7 +357,33 @@ Size of the kernel thread pool for `@KernelThreadRunner` functions. The framewor
 |------|---------|
 | `int` | _(from `@PreLoad`)_ |
 
-Override the concurrency instance count for any named route at startup. Example: `worker.instances.my.service=50`.
+Override the concurrency instance count of a function whose `@PreLoad` declares this key as its
+`envInstances` parameter. Declared instance counts are rules of thumb — this key is what lets an
+operations team tune a function's concurrency in QA and Perf environments before promoting to
+Production, without a rebuild. The built-ins below all follow the `worker.instances.<route>`
+naming convention; your own functions opt in the same way, e.g.
+`@PreLoad(route="my.service", instances=50, envInstances="worker.instances.my.service")`.
+To override the instance count of a function that does not declare `envInstances`, use
+[`yaml.preload.override`](#yamlpreloadoverride) instead.
+
+### `worker.instances.actuator.services`
+
+| Type | Default |
+|------|---------|
+| `int` | `5` |
+
+One knob for the whole actuator family — `actuator.services` and its aliases
+(`info.actuator.service`, `routes.actuator.service`, `env.actuator.service`,
+`health.actuator.service`, `liveness.actuator.service`, `lib.actuator.service`) share a
+single worker pool size.
+
+### `worker.instances.http.flow.adapter`
+
+| Type | Default |
+|------|---------|
+| `int` | `200` |
+
+Instance count for the built-in `http.flow.adapter` (Event Script's HTTP-to-flow adapter).
 
 ### `worker.instances.no.op`
 
@@ -383,8 +409,8 @@ Instance count for the built-in `resilience.handler`.
 
 Instance count for the built-in `simple.exception.handler`.
 
-> The `worker.instances.<route>` pattern accepts any registered route name with dots preserved:
-> `worker.instances.v1.get.profile=100`.
+> Keys keep the route's dots as-is: a function declared with
+> `envInstances = "worker.instances.v1.get.profile"` is tuned by `worker.instances.v1.get.profile=100`.
 
 ---
 

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/EventApiAuth.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/EventApiAuth.java
@@ -43,9 +43,14 @@ import java.util.Map;
  * headers on the envelope become session info that rides to the target
  * function as read-only headers - the "user" header in this demo.
  * Replace this class with your own OAuth 2.0 bearer-token validation for
- * production use.
+ * production use.<p>
+ *
+ * A real deployment verifies the bearer token against an OAuth 2.0 security
+ * authority - an I/O-bound call - hence the higher instance count. The
+ * default is a rule of thumb; the envInstances key lets an operations team
+ * tune it in QA and Perf environments before promoting to Production.
  */
-@PreLoad(route="event.api.auth", instances=10)
+@PreLoad(route="event.api.auth", instances=30, envInstances = "worker.instances.event.api.auth")
 public class EventApiAuth implements TypedLambdaFunction<AsyncHttpRequest, Object> {
     private static final Logger log = LoggerFactory.getLogger(EventApiAuth.class);
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-25 | agent: Claude Code (2026-07-25-005125)
+- **last_session:** 2026-07-27 | agent: Claude Code (2026-07-27-005415)
 - **last_review:** 2026-07-24 | through 2026-07-24-154543.md
 - **last_invariant_check:** 2026-06-29 | 2026-06-29-223651.md (re-verify prompted — cadence reset; pending Eric via Open Thread thread-reverify-invariants-2026q2)
 
@@ -346,6 +346,27 @@
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-06-21 | uses: 1 | tier: working -->
 
 ## Open Threads
+
+- [ ] (feature in flight — 2026-07-26) **Ops-tunable worker instances, both engines (Eric's
+  /info/routes review round).** Context: the Rust typed-AsyncHttpRequest arc shipped
+  `/info/routes` (Rust branch `feature/typed-async-http-request`, unpushed), Eric reviewed
+  the live output and ruled: actuators → 5 instances, Rust demo `http.request.filter` → 20,
+  `event.api.auth` → 30 (real-world = OAuth2 bearer-token verification, I/O-bound), and the
+  ops-tunability principle: **declared counts are rules of thumb; operations teams tune in
+  QA/Perf via config before promoting to Production.** Java commit `6f0f03df` on
+  `feature/ops-tunable-instances` (NOT pushed): ActuatorServices 30 → 5 + NEW
+  `worker.instances.actuator.services` (one knob, 7 aliases); lambda-example event.api.auth
+  10 → 30 + `worker.instances.event.api.auth`; **doc bug fixed** — configuration-reference
+  claimed `worker.instances.<route>` overrides ANY route, but code (AppStarter.
+  getInstancesFromEnv + Platform.register) only honors it where `@PreLoad` declares
+  `envInstances` (any-route override = `yaml.preload.override`); added missing
+  `worker.instances.http.flow.adapter` section. Proof: platform-core 424 green WITH the
+  actuator key active (=8) + `actuatorFamilySharesOneEnvInstanceKey`; lambda-example 14.
+  **Cross-engine key parity decision: the Rust port's five per-endpoint actuator services
+  share the SAME key name `worker.instances.actuator.services`** (its actuator.services
+  route is unported; one runbook line tunes both engines). Rust half in flight in the agent
+  session (same branch/commit as the typed-request arc). Close when both PRs merge.
+  <!-- id: thread-ops-tunable-instances | created: 2026-07-26 | last_used: 2026-07-26 | uses: 1 | tier: working | origin: 2026-07-27-005415 -->
 
 - [x] (feature in flight — 2026-07-25; ARC COMPLETE 2026-07-26 — P1 AND P2 merged both
   repos) **Annotation → macro consistency arc (Eric's initiative; design RATIFIED — see

--- a/memory/sessions/2026-07-27-005415.md
+++ b/memory/sessions/2026-07-27-005415.md
@@ -1,0 +1,60 @@
+# Session (2026-07-27T00:54:15.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Ops-tunable worker instances (Java half of Eric's /info/routes review round).** The Rust
+port's new `/info/routes` actuator (typed-AsyncHttpRequest arc, Rust branch
+`feature/typed-async-http-request`) made instance counts visible, and Eric's review of the
+live output turned into a two-repo instruction: actuator endpoints → 5 instances,
+`http.request.filter` (Rust demo) → 20, `event.api.auth` → 30, **and** wire the
+ops-tunability story ("there are rule-of-thumbs for the initial numbers but we need to give
+the operational folks ability to tune them" — a real `event.api.auth` verifies bearer tokens
+against an OAuth2 security authority, an I/O-bound call).
+
+**Java reference commit `6f0f03df` on `feature/ops-tunable-instances` (NOT pushed — Eric
+gates):**
+
+- `ActuatorServices`: instances 30 → 5 + `envInstances` via the new
+  **`worker.instances.actuator.services`** key — ONE knob for the whole aliased family
+  (Java's actuators are a single class with 7 route aliases, so one key is the only possible
+  granularity; the Rust port adopts the SAME key name across its five per-endpoint services
+  for cross-engine runbook parity).
+- lambda-example `event.api.auth`: 10 → 30 + `envInstances = worker.instances.event.api.auth`;
+  javadoc now models the OAuth2 rationale + QA/Perf-before-Production tuning practice.
+- **Doc bug found and fixed (truthful-docs, the PR #234 precedent):**
+  `configuration-reference.md` claimed `worker.instances.<route>` overrides ANY registered
+  route. Verified against `AppStarter.getInstancesFromEnv` + `Platform.register`: the key
+  only applies to functions whose `@PreLoad` DECLARES it via `envInstances` (four built-ins
+  before this round); the any-route override is `yaml.preload.override`'s job. Page now
+  states the real mechanism; added the missing `worker.instances.http.flow.adapter` section
+  and the new actuator key section.
+- Test proof: `worker.instances.actuator.services=8` set in platform-core's test
+  application.properties, so the whole 424-test suite runs WITH the override active
+  (additive-proof pattern from the traceparent round); new regression
+  `actuatorFamilySharesOneEnvInstanceKey` asserts all seven aliases honor it.
+  lambda-example 14 green.
+- CHANGELOG: Changed (actuator default + knob, demo auth) + Fixed (truthful
+  `worker.instances.<route>` docs).
+
+**Rust half delegated to the persistent agent session** (folds into the same
+`feature/typed-async-http-request` commit): actuators 1 → 5 each sharing the family key
+`worker.instances.actuator.services` (route unported; key name deliberately shared with
+Java), hello-world `http.request.filter` 2 → 20, `event.api.auth` 10 → 30, per-route demo
+keys, docs + e2e updates. In flight at log time.
+
+Earlier in this working session (same conversation, before this seam): answered Eric's
+question on the Rust default-endpoint mechanism (embedded `DEFAULT_REST_YAML` constant +
+merge-unless-claimed = Java's default-rest.yaml semantics) → led to the agent relocating it
+to a real `crates/platform-core/resources/default-rest.yaml` via `include_str!`
+(discoverable + byte-diffable against Java's copy); `/info/routes` shipped in the Rust port
+(Eric verified live: exact Java shape, pretty-printed, "DevOps folks would love it").
+
+## Memory References
+
+- referenced: registration-metadata-contract (envInstances boot-time resolution semantics),
+  thread-annotation-macro-consistency (contract context), conv-telemetry-presentation-parity
+  (cross-engine key-name parity rationale), release-4-8-1-shipped (flow-authoring context),
+  vision-mercury-composable
+- created: (fact folded into thread) thread-ops-tunable-instances

--- a/system/platform-core/src/main/java/org/platformlambda/core/services/ActuatorServices.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/services/ActuatorServices.java
@@ -18,7 +18,9 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@PreLoad(route=ActuatorServices.SERVICE_NAMES, instances=30)
+import static org.platformlambda.core.util.common.PlatformConstants.ENV_INSTANCES_PREFIX;
+
+@PreLoad(route=ActuatorServices.SERVICE_NAMES, instances=5, envInstances = ActuatorServices.ENV_INSTANCE_PROPERTY)
 public class ActuatorServices implements TypedLambdaFunction<EventEnvelope, Object> {
     public static final String ACTUATOR_SERVICES = "actuator.services";
     public static final String INFO_ACTUATOR = "info.actuator.service";
@@ -30,6 +32,8 @@ public class ActuatorServices implements TypedLambdaFunction<EventEnvelope, Obje
     public static final String SERVICE_NAMES = ACTUATOR_SERVICES + "," + INFO_ACTUATOR + "," + ENV_ACTUATOR + "," +
                                                 ROUTES_ACTUATOR_SERVICE + "," + LIB_ACTUATOR + "," +
                                                 HEALTH_ACTUATOR + "," + LIVENESS_ACTUATOR;
+    // one knob tunes the whole actuator family - all route aliases share this class's worker pool size
+    public static final String ENV_INSTANCE_PROPERTY = ENV_INSTANCES_PREFIX + ACTUATOR_SERVICES;
     private static final Logger log = LoggerFactory.getLogger(ActuatorServices.class);
     private static final Utility util = Utility.getInstance();
     private static final SimpleCache cache = SimpleCache.createCache("health.info", 5000);

--- a/system/platform-core/src/test/java/org/platformlambda/core/EnvInstanceOverrideTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EnvInstanceOverrideTest.java
@@ -21,6 +21,7 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.platformlambda.common.TestBase;
+import org.platformlambda.core.services.ActuatorServices;
 import org.platformlambda.core.services.NoOpFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.system.ServiceDef;
@@ -58,6 +59,15 @@ class EnvInstanceOverrideTest extends TestBase {
                 Integer.parseInt(reader.getProperty(NoOpFunction.ENV_INSTANCE_PROPERTY)),
                 routeToInstancesMap.get(NoOpFunction.ROUTE)
         );
+    }
+
+    @Test
+    void actuatorFamilySharesOneEnvInstanceKey() {
+        int expected = Integer.parseInt(reader.getProperty(ActuatorServices.ENV_INSTANCE_PROPERTY));
+        for (String route : ActuatorServices.SERVICE_NAMES.split(",")) {
+            assertEquals(expected, routeToInstancesMap.get(route.trim()),
+                    route + " should honor " + ActuatorServices.ENV_INSTANCE_PROPERTY);
+        }
     }
 
 }

--- a/system/platform-core/src/test/resources/application.properties
+++ b/system/platform-core/src/test/resources/application.properties
@@ -123,6 +123,7 @@ http.traceparent.header=X-Trace-Context
 stack.trace.transport.size=5
 
 worker.instances.no.op=750
+worker.instances.actuator.services=8
 
 #
 # "skip.rpc.tracing" tells the system to skip tracing of RPC calls for the list of service routes.


### PR DESCRIPTION
## What

- **Actuator family default 30 → 5, with an operations knob.** `ActuatorServices`
  (`actuator.services` and its aliases serving `/info`, `/info/routes`, `/info/lib`, `/env`,
  `/health`, `/livenessprobe`) now declares `envInstances` via the new
  **`worker.instances.actuator.services`** parameter — one knob for the whole aliased family,
  following the same convention as `no.op` and the Event Script built-ins.
- **lambda-example `event.api.auth` demo: 10 → 30 + `worker.instances.event.api.auth`.** The
  javadoc now states the real-world shape: a production authenticator verifies bearer tokens
  against an OAuth 2.0 security authority — an I/O-bound call — hence the higher rule of thumb
  and the tuning knob.
- **`worker.instances.<route>` documented truthfully.** The configuration reference claimed the
  pattern overrides *any* registered route; the code (`AppStarter.getInstancesFromEnv`) only
  honors it where `@PreLoad` declares the key via `envInstances` — overriding an arbitrary
  function's count is `yaml.preload.override`'s job. The page now states the real mechanism and
  adds the previously undocumented `worker.instances.http.flow.adapter` section plus the new
  actuator key.
- **Proof:** the platform-core suite runs with `worker.instances.actuator.services=8` active in
  test configuration, so all 424 tests are additive evidence; a new regression
  (`actuatorFamilySharesOneEnvInstanceKey`) asserts all seven aliases honor the override.
  lambda-example: 14 tests green.

## Why

The `/info/routes` actuator makes worker instance counts visible to operators, and visibility
demands tunability: declared instance counts are rules of thumb — the initial numbers — and
operations teams need to fine-tune concurrency in QA and Perf environments before promoting to
Production, without a rebuild. The actuator family had neither the rule-of-thumb default nor a
knob.

The key name `worker.instances.actuator.services` is deliberately shared with the Rust engine,
which lands the same defaults and knob in lock-step: one runbook line tunes actuators across a
polyglot fleet. The documentation correction follows the truthful-docs precedent (#234) — the
reference page promised a generic any-route override that the code never implemented.

Co-Authored-By: Claude Code <noreply@anthropic.com>