### PR TITLE
Worked example: second-level routing in examples/kafka-demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    writes a Map, the wire carries JSON, and a consuming `serializer: 'json'` binding hands
    its flow a Map again. Non-schema-registry topics only: with a `subject` header the body
    contract stays a byte[] JSON document, unchanged.
+3. **Worked example: second-level routing in `examples/kafka-demo`.** A new `demo.orders`
+   topic sits beside the direct-routing `demo.inbound`, so one `kafka-flow-adapter.yaml`
+   shows both routing styles side by side. The rule list exercises every grammar element —
+   exact and wildcard header rules to a specific flow (whose Map response demonstrates the
+   outbound auto-serialization), a body-path rule to a `task://` function, and the
+   mandatory default flow handling both Map and raw-byte[] bodies — driven from a new
+   `publish-orders.js` console program with one keyword per routing rule.
 
 ---
 ## Version 4.11.0, 7/30/2026

--- a/examples/kafka-demo/README.md
+++ b/examples/kafka-demo/README.md
@@ -1,9 +1,9 @@
 # kafka-demo — minimalist-kafka worked example
 
-A hands-on, end-to-end demonstration of the **minimalist-kafka** consumer + producer pattern. You publish a
-message from a terminal, it travels through Kafka into a composable Java app, gets processed, is published
-to another topic, and shows up in a second terminal — with the whole path visible in the Java app's
-telemetry log.
+A hands-on, end-to-end demonstration of the **minimalist-kafka** consumer + producer pattern — including
+both **routing styles** of the Kafka flow adapter, side by side. You publish a message from a terminal, it
+travels through Kafka into a composable Java app, gets processed, is published to another topic, and shows
+up in a second terminal — with the whole path visible in the Java app's telemetry log.
 
 ```
   publish-inbound.js  --(demo.inbound)-->  kafka-demo (Java)  --(demo.outbound)-->  listen-outbound.js
@@ -11,12 +11,21 @@ telemetry log.
                                             |  -> demo.processor       |
                                             |  -> simple.kafka.notification
                                             +--------------------------+
+
+  publish-orders.js   --(demo.orders)--->  kafka-demo (Java)  --(demo.outbound)-->  listen-outbound.js
+   (program-3, you type)                    |  flow adapter: SECOND-LEVEL ROUTING (per-record rules)
+                                            |  -> flow://demo-order-flow       (type=order / order-*)
+                                            |  -> task://demo.refund.processor (body event.kind=refund)
+                                            |  -> flow://demo-catch-all-flow   (default)
 ```
 
 The Java app is pure minimalist-kafka: the **Kafka flow adapter** binds `demo.inbound` to the
-`kafka-demo-flow`, whose `demo.processor` task wraps the message with processing metadata, and
-`simple.kafka.notification` publishes the result to `demo.outbound`. No code wires those steps together —
-the [flow YAML](src/main/resources/flows/kafka-demo-flow.yml) does (see ADR-0007).
+`kafka-demo-flow` (**direct routing** — every message goes to one flow), whose `demo.processor` task wraps
+the message with processing metadata, and `simple.kafka.notification` publishes the result to
+`demo.outbound`. The `demo.orders` binding uses **[second-level
+routing](../../docs/guides/minimalist-kafka.md#routing)** instead — a rule list inspects each record and
+picks the target per message. No code wires any of those steps together — the flow YAML does (see
+ADR-0007).
 
 ## Prerequisites
 
@@ -50,7 +59,7 @@ Wait for it to report the broker is up on `127.0.0.1:9092`.
 ```shell
 cd examples/kafka-demo/node
 node create-topics.js
-# -> created (10 partitions each): demo.inbound, demo.outbound
+# -> created (10 partitions each): demo.inbound, demo.orders, demo.outbound
 ```
 
 ### Terminal C — start the kafka-demo Java app
@@ -100,19 +109,69 @@ telemetry, and at the listener — proof the trace stays continuous across both 
 new `span_id`; `simple.kafka.notification`'s span becomes the parent of the next hop, while the trace-id is
 carried unchanged.) If the publisher sends no `traceparent`, the flow simply starts a fresh trace instead.
 
