### PR TITLE
Version-aware Redis consume for the graph state store (GETDEL compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## Unreleased
 
+### Fixed
+
+1. **Graph state store works on Redis servers older than 6.2 (field report).** The
+   suspend/resume Redis store consumed records with `GETDEL`, a Redis 6.2+ command —
+   unavailable on older managed enterprise servers and on the community Windows binary
+   (5.0.14) bundled by `redis-standalone`, where a resume failed with
+   `ERR unknown command GETDEL`. The consume strategy is now **version-aware**: the store
+   reads the server version from `INFO server` once per connection (stated in the startup
+   log) and uses native `GETDEL` on 6.2+ or an equally atomic `MULTI/EXEC` `GET`+`DEL`
+   transaction on older servers — the at-most-once resume guarantee holds on both paths,
+   and an undetectable version selects the transactional fallback, which works everywhere.
+
 ### Added
 
 1. **Second-level routing for the Kafka Flow Adapter.** A binding may replace its single

--- a/docs/guides/knowledge-graph/workflow-suspension.md
+++ b/docs/guides/knowledge-graph/workflow-suspension.md
@@ -211,8 +211,10 @@ curl -s -X POST http://127.0.0.1:8085/api/graph/tutorial-14 \
   suspend *after* the join instead. Joins whose predecessors completed before suspension
   work: their completion marks are part of the persisted state.
 - **One resume per transaction.** The shipped stores consume the record atomically on
-  retrieval (Redis `GETDEL`), so a duplicate resume — a double click, a retried message —
-  finds nothing and behaves as a fresh run instead of double-executing the continuation.
+  retrieval (Redis `GETDEL` on 6.2+, or a `MULTI/EXEC` `GET`+`DEL` transaction on older
+  servers — detected automatically), so a duplicate resume — a double click, a retried
+  message — finds nothing and behaves as a fresh run instead of double-executing the
+  continuation.
   A later checkpoint in the resumed run simply persists a new record under the same ID.
 - **The correlation ID is a resume capability.** Whoever presents it continues the
   workflow: protect resume-bearing endpoints with rest.yaml `authentication`, and use
@@ -262,9 +264,14 @@ store of ~60 lines (`FileStateStore` in the minigraph test sources).
 ## The Redis store module
 
 `extensions/minigraph-state-redis` ships `v1.redis.persist.model` (SETEX, native expiry)
-and `v1.redis.retrieve.model` (atomic `GETDEL` — Redis 6.2+). Include the jar and the two
-functions register automatically; the connection is lazy, so the application boots
-normally without Redis until a workflow actually suspends. Configuration uses the same
+and `v1.redis.retrieve.model` (atomic consume-on-retrieve). The consume strategy is
+**version-aware**: native `GETDEL` on Redis 6.2+, or an equally atomic `MULTI/EXEC`
+`GET`+`DEL` transaction on older servers — detected once per connection from
+`INFO server` and stated in the startup log, since enterprise deployments rarely control
+their managed Redis version (and the community Windows binary used by `redis-standalone`
+is 5.0.14). Include the jar and the two functions register automatically; the connection
+is lazy, so the application boots normally without Redis until a workflow actually
+suspends. Configuration uses the same
 `redis.*` keys as the sync-over-async extension (`redis.host`, `redis.port`,
 `redis.password`, `redis.ssl`, `redis.database`, `redis.timeout.ms`), and the worker
 counts are ops-tunable via `worker.instances.v1.redis.persist.model` /

--- a/docs/guides/reserved-names-and-headers.md
+++ b/docs/guides/reserved-names-and-headers.md
@@ -68,7 +68,7 @@ to avoid breaking the system unintentionally.
 | graph.suspend                | Persist workflow state at a graph suspension point            | minigraph        |
 | graph.resume                 | Restore workflow state and continue past the suspension point | minigraph        |
 | v1.redis.persist.model       | Redis store for graph suspend (SETEX with native expiry)      | minigraph-state-redis |
-| v1.redis.retrieve.model      | Redis store for graph resume (atomic GETDEL consume)          | minigraph-state-redis |
+| v1.redis.retrieve.model      | Redis store for graph resume (atomic consume-on-retrieve)     | minigraph-state-redis |
 
 Routes from the last rows belong to **opt-in extension modules** (`minimalist-kafka`,
 `sync-over-async`, `minigraph-state-redis`) and the knowledge graph engine: they are reserved only

--- a/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RedisStateConnection.java
+++ b/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RedisStateConnection.java
@@ -49,9 +49,15 @@ class RedisStateConnection {
     // one shared namespace so a workflow suspended by one application instance
     // can resume on any other instance sharing the same Redis
     static final String KEY_PREFIX = "graph:state:";
+    private static final String REDIS_VERSION = "redis_version:";
+    private static final String UNKNOWN = "unknown";
     private static final Object SAFETY = new Object();
     private static RedisClient client;
     private static StatefulRedisConnection<String, byte[]> connection;
+    // Whether the connected server supports GETDEL (Redis 6.2+). Enterprise deployments rarely
+    // control their managed Redis version (AWS/Azure/GCP), and the redis-standalone Windows binary
+    // is 5.0.14 - detected once per connection from INFO server.
+    private static volatile boolean nativeGetdel = true;
 
     private RedisStateConnection() {}
 
@@ -62,6 +68,73 @@ class RedisStateConnection {
             }
             return connection.sync();
         }
+    }
+
+    /**
+     * Consume-on-retrieve: return the record under the key and delete it ATOMICALLY - the
+     * at-most-once resume guarantee (a duplicate resume request must find nothing). A Redis 6.2+
+     * server uses native GETDEL; an older server gets the same guarantee from a MULTI/EXEC
+     * transaction pairing GET with DEL (supported since Redis 1.2). The strategy is chosen per
+     * connection from INFO server.
+     *
+     * @param key the fully-prefixed record key
+     * @return the stored value, or null when absent or expired
+     */
+    static byte[] consume(String key) {
+        var cmd = commands();
+        if (nativeGetdel) {
+            return cmd.getdel(key);
+        }
+        // the shared connection's MULTI state must not interleave with another thread's commands,
+        // so the whole transaction runs under the connection lock (suspend/resume traffic is
+        // human-checkpoint scale - serializing the fallback path costs nothing observable)
+        synchronized (SAFETY) {
+            cmd.multi();
+            try {
+                cmd.get(key);
+                cmd.del(key);
+            } catch (RuntimeException e) {
+                cmd.discard();   // leave the shared connection clean before failing loudly
+                throw e;
+            }
+            return cmd.exec().get(0);
+        }
+    }
+
+    /**
+     * Extract the server version from {@code INFO server} output, or "unknown" when absent.
+     * Visible for testing.
+     */
+    static String redisVersion(String serverInfo) {
+        for (String line : serverInfo.split("\n")) {
+            if (line.startsWith(REDIS_VERSION)) {
+                return line.substring(REDIS_VERSION.length()).trim();
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * GETDEL needs Redis 6.2 or later; an unparseable version selects the transactional fallback,
+     * which works on every server. Visible for testing.
+     */
+    static boolean supportsGetdel(String version) {
+        var parts = version.split("\\.");
+        if (parts.length < 2) {
+            return false;
+        }
+        try {
+            int major = Integer.parseInt(parts[0]);
+            int minor = Integer.parseInt(parts[1]);
+            return major > 6 || (major == 6 && minor >= 2);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /** Force the consume strategy (true = native GETDEL, false = transactional). Visible for testing. */
+    static void overrideConsumeStrategy(boolean useGetdel) {
+        nativeGetdel = useGetdel;
     }
 
     private static void connect() {
@@ -83,7 +156,18 @@ class RedisStateConnection {
             Runtime.getRuntime().addShutdownHook(new Thread(RedisStateConnection::shutdown));
         }
         connection = client.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
-        log.info("Graph state store connected to redis://{}:{}/{}", host, port, database);
+        // version-aware consume strategy: enterprise Redis versions are outside our control,
+        // so detect GETDEL support (6.2+) instead of assuming it
+        String version;
+        try {
+            version = redisVersion(connection.sync().info("server"));
+        } catch (RuntimeException e) {
+            // e.g. a managed server restricting INFO: the transactional fallback works everywhere
+            version = UNKNOWN;
+        }
+        nativeGetdel = supportsGetdel(version);
+        log.info("Graph state store connected to redis://{}:{}/{} (Redis {}, consume via {})",
+                host, port, database, version, nativeGetdel ? "GETDEL" : "transactional GET+DEL");
     }
 
     private static void shutdown() {

--- a/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RetrieveModel.java
+++ b/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RetrieveModel.java
@@ -36,8 +36,10 @@ import static org.platformlambda.graph.redis.RedisStateConnection.KEY_PREFIX;
  * <p>
  * Contract: headers type=get; body {cid}. Returns the persisted record, or an empty map
  * when absent-or-expired (a fresh transaction is the normal case, not an error). The
- * record is CONSUMED atomically on retrieval (Redis GETDEL), so a duplicate resume
- * request cannot execute the continuation twice. Requires Redis 6.2 or later.
+ * record is CONSUMED atomically on retrieval, so a duplicate resume request cannot
+ * execute the continuation twice - via native GETDEL on Redis 6.2+, or a MULTI/EXEC
+ * GET+DEL transaction on older servers (the strategy is detected per connection, since
+ * enterprise deployments rarely control their managed Redis version).
  */
 @PreLoad(route = "v1.redis.retrieve.model", instances = 50,
          envInstances = "worker.instances.v1.redis.retrieve.model")
@@ -58,7 +60,7 @@ public class RetrieveModel implements TypedLambdaFunction<Map<String, Object>, O
         if (cid == null) {
             throw new IllegalArgumentException("Missing cid");
         }
-        var data = RedisStateConnection.commands().getdel(KEY_PREFIX + cid);
+        var data = RedisStateConnection.consume(KEY_PREFIX + cid);
         if (data == null) {
             return new HashMap<String, Object>();
         }

--- a/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateStoreTest.java
+++ b/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateStoreTest.java
@@ -79,6 +79,56 @@ class RedisStateStoreTest extends RedisStateTestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void transactionalConsumeGivesTheSameContractOnPre62Servers() throws TimeoutException {
+        // enterprise Redis versions are outside our control (managed AWS/Azure/GCP servers; the
+        // redis-standalone Windows binary is 5.0.14): the pre-6.2 strategy replaces GETDEL with a
+        // MULTI/EXEC GET+DEL transaction. MULTI/EXEC works on every server, so the fallback is
+        // exercised for real against the embedded 6.2 server - same contract, both strategies.
+        RedisStateConnection.overrideConsumeStrategy(false);
+        try {
+            var cid = Utility.getInstance().getUuid();
+            assertEquals(200, request(PERSIST, "put", sampleEnvelope(cid, 30)).getStatus());
+            var restored = request(RETRIEVE, "get", Map.of("cid", cid));
+            assertEquals(200, restored.getStatus());
+            var record = new MultiLevelMap((Map<String, Object>) restored.getBody());
+            assertEquals("step-1", record.getElement("node"));
+            assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) record.getElement("model.binary"));
+            // consumed atomically by the transaction - a duplicate resume finds nothing
+            var again = request(RETRIEVE, "get", Map.of("cid", cid));
+            assertEquals(200, again.getStatus());
+            assertTrue(((Map<String, Object>) again.getBody()).isEmpty(),
+                    "the record must be consumed on read by the transactional strategy");
+            assertNull(testConnection.sync().get("graph:state:" + cid));
+        } finally {
+            RedisStateConnection.overrideConsumeStrategy(true);
+        }
+    }
+
+    @Test
+    void redisVersionIsExtractedFromInfoOutput() {
+        assertEquals("6.2.7", RedisStateConnection.redisVersion(
+                "# Server\r\nredis_version:6.2.7\r\nredis_mode:standalone\r\n"));
+        assertEquals("5.0.14.1", RedisStateConnection.redisVersion("redis_version:5.0.14.1\r\n"));
+        assertEquals("unknown", RedisStateConnection.redisVersion("# Server\r\nredis_mode:standalone\r\n"));
+    }
+
+    @Test
+    void getdelNeedsRedis62OrLater() {
+        assertTrue(RedisStateConnection.supportsGetdel("6.2.0"));
+        assertTrue(RedisStateConnection.supportsGetdel("6.2.7"));
+        assertTrue(RedisStateConnection.supportsGetdel("7.4.1"));
+        assertTrue(RedisStateConnection.supportsGetdel("8.0"));
+        assertFalse(RedisStateConnection.supportsGetdel("6.0.9"));
+        assertFalse(RedisStateConnection.supportsGetdel("5.0.14.1"));   // the Windows binary
+        assertFalse(RedisStateConnection.supportsGetdel("3.0.504"));
+        // an unparseable version selects the transactional fallback, which works everywhere
+        assertFalse(RedisStateConnection.supportsGetdel("unknown"));
+        assertFalse(RedisStateConnection.supportsGetdel("x.y.z"));
+        assertFalse(RedisStateConnection.supportsGetdel("7"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void absentCorrelationIdIsANormalEmptyResult() throws TimeoutException {
         var response = request(RETRIEVE, "get", Map.of("cid", Utility.getInstance().getUuid()));
         assertEquals(200, response.getStatus());

--- a/helpers/redis-standalone/src/main/java/org/platformlambda/system/EmbeddedRedis.java
+++ b/helpers/redis-standalone/src/main/java/org/platformlambda/system/EmbeddedRedis.java
@@ -28,8 +28,11 @@ import java.io.IOException;
 
 /**
  * Thin lifecycle wrapper around the {@code embedded-redis} server. The library bundles a real
- * {@code redis-server} binary (macOS/Linux, arm64 + amd64) and runs it as a subprocess, so a developer
- * can spin up a standalone Redis for local development and testing with <b>no Docker image</b>.
+ * {@code redis-server} binary and runs it as a subprocess, so a developer can spin up a standalone
+ * Redis for local development and testing with <b>no Docker image</b>. Bundled versions differ by
+ * platform: Redis 6.2.x on macOS/Linux (arm64 + amd64), but <b>5.0.14 on Windows</b> (the community
+ * Windows port stopped there) - consumers must not assume 6.2+ commands; the graph state store
+ * detects the server version and adapts (see minigraph-state-redis).
  *
  * <p>Like the {@code kafka-standalone} helper, this is for development and testing only - not production.
  * A single server is started on the configured port (default 6379).</p>


### PR DESCRIPTION
## What

The suspend/resume Redis state store consumed records with `GETDEL`, a Redis 6.2+ command.
The consume strategy is now **version-aware**: `RedisStateConnection` reads `redis_version`
from `INFO server` once per connection and states the choice in the startup log — native
`GETDEL` on 6.2+ (production servers see zero change), or an equally atomic `MULTI/EXEC`
transaction pairing `GET` with `DEL` (supported since Redis 1.2) on older servers. An
unparseable version, or a managed server that restricts `INFO`, selects the transactional
fallback, which works everywhere. The at-most-once consume-on-retrieve guarantee (ADR-0010)
holds on both paths — a plain sequential GET → DEL would have opened a double-resume race,
so the fallback wraps the pair in a transaction.

Docs updated (workflow-suspension guide, reserved-names table, `EmbeddedRedis` javadoc now
records the per-platform binary versions, CHANGELOG); the permanent suspend/resume interop
report is deliberately untouched — it records the drive as it ran.

## Why

A field developer on a Windows VDI (no Docker, relying on `redis-standalone`) hit
`ERR unknown command GETDEL` running tutorial-14: the `embedded-redis` library bundles real
Redis 6.2.x binaries for macOS/Linux but only **5.0.14 for Windows** — the community Windows
port stopped there, so the server side cannot be upgraded. More broadly, deployed
environments are Linux, but enterprise **managed Redis versions (AWS/Azure/GCP) are outside
our control** — the store must adapt to the server it is given rather than assume 6.2+.
`GETDEL` was the repository's only ≥ 6.2 command; `SETEX` and the sync-over-async command
surface are old-version-safe.

## Testing

- 10/10 in `minigraph-state-redis`, covering both layers the fix separates:
  **selection** — version-threshold units prove `5.0.14.1` (the Windows binary), `6.0.9`,
  `3.0.504`, and unparseable versions select the transactional path while `6.2.0`+ selects
  `GETDEL`, plus `INFO server` parsing with real `\r\n` output; **execution** — the
  transactional strategy is exercised for real against the embedded 6.2 server via a
  forced-strategy override (`MULTI`/`GET`/`DEL`/`EXEC` semantics are identical on every
  Redis since 1.2), asserting the same contract as the `GETDEL` path: record returned once
  with full fidelity, a duplicate resume finds empty, key gone.
- Full 29-module reactor green.

**Field validation (Windows VDI):** after this fix, the app's startup log should read
`Graph state store connected to ... (Redis 5.0.14.1, consume via transactional GET+DEL)`
and tutorial-14's suspend/resume sequence should complete normally.

The Rust port has the identical exposure and will be fixed in lock-step (handoff prepared) —
the suspend/resume surface is regression-critical on both engines.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>