### PR TITLE
Pin the restore merge's literal-key immunity to composite-path forgery

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -16,7 +16,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-07-29 | agent: Claude Code (2026-07-29-190328)
+- **last_session:** 2026-07-30 | agent: Claude Code (2026-07-30-030533)
 - **last_review:** 2026-07-27 | through 2026-07-27-214357.md
 - **last_invariant_check:** 2026-07-27 | 2026-07-27-215011.md (all 15 confirmed by Eric — one-by-one walkthrough with live-tree evidence; thread-reverify-invariants-2026q2 closed)
 
@@ -329,6 +329,14 @@
   into the Rust v4.10.2.
   <!-- id: conv-telemetry-presentation-parity | created: 2026-07-23 | last_used: 2026-07-29 | uses: 8 | tier: active | origin: 2026-07-23-145132 -->
 
+- **The `helpers/` standalone servers exist for Docker-less developer machines and are
+  the standard local test servers for Rust ports (Eric, 2026-07-29).** They embed REAL
+  redis/kafka servers as plain `java -jar` apps because many field developers work on
+  Windows — especially VDI environments with no virtualization system, where Docker/
+  Testcontainers are unavailable. Usage convention: redis-standalone serves the Rust
+  minigraph-playground (suspend/resume live drives); kafka-standalone + the
+  schema-registry mock will serve the future minimalist-kafka Rust port.
+  <!-- id: conv-helpers-docker-less | created: 2026-07-29 | last_used: 2026-07-29 | uses: 1 | tier: working | origin: 2026-07-29-190328 -->
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
   <!-- id: conv-add-capability | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
@@ -351,7 +359,15 @@
 
 ## Open Threads
 