+## Second-level routing — one topic, many targets
+
+The `demo.orders` binding shows the adapter's **second-level routing**: instead of one `flow`, a `flows`
+rule list inspects a key-value of each record and picks the target per message — the common Kafka pattern
+of one topic carrying mixed event types. See the rule grammar in
+[`kafka-flow-adapter.yaml`](src/main/resources/kafka-flow-adapter.yaml); the first matching rule wins, in
+declaration order, and the mandatory `default` catches the rest. `serializer: 'json'` decodes each JSON
+record to a `Map` before routing, so the `input.body` rule can match — a non-JSON record keeps its raw
+`byte[]` and falls through to the default.
+
+### Terminal F — publish mixed events (program-3)
+```shell
+cd examples/kafka-demo/node
+node publish-orders.js
+```
+One command per routing rule (an optional trailing JSON overrides the canned payload):
+
+| You type | Record shape | Rule that fires | Target |
+|----------|--------------|-----------------|--------|
+| `order` | `type: order` header + JSON body | `input.header.type(order)` — exact | `flow://demo-order-flow` |
+| `order-42` | `type: order-42` header + JSON body | `input.header.type(order-*)` — wildcard | `flow://demo-order-flow` |
+| `refund` | no `type` header, `{"event":{"kind":"refund"},...}` body | `input.body.event.kind(refund)` — body path | `task://demo.refund.processor` |
+| `hello world` | raw text (not JSON) | none — falls through | `default` → `flow://demo-catch-all-flow` |
+
+**What you should see per command:**
+
+- `order` / `order-42` — the Java log shows `OrderProcessor - Order event routed by rule type(...)`, and
+  **Terminal D** receives the processed order on `demo.outbound` with `"routedBy"` naming the matched key.
+  The flow publishes the processor's `Map` straight through `simple.kafka.notification`, which
+  **auto-serializes it to JSON bytes** — the outbound symmetry of `serializer: 'json'` (`Map` in the
+  function, JSON on the wire).
+- `refund` — the **Java log** shows `RefundProcessor - Refund routed by rule input.body.event.kind(refund)`
+  with the same `cid`/`traceId` the publisher printed. Nothing arrives on `demo.outbound`: a `task://`
+  target invokes the function **directly** — all record headers copied verbatim, the whole payload as the
+  body, no flow and no data mapping. Use it for processing simple enough that a flow is overweight;
+  anything needing orchestration (like publishing onward) belongs in a `flow://` target.
+- anything else — **Terminal D** receives the annotated record from `demo-catch-all-flow` with
+  `"routedBy": "default"` and a `"shape"` field showing whether the body arrived as a decoded `Map`/`List`
+  or as raw bytes (`serializer: 'json'` is best-effort: an unparseable record passes through unchanged,
+  and the default handler deals with it — the pattern a production catch-all should follow).
+
+Each published record carries its own `traceparent`, so every routed message — flow or task — shows full
+trace continuity in the telemetry log, exactly like the direct-routing path.
+
 ## How it maps to minimalist-kafka
 
 | Piece | What it shows |
 |-------|---------------|
-| [`kafka-flow-adapter.yaml`](src/main/resources/kafka-flow-adapter.yaml) | the **consumer** side: bind a topic to a flow, with a consumer group |
+| [`kafka-flow-adapter.yaml`](src/main/resources/kafka-flow-adapter.yaml) | the **consumer** side, both styles: direct routing (`flow`) and second-level routing (`flows` + `serializer` + `ttl`) |
 | [`kafka-demo-flow.yml`](src/main/resources/flows/kafka-demo-flow.yml) | orchestration as config: `demo.processor` → `simple.kafka.notification` |
+| [`demo-order-flow.yml`](src/main/resources/flows/demo-order-flow.yml) | a rule-selected **specific flow**; publishes a `Map` that `simple.kafka.notification` auto-serializes |
+| [`demo-catch-all-flow.yml`](src/main/resources/flows/demo-catch-all-flow.yml) | the mandatory **default** flow; its task handles both body shapes (Map or raw bytes) |
 | [`DemoProcessor.java`](src/main/java/com/accenture/kafka/demo/tasks/DemoProcessor.java) | a self-contained function (the unit of work), in a `tasks` package per the [Code Conventions](../../docs/guides/code-conventions.md) |
+| [`RefundProcessor.java`](src/main/java/com/accenture/kafka/demo/tasks/RefundProcessor.java) | a **`task://` routing target**: invoked directly by the adapter — headers copied verbatim, payload as body, no flow |
 | `simple.kafka.notification` | the **producer** side: publish to a topic via data mapping (`text(demo.outbound) -> header.topic`) |
 
 ## Notes
 
 - Point at a different broker with `export KAFKA_BOOTSTRAP_SERVERS=host:port` (both the Java app and the
   Node programs honor it).
