### PR TITLE
docs(core): ManagedCache eviction behavior documented truthfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `SimplePluginLoader` already emits, so every registry reports duplicates consistently:
    WARN + last-wins.
 
-2. **`worker.instances.<route>` documented truthfully.** The configuration reference
+2. **`ManagedCache` eviction behavior documented truthfully.** Under `maxItems` capacity
+   pressure, eviction is approximate and non-deterministic (Caffeine W-TinyLFU admission
+   with randomized anti-HashDoS jitter) — callers must not rely on which entry survives.
+   Entry expiry remains exact. The javadoc now states this, and notes the deliberate
+   cross-engine asymmetry: the Rust port's `ManagedCache` uses strict, deterministic LRU
+   (moka). No behavior change; no in-repo consumer runs near its capacity bound.
+
+3. **`worker.instances.<route>` documented truthfully.** The configuration reference
    claimed the pattern overrides the instance count of *any* registered route; it
    actually applies only to functions whose `@PreLoad` declares the key via
    `envInstances` (overriding an arbitrary function's count is `yaml.preload.override`'s

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-27 | agent: Claude Code (2026-07-27-215011)
+- **last_session:** 2026-07-28 | agent: Claude Code (2026-07-28-005814)
 - **last_review:** 2026-07-27 | through 2026-07-27-214357.md
 - **last_invariant_check:** 2026-07-27 | 2026-07-27-215011.md (all 15 confirmed by Eric — one-by-one walkthrough with live-tree evidence; thread-reverify-invariants-2026q2 closed)
 
@@ -180,6 +180,24 @@
   for the release-bump surface and prior caveats.
   <!-- id: release-4-8-0-shipped | created: 2026-07-10 | last_used: 2026-07-24 | uses: 8 | tier: active | origin: 2026-07-11-031930 -->
 
+- **ManagedCache eviction: Java accepts + documents non-determinism; Rust is strict LRU —
+  a deliberate cross-engine asymmetry (Eric, 2026-07-27).** Java's `ManagedCache` keeps
+  Caffeine (3.2.4) W-TinyLFU: under `maxItems` pressure eviction is approximate and
+  non-deterministic (frequency-based admission + anti-HashDoS jitter admitting 1/128
+  losing candidates at random + lossy read buffers; no policy knob exists in the builder).
+  Javadoc on both `createCache` overloads + CHANGELOG state it; callers must never rely on
+  which entry survives nor assert eviction victims. The Rust port's ManagedCache is moka
+  `EvictionPolicy::lru()` (deterministic; increment 71, Rust PR #185) per Eric's
+  "deterministic eviction" ruling there. Eviction is internal state, NOT a presentation
+  surface — [[conv-telemetry-presentation-parity]] does not require closing this gap.
+  **"Frequency aging" is NOT a determinism remediation** (investigated vs the pinned jar:
+  `FrequencySketch.reset()` already ages counters; aging fixes stale popularity, not
+  reproducibility). Revisit trigger: the first consumer that truly runs at capacity
+  (schema-registry caches are the candidate); today every caller uses the 2-arg form
+  (default maxItems 2000, nothing close). Full handoff + options record:
+  the Rust repo's docs/design/managed-cache-port.md.
+  <!-- id: managed-cache-eviction-determinism | created: 2026-07-28 | last_used: 2026-07-28 | uses: 1 | tier: working | origin: 2026-07-28-005814 -->
+
 - **Application log context is ON by default (2026-07-22, Eric via leadership request; branch
   `feature/lambda-example-interop-echo`, ships in the next release).** platform-core carries a built-in
   `default-log-context.yaml` (cid/traceId/tracePath/spanId/parentSpanId/service/timestamp); when json/compact
@@ -268,7 +286,7 @@
   lock-step on both engines (with closely matching error messages — presentation parity extends
   to error text), or flows stop being portable. Precedent: the #220 collection plugins mirrored
   into the Rust v4.10.2.
-  <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-27 | uses: 6 | tier: active | origin: 2026-07-23-145132 -->
+  <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-28 | uses: 7 | tier: active | origin: 2026-07-23-145132 -->
 
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
@@ -412,7 +430,7 @@
   GitHub web-UI 500 delayed PR creation (API was healthy; status page lagged); EMU
   accounts CANNOT create PRs via API either (GraphQL + REST both 403) — web UI is the only
   PR path. Sixth lock-step release of the 4.10 arc.
-  <!-- id: thread-release-4-10-5 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: active | origin: 2026-07-24-154543 -->
+  <!-- id: thread-release-4-10-5 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: archive-candidate | origin: 2026-07-24-154543 -->
 
 - [x] (release in flight — 2026-07-24; CLOSED same day) **v4.10.4 SHIPPED AND PUBLISHED in
   lock-step (both repos) — standards-first traceparent carrier + interop header hygiene.**
@@ -427,7 +445,7 @@
   before assuming pushed commits appear in it. Fifth lock-step release of the 4.10 arc:
   4.10.0 interop → 4.10.1 presentation parity → 4.10.2 boundary demarcation → 4.10.3 field
   roll-up → 4.10.4 standards-first traceparent + hygiene.
-  <!-- id: thread-release-4-10-4 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: active | origin: 2026-07-24-154543 -->
+  <!-- id: thread-release-4-10-4 | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: archive-candidate | origin: 2026-07-24-154543 -->
 
 - [x] (feature in flight — 2026-07-24; CLOSED same day — RELEASED in v4.10.4) **Configurable traceparent header name (field request).**
   Field wants `http.traceparent.header` / `kafka.traceparent.header` /
@@ -480,7 +498,7 @@
   **RELEASED 2026-07-24 in v4.10.4 both repos ([[thread-release-4-10-4]]) — the full arc
   closed: field request → design ruling → lock-step implementation → ce_traceparent live
   interop → hygiene round → standards position → release.**
-  <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: active | origin: 2026-07-24-154543 -->
+  <!-- id: thread-traceparent-header-config | created: 2026-07-24 | last_used: 2026-07-24 | uses: 1 | tier: archive-candidate | origin: 2026-07-24-154543 -->
 
 - [x] (release in flight — 2026-07-23; CLOSED same day) **v4.10.3 SHIPPED AND PUBLISHED in
   lock-step (both repos) — field-deployment roll-up.** Releases are immutable (Eric), so the

--- a/memory/sessions/2026-07-28-005814.md
+++ b/memory/sessions/2026-07-28-005814.md
@@ -1,0 +1,36 @@
+# Session (2026-07-28T00:58:14.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**ManagedCache eviction determinism — handoff reviewed, Copilot's "aging" suggestion
+investigated and ruled out, Eric chose accept + document (option 1 + revisit trigger).**
+
+Reviewed `/tmp/managed-cache-eviction-determinism-handoff.md` from the Rust-port session
+(its half shipped: Rust ManagedCache = moka `EvictionPolicy::lru()`, increment 71,
+PR #185). Verified every Java claim against the tree: `ManagedCache.createCache` builds
+plain Caffeine `maximumSize + expireAfterWrite` (no policy knob exists), Caffeine 3.2.4
+pinned, Guava→Caffeine migration was deliberate (commit `07e2d20c`), and every in-repo
+caller uses the 2-arg form (maxItems = default 2000, nothing near capacity).
+
+**Copilot's frequency-aging suggestion is a category error, evidence from the pinned jar
+itself:** `FrequencySketch` in caffeine-3.2.4.jar already carries `sampleSize` /
+`RESET_MASK` / `reset()` — the exact periodic counter-halving Copilot proposed is built
+into W-TinyLFU. Aging remediates *stale popularity* (hit-rate/adaptivity), not
+*determinism*: admission still compares workload-history-dependent estimates, the
+anti-HashDoS jitter (`ADMIT_HASHDOS_THRESHOLD` + `admit()`, verified present) still
+randomizes 1/128 of losing candidates, read buffers stay lossy — and aging adds timing
+dependence (same access lands before/after a halving).
+
+**Eric's ruling: apply option 1** — javadoc note on both `createCache` overloads
+(size-eviction approximate + non-deterministic; expiry exact; don't assert victims;
+Rust port deliberately strict-LRU/deterministic) + CHANGELOG Fixed entry
+(truthful-docs precedent). No engine change; branch
+`docs/managed-cache-eviction-note`, platform-core compiles clean.
+
+## Memory References
+
+- referenced: conv-telemetry-presentation-parity (boundary case — eviction is internal
+  state, not a presentation surface, so cross-engine eviction parity is NOT required)
+- created: managed-cache-eviction-determinism

--- a/system/platform-core/src/main/java/org/platformlambda/core/util/ManagedCache.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/util/ManagedCache.java
@@ -70,7 +70,9 @@ public class ManagedCache {
     }
 
     /**
-     * Obtain a ManagedCache instance
+     * Obtain a ManagedCache instance with the default maxItems bound
+     * <p>
+     * See {@link #createCache(String, long, long)} for the eviction-behavior note.
      *
      * @param name     of cache store
      * @param expiryMs in milliseconds
@@ -82,6 +84,15 @@ public class ManagedCache {
 
     /**
      * Obtain a ManagedCache instance
+     * <p>
+     * Eviction under maxItems capacity pressure is approximate and non-deterministic.
+     * The underlying Caffeine cache uses W-TinyLFU admission with randomized jitter,
+     * so which entry survives when the cache is full is unpredictable and may vary
+     * between identical runs - do not rely on a specific entry being retained or
+     * evicted, and do not assert eviction victims in tests. Expiry (expiryMs) is
+     * exact per entry; only size-based eviction is approximate. The Rust port's
+     * ManagedCache deliberately differs here: it uses strict LRU eviction (moka),
+     * which is deterministic.
      *
      * @param name     of cache store
      * @param expiryMs in milliseconds


### PR DESCRIPTION
## What

- **Javadoc on both `ManagedCache.createCache` overloads**: under `maxItems` capacity
  pressure, eviction is approximate and non-deterministic — Caffeine's W-TinyLFU admission
  compares estimated historic frequency and injects randomized anti-HashDoS jitter, so which
  entry survives a full cache is unpredictable and may vary between identical runs. Callers
  must not rely on a specific entry being retained, and must not assert eviction victims in
  tests. Entry expiry (`expiryMs`) remains exact. The note also records the deliberate
  cross-engine asymmetry: the Rust port's `ManagedCache` uses strict, deterministic LRU
  (moka `EvictionPolicy::lru()`, Rust PR #185).
- **CHANGELOG entry** under Fixed, following the truthful-documentation precedent.
- No behavior change — documentation only. platform-core compiles clean.

## Why

While porting `ManagedCache`, the Rust session found that the Java original's size-based
eviction is non-deterministic on three levels (frequency-based admission, deliberate 1/128
random admission of losing candidates, lossy read buffers) with no opt-out in the Caffeine
builder. An investigation ruled out "frequency aging" as a remediation: Caffeine 3.2.4
already ages its frequency sketch (`FrequencySketch.reset()` — verified in the pinned jar),
and aging addresses stale popularity, not reproducibility.

The maintainer's ruling is accept-and-document: no in-repo consumer runs anywhere near its
capacity bound (every caller uses the default 2000-item limit), the Guava→Caffeine migration
was deliberate and keeps its throughput, and cache victim selection is internal state — not
part of the cross-engine presentation-parity contract. Documenting the behavior honestly
keeps both engines truthful on paper; the decision is revisited only if a consumer ever
genuinely runs at capacity.

Co-Authored-By: Claude Code <noreply@anthropic.com>