### PR TITLE
kafka-demo: manual-regression feedback round (DLQ demo end-to-end)

### DIFF
--- a/examples/kafka-demo/README.md
+++ b/examples/kafka-demo/README.md
@@ -59,8 +59,12 @@ Wait for it to report the broker is up on `127.0.0.1:9092`.
 ```shell
 cd examples/kafka-demo/node
 node create-topics.js
-# -> created (10 partitions each): demo.inbound, demo.orders, demo.outbound
+# -> created (10 partitions each): demo.inbound, demo.orders, demo.outbound,
+#    demo.inbound.dlq, demo.orders.dlq
 ```
+The two DLQ topics are created up front because dead-letter topics must be **pre-provisioned**
+(Kafka auto-creation is off in production) — and creating them makes the failure path a
+first-class part of the demo (see [the failure path](#failure-path)).
 
 ### Terminal C — start the kafka-demo Java app
 ```shell
@@ -124,14 +128,33 @@ record to a `Map` before routing, so the `input.body` rule can match — a non-J
 cd examples/kafka-demo/node
 node publish-orders.js
 ```
-One command per routing rule (an optional trailing JSON overrides the canned payload):
+One command per routing rule:
 
-| You type | Record shape | Rule that fires | Target |
-|----------|--------------|-----------------|--------|
-| `order` | `type: order` header + JSON body | `input.header.type(order)` — exact | `flow://demo-order-flow` |
-| `order-42` | `type: order-42` header + JSON body | `input.header.type(order-*)` — wildcard | `flow://demo-order-flow` |
-| `refund` | no `type` header, `{"event":{"kind":"refund"},...}` body | `input.body.event.kind(refund)` — body path | `task://demo.refund.processor` |
-| `hello world` | raw text (not JSON) | none — falls through | `default` → `flow://demo-catch-all-flow` |
+**1. Exact header rule (`type=order`) routes to `flow://demo-order-flow`**
+```
+command: order [json]
+example: order {"item": "mobile-phone", "qty": 1}
+```
+
+**2. Wildcard header rule (`type=order-*`) also routes to `flow://demo-order-flow`**
+```
+command: order-<id> [json]
+example: order-123 {"item": "laptop", "qty": 1}
+```
+
+**3. Body rule (`event.kind=refund`) routes to `task://demo.refund.processor`**
+```
+command: refund [json]
+example: refund {"order_id": "order-123"}
+```
+The optional json holds the refund **details** only — the `{"event":{"kind":"refund"}}` envelope
+the body rule matches on is added by the script, so the example above routes to the task.
+
+**4. When no rule matches, `default` routes to `flow://demo-catch-all-flow`**
+```
+command: <anything else>
+example: hello
+```
 
 **What you should see per command:**
 
@@ -153,6 +176,40 @@ One command per routing rule (an optional trailing JSON overrides the canned pay
 Each published record carries its own `traceparent`, so every routed message — flow or task — shows full
 trace continuity in the telemetry log, exactly like the direct-routing path.
 
+### The failure path — retries then dead-letter {#failure-path}
+
+`serializer: 'json'` is **best-effort**: an unparseable record keeps its raw `byte[]` and simply passes
+to whichever target the rules select. Start the dead-letter listener in its own terminal (program-4):
+
+```shell
+cd examples/kafka-demo/node
+node listen-dlq.js
+```
+
+Then send an order whose payload is plain text:
+
+```
+> order hello
+```
+
+The `type=order` header matches, so the record reaches `demo-order-flow` — whose Map-typed processor
+cannot digest raw bytes and **throws the exception back to the Kafka flow adapter**. Watch the Java
+terminal: the flow fails, the adapter **retries 3 times** (`kafka.flow.max.retries`), then
+**dead-letters the original record to `demo.orders.dlq`** and moves on — the partition never stalls.
+The DLQ listener prints the intercepted record — headers and body preserved verbatim, plus the
+`dlq.error` (why it failed) and `dlq.origin.topic` (where it came from) headers:
+
+```
+[...] <- demo.orders.dlq[p4] cid=2f1c...
+[...]    origin: demo.orders
+[...]    error:  java.lang.IllegalStateException: flow 'demo-order-flow' returned status 500
+[...]    body:   hello
+```
+
+This is the production contract for a malformed event, demonstrated live. (The default flow, by
+contrast, accepts raw bytes by design — compare with `hello` above, which has no matching rule and
+lands in the catch-all normally.)
+
 ## How it maps to minimalist-kafka
 
 | Piece | What it shows |
@@ -163,6 +220,7 @@ trace continuity in the telemetry log, exactly like the direct-routing path.
 | [`demo-catch-all-flow.yml`](src/main/resources/flows/demo-catch-all-flow.yml) | the mandatory **default** flow; its task handles both body shapes (Map or raw bytes) |
 | [`DemoProcessor.java`](src/main/java/com/accenture/kafka/demo/tasks/DemoProcessor.java) | a self-contained function (the unit of work), in a `tasks` package per the [Code Conventions](../../docs/guides/code-conventions.md) |
 | [`RefundProcessor.java`](src/main/java/com/accenture/kafka/demo/tasks/RefundProcessor.java) | a **`task://` routing target**: invoked directly by the adapter — headers copied verbatim, payload as body, no flow |
+| [`listen-dlq.js`](node/listen-dlq.js) | the **dead-letter side**: prints intercepted records with their `dlq.error` / `dlq.origin.topic` headers (see [the failure path](#failure-path)) |
 | `simple.kafka.notification` | the **producer** side: publish to a topic via data mapping (`text(demo.outbound) -> header.topic`) |
 
 ## Notes
@@ -170,8 +228,8 @@ trace continuity in the telemetry log, exactly like the direct-routing path.
 - Point at a different broker with `export KAFKA_BOOTSTRAP_SERVERS=host:port` (both the Java app and the
   Node programs honor it).
 - On repeated processing failure, a message is dead-lettered to the binding's configured `dlq-topic`
-  (`demo.inbound.dlq` / `demo.orders.dlq` in `kafka-flow-adapter.yaml`); pre-create those topics if you
-  want to exercise the failure path — it applies identically to `flow://` and `task://` targets. The happy
-  path never touches them.
+  (`demo.inbound.dlq` / `demo.orders.dlq` in `kafka-flow-adapter.yaml`); `create-topics.js` pre-creates
+  both, and the failure handling applies identically to `flow://` and `task://` targets — see
+  [the failure path](#failure-path). The happy path never touches them.
 - The second-level routing rule grammar (selectors, the three matcher modes, targets, `serializer`,
   `ttl`) is documented in the [Minimalist Kafka guide](../../docs/guides/minimalist-kafka.md#routing).

--- a/examples/kafka-demo/node/config.js
+++ b/examples/kafka-demo/node/config.js
@@ -6,6 +6,9 @@ export default {
   inboundTopic: 'demo.inbound',   // node publisher -> here -> kafka-demo Java app (direct routing)
   ordersTopic: 'demo.orders',     // node publisher -> here -> kafka-demo Java app (second-level routing)
   outboundTopic: 'demo.outbound', // kafka-demo Java app -> here -> node listener
+  // dead-letter topics for the two consumer bindings - DLQ topics must be pre-provisioned
+  // (auto-creation is off in production), so the create-topics helper makes them too
+  dlqTopics: ['demo.inbound.dlq', 'demo.orders.dlq'],
   partitions: 10,
   // ISO-8601 timestamp for simple, sortable console logging
   ts: () => new Date().toISOString(),

--- a/examples/kafka-demo/node/create-topics.js
+++ b/examples/kafka-demo/node/create-topics.js
@@ -11,7 +11,7 @@ const { Kafka } = kafkajs;
   const admin = kafka.admin();
   await admin.connect();
   try {
-    const wanted = [cfg.inboundTopic, cfg.ordersTopic, cfg.outboundTopic];
+    const wanted = [cfg.inboundTopic, cfg.ordersTopic, cfg.outboundTopic, ...cfg.dlqTopics];
     const existing = await admin.listTopics();
     const toCreate = wanted
       .filter((t) => !existing.includes(t))

--- a/examples/kafka-demo/node/listen-dlq.js
+++ b/examples/kafka-demo/node/listen-dlq.js
@@ -1,0 +1,38 @@
+// listen-dlq.js (program-4) - listen on the dead-letter topics and print every intercepted message.
+// Run in its own terminal:  node listen-dlq.js
+//
+// A message lands here after exhausting its retries (kafka.flow.max.retries) - the adapter parks the
+// ORIGINAL record (headers + body preserved verbatim) with two extra headers: 'dlq.error' (why it
+// failed) and 'dlq.origin.topic' (the concrete topic it came from). Trigger one with the failure-path
+// command in publish-orders.js:  order hello
+
+import kafkajs from 'kafkajs';
+import cfg from './config.js';
+
+const { Kafka } = kafkajs;
+
+(async () => {
+  const kafka = new Kafka({ clientId: 'kafka-demo-dlq-listener', brokers: cfg.brokers });
+  const consumer = kafka.consumer({ groupId: 'kafka-demo-node-dlq-listener' });
+  await consumer.connect();
+  for (const topic of cfg.dlqTopics) {
+    await consumer.subscribe({ topic, fromBeginning: false });
+  }
+  console.log(`[${cfg.ts()}] listening on '${cfg.dlqTopics.join("', '")}' (Ctrl-C to quit) ...`);
+
+  await consumer.run({
+    eachMessage: async ({ topic, partition, message }) => {
+      const h = message.headers || {};
+      const cid = h.cid ? h.cid.toString() : '(none)';
+      const origin = h['dlq.origin.topic'] ? h['dlq.origin.topic'].toString() : '(none)';
+      const error = h['dlq.error'] ? h['dlq.error'].toString() : '(none)';
+      console.log(`[${cfg.ts()}] <- ${topic}[p${partition}] cid=${cid}`);
+      console.log(`[${cfg.ts()}]    origin: ${origin}`);
+      console.log(`[${cfg.ts()}]    error:  ${error}`);
+      console.log(`[${cfg.ts()}]    body:   ${message.value ? message.value.toString() : '(null)'}`);
+    },
+  });
+})().catch((e) => {
+  console.error(`[${cfg.ts()}] error:`, e.message);
+  process.exit(1);
+});

--- a/examples/kafka-demo/node/publish-orders.js
+++ b/examples/kafka-demo/node/publish-orders.js
@@ -27,21 +27,35 @@ function toRecord(line) {
   const rest = space === -1 ? '' : line.substring(space + 1).trim();
   const customJson = rest.startsWith('{') || rest.startsWith('[') ? rest : null;
   if (keyword === 'order' || keyword.startsWith('order-')) {
-    const rule = keyword === 'order'
+    const matched = keyword === 'order'
       ? 'input.header.type(order) [exact]' : 'input.header.type(order-*) [wildcard]';
+    // The rest of the line is the payload VERBATIM - json or not. A non-JSON payload keeps its raw
+    // byte[] under serializer 'json', and the Map-typed order processor cannot digest raw bytes:
+    // type 'order hello' to demo the failure path (3 retries, then dead-letter to demo.orders.dlq).
+    const value = rest || JSON.stringify({ item: 'keyboard', qty: 1 });
+    const failurePath = rest.length > 0 && !customJson;
     return {
       headers: { type: keyword },
-      value: customJson || JSON.stringify({ item: 'keyboard', qty: 1 }),
-      rule: `${rule} -> flow://demo-order-flow`,
+      value,
+      rule: failurePath
+        ? `${matched} -> flow://demo-order-flow - payload is NOT JSON: expect 3 retries then dead-letter to demo.orders.dlq`
+        : `${matched} -> flow://demo-order-flow`,
     };
   }
   if (keyword === 'refund') {
-    // no 'type' header: the header rules cannot match, so the input.body rule decides
+    // no 'type' header: the header rules cannot match, so the input.body rule decides.
+    // The optional json holds the refund DETAILS only - the {"event":{"kind":"refund"}} envelope
+    // the body rule matches on is added here, so 'refund {"order_id":"order-123"}' routes correctly.
+    let details;
+    try {
+      details = customJson ? JSON.parse(customJson) : { orderId: randomUUID().substring(0, 8) };
+    } catch (e) {
+      return { error: `invalid json after 'refund': ${e.message}` };
+    }
     return {
       headers: {},
-      value: customJson
-        || JSON.stringify({ event: { kind: 'refund' }, orderId: randomUUID().substring(0, 8) }),
-      rule: 'input.body.event.kind(refund) [body path] -> task://demo.refund.processor (see the Java log)',
+      value: JSON.stringify({ event: { kind: 'refund' }, ...details }),
+      rule: 'input.body.event.kind(refund) [body rule] -> task://demo.refund.processor (see the Java log)',
     };
   }
   // raw text: not a JSON object/array, so serializer 'json' keeps the byte[] and no rule matches
@@ -57,14 +71,42 @@ function toRecord(line) {
   // DefaultPartitioner avoids kafkajs' legacy-partitioner warning and spreads across the 10 partitions
   const producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner });
   await producer.connect();
-  console.log(`[${cfg.ts()}] connected. Publish to '${cfg.ordersTopic}' (Ctrl-C to quit). Commands:`);
-  console.log('  order [json]      -> exact rule    -> demo-order-flow');
-  console.log('  order-<x> [json]  -> wildcard rule -> demo-order-flow');
-  console.log('  refund [json]     -> body rule     -> task demo.refund.processor');
-  console.log('  <anything else>   -> default       -> demo-catch-all-flow');
+  console.log(`[${cfg.ts()}] connected. Publish to '${cfg.ordersTopic}' (Ctrl-C to quit).`);
+  console.log('');
+  console.log('1. Exact header rule (type=order) routes to flow://demo-order-flow');
+  console.log('');
+  console.log('   command: order [json]');
+  console.log('   example: order {"item": "mobile-phone", "qty": 1}');
+  console.log('');
+  console.log('2. Wildcard header rule (type=order-*) also routes to flow://demo-order-flow');
+  console.log('');
+  console.log('   command: order-<id> [json]');
+  console.log('   example: order-123 {"item": "laptop", "qty": 1}');
+  console.log('');
+  console.log('3. Body rule (event.kind=refund) routes to task://demo.refund.processor');
+  console.log('');
+  console.log('   command: refund [json]      (json = refund details; the event envelope is added)');
+  console.log('   example: refund {"order_id": "order-123"}');
+  console.log('');
+  console.log('4. When no rule matches, default routes to flow://demo-catch-all-flow');
+  console.log('');
+  console.log('   command: <anything else>');
+  console.log('   example: hello');
+  console.log('');
+  console.log('5. Failure path: a non-JSON payload on a matched order rule triggers the DLQ');
+  console.log('');
+  console.log('   command: order <plain text>');
+  console.log('   example: order hello');
+  console.log('   The order flow cannot digest raw bytes: 3 retries, then the original record is');
+  console.log('   dead-lettered to demo.orders.dlq - watch it arrive with:  node listen-dlq.js');
+  console.log('');
 
   async function publishOne(text) {
-    const { headers, value, rule } = toRecord(text);
+    const { headers, value, rule, error } = toRecord(text);
+    if (error) {
+      console.error(`[${cfg.ts()}] not published - ${error}`);
+      return;
+    }
     const cid = randomUUID();
     // W3C traceparent: the adapter adopts this trace-id, so the selected flow/task (and any message
     // it publishes to demo.outbound) shares it - end-to-end trace continuity per routed message.


### PR DESCRIPTION
## What

Five improvements to the second-level routing demo from the maintainer's manual regression:

1. **DLQ topics pre-created** — `create-topics.js` now makes `demo.inbound.dlq` and
   `demo.orders.dlq` alongside the three main topics. Dead-letter topics must be
   pre-provisioned (auto-creation is off in production), and creating them removes the
   `UNKNOWN_TOPIC_OR_PARTITION` warning while making the failure path a first-class demo
   scenario.
2. **`refund <json>` routes as a user expects** — the optional json is now the refund
   *details*, and the script adds the `{"event":{"kind":"refund"}}` envelope the body rule
   matches on; previously a custom json replaced the whole payload and silently missed the
   rule, falling to the default.
3. **`order <plain text>` is the canonical DLQ trigger** — the rest of the line is now the
   payload verbatim (previously plain text was silently discarded for the canned payload).
   `order hello` sends raw bytes under a matched header rule: the Map-typed order processor
   cannot digest them and throws back to the Kafka flow adapter — 3 retries, then dead-letter.
   The publisher announces the expected outcome at publish time, and it is instruction 5 in
   the banner.
4. **New `listen-dlq.js` (program-4)** — subscribes to both DLQ topics and prints each
   intercepted record: cid, `dlq.origin.topic`, `dlq.error`, and the preserved body.
5. **Instructions reformatted** to a numbered command/example style in both the script
   banner and the README, with a new `#failure-path` README section walking the whole loop.

## Why

The demo doubles as the manual-regression procedure and the developer migration template for
second-level routing, so the maintainer's own test-drive feedback goes straight back into it.
The failure-path scenario is the important addition: it passes a byte array into a composable
function that expects a Map, proving live that the function throws back to the Kafka flow
adapter and the exception flows into the bounded-retry → dead-letter envelope — the ratified
best-effort `serializer` contract, now observable end-to-end (publish → Java retries → the
intercepted record in the DLQ listener) rather than only stated in the docs.

## Testing

Verified live against kafka-standalone: `refund {"order_id": "order-123"}` routed to
`task://demo.refund.processor` via the body rule (envelope merged); `order hello` produced
exactly 3 retries then a clean dead-letter to the pre-created `demo.orders.dlq` — no
UNKNOWN_TOPIC warning, no data loss — and `listen-dlq.js` printed the intercepted record
(origin `demo.orders`, error `flow 'demo-order-flow' returned status 500`, body `hello`
verbatim); wildcard and default paths re-verified alongside. Module tests 8/8 unchanged.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>