-- On repeated processing failure, a message is dead-lettered to `demo.inbound.dlq` (the binding's configured
-  `dlq-topic` in `kafka-flow-adapter.yaml`); pre-create that topic if you want to exercise the failure path.
-  The happy path never touches it.
+- On repeated processing failure, a message is dead-lettered to the binding's configured `dlq-topic`
+  (`demo.inbound.dlq` / `demo.orders.dlq` in `kafka-flow-adapter.yaml`); pre-create those topics if you
+  want to exercise the failure path — it applies identically to `flow://` and `task://` targets. The happy
+  path never touches them.
+- The second-level routing rule grammar (selectors, the three matcher modes, targets, `serializer`,
+  `ttl`) is documented in the [Minimalist Kafka guide](../../docs/guides/minimalist-kafka.md#routing).

--- a/examples/kafka-demo/node/config.js
+++ b/examples/kafka-demo/node/config.js
@@ -3,7 +3,8 @@
 
 export default {
   brokers: (process.env.KAFKA_BOOTSTRAP_SERVERS || '127.0.0.1:9092').split(','),
-  inboundTopic: 'demo.inbound',   // node publisher -> here -> kafka-demo Java app
+  inboundTopic: 'demo.inbound',   // node publisher -> here -> kafka-demo Java app (direct routing)
+  ordersTopic: 'demo.orders',     // node publisher -> here -> kafka-demo Java app (second-level routing)
   outboundTopic: 'demo.outbound', // kafka-demo Java app -> here -> node listener
   partitions: 10,
   // ISO-8601 timestamp for simple, sortable console logging

--- a/examples/kafka-demo/node/create-topics.js
+++ b/examples/kafka-demo/node/create-topics.js
@@ -11,7 +11,7 @@ const { Kafka } = kafkajs;
   const admin = kafka.admin();
   await admin.connect();
   try {
-    const wanted = [cfg.inboundTopic, cfg.outboundTopic];
+    const wanted = [cfg.inboundTopic, cfg.ordersTopic, cfg.outboundTopic];
     const existing = await admin.listTopics();
     const toCreate = wanted
       .filter((t) => !existing.includes(t))

--- a/examples/kafka-demo/node/publish-orders.js
+++ b/examples/kafka-demo/node/publish-orders.js
@@ -1,0 +1,109 @@
+// publish-orders.js (program-3) - drive the SECOND-LEVEL ROUTING demo: publish mixed event types to
+// demo.orders and watch the adapter's rule list pick a different target per message.
+// Run in its own terminal:  node publish-orders.js   (then type a command and press Enter)
+//
+// Console commands (first word decides the record shape; each exercises one routing rule):
+//
+//   order [json]       'type: order' header (+ JSON body)   -> exact rule    -> flow://demo-order-flow
+//   order-<x> [json]   'type: order-<x>' header (+ body)    -> wildcard rule -> flow://demo-order-flow
+//   refund [json]      NO type header, {"event":{"kind":"refund"},...} body
+//                                                           -> body rule     -> task://demo.refund.processor
+//   <anything else>    raw text (not JSON, no type header)  -> default       -> flow://demo-catch-all-flow
+//
+// The optional [json] overrides the canned payload, e.g.:  order {"item":"laptop","qty":2}
+// Rule evaluation is first-match-wins in declaration order; a non-match falls through to 'default'.
+
+import readline from 'node:readline';
+import { randomUUID, randomBytes } from 'node:crypto';
+import kafkajs from 'kafkajs';
+import cfg from './config.js';
+
+const { Kafka, Partitioners } = kafkajs;
+
+// Build {headers, value, rule} for one console line - the record shape decides which rule fires.
+function toRecord(line) {
+  const space = line.indexOf(' ');
+  const keyword = space === -1 ? line : line.substring(0, space);
+  const rest = space === -1 ? '' : line.substring(space + 1).trim();
+  const customJson = rest.startsWith('{') || rest.startsWith('[') ? rest : null;
+  if (keyword === 'order' || keyword.startsWith('order-')) {
+    const rule = keyword === 'order'
+      ? 'input.header.type(order) [exact]' : 'input.header.type(order-*) [wildcard]';
+    return {
+      headers: { type: keyword },
+      value: customJson || JSON.stringify({ item: 'keyboard', qty: 1 }),
+      rule: `${rule} -> flow://demo-order-flow`,
+    };
+  }
+  if (keyword === 'refund') {
+    // no 'type' header: the header rules cannot match, so the input.body rule decides
+    return {
+      headers: {},
+      value: customJson
+        || JSON.stringify({ event: { kind: 'refund' }, orderId: randomUUID().substring(0, 8) }),
+      rule: 'input.body.event.kind(refund) [body path] -> task://demo.refund.processor (see the Java log)',
+    };
+  }
+  // raw text: not a JSON object/array, so serializer 'json' keeps the byte[] and no rule matches
+  return {
+    headers: {},
+    value: line,
+    rule: 'default -> flow://demo-catch-all-flow (raw bytes pass through)',
+  };
+}
+
+(async () => {
+  const kafka = new Kafka({ clientId: 'kafka-demo-orders-publisher', brokers: cfg.brokers });
+  // DefaultPartitioner avoids kafkajs' legacy-partitioner warning and spreads across the 10 partitions
+  const producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner });
+  await producer.connect();
+  console.log(`[${cfg.ts()}] connected. Publish to '${cfg.ordersTopic}' (Ctrl-C to quit). Commands:`);
+  console.log('  order [json]      -> exact rule    -> demo-order-flow');
+  console.log('  order-<x> [json]  -> wildcard rule -> demo-order-flow');
+  console.log('  refund [json]     -> body rule     -> task demo.refund.processor');
+  console.log('  <anything else>   -> default       -> demo-catch-all-flow');
+
+  async function publishOne(text) {
+    const { headers, value, rule } = toRecord(text);
+    const cid = randomUUID();
+    // W3C traceparent: the adapter adopts this trace-id, so the selected flow/task (and any message
+    // it publishes to demo.outbound) shares it - end-to-end trace continuity per routed message.
+    const traceId = randomBytes(16).toString('hex');
+    const traceparent = `00-${traceId}-${randomBytes(8).toString('hex')}-01`;
+    try {
+      await producer.send({
+        topic: cfg.ordersTopic,
+        messages: [{ value, headers: { ...headers, cid, traceparent } }],
+      });
+      console.log(`[${cfg.ts()}] -> ${cfg.ordersTopic} cid=${cid} traceId=${traceId}`);
+      console.log(`[${cfg.ts()}]    expected: ${rule}`);
+    } catch (e) {
+      console.error(`[${cfg.ts()}] publish failed:`, e.message);
+    }
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' });
+  rl.prompt();
+
+  // chain the sends so they stay ordered and can be awaited on close - the script then works both
+  // interactively AND with piped input for scripted regression runs, e.g.
+  //   printf 'order\nrefund\nhello\n' | node publish-orders.js
+  let inflight = Promise.resolve();
+
+  rl.on('line', (line) => {
+    const text = line.trim();
+    if (text.length > 0) {
+      inflight = inflight.then(() => publishOne(text));
+    }
+    rl.prompt();
+  });
+
+  rl.on('close', async () => {
+    await inflight;
+    await producer.disconnect();
+    process.exit(0);
+  });
+})().catch((e) => {
+  console.error(`[${cfg.ts()}] error:`, e.message);
+  process.exit(1);
+});

--- a/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/CatchAllProcessor.java
+++ b/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/CatchAllProcessor.java
@@ -1,0 +1,76 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The task of {@code demo-catch-all-flow} - the DEFAULT FLOW of the second-level routing demo,
+ * reached when NO routing rule matches a {@code demo.orders} record.
+ *
+ * <p>The body can be either shape here, so the input type is {@code Object}: a {@code Map} (a JSON
+ * record that matched no rule) or the raw {@code byte[]} (a record {@code serializer: 'json'} could
+ * not parse - best-effort by design, the raw bytes simply pass through). Handling both is the
+ * pattern a production default handler should follow.</p>
+ */
+@PreLoad(route = "demo.catch.all", instances = 10)
+public class CatchAllProcessor implements TypedLambdaFunction<Object, Map<String, Object>> {
+    private static final Logger log = LoggerFactory.getLogger(CatchAllProcessor.class);
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Object input, int instance) {
+        PostOffice po = new PostOffice(headers, instance);
+        Map<String, Object> response = new HashMap<>();
+        // a raw byte[] means serializer: 'json' could not parse the record - show it as text;
+        // a Map/List is a well-formed JSON record that simply matched no routing rule
+        switch (input) {
+            case byte[] bytes -> {
+                response.put("received", new String(bytes, StandardCharsets.UTF_8));
+                response.put("shape", "raw bytes (not a JSON object/array)");
+            }
+            case Map<?, ?> map -> {
+                response.put("received", map);
+                response.put("shape", "map (JSON object, no rule matched)");
+            }
+            case List<?> list -> {
+                response.put("received", list);
+                response.put("shape", "list (JSON array, no rule matched)");
+            }
+            case null, default -> {
+                response.put("received", String.valueOf(input));
+                response.put("shape", "other");
+            }
+        }
+        log.info("Unmatched record caught by the default rule (cid={}, traceId={}): {}",
+                po.getMyCorrelationId(), po.getTraceId(), response.get("shape"));
+        response.put("processedBy", "demo-catch-all-flow");
+        response.put("routedBy", "default");
+        response.put("traceId", po.getTraceId());
+        return response;
+    }
+}

--- a/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/OrderProcessor.java
+++ b/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/OrderProcessor.java
@@ -1,0 +1,64 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The task of {@code demo-order-flow} - the SPECIFIC FLOW of the second-level routing demo, selected
+ * when a {@code demo.orders} record's {@code type} header matches the {@code order} (exact) or
+ * {@code order-*} (wildcard) routing rule.
+ *
+ * <p>The binding's {@code serializer: 'json'} decoded the record before routing, so the input is a
+ * {@code Map} - no byte[] handling here. The function returns a {@code Map} too: the flow maps it
+ * straight into {@code simple.kafka.notification}, which auto-serializes a Map body to JSON bytes on
+ * a non-schema topic (the outbound symmetry of {@code serializer: 'json'}).</p>
+ *
+ * <p>{@code header.type} is the routing key the rule matched on (mapped by the flow from the raw
+ * record header), echoed in the response so the outbound message shows which rule fired.</p>
+ */
+@PreLoad(route = "demo.order.processor", instances = 10)
+public class OrderProcessor implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+    private static final Logger log = LoggerFactory.getLogger(OrderProcessor.class);
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        PostOffice po = new PostOffice(headers, instance);
+        String type = headers.get("type");
+        log.info("Order event routed by rule type({}) (cid={}, traceId={}): {}",
+                type, po.getMyCorrelationId(), po.getTraceId(), input);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("order", input);
+        response.put("routedBy", "input.header.type(" + type + ")");
+        response.put("processedBy", "demo-order-flow");
+        // Instant is serialized as an ISO-8601 / RFC-3339 string by the built-in mapper (platform-core)
+        response.put("processedAt", Instant.now());
+        response.put("traceId", po.getTraceId());   // continuous across the Kafka hop
+        return response;
+    }
+}