-- [ ] (feature — **P1-P4 MERGED 2026-07-28 as
+- [x] (feature — COMPLETE: **P5 Rust lock-step arc MERGED 2026-07-30 as mercury PR #186**
+  (five commits `304fc5a0`→`9326cf55`; 296 tests/clippy 0; Rust ADR twins accepted via the
+  merge; Java-side 5-lens consistency review confirmed 22 findings incl. 4 blockers — the
+  composite-path forged-record bypass, the missing instantiate auto-cid edge, the walker
+  seen-marking race, RESERVED_PARAMETERS missing 'suspend' — all fixed; live drive vs the
+  real redis-standalone helper matched the Java reply contract byte-for-byte with correct
+  cid/span presentation. Reciprocal Java pin: branch `test/pin-restore-putall-immunity`
+  commit `198869b3`, awaiting Eric's PR-or-release-prep call. Both engines now carry the
+  IDENTICAL suspend/resume surface — the whole P1-P5 arc is done.) **P1-P4 MERGED 2026-07-28 as
   [PR #238](https://github.com/Accenture/mercury-composable/pull/238), squash `168527ff`;
   ADR-0010 thereby ACCEPTED (the merge was the ledger gate). Eric drove three manual-test
   refinement rounds before merging: business-cid fidelity (walkers stamp the my_cid tag

--- a/memory/sessions/2026-07-29-190328.md
+++ b/memory/sessions/2026-07-29-190328.md
@@ -114,6 +114,13 @@ instantiate+run rounds sharing one model.cid → inspect output.body; seen prove
 no-re-execution; 404 rejection probe), and the workflow-suspension guide now shows all
 four curl runs explicitly (runs 2-3 were prose).
 
+**Also: Java-side pin from the P5 consistency review (branch
+test/pin-restore-putall-immunity, commit local).** The review's blocker #0 (the Rust
+restore merge's composite-path bypass of the reserved-key strip) prompted the agent's
+suggestion to pin Java's putAll immunity: the forged-record regression now also injects
+"cid.x"/"ttl[0]" as LITERAL record keys — a future refactor toward path-based writes
+cannot silently reopen the guarantee. Engine 88 green.
+
 ## Memory References
 
 - referenced: thread-graph-suspend-resume, graph-suspend-resume-design,

--- a/memory/sessions/2026-07-30-030533.md
+++ b/memory/sessions/2026-07-30-030533.md
@@ -1,0 +1,70 @@
+# Session (2026-07-30T03:05:33.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**P5 — the Rust suspend/resume lock-step arc: COMPLETE and MERGED as mercury PR #186.**
+Driven from this session via the persistent Rust-port agent (SendMessage per increment;
+Eric gated the push and the merge). The Java side authored the handoff
+(/tmp/graph-suspend-resume-rust-handoff-p5.md — the full final-surface spec with
+do-not-port flags for the two superseded intermediate designs) and ran the consistency
+review; the Rust agent implemented and self-gated each increment.
+
+**The five commits (branch feature/graph-suspend-resume → merged):**
+P5-1 `304fc5a0` engine core (skills, walkers, model.run, fixtures + suite);
+P5-2 `da53dfc4` mandatory gate (compiled-or-404, manifest `location`, model validator,
+pre-run check, parser-test-32 twin); P5-3 `4374a723` minigraph-state-redis crate
+(redis-rs v1.5.0 ConnectionManager = the Lettuce analog, lazy connect, SETEX/GETDEL,
+RESP2 in-process server double for unit tests — client wire path real); P5-4
+`6032262d` tutorial-14 verbatim + all docs/help/catalog + webapp bundle + Rust ADR
+twins (Rust ADR-0009/0010 ↔ Java ADR-0010/0011; "session persistence out-of-scope"
+superseded); fix round `9326cf55`. Final gate 296 tests / clippy 0 / fmt clean.
+
+**Java-side consistency review (5-lens workflow, 28 agents, every finding adversarially
+verified): 22 confirmed — 4 blockers, 6 should-fix, 12 nits — ALL closed in the fix
+round.** The blockers: (1) the Rust restore merge wrote persisted keys through a
+path-interpreting setter, so a forged record key "cid.x"/"ttl[0]" bypassed the literal
+reserved-key strip and could clobber model.cid — fixed to literal key-level putAll +
+forged-composite-key regression; (2) the playground instantiate edge was missing the
+f2107126 auto-cid + reminder (dry-run suspend graphs failed on Rust); (3) walker
+seen-marking used an overwriting insert (transient join-barrier flip) — now
+insert-if-absent; (4) RESERVED_PARAMETERS omitted 'suspend'. Notable should-fix: Rust
+dry-runs emitted NO telemetry (now mint the minigraph.playground//graph/playground
+trace — 22 records where there were zero); the span-topology twin test added.
+Review lens verdicts: all 15 fixtures byte-identical; error strings verbatim;
+gate/validator rule-for-rule; two-lane split honored.
+
+**Reciprocal finding applied on the JAVA side:** branch
+`test/pin-restore-putall-immunity` (commit `198869b3`, engine 88 green) — the
+forged-record regression now injects "cid.x"/"ttl[0]" as LITERAL record keys, pinning
+putAll's structural immunity against any future refactor toward path-based writes
+(exactly the trap the port fell into). Awaiting Eric's call: own PR or ride release
+prep. (Commit hygiene note: the first attempt swept .interop-mercury and
+memory/continuity.md in via `git add -A` — rebuilt the commit to the test file only;
+memory commits stay human-initiated.)
+
+**Live parity evidence (drive vs the real redis-standalone helper):** reply contract
+byte-for-byte with Java's tutorial (run flag per run, full history on run 4, 404 +
+run=fresh rejection); business cid on every traced store line; store spans chained
+under skill spans; no re-executed checkpoint spans on resume.
+
+**Porting notes recorded (both repos):** Rust task-scoped trace context makes Java's
+eager-dispatch Mono workaround unnecessary (plain await, same topology); compiled-or-404
+exposed five Rust fixtures riding the lazy path + the Rust example app's missing
+manifest (live migration evidence for the field note); the helpers convention with
+Eric's WHY (Windows/VDI machines have no virtualization for Docker — `java -jar`
+helpers embed real servers; redis-standalone now, kafka-standalone +
+schema-registry-mock for the future minimalist-kafka port).
+
+**State:** both engines now carry the IDENTICAL suspend/resume surface. Next: the
+official release (Eric planning; lock-step option fully available), and the Java pin
+branch decision.
+
+## Memory References
+
+- referenced: thread-graph-suspend-resume, compilegraph-mandatory-gate,
+  graph-suspend-resume-design, conv-telemetry-presentation-parity,
+  conv-helpers-docker-less, bp-graph-workflow-suspension
+- updated: thread-graph-suspend-resume (P5 merged — the P1-P5 arc is COMPLETE; thread
+  checked off), conv-helpers-docker-less (created earlier this session, exercised here)

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/suspend/GraphSuspendResumeTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/suspend/GraphSuspendResumeTest.java
@@ -191,6 +191,15 @@ class GraphSuspendResumeTest {
         forged.setElement("data.model.cid", "forged-cid");
         forged.setElement("data.model.instance", "forged-instance");
         forged.setElement("data.model.run", "resume");
+        // composite-path vectors, injected as LITERAL record keys: the restore merge
+        // must treat persisted keys literally (putAll) - a path-interpreting write
+        // would let "cid.x" descend into and replace model.cid (the trap the Rust
+        // port's consistency review caught; this pins the Java immunity)
+        if (forged.getElement("data.model") instanceof Map<?, ?> forgedModel) {
+            var literal = (Map<String, Object>) forgedModel;
+            literal.put("cid.x", "forged-nested");
+            literal.put("ttl[0]", "forged-indexed");
+        }
         Files.write(file.toPath(), msgPack.pack(forged.getMap()));
         // resume with the real correlation ID: the workflow continues, but none of the
         // forged reserved keys may reach the state machine - model.cid is a capability


### PR DESCRIPTION
## What

A test-only hardening of the suspend/resume forged-record regression, plus the memory
records closing the P5 cross-engine arc:

1. `GraphSuspendResumeTest.restoredRecordCannotOverrideReservedModelKeys` now also
   injects composite-path vectors — `"cid.x"` and `"ttl[0]"` — as **literal** keys in
   the forged store record's model map, asserting the resumed run's identity survives.
   Java's restore merge uses a literal `putAll`, which is structurally immune: such keys
   land as inert literal entries and can never descend into `model.cid` / `model.ttl`.
   No production code changes; engine suite green.

2. The committed `memory/` records for the completed P5 arc: the Rust engine's
   suspend/resume lock-step port merged as mercury PR #186 — both engines now carry the
   identical feature surface.

## Why

The Java-side consistency review of the Rust port (mercury #186) caught a real blocker
in the port's first restore-merge implementation: persisted model keys written through a
path-interpreting setter let a forged record key like `"cid.x"` bypass the literal
reserved-key strip and replace `model.cid` — the exact capability the production-polish
round (#240) hardened, defeated by an innocent-looking idiom. The Rust side fixed it and
suggested the reciprocal pin: since Java's immunity is structural rather than asserted,
a future refactor of the merge toward path-based writes would reopen the hole without
failing any test. These nine lines make that refactor fail loudly. A small deliverable
of the cross-engine review loop paying off in both directions.

Co-Authored-By: Claude Code <noreply@anthropic.com>