### PR TITLE
Fold the Code/Documentation Conventions tabs into the Reference tab

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,10 +159,9 @@ nav:
     - Interop Test Report — Suspend/Resume: test-reports/suspend-resume-interop.md
     - Reserved Names & Headers: guides/reserved-names-and-headers.md
     - Actuators & HTTP Client: guides/actuators-and-http-client.md
+    - Code Conventions: guides/code-conventions.md
+    - Documentation Conventions: guides/documentation-conventions.md
     - Release Notes: https://github.com/Accenture/mercury-composable/blob/main/CHANGELOG.md
-
-  - Code Conventions: guides/code-conventions.md
-  - Documentation Conventions: guides/documentation-conventions.md
   - Contributing: https://github.com/Accenture/mercury-composable/blob/main/CONTRIBUTING.md
   - Code of Conduct: https://github.com/Accenture/mercury-composable/blob/main/CODE_OF_CONDUCT.md
   - Inclusivity: https://github.com/Accenture/mercury-composable/blob/main/INCLUSIVITY.md


### PR DESCRIPTION
## What

The top-navigation tab row exceeded the screen's real estate (the last tab was
truncated on a standard laptop width). The two single-page tabs — Code Conventions and
Documentation Conventions — move into the Reference section as regular entries, placed
just before the external Release Notes link. Ten tab sections become eight; no page
moves on disk, so every existing link and bookmark keeps working. mkdocs `--strict`
clean.

## Why

Pre-release docs polish for v4.11.0: the nav must present cleanly on the screens the
documentation is read on, and both conventions pages are reference material by nature —
Reference is where a reader would look for them. The Rust repo folds its Background tab
into Reference in the twin PR for cross-repo consistency.

Co-Authored-By: Claude Code <noreply@anthropic.com>