--- a/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/RefundProcessor.java
+++ b/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/RefundProcessor.java
@@ -1,0 +1,62 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.PostOffice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The SPECIFIC TASK of the second-level routing demo - the {@code task://demo.refund.processor}
+ * target, selected when the {@code input.body.event.kind(refund)} rule matches a {@code demo.orders}
+ * record's payload (a body rule needs the Map that {@code serializer: 'json'} decoded).
+ *
+ * <p>A {@code task://} target invokes this function DIRECTLY - no flow, no data mapping. The adapter
+ * copies all inbound Kafka record headers verbatim onto the input headers, passes the whole decoded
+ * payload as the body, and injects the business correlation-id (readable via
+ * {@code PostOffice.getMyCorrelationId()}) with full trace continuity. Returning normally
+ * (status &lt; 400) lets the adapter commit the offset; throwing follows the same bounded-retry then
+ * dead-letter path as a flow failure.</p>
+ *
+ * <p>Use a task for processing simple enough that a flow is overweight - record, count, notify. This
+ * demo task just acknowledges the refund in the application log (watch the Java terminal); anything
+ * needing orchestration - like publishing onward - belongs in a {@code flow://} target instead.</p>
+ */
+@PreLoad(route = "demo.refund.processor", instances = 10)
+public class RefundProcessor implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+    private static final Logger log = LoggerFactory.getLogger(RefundProcessor.class);
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        PostOffice po = new PostOffice(headers, instance);
+        log.info("Refund routed by rule input.body.event.kind(refund) (cid={}, traceId={}): {}",
+                po.getMyCorrelationId(), po.getTraceId(), input);
+
+        Map<String, Object> ack = new HashMap<>();
+        ack.put("status", "refund recorded");
+        ack.put("refund", input);
+        ack.put("cid", po.getMyCorrelationId());
+        return ack;
+    }
+}

--- a/examples/kafka-demo/src/main/resources/flows.yaml
+++ b/examples/kafka-demo/src/main/resources/flows.yaml
@@ -3,3 +3,5 @@
 #
 flows:
   - 'kafka-demo-flow.yml'
+  - 'demo-order-flow.yml'
+  - 'demo-catch-all-flow.yml'

--- a/examples/kafka-demo/src/main/resources/flows/demo-catch-all-flow.yml
+++ b/examples/kafka-demo/src/main/resources/flows/demo-catch-all-flow.yml
@@ -1,0 +1,36 @@
+#
+# The DEFAULT FLOW of the second-level routing demo: reached when NO routing rule matches a
+# demo.orders record - the mandatory 'default' entry in kafka-flow-adapter.yaml selects it.
+#
+# The body here can be EITHER shape: a Map (a JSON record that matched no rule) or the raw byte[]
+# (a record that serializer: 'json' could not parse - best-effort by design, the raw bytes simply
+# pass through). demo.catch.all accepts Object input and handles both, which is exactly the
+# pattern a production default handler should follow.
+#
+flow:
+  id: 'demo-catch-all-flow'
+  description: 'Catch every demo.orders record no routing rule matched and publish to demo.outbound'
+  ttl: 30s
+
+first.task: 'demo.catch.all'
+
+tasks:
+  - input:
+      - 'input.body -> *'
+      - 'model.cid -> header.cid'
+    process: 'demo.catch.all'
+    output:
+      - 'result -> model.payload'
+    description: 'Annotate the unmatched record (Map or raw byte[])'
+    execution: sequential
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(demo.outbound) -> header.topic'
+      - 'model.cid -> header.cid'
+      - 'model.payload -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the annotated record - a Map, auto-serialized to JSON bytes'
+    execution: end

--- a/examples/kafka-demo/src/main/resources/flows/demo-order-flow.yml
+++ b/examples/kafka-demo/src/main/resources/flows/demo-order-flow.yml
@@ -1,0 +1,41 @@
+#
+# The SPECIFIC FLOW of the second-level routing demo: selected when a demo.orders record's 'type'
+# header matches 'order' (exact rule) or 'order-*' (wildcard rule) - see kafka-flow-adapter.yaml.
+#
+# The binding's serializer: 'json' has already decoded the JSON record, so input.body arrives here
+# as a Map (no byte[] handling needed). The processor returns a Map, and the flow publishes it
+# straight through simple.kafka.notification - which auto-serializes a Map body to JSON bytes on a
+# non-schema topic. That is the OUTBOUND symmetry of serializer: 'json': Map in the producing
+# function, JSON bytes on the wire, and a Map again in any consuming binding that opts in.
+#
+# input.header.type is the routing key the rule matched on, mapped from the raw record header so
+# the processor (and the outbound message) can show WHICH rule selected this flow.
+#
+flow:
+  id: 'demo-order-flow'
+  description: 'Process an order event selected by a routing rule and publish to demo.outbound'
+  ttl: 30s
+
+first.task: 'demo.order.processor'
+
+tasks:
+  - input:
+      - 'input.body -> *'
+      - 'model.cid -> header.cid'
+      - 'input.header.type -> header.type'
+    process: 'demo.order.processor'
+    output:
+      - 'result -> model.payload'
+    description: 'Process the order event (a Map, decoded by the binding''s serializer)'
+    execution: sequential
+    next:
+      - 'simple.kafka.notification'
+
+  - input:
+      - 'text(demo.outbound) -> header.topic'
+      - 'model.cid -> header.cid'
+      - 'model.payload -> *'
+    process: 'simple.kafka.notification'
+    output: []
+    description: 'Publish the processed order - a Map, auto-serialized to JSON bytes'
+    execution: end

--- a/examples/kafka-demo/src/main/resources/kafka-flow-adapter.yaml
+++ b/examples/kafka-demo/src/main/resources/kafka-flow-adapter.yaml
@@ -1,6 +1,8 @@
 #
-# Kafka Flow Adapter configuration for the worked example: bind the inbound demo topic to the demo flow.
-# The adapter starts one consumer thread for the topic and routes every message into 'kafka-demo-flow'.
+# Kafka Flow Adapter configuration for the worked example - both routing styles side by side:
+#
+#   demo.inbound  -> DIRECT routing:       every message goes to one flow ('flow')
+#   demo.orders   -> SECOND-LEVEL routing: a rule list picks the target per message ('flows')
 #
 consumer:
   - topic: 'demo.inbound'
@@ -8,3 +10,27 @@ consumer:
     group: '${KAFKA_DEMO_CONSUMER_GROUP:kafka-demo-group}'
     dlq-topic: 'demo.inbound.dlq'      # pre-provision this topic to exercise the failure path
     # partition: 0                    # optional; pins one partition (manual assign, no group rebalancing)
+
+  # Second-level routing: one topic carrying mixed event types. 'flows' (instead of a single 'flow')
+  # inspects a key-value of each record and picks the target per message - the FIRST matching rule
+  # wins, in declaration order, and the mandatory 'default' catches the rest. A non-match (missing
+  # header/key, non-JSON body for an input.body rule) is never an error - it just falls through.
+  #
+  # serializer: 'json' decodes each JSON record to a Map before routing, so the input.body rule can
+  # match and the selected flow/task receives a Map. A record that is not a JSON object/array keeps
+  # its raw byte[] and simply passes to the selected target (best-effort by design).
+  #
+  # Targets: flow://<flow-id> dispatches to an Event Script flow exactly like direct routing;
+  # task://<route> invokes a registered function DIRECTLY (all record headers copied verbatim, the
+  # whole payload as the body) - for processing simple enough that a flow is overweight. 'ttl' is
+  # the deadline for task:// invocations (a bare function has no flow ttl; default 30s).
+  - topic: 'demo.orders'
+    group: '${KAFKA_DEMO_ORDERS_GROUP:kafka-demo-orders-group}'
+    serializer: 'json'
+    ttl: '15s'
+    dlq-topic: 'demo.orders.dlq'       # pre-provision this topic to exercise the failure path
+    flows:
+      - 'input.header.type(order) -> flow://demo-order-flow'
+      - 'input.header.type(order-*) -> flow://demo-order-flow'
+      - 'input.body.event.kind(refund) -> task://demo.refund.processor'
+      - 'default -> flow://demo-catch-all-flow'

--- a/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/CatchAllProcessorTest.java
+++ b/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/CatchAllProcessorTest.java
@@ -1,0 +1,71 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * demo.catch.all is the default flow's task, so it must handle BOTH body shapes: the raw byte[] of a
+ * record serializer: 'json' could not parse, and a decoded Map/List that simply matched no rule.
+ */
+class CatchAllProcessorTest {
+
+    private final CatchAllProcessor processor = new CatchAllProcessor();
+
+    private static Map<String, String> headers() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.catch.all");
+        headers.put("my_trace_id", "trace-1234");
+        headers.put("my_trace_path", "KAFKA demo.orders");
+        return headers;
+    }
+
+    @Test
+    void rawBytesAreShownAsText() {
+        Map<String, Object> response = processor.handleEvent(headers(),
+                "not-json".getBytes(StandardCharsets.UTF_8), 1);
+        assertEquals("not-json", response.get("received"));
+        assertEquals("raw bytes (not a JSON object/array)", response.get("shape"));
+        assertEquals("default", response.get("routedBy"));
+        assertEquals("demo-catch-all-flow", response.get("processedBy"));
+    }
+
+    @Test
+    void unmatchedJsonObjectPassesThroughAsMap() {
+        Map<String, Object> body = Map.of("hello", "world");
+        Map<String, Object> response = processor.handleEvent(headers(), body, 1);
+        assertEquals(body, response.get("received"));
+        assertEquals("map (JSON object, no rule matched)", response.get("shape"));
+    }
+
+    @Test
+    void unmatchedJsonArrayPassesThroughAsList() {
+        List<Object> body = List.of(Map.of("n", 1));
+        Map<String, Object> response = processor.handleEvent(headers(), body, 1);
+        assertEquals(body, response.get("received"));
+        assertEquals("list (JSON array, no rule matched)", response.get("shape"));
+    }
+}

