### PR TITLE
Log context cid is business-or-nothing; the Playground edge creates model.cid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      so every skill and store function sees the business ID — not internal routing IDs —
      in `my_correlation_id`; the suspend/resume skills also annotate their trace spans
      with `cid`. In the same spirit, the application log context's `$cid` token
-     (platform-core) now resolves to the **business** correlation-id whenever the
-     delivered event carries one — internal correlation-ids (RPC inbox references,
-     skill-callback composites) are routing metadata and appear only as a fallback.
+     (platform-core) now resolves to the **business** correlation-id only — when the
+     delivered event carries no business context the key is omitted; internal
+     correlation-ids (RPC inbox references, skill-callback composites) are routing
+     metadata and never appear under the `cid` label. Since every edge guarantees a
+     business correlation-id, a missing `cid` on a traced log line signals a propagation
+     defect. The Playground's `instantiate graph` command is the dry-run's edge and now
+     auto-creates `model.cid` (with a reminder) when the initial data mapping does not
+     supply one.
    - **Declarative response status**: a graph can stage its HTTP status
      (e.g. `int(404) -> output.status`); `graph.executor` applies it to the graph's reply
      at completion.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -306,10 +306,12 @@ function's route), and `$utc` (the log line's UTC timestamp). A token (or env va
 **omitted** from the block rather than printed as `null` — so a root span simply has no `parentSpanId` key.
 
 `$cid` is the **business correlation ID** — the value received from the external source or created at the
-edge, the same one `PostOffice.getMyCorrelationId()` returns — whenever the delivered event carries one.
-Internal correlation IDs (routing metadata such as RPC inbox references or the graph engine's skill-callback
-IDs) appear only as a fallback when no business context exists, so log aggregation correlates on the ID your
-callers know.
+edge, the same one `PostOffice.getMyCorrelationId()` returns. When the delivered event carries no business
+context, the key is simply **omitted**: internal correlation IDs (routing metadata such as RPC inbox
+references or the graph engine's skill-callback IDs) never appear under the `cid` label, so log aggregation
+always correlates on the ID your callers know — or on nothing, never on something misleading. Because every
+edge guarantees a business correlation ID (a fresh one is generated when the caller supplies none), **a
+missing `cid` on a traced log line indicates a propagation defect worth fixing**, not a normal condition.
 
 ### Adding your own key-values {#log-context-custom}
 

--- a/memory/sessions/2026-07-29-152653.md
+++ b/memory/sessions/2026-07-29-152653.md
@@ -1,0 +1,38 @@
+# Session (2026-07-29T15:26:53.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+**Log-context `$cid` polish (Eric's pre-P5 ruling): business-or-nothing.** The previous
+fallback (business tag, else the ENVELOPE correlation-id) could still surface an internal
+routing id under the `cid` label — misleading to DevOps. WorkerHandler now resolves the
+log-context cid EXACTLY like the injected `my_correlation_id` (engine `my_cid` tag, else
+a legacy pre-4.10.2 peer's transported header) and leaves it **unset** otherwise — the
+log-context omit-null contract then skips the key entirely. Branch
+`fix/log-context-business-cid-only`.
+
+- Regression `logContextCidIsTheBusinessCorrelationIdOnly` pins all three scenarios:
+  tag wins over envelope id; legacy header honored; no business context → the `cid` key
+  is ABSENT (containsKey false), never the internal id. The original context test now
+  drives via the tag.
+- Docs: observability guide `$cid` paragraph — "correlates on the ID your callers know —
+  or on nothing, never on something misleading". CHANGELOG bullet updated.
+- **Eric's refinement: a missing cid is a BUG SIGNAL.** Every edge guarantees a business
+  correlation id (fresh UUID when the caller supplies none), so an unset cid on a traced
+  log line indicates a propagation defect (e.g. yesterday's eager-future/Mono fix would
+  have announced itself this way). Documented in the observability guide.
+- **Playground edge parity:** `instantiate graph` is the dry-run's edge — it now
+  auto-creates model.cid (fresh UUID) when the initial data mapping does not supply one,
+  with a reminder line ("No business correlation ID given - this dry-run created
+  model.cid = ..."); a supplied model.cid is honored silently. Pinned in
+  CompanionSyncTest (both cases).
+- **P5 parity note:** the Rust port's log-context `$cid` must mirror business-or-nothing
+  (this supersedes the earlier "fallback to envelope cid" shape from PR #238).
+
+platform-core 425 green (3-scenario log-context suite); full reactor green.
+
+## Memory References
+
+- referenced: thread-graph-suspend-resume (P5 parity list extended),
+  graph-suspend-resume-design (the business/internal cid taxonomy this enforces)

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -1368,6 +1368,15 @@ public class GraphCommandService extends GraphLambdaFunction {
                 stateMachine.setElement(INPUT_BODY_NAMESPACE, new HashMap<>());
             }
             stateMachine.setElement(OUTPUT, new HashMap<>());
+            // the instantiate command is the dry-run's edge: like the REST edge, it
+            // guarantees a business correlation ID - auto-created when the initial data
+            // mapping did not supply one, with a reminder so the user knows
+            if (!(stateMachine.getElement(MODEL_CID) instanceof String cid) || cid.isBlank()) {
+                var generated = util.getUuid();
+                stateMachine.setElement(MODEL_CID, generated);
+                po.send(new EventEnvelope().setTo(outRoute).setBody(
+                        "No business correlation ID given - this dry-run created model.cid = " + generated));
+            }
             var timeout = getModelTtl(graphInstance);
             log.info("Instantiate graph with {} nodes, model.ttl = {} ms", nodeCount, timeout);
             graphInstances.put(inRoute, graphInstance);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -120,6 +120,19 @@ class CompanionSyncTest {
             syncCommand(po, sid, "connect mapper to end with second");
             var instantiated = syncCommand(po, sid, "instantiate graph\ntext(hello world) -> input.body.id");
             assertEquals(Boolean.TRUE, instantiated.get("ok"), "instantiate -> ok:true: " + instantiated);
+            // the instantiate command is the dry-run's edge: it guarantees a business
+            // correlation ID like the REST edge does, with a reminder when auto-created
+            var initOutput = ((List<?>) instantiated.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(initOutput.stream().anyMatch(
+                            l -> l.startsWith("No business correlation ID given - this dry-run created model.cid = ")),
+                    "the dry-run edge must auto-create model.cid with a reminder: " + initOutput);
+            // an explicitly mapped model.cid is honored without the reminder
+            var withCid = syncCommand(po, sid,
+                    "instantiate graph\ntext(hello world) -> input.body.id\ntext(dry-run-77) -> model.cid");
+            assertEquals(Boolean.TRUE, withCid.get("ok"), "instantiate with cid -> ok:true: " + withCid);
+            var withCidOutput = ((List<?>) withCid.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(withCidOutput.stream().noneMatch(l -> l.contains("created model.cid")),
+                    "a supplied model.cid must be honored without the reminder: " + withCidOutput);
 
             var ran = syncCommand(po, sid, "run");
             assertEquals(Boolean.TRUE, ran.get("ok"), "sync run -> ok:true: " + ran);

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -115,13 +115,14 @@ public class WorkerHandler {
             // traceId is available (trace.id != null), per the log-context contract.
             TraceInfo logTrace = po.getTrace(parentRoute, instance);
             if (logTrace != null && logTrace.id != null) {
-                // the log context 'cid' is the BUSINESS correlation-id when the event carries
-                // one (the engine's my_cid tag - the same source as the injected
-                // my_correlation_id); the envelope correlation-id is internal routing metadata
-                // and is only a fallback when no business context exists
-                String businessCid = event.getTag(EventEmitter.BUSINESS_CID_TAG);
-                LogContextManager.register(threadId, new LogContext(logTrace,
-                        businessCid != null? businessCid : event.getCorrelationId()));
+                // the log context 'cid' is the BUSINESS correlation-id only, resolved exactly
+                // like the injected my_correlation_id: the engine's my_cid tag, else a legacy
+                // pre-4.10.2 peer's transported header. When no business context exists the
+                // token stays unset and the context block omits it - an internal routing id
+                // under the 'cid' label would mislead log aggregation
+                String businessCid = event.getTag(EventEmitter.BUSINESS_CID_TAG) != null?
+                        event.getTag(EventEmitter.BUSINESS_CID_TAG) : event.getHeaders().get(MY_CORRELATION_ID);
+                LogContextManager.register(threadId, new LogContext(logTrace, businessCid));
             }
         }
         ProcessStatus ps = processEvent(event, rpc);

--- a/system/platform-core/src/test/java/org/platformlambda/core/logging/WorkerLogContextTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/logging/WorkerLogContextTest.java
@@ -85,7 +85,8 @@ class WorkerLogContextTest extends TestBase {
         LogContextConfig.setInstanceForTest(enabledConfig());
         try {
             PostOffice po = new PostOffice("unit.test", traceId, "GET /api/log/ctx");
-            po.send(new EventEnvelope().setTo(route).setBody("x").setCorrelationId(cid));
+            po.send(new EventEnvelope().setTo(route).setBody("x")
+                    .addTag(EventEmitter.BUSINESS_CID_TAG, cid));
 
             Map<String, Object> rendered = bench.poll(10, TimeUnit.SECONDS);
             assertNotNull(rendered, "function should have rendered the log context");
@@ -108,15 +109,16 @@ class WorkerLogContextTest extends TestBase {
     }
 
     @Test
-    void businessCorrelationIdWinsInLogContext() throws InterruptedException {
-        // the log context 'cid' is the business correlation-id (the engine my_cid tag) when
-        // present - the envelope correlation-id is internal routing metadata (e.g. the graph
-        // engine's composite skill-callback ids) and is only a fallback
+    void logContextCidIsTheBusinessCorrelationIdOnly() throws InterruptedException {
+        // the log context 'cid' resolves exactly like the injected my_correlation_id:
+        // the engine my_cid tag, else a legacy peer's transported header, else UNSET -
+        // an internal routing id (an envelope correlation-id such as the graph engine's
+        // composite skill-callback ids) must never appear under the 'cid' label
         Platform platform = Platform.getInstance();
         String route = "log.context.business.cid.function";
-        String traceId = util.getUuid();
         String internalCid = "internal-" + util.getUuid();
         String businessCid = "order-" + util.getUuid();
+        String legacyCid = "legacy-" + util.getUuid();
         BlockingQueue<Map<String, Object>> bench = new ArrayBlockingQueue<>(1);
         LambdaFunction f = (headers, input, instance) -> {
             LogContext ctx = LogContextManager.get(Thread.currentThread().threadId());
@@ -126,12 +128,25 @@ class WorkerLogContextTest extends TestBase {
         platform.registerPrivate(route, f, 1);
         LogContextConfig.setInstanceForTest(enabledConfig());
         try {
-            PostOffice po = new PostOffice("unit.test", traceId, "GET /api/log/business/cid");
+            PostOffice po = new PostOffice("unit.test", util.getUuid(), "GET /api/log/business/cid");
+            // 1. the business tag wins over the envelope correlation-id
             po.send(new EventEnvelope().setTo(route).setBody("x").setCorrelationId(internalCid)
                     .addTag(EventEmitter.BUSINESS_CID_TAG, businessCid));
-            Map<String, Object> rendered = bench.poll(10, TimeUnit.SECONDS);
-            assertNotNull(rendered, "function should have rendered the log context");
-            assertEquals(businessCid, rendered.get("cid"), "the business correlation-id must win");
+            Map<String, Object> tagged = bench.poll(10, TimeUnit.SECONDS);
+            assertNotNull(tagged, "function should have rendered the log context");
+            assertEquals(businessCid, tagged.get("cid"), "the business correlation-id must win");
+            // 2. a legacy pre-4.10.2 peer's transported header is honored
+            po.send(new EventEnvelope().setTo(route).setBody("x").setCorrelationId(internalCid)
+                    .setHeader("my_correlation_id", legacyCid));
+            Map<String, Object> legacy = bench.poll(10, TimeUnit.SECONDS);
+            assertNotNull(legacy, "function should have rendered the log context");
+            assertEquals(legacyCid, legacy.get("cid"), "a legacy peer's business cid must be honored");
+            // 3. no business context: the key is OMITTED - never the internal correlation-id
+            po.send(new EventEnvelope().setTo(route).setBody("x").setCorrelationId(internalCid));
+            Map<String, Object> unset = bench.poll(10, TimeUnit.SECONDS);
+            assertNotNull(unset, "function should have rendered the log context");
+            assertFalse(unset.containsKey("cid"),
+                    "an unresolved business correlation-id must be omitted, not substituted: " + unset);
         } finally {
             platform.release(route);
             LogContextConfig.setInstanceForTest(null);


### PR DESCRIPTION
## What

- **`$cid` in the application log context resolves to the business correlation ID only** —
  the same resolution as the injected `my_correlation_id` (the engine's business-cid tag,
  else a legacy pre-4.10.2 peer's transported header). When the delivered event carries no
  business context the token stays **unset** and the context block omits the key; internal
  correlation IDs (RPC inbox references, the graph engine's skill-callback composites)
  never appear under the `cid` label.
- **The Playground's `instantiate graph` command is the dry-run's edge**: it now
  auto-creates `model.cid` when the initial data mapping does not supply one, with a
  reminder line ("No business correlation ID given - this dry-run created model.cid = …");
  a supplied `model.cid` is honored silently.
- Regressions pin the whole policy: the platform-core log-context suite covers all three
  resolutions (tag wins over the envelope ID; legacy header honored; no business context →
  the key is absent, never the internal ID), and the playground sync suite covers both
  instantiate cases. Observability guide and CHANGELOG updated.

platform-core 425 tests green; minigraph 86 green; full reactor green.

## Why

A fallback to the envelope correlation ID could still surface an internal routing ID under
the `cid` label — misleading to DevOps teams correlating logs on the ID their callers know.
Business-or-nothing makes the field trustworthy, and it turns absence into a diagnostic:
since every edge — REST, Kafka adapter, and now the Playground's instantiate command —
guarantees a business correlation ID (generating a fresh one when the caller supplies
none), a missing `cid` on a traced log line reliably points at a propagation defect (the
recent eager-future span fix is exactly the class of bug it would have flagged). This
refines the log-context semantics shipped in #238 before the Rust engine mirrors them in
the lock-step arc.

Co-Authored-By: Claude Code <noreply@anthropic.com>