--- a/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/OrderProcessorTest.java
+++ b/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/OrderProcessorTest.java
@@ -1,0 +1,62 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * demo.order.processor receives the serializer-decoded Map (the flow's 'input.body -> *') plus the
+ * routing key under the 'type' header. It is directly testable with the reserved my_* headers a
+ * flow would carry.
+ */
+class OrderProcessorTest {
+
+    private final OrderProcessor processor = new OrderProcessor();
+
+    @Test
+    void wrapsTheOrderWithRoutingAndProcessingMetadata() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.order.processor");
+        headers.put("my_trace_id", "trace-1234");
+        headers.put("my_trace_path", "KAFKA demo.orders");
+        headers.put("type", "order");
+        Map<String, Object> order = Map.of("item", "keyboard", "qty", 1);
+        Map<String, Object> response = processor.handleEvent(headers, order, 1);
+        assertEquals(order, response.get("order"));
+        assertEquals("input.header.type(order)", response.get("routedBy"));
+        assertEquals("demo-order-flow", response.get("processedBy"));
+        assertEquals("trace-1234", response.get("traceId"));
+        assertNotNull(response.get("processedAt"));
+    }
+
+    @Test
+    void echoesTheWildcardMatchedRoutingKey() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.order.processor");
+        headers.put("type", "order-42");
+        Map<String, Object> response = processor.handleEvent(headers, Map.of("item", "mouse"), 1);
+        assertEquals("input.header.type(order-42)", response.get("routedBy"));
+    }
+}

--- a/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/RefundProcessorTest.java
+++ b/examples/kafka-demo/src/test/java/com/accenture/kafka/demo/tasks/RefundProcessorTest.java
@@ -1,0 +1,50 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.kafka.demo.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * demo.refund.processor is a task:// routing target: the adapter invokes it directly with the
+ * decoded payload as the body and the business cid injected as my_correlation_id. Directly testable
+ * with the reserved my_* headers the adapter's dispatch would carry.
+ */
+class RefundProcessorTest {
+
+    private final RefundProcessor processor = new RefundProcessor();
+
+    @Test
+    void acknowledgesTheRefundWithTheBusinessCid() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("my_route", "demo.refund.processor");
+        headers.put("my_trace_id", "trace-1234");
+        headers.put("my_trace_path", "KAFKA demo.orders");
+        headers.put("my_correlation_id", "refund-001");
+        Map<String, Object> refund = Map.of("event", Map.of("kind", "refund"), "orderId", "abc123");
+        Map<String, Object> ack = processor.handleEvent(headers, refund, 1);
+        assertEquals("refund recorded", ack.get("status"));
+        assertEquals(refund, ack.get("refund"));
+        assertEquals("refund-001", ack.get("cid"));
+    }
+}


### PR DESCRIPTION
## What

`examples/kafka-demo` now demonstrates both routing styles of the Kafka flow adapter side by
side in one `kafka-flow-adapter.yaml`:

- The existing `demo.inbound` binding keeps **direct routing** (`flow`) unchanged.
- A new `demo.orders` binding shows **second-level routing** (`flows`) with every grammar
  element exercised: an exact header rule (`type(order)`) and a wildcard rule (`type(order-*)`)
  to a specific flow (`demo-order-flow`), a body-path rule (`input.body.event.kind(refund)`) to
  a specific task (`task://demo.refund.processor`), and the mandatory `default` to a catch-all
  flow — plus `serializer: 'json'`, a per-binding `ttl` for the task target, and its own
  `dlq-topic`.

The three new targets each teach one pattern: `demo-order-flow`'s processor receives the
serializer-decoded Map and returns a Map that `simple.kafka.notification` **auto-serializes**
to `demo.outbound` (the outbound symmetry); `demo.refund.processor` shows the `task://`
dispatch contract (headers copied verbatim, whole payload as body, business cid via
`getMyCorrelationId()`, commit-on-success) and its javadoc says when a task is the wrong tool;
`demo-catch-all-flow`'s processor takes `Object` input and handles both body shapes — decoded
Map/List or the raw byte[] of an unparseable record — the pattern a production default handler
should follow.

A new node console program, `publish-orders.js`, drives it: one keyword per routing rule
(`order`, `order-42`, `refund`, anything else), an optional JSON payload override, and the
expected rule printed per publish. It works interactively and **piped**
(`printf 'order\nrefund\n' | node publish-orders.js`) for scripted regression runs.
`create-topics.js` gains the `demo.orders` topic; the README documents the whole drive with a
per-command expectations table.

## Why

Demo apps serve two purposes here: they are the **manual regression path** for important
features, and they are the **template developers follow** when adopting them. Second-level
routing will replace proprietary per-record dispatch implementations in the field, so
developers reconfiguring their applications need a complete, runnable reference — every
selector, matcher mode, and target kind in one binding, next to the direct-routing style they
already use.

## Testing

- Unit tests 8/8 (three new task-test classes following the existing `DemoProcessorTest`
  pattern); module build green.
- Live smoke drive of the exact developer path: kafka-standalone → `create-topics.js` → app
  boot (binding log shows "second-level routing (3 rules + default), serializer 'json', task
  ttl 15s") → all four rules driven through the real `publish-orders.js` → app log verified
  per rule (correct processor, cid, trace id, and span topology: flow targets via
  `task.executor`, the task target as a single direct span from `kafka.flow.adapter`) →
  outbound delivery confirmed through the real `listen-outbound.js` (the order Map arrived as
  auto-serialized JSON with `routedBy` naming the matched rule; raw text arrived annotated
  `routedBy: default`).
- Drive-found fix included: `publish-orders.js` awaits in-flight publishes on close, so piped
  (scripted) runs cannot lose records.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>