### PR TITLE
IDE + Sonar polish: complexity extractions and parameterized rejection tests

### DIFF
--- a/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/PersistModel.java
+++ b/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/PersistModel.java
@@ -31,7 +31,7 @@ import static org.platformlambda.graph.redis.RedisStateConnection.KEY_PREFIX;
 
 /**
  * Redis implementation of the suspend/resume state-store PERSIST contract, invoked by
- * the graph.suspend skill through the node's "task" property.
+ * the 'graph.suspend' skill through the node's "task" property.
  * <p>
  * Contract: headers type=put; body {cid, node, ttl, model, seen, run}. The record is
  * stored opaquely (MsgPack bytes) under the business correlation ID with the requested

--- a/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RedisStateConnection.java
+++ b/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RedisStateConnection.java
@@ -40,8 +40,8 @@ import java.time.Duration;
  * resume then fails loudly instead. Lettuce reconnects automatically after an outage.
  * <p>
  * Configuration keys (shared with the sync-over-async extension, so an application
- * configures Redis once): redis.host, redis.port, redis.password, redis.ssl,
- * redis.database, redis.timeout.ms - all resolvable through the usual
+ * configures Redis once): 'redis.host', 'redis.port', 'redis.password', 'redis.ssl',
+ * 'redis.database', 'redis.timeout.ms' - all resolvable through the usual
  * ${ENV_VAR:default} substitution, e.g. redis.password=${REDIS_PASSWORD:}.
  */
 class RedisStateConnection {

--- a/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RetrieveModel.java
+++ b/extensions/minigraph-state-redis/src/main/java/org/platformlambda/graph/redis/RetrieveModel.java
@@ -32,7 +32,7 @@ import static org.platformlambda.graph.redis.RedisStateConnection.KEY_PREFIX;
 
 /**
  * Redis implementation of the suspend/resume state-store RETRIEVE contract, invoked by
- * the graph.resume skill through the node's "task" property.
+ * the 'graph.resume' skill through the node's "task" property.
  * <p>
  * Contract: headers type=get; body {cid}. Returns the persisted record, or an empty map
  * when absent-or-expired (a fresh transaction is the normal case, not an error). The

--- a/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateStoreTest.java
+++ b/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateStoreTest.java
@@ -64,12 +64,12 @@ class RedisStateStoreTest extends RedisStateTestBase {
         // retrieve returns the record with full fidelity, including binary values
         var restored = request(RETRIEVE, "get", Map.of("cid", cid));
         assertEquals(200, restored.getStatus());
-        var record = new MultiLevelMap((Map<String, Object>) restored.getBody());
-        assertEquals("step-1", record.getElement("node"));
-        assertEquals(42, record.getElement("model.amount"));
-        assertEquals("approval", record.getElement("model.nested.stage"));
-        assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) record.getElement("model.binary"));
-        assertEquals(true, record.getElement("run.step-1"));
+        var restoredRecord = new MultiLevelMap((Map<String, Object>) restored.getBody());
+        assertEquals("step-1", restoredRecord.getElement("node"));
+        assertEquals(42, restoredRecord.getElement("model.amount"));
+        assertEquals("approval", restoredRecord.getElement("model.nested.stage"));
+        assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) restoredRecord.getElement("model.binary"));
+        assertEquals(true, restoredRecord.getElement("run.step-1"));
         // the record is consumed atomically - a duplicate resume finds nothing
         var again = request(RETRIEVE, "get", Map.of("cid", cid));
         assertEquals(200, again.getStatus());
@@ -90,9 +90,9 @@ class RedisStateStoreTest extends RedisStateTestBase {
             assertEquals(200, request(PERSIST, "put", sampleEnvelope(cid, 30)).getStatus());
             var restored = request(RETRIEVE, "get", Map.of("cid", cid));
             assertEquals(200, restored.getStatus());
-            var record = new MultiLevelMap((Map<String, Object>) restored.getBody());
-            assertEquals("step-1", record.getElement("node"));
-            assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) record.getElement("model.binary"));
+            var restoredRecord = new MultiLevelMap((Map<String, Object>) restored.getBody());
+            assertEquals("step-1", restoredRecord.getElement("node"));
+            assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) restoredRecord.getElement("model.binary"));
             // consumed atomically by the transaction - a duplicate resume finds nothing
             var again = request(RETRIEVE, "get", Map.of("cid", cid));
             assertEquals(200, again.getStatus());
@@ -137,10 +137,10 @@ class RedisStateStoreTest extends RedisStateTestBase {
 
     @SuppressWarnings("unchecked")
     @Test
-    void expiredRecordIsGone() throws TimeoutException, InterruptedException {
+    void expiredRecordIsGone() throws TimeoutException {
         var cid = Utility.getInstance().getUuid();
         assertEquals(200, request(PERSIST, "put", sampleEnvelope(cid, 1)).getStatus());
-        Thread.sleep(1300);
+        Utility.getInstance().sleep(1300);
         var response = request(RETRIEVE, "get", Map.of("cid", cid));
         assertEquals(200, response.getStatus());
         assertTrue(((Map<String, Object>) response.getBody()).isEmpty(), "the record must expire natively");

--- a/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateTestBase.java
+++ b/extensions/minigraph-state-redis/src/test/java/org/platformlambda/graph/redis/RedisStateTestBase.java
@@ -40,7 +40,6 @@ public abstract class RedisStateTestBase {
     protected static final String DATA_DIR = "/tmp/graph-state-redis";
     protected static final int REDIS_PORT = 16380;
     private static final AtomicBoolean started = new AtomicBoolean(false);
-    private static RedisServer redisServer;
     protected static RedisClient testClient;
     protected static StatefulRedisConnection<String, String> testConnection;
 
@@ -52,7 +51,7 @@ public abstract class RedisStateTestBase {
             if (!dir.exists() && !dir.mkdirs()) {
                 throw new IllegalStateException("Unable to create " + DATA_DIR);
             }
-            redisServer = RedisServer.newRedisServer()
+            var redisServer = RedisServer.newRedisServer()
                     .port(REDIS_PORT)
                     .setting("dir " + DATA_DIR)
                     .setting("save \"\"")

--- a/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/CompileFlows.java
@@ -70,16 +70,16 @@ public class CompileFlows implements EntryPoint {
      * Reserved state-machine keys that a data mapping must never overwrite:
      * <ul>
      * <li>the READ-only metadata seeded into each flow instance by the engine (see FlowInstance) -
-     *     model.cid, model.instance, model.flow, model.ttl and model.trace. A corrupted model.cid,
+     *     'model.cid', 'model.instance', 'model.flow', 'model.ttl' and 'model.trace'. A corrupted model.cid,
      *     for example, would propagate to downstream systems through any later
      *     'model.cid -> ...' mapping.</li>
-     * <li>the model.none null constant - it works because the 'none' key is never set, so a write
+     * <li>the 'model.none' null constant - it works because the 'none' key is never set, so a write operation
      *     would silently turn every later 'model.none -> X' clear-operation into a value copy.</li>
-     * <li>the model.run flag - engine-managed flow metadata written only by the knowledge
-     *     graph's graph.resume skill ('resume' | 'fresh'); application logic reads it to react
+     * <li>the 'model.run' flag - engine-managed flow metadata written only by the knowledge
+     *     graph's 'graph.resume' skill ('resume' | 'fresh'); application logic reads it to react
      *     to a resumed-vs-fresh condition, so an overwrite would lie to that logic.</li>
      * </ul>
-     * The model.parent and model.root keys are protected as whole namespaces by
+     * The 'model.parent' and 'model.root' keys are protected as whole namespaces by
      * DataMappingHelper.validModel; writing beneath them (model.parent.*) is the shared-state
      * mechanism and stays allowed.
      */
@@ -337,7 +337,7 @@ public class CompileFlows implements EntryPoint {
 
     /**
      * Detect a data mapping target (RHS) that would overwrite a reserved key of the flow
-     * instance's state machine (the READ-only metadata or the model.none null constant).
+     * instance's state machine (the READ-only metadata or the 'model.none' null constant).
      * Exact matches are rejected for all reserved keys; nested writes (e.g. {@code model.cid.x}
      * or {@code model.cid[0]}) are also rejected for the scalar keys because they would replace
      * the scalar with a map or list. Nested writes under {@code model.parent} / {@code model.root}
@@ -634,13 +634,7 @@ public class CompileFlows implements EntryPoint {
                 throw new IllegalArgumentException(String.format(
                         "%s %s. ttl is only applicable to a sub-flow task", INVALID_TASK, md.uniqueTaskName));
             }
-            var util = Utility.getInstance();
-            int seconds = util.getDurationInSeconds(md.ttl);
-            if (seconds < 1) {
-                throw new IllegalArgumentException(String.format(
-                        "%s %s. ttl must be a positive duration (e.g. 8s)", INVALID_TASK, md.uniqueTaskName));
-            }
-            long ttlMs = seconds * 1000L;
+            long ttlMs = getValidTtlSeconds(md) * 1000L;
             if (ttlMs < entry.ttl) {
                 task.setTtl(ttlMs);
             } else {
@@ -648,6 +642,15 @@ public class CompileFlows implements EntryPoint {
                         INVALID_TASK, md.uniqueTaskName));
             }
         }
+    }
+
+    private int getValidTtlSeconds(FlowConfigMetadata md) {
+        int seconds = Utility.getInstance().getDurationInSeconds(md.ttl);
+        if (seconds < 1) {
+            throw new IllegalArgumentException(String.format(
+                    "%s %s. ttl must be a positive duration (e.g. 8s)", INVALID_TASK, md.uniqueTaskName));
+        }
+        return seconds;
     }
 
     private void setDelayFromModelVar(FlowConfigMetadata md, Task task) {

--- a/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/TaskExecutor.java
@@ -958,60 +958,71 @@ public class TaskExecutor implements TypedLambdaFunction<EventEnvelope, Void> {
         flowInstance.tasks.add(taskMetrics);
         final var compositeInternalCorrelationId = seq > 0? uuid + "#" + seq : uuid;
         if (functionRoute.startsWith(FLOW_PROTOCOL)) {
-            var flowId = functionRoute.substring(FLOW_PROTOCOL.length());
-            var subFlow = Flows.getFlow(flowId);
-            if (subFlow == null) {
-                log.error("Unable to process flow {}:{} - missing sub-flow {}",
-                        flowInstance.getFlow().id, flowInstance.id, functionRoute);
-                abortFlow(flowInstance, 500, functionRoute+" not defined", parentSpanId);
-                return;
-            }
-            Map<String, Object> dataset = new HashMap<>();
-            dataset.put(TTL, resolveChildTtl(flowInstance, task, deferred));
-            dataset.put(BODY, unwrapBodyIfWildcard(md));
-            if (!md.optionalHeaders.isEmpty()) {
-                dataset.put(HEADER, md.optionalHeaders);
-            }
-            // execute a subflow
-            var forward = new EventEnvelope().setTo(EventScriptManager.SERVICE_NAME)
-                                                .setReplyTo(TaskExecutor.SERVICE_NAME)
-                                                .setHeader(PARENT, flowInstance.id)
-                                                .setHeader(FLOW_ID, flowId).setBody(dataset)
-                                                // sub-flow inherits the parent's business correlation-id (model.cid)
-                                                .setHeader(EventScriptManager.BUSINESS_CORRELATION_ID,
-                                                        flowInstance.businessCorrelationId)
-                                                .setCorrelationId(compositeInternalCorrelationId)
-                                                .setSpanId(parentSpanId);
-            var po = new PostOffice(functionRoute, flowInstance.getTraceId(), flowInstance.getTracePath());
-            // the delay parameter defers a sub-flow launch the same way it defers a
-            // function task; the child's own TTL timer only starts on delivery, and the
-            // pending launch is cancelled if this flow ends during the delay window
-            if (deferred > 0) {
-                flowInstance.pendingFutureEvents.add(
-                        po.sendLater(forward, new Date(System.currentTimeMillis() + deferred)));
-            } else {
-                po.send(forward);
-            }
+            launchSubFlow(flowInstance, task, md, deferred, compositeInternalCorrelationId, parentSpanId);
         } else {
-            var po = new PostOffice(TaskExecutor.SERVICE_NAME,
-                                            flowInstance.getTraceId(), flowInstance.getTracePath());
-            var event = new EventEnvelope().setTo(functionRoute).setReplyTo(TaskExecutor.SERVICE_NAME)
-                                            .setCorrelationId(compositeInternalCorrelationId)
-                                            .setBody(unwrapBodyIfWildcard(md))
+            sendTaskEvent(flowInstance, md, deferred, functionRoute, compositeInternalCorrelationId, parentSpanId);
+        }
+    }
+
+    private void launchSubFlow(FlowInstance flowInstance, Task task, InputMappingMetadata md,
+                               long deferred, String correlationId, String parentSpanId) {
+        var functionRoute = task.getFunctionRoute();
+        var flowId = functionRoute.substring(FLOW_PROTOCOL.length());
+        var subFlow = Flows.getFlow(flowId);
+        if (subFlow == null) {
+            log.error("Unable to process flow {}:{} - missing sub-flow {}",
+                    flowInstance.getFlow().id, flowInstance.id, functionRoute);
+            abortFlow(flowInstance, 500, functionRoute+" not defined", parentSpanId);
+            return;
+        }
+        Map<String, Object> dataset = new HashMap<>();
+        dataset.put(TTL, resolveChildTtl(flowInstance, task, deferred));
+        dataset.put(BODY, unwrapBodyIfWildcard(md));
+        if (!md.optionalHeaders.isEmpty()) {
+            dataset.put(HEADER, md.optionalHeaders);
+        }
+        // execute a subflow
+        var forward = new EventEnvelope().setTo(EventScriptManager.SERVICE_NAME)
+                                            .setReplyTo(TaskExecutor.SERVICE_NAME)
+                                            .setHeader(PARENT, flowInstance.id)
+                                            .setHeader(FLOW_ID, flowId).setBody(dataset)
+                                            // sub-flow inherits the parent's business correlation-id (model.cid)
+                                            .setHeader(EventScriptManager.BUSINESS_CORRELATION_ID,
+                                                    flowInstance.businessCorrelationId)
+                                            .setCorrelationId(correlationId)
                                             .setSpanId(parentSpanId);
-            md.optionalHeaders.forEach(event::setHeader);
-            // carry the flow's business correlation-id (model.cid) on the engine-managed envelope tag -
-            // never as an envelope header - so the worker injects my_correlation_id at delivery and a
-            // mapped optional header cannot collide with the framework value
-            event.addTag(EventEmitter.BUSINESS_CID_TAG, flowInstance.businessCorrelationId);
-            // execute task by sending event (a deferred dispatch is cancelled at teardown
-            // so it cannot fire after this flow has ended - same contract as a sub-flow)
-            if (deferred > 0) {
-                flowInstance.pendingFutureEvents.add(
-                        po.sendLater(event, new Date(System.currentTimeMillis() + deferred)));
-            } else {
-                po.send(event);
-            }
+        var po = new PostOffice(functionRoute, flowInstance.getTraceId(), flowInstance.getTracePath());
+        // the delay parameter defers a sub-flow launch the same way it defers a
+        // function task; the child's own TTL timer only starts on delivery, and the
+        // pending launch is canceled if this flow ends during the delay window
+        if (deferred > 0) {
+            flowInstance.pendingFutureEvents.add(
+                    po.sendLater(forward, new Date(System.currentTimeMillis() + deferred)));
+        } else {
+            po.send(forward);
+        }
+    }
+
+    private void sendTaskEvent(FlowInstance flowInstance, InputMappingMetadata md, long deferred,
+                               String functionRoute, String correlationId, String parentSpanId) {
+        var po = new PostOffice(TaskExecutor.SERVICE_NAME,
+                                        flowInstance.getTraceId(), flowInstance.getTracePath());
+        var event = new EventEnvelope().setTo(functionRoute).setReplyTo(TaskExecutor.SERVICE_NAME)
+                                        .setCorrelationId(correlationId)
+                                        .setBody(unwrapBodyIfWildcard(md))
+                                        .setSpanId(parentSpanId);
+        md.optionalHeaders.forEach(event::setHeader);
+        // carry the flow's business correlation-id (model.cid) on the engine-managed envelope tag -
+        // never as an envelope header - so the worker injects my_correlation_id at delivery and a
+        // mapped optional header cannot collide with the framework value
+        event.addTag(EventEmitter.BUSINESS_CID_TAG, flowInstance.businessCorrelationId);
+        // execute task by sending event (a deferred dispatch is canceled at teardown
+        // so it cannot fire after this flow has ended - same contract as a sub-flow)
+        if (deferred > 0) {
+            flowInstance.pendingFutureEvents.add(
+                    po.sendLater(event, new Date(System.currentTimeMillis() + deferred)));
+        } else {
+            po.send(event);
         }
     }
 

--- a/system/event-script-engine/src/main/java/com/accenture/models/FlowInstance.java
+++ b/system/event-script-engine/src/main/java/com/accenture/models/FlowInstance.java
@@ -51,7 +51,7 @@ public class FlowInstance {
     public final ConcurrentMap<Integer, PipeInfo> pipeMap = new ConcurrentHashMap<>();
     public final Queue<TaskMetrics> tasks = new ConcurrentLinkedQueue<>();
     public final ConcurrentMap<String, TaskMetrics> metrics = new ConcurrentHashMap<>();
-    // future-event ids of tasks scheduled with a 'delay' - cancelled at teardown so a
+    // future-event ids of tasks scheduled with a 'delay' - canceled at teardown so a
     // deferred launch (notably a sub-flow) cannot fire after this flow has ended
     public final Queue<String> pendingFutureEvents = new ConcurrentLinkedQueue<>();
     private final ConcurrentMap<String, Object> shared = new ConcurrentHashMap<>();

--- a/system/event-script-engine/src/main/java/com/accenture/models/SimplePlugin.java
+++ b/system/event-script-engine/src/main/java/com/accenture/models/SimplePlugin.java
@@ -22,7 +22,7 @@ import java.lang.annotation.*;
 
 /**
  * This indicates the class is a Plugin to be used as a PluggableFunction for calculations that can be called from
- * event script. Pluggable functions start with `f:<name>(args...)`
+ * event script. Pluggable functions start with `f:<name> (args...)`
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/system/event-script-engine/src/main/java/com/accenture/services/Resilience4Flow.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/Resilience4Flow.java
@@ -35,13 +35,13 @@ import static org.platformlambda.core.util.common.PlatformConstants.ENV_INSTANCE
  * This is a generic resilience handler. It will retry, abort, use an alternative path or exercise a brief backoff.
  * <p>
  * The following parameters (input data mapping) define behavior:
- * 'max_attempts' - when the handler has used all the attempts, it will abort.
- * 'attempt' - this tells the handler how many attempts it has tried
- * 'status' - you should map the error status code in this field
- * 'message' - you should map the error message in this field
- * 'alternative' (start-end, code, code) - the optional codes and range of status codes to tell the handler to reroute
- * 'delay' - the delay in milliseconds before exercising retry or reroute. Minimum valued is 10 ms.
- *           Delay is skipped for the first retry. This slight delay is a protection mechanism.
+ * 1. 'max_attempts' - when the handler has used all the attempts, it will abort.
+ * 2. 'attempt' - this tells the handler how many attempts it has tried
+ * 3. 'status' - you should map the error status code in this field
+ * 4. 'message' - you should map the error message in this field
+ * 5. 'alternative' (start-end, code, code) - the optional codes and range of status codes to tell handler to reroute
+ * 6. 'delay' - the delay in milliseconds before exercising retry or reroute. Minimum valued is 10 milliseconds.
+ *              Delay is skipped for the first retry. This slight delay is a protection mechanism.
  * <p>
  * Optional backoff behavior:
  * 'cumulative' - the total number of failures since last success or backoff reset if any
@@ -64,7 +64,7 @@ import static org.platformlambda.core.util.common.PlatformConstants.ENV_INSTANCE
  *                    Not set if not in backoff mode.
  * <p>
  * 'result.attempt' should be saved in the state machine with the "model." namespace
- * 'result.cumulative' and result.backoff should be saved in the temporary file system or an external state machine
+ * 'result.cumulative' and 'result.backoff' should be saved in the temporary file system or an external state machine
  * <p>
  *     For non-blocking operation, this function is defined as an EventInterceptor for scheduling of future retries
  *     that are delayed. While a regular composable function returns a result, an EventInterceptor function must send

--- a/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
@@ -62,10 +62,10 @@ public class RecursiveClassTypeExaminer extends ClassVisitor {
         }
 
         if (interfaceNames != null) {
-            for (String iface : interfaceNames) {
-                String ifaceName = iface.replace('/', '.');
-                interfaces.add(ifaceName);
-                types.add(ifaceName);
+            for (String iFace : interfaceNames) {
+                String iFaceName = iFace.replace('/', '.');
+                interfaces.add(iFaceName);
+                types.add(iFaceName);
             }
         }
     }

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -411,7 +411,6 @@ class FlowTests extends TestBase {
                 "W3C traceparent should carry the flow's trace-id, got: " + forwarded);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     void declarativeSinkHttpTaskPropagatesTraceContext() throws ExecutionException, InterruptedException {
         // The same declarative application-to-application case, in the field's exact flow shape:

--- a/system/event-script-engine/src/test/java/com/accenture/flows/SpanPropagationTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/SpanPropagationTest.java
@@ -225,7 +225,7 @@ class SpanPropagationTest extends TestBase {
         List<Span> spans = new ArrayList<>();
         for (Map<String, Object> dataset : datasets) {
             Map<String, Object> metrics = (Map<String, Object>) dataset.get(TRACE);
-            // Skip records without a span_id: a RPC round-trip record adopts the responder's
+            // Skip records without a span_id: an RPC round-trip record adopts the responder's
             // span id only on a direct RPC - a flow reply is relayed on behalf of
             // event.script.manager by a task that reports its own span, so the caller's
             // round-trip measurement carries parent_span_id but no span_id and is not a

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -235,6 +235,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
@@ -297,8 +297,8 @@ public class KafkaFlowAdapter implements AutoCloseable {
 
     /**
      * Fail fast when a routing rule names a flow that was never compiled or a task route that is not in
-     * the platform registry - functions preload before this {@code @MainApplication} adapter starts, so
-     * target existence is checkable here rather than failing every matching message at runtime.
+     * the platform registry - functions preload before this {@code @MainApplication} adapter starts.
+     * Therefore, target existence is checkable here rather than failing every matching message at runtime.
      */
     private static void validateRoutingTargets(int i, String label, RoutingRuleSet routing) {
         for (RoutingRuleSet.Target target : routing.allTargets()) {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -395,7 +395,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
                 running = false;
                 return false;   // do not commit a message that was interrupted mid-processing
             } catch (ExecutionException e) {
-                cause = e.getCause() != null ? e.getCause() : e;
+                cause = rootCause(e);
             } catch (RuntimeException e) {
                 // a synchronous dispatch error - e.g. a task route released AFTER startup validation
                 // ("Route X not found") - joins the same retry/DLQ envelope instead of escaping to the
@@ -431,6 +431,10 @@ public class KafkaFlowConsumer implements AutoCloseable {
             throws InterruptedException, ExecutionException {
         PostOffice po = PostOffice.trackable(ADAPTER_ROUTE, traceId, tracePath);
         return po.request(forward, resolveTtl(forward)).get();
+    }
+
+    private static Throwable rootCause(ExecutionException e) {
+        return e.getCause() != null? e.getCause() : e;
     }
 
     /**
@@ -476,8 +480,8 @@ public class KafkaFlowConsumer implements AutoCloseable {
      * write, preserving its headers + body. Visible (package-private, non-final) so the commit-gating can be
      * unit-tested.
      *
-     * <p>If no {@code dlq-topic} is configured, or the write to it <b>fails</b>, there is no further
-     * fallback - an "exception of an exception" in the latter case. Refusing to commit would redeliver the
+     * <p>If no {@code dlq-topic} is configured, or write to it <b>fails</b>, there is no further
+     * fallback - an "exception to an exception" in the latter case. Refusing to commit would redeliver the
      * same poison message, which would fail the flow (and the DLQ write, if configured) again, indefinitely -
      * a self-sustaining retry/recovery storm, a known cause of prolonged outages. So instead we log a loud
      * {@code ERROR} and commit, deliberately accepting the loss of this one message in exchange for
@@ -521,7 +525,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
             running = false;
             return false;   // shutdown in progress: redeliver on the next start, do not commit
         } catch (ExecutionException | TimeoutException e) {
-            // an "exception of an exception": the last line of defense failed. Drop loudly rather than
+            // an "exception to an exception": the last line of defense failed. Drop loudly rather than
             // block the partition retrying forever (a recovery storm). Future: an alternative-path store.
             log.error("DATA LOSS: dead-letter write to {} failed; dropping '{}' offset {} to avoid a "
                             + "redelivery storm (ensure the DLQ topic exists). Cause: {}",

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Kafka health-check function for the platform's health endpoint.
+ * Kafka health check function for the platform's health endpoint.
  *
  * <p>Add {@code kafka.health} to {@code mandatory.health.dependencies} (or
  * {@code optional.health.dependencies}) in application.properties and the {@code /health}

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
@@ -32,14 +32,14 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Thread-safe wrapper around a Kafka producer, shared as a singleton by {@code
- * simple.kafka.notification}. The record is sent <b>eagerly</b> (the send is issued before the returned
+ * simple.kafka.notification}. The record is sent <b>eagerly</b> (send is issued before the returned
  * {@link Mono} is subscribed), and the {@code Mono<Void>} completes when the broker acknowledges the
  * record or errors when the send fails. This lets a caller that cares - e.g. a synchronous REST facade -
- * await delivery and fail-fast on a publish failure, while a drop-n-forget caller can simply ignore the
+ * await delivery and fail-fast on a publishing failure, while a drop-n-forget caller can simply ignore the
  * Mono (the record is still sent).
  *
  * <p>Delivery failures (e.g. broker unreachable past {@code delivery.timeout.ms}) are always logged via
- * {@code doOnError}, so a failed publish is visible even when no subscriber observes the Mono.</p>
+ * {@code doOnError}, so a failed publishing is visible even when no subscriber observes the Mono.</p>
  */
 public class KafkaRequestPublisher implements AutoCloseable {
 
@@ -53,7 +53,7 @@ public class KafkaRequestPublisher implements AutoCloseable {
 
     /**
      * Send a message eagerly and return a {@link Mono} that completes on broker acknowledgement (or errors
-     * on a delivery failure). The send is issued immediately, so a caller that ignores the Mono still
+     * on a delivery failure). Send is issued immediately, so a caller that ignores the Mono still
      * publishes; a caller that subscribes (e.g. via the composable function machinery) observes success or
      * failure and can react - the basis for fail-fast on the synchronous request path.
      *

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/RoutingRuleSet.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/RoutingRuleSet.java
@@ -76,7 +76,7 @@ public final class RoutingRuleSet {
     private static final String BODY_SELECTOR = BODY_PREFIX + ".";
     private static final String BODY_INDEX_SELECTOR = BODY_PREFIX + "[";
     // synthetic root the record body is evaluated under - makes a top-level List addressable and keeps
-    // every lookup path away from MultiLevelMap's '$'-JsonPath dispatch (full-path prefix check only)
+    // every lookup path away from MultiLevelMap's '$' JsonPath dispatch (full-path prefix check only)
     private static final String BODY_ROOT = "body";
     private static final String DEFAULT_RULE = "default";
     private static final String ARROW = "->";

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleKafkaNotification.java
@@ -48,7 +48,7 @@ import java.util.concurrent.ConcurrentMap;
  * because Kafka is asynchronous.
  *
  * <p><b>Trace propagation.</b> Rather than forwarding the caller's (now-stale) traceparent, it stamps a
- * fresh W3C {@code traceparent} built from this function's <i>own</i> current span, so the consuming side
+ * fresh W3C {@code traceparent} built from this function's <i>own</i> current span. Therefore, the consuming side
  * adopts this span as the parent of the next hop - keeping the trace continuous across the Kafka boundary.</p>
  *
  * <p>byte[] is the wire form for headers and body so no custom Kafka serializer/deserializer is needed.
@@ -57,21 +57,21 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <p>It returns the {@code Mono<Void>} from the publisher: the platform-core worker subscribes to it,
  * deferring the function's completion until the broker acknowledges. A caller using {@code po.request}
- * (RPC) therefore learns whether the publish succeeded - a publish failure propagates back as an error -
+ * (RPC) therefore learns whether the publishing succeeded - a publishing failure propagates back as an error -
  * while a {@code po.send} (async) caller simply doesn't observe it. The Mono is realized as {@code null}
  * (a {@code Void} body) on success.</p>
  *
  * <p><b>{@code @KernelThreadRunner}.</b> When the Schema Registry is used, this function builds Confluent
  * serializers, which use {@code synchronized} internally and are not thread-safe. Running on a kernel thread
  * (rather than a virtual thread) avoids pinning a virtual-thread carrier on those {@code synchronized}
- * sections, and each worker instance is single-flight - so each instance keeps its <b>own</b>
+ * sections, and each worker instance is single-flight. Therefore, each instance keeps its <b>own</b>
  * {@link SchemaCodec.Encoder} (in {@link #encoders}, keyed by instance), guaranteeing a Confluent serializer
  * is never touched by two threads at once.</p>
  *
  * <p><b>Keep the worker pool small.</b> Because {@code @KernelThreadRunner} puts each instance on a (scarce)
  * kernel thread rather than a virtual thread, keep {@code instances} low - {@code 5} is the default here.
  * Kafka publishing is fast and mostly waits on the broker ack, so a handful of single-flight workers sustain
- * high throughput while holding kernel-thread usage down. Raise it only if profiling shows the publish path
+ * high throughput while holding kernel-thread usage down. Raise it only if profiling shows the publishing path
  * is genuinely the bottleneck.</p>
  *
  * <p><b>Extension seam.</b> The publisher, schema codec, and outbound header names are resolved through
@@ -239,11 +239,12 @@ public class SimpleKafkaNotification implements TypedLambdaFunction<Object, Mono
     }
 
     /**
-     * Whether an event header is forwarded verbatim as a Kafka header. Excludes routing/encoding directives
-     * (topic/partition/subject/version), the inbound traceparent under the standard or configured name
-     * (replaced with this hop's own span), the correlation-id and configured trace-id headers (stamped
-     * explicitly from the resolved values), and the framework's read-only reserved headers
-     * (my_route / my_trace_id / my_trace_path / my_correlation_id).
+     * Whether an event header is forwarded verbatim as a Kafka header.
+     * Excludes:
+     * 1. routing/encoding directives (topic/partition/subject/version)
+     * 2. the inbound traceparent under the standard or configured name (replaced with this hop's own span)
+     * 3. the correlation-id and configured trace-id headers (stamped explicitly from the resolved values)
+     * 4. and the framework's read-only reserved headers (my_route / my_trace_id / my_trace_path / my_correlation_id)
      */
     private boolean isPropagatableHeader(String key) {
         return !KafkaHeaders.TOPIC.equals(key)

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleRandomPartitioner.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/SimpleRandomPartitioner.java
@@ -31,9 +31,9 @@ import java.util.Map;
  * A perfectly stateless partitioner: each keyless record goes to a uniformly random partition.
  *
  * <p>Kafka's built-in default is a <i>sticky</i> partitioner - it keeps writing to one partition until a
- * batch closes, which is throughput-friendly but skews low-volume traffic badly (an app publishing a few
+ * batch closes, which is throughput-friendly but skews low-volume traffic badly. An app publishing a few
  * messages at a time can land everything on a single partition, leaving a multi-instance consumer group
- * mostly idle). The built-in {@code RoundRobinPartitioner} fixes the skew but keeps per-topic counters and
+ * mostly idle. The built-in {@code RoundRobinPartitioner} fixes the skew but keeps per-topic counters and
  * has known unevenness when batches are recreated. Random distribution needs no state at all and converges
  * on uniform - the pattern proven in field deployments of this library.</p>
  *

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/JsonSchemaSerde.java
@@ -77,9 +77,9 @@ class JsonSchemaSerde implements SchemaSerde {
     public byte[] serialize(String topic, int schemaId, Object value) {
         /*
          * Envelope the value with its (pre-registered) schema, so the serializer uses that schema directly
-         * instead of DERIVING one from the value's Map<String,Object> type - the derivation can't introspect
+         * instead of DERIVING one from the value's Map<String,Object> type. The derivation can't introspect
          * the Object-typed map values (noisy "Unable to process java.lang.Object" warnings) and is wasted
-         * work. use.schema.id still pins the wire id and resolves via getSchemaById (no subject lookup).
+         * work. Use.schema.id still pins the wire id and resolves via getSchemaById (no subject lookup).
          */
         JsonNode node = JSON.valueToTree(value);
         Object enveloped = JsonSchemaUtils.envelope(jsonSchemaById(schemaId), node);

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ManagedCacheSchemaRegistryClient.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/ManagedCacheSchemaRegistryClient.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * and TTL-expired by the platform housekeeper - nothing is written to disk.
  *
  * <p><b>Positive results only.</b> A not-found id is never cached (the registry lookup throws before the
- * cache write), so a schema registered while the app is running becomes visible on the very next lookup -
+ * cache write). Therefore, a schema registered while the app is running becomes visible on the very next lookup -
  * no stale "not found" lingers until a TTL elapses or the pod restarts. ({@link SchemaCodec} also pins
  * Confluent's own "missing" caches off, so no layer remembers an absent id.)</p>
  *

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -104,7 +104,7 @@ public class SchemaCodec {
      * The classloader that loaded the Confluent serde classes. Confluent's config validation resolves classes
      * (e.g. the default {@code context.name.strategy} → {@code NullContextNameStrategy}) via the <b>thread
      * context</b> classloader. When the producer runs on a {@code @KernelThreadRunner} pool thread - whose
-     * context classloader is not the application's - that lookup fails, so a serde build/use is wrapped with
+     * context classloader is not the application's - that lookup fails. Therefore, a serde build/use is wrapped with
      * {@link #withSerdeClassLoader} to set this for the duration of the call and restore the previous one after.
      */
     private static final ClassLoader SERDE_CLASSLOADER = AbstractKafkaSchemaSerDeConfig.class.getClassLoader();
@@ -279,7 +279,7 @@ public class SchemaCodec {
     }
 
     /**
-     * @param data the bytes to inspect (may be {@code null})
+     * @param data the bytes to inspect (maybe {@code null})
      * @return {@code true} if the bytes are Confluent-framed (magic byte + 4-byte id + payload)
      */
     public static boolean isFramed(byte[] data) {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
@@ -19,11 +19,15 @@
 package org.platformlambda.mini.kafka;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.platformlambda.core.util.ConfigReader;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -276,50 +280,38 @@ class KafkaFlowAdapterConfigTest {
         assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
-    @Test
-    void rejectsFlowsThatIsNotAList() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders", "flows", "default -> flow://f")));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
+    /**
+     * The second-level routing and serializer validation rejections share one shape
+     * (a bad consumer entry -> fail-fast at build), so they run as one parameterized
+     * test with named cases. The unknown-flow case works because no flow is compiled
+     * in this test JVM - any flow:// target fails the cross-reference check.
+     */
+    private static Stream<Arguments> invalidRoutingOrSerializerEntries() {
+        return Stream.of(
+                Arguments.of("flows is not a list",
+                        Map.of("topic", "orders", "flows", "default -> flow://f")),
+                Arguments.of("empty flows list",
+                        Map.of("topic", "orders", "flows", List.of())),
+                Arguments.of("malformed routing rule",
+                        Map.of("topic", "orders",
+                                "flows", List.of("this is not a rule", "default -> flow://f"))),
+                Arguments.of("flows without a default rule",
+                        Map.of("topic", "orders",
+                                "flows", List.of("input.header.type(order) -> flow://order-flow"))),
+                Arguments.of("routing rule referencing an unknown flow",
+                        Map.of("topic", "orders",
+                                "flows", List.of("default -> flow://no-such-flow"))),
+                Arguments.of("unsupported serializer",
+                        Map.of("topic", "orders", "flow", "f", "serializer", "xml")),
+                Arguments.of("serializer combined with schema decoding",
+                        Map.of("topic", "orders", "flow", "f",
+                                "serializer", "json", "schema.enabled", "true")));
     }
 
-    @Test
-    void rejectsEmptyFlowsList() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders", "flows", List.of())));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
-    }
-
-    @Test
-    void rejectsMalformedRoutingRule() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders",
-                "flows", List.of("this is not a rule", "default -> flow://f"))));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
-    }
-
-    @Test
-    void rejectsFlowsWithoutDefault() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders",
-                "flows", List.of("input.header.type(order) -> flow://order-flow"))));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
-    }
-
-    @Test
-    void rejectsRoutingRuleReferencingUnknownFlow() {
-        // no flow is compiled in this test JVM, so any flow:// target fails the cross-reference check
-        ConfigReader config = config(List.of(Map.of("topic", "orders",
-                "flows", List.of("default -> flow://no-such-flow"))));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
-    }
-
-    @Test
-    void rejectsUnsupportedSerializer() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders", "flow", "f", "serializer", "xml")));
-        assertThrows(IllegalArgumentException.class, () -> build(config));
-    }
-
-    @Test
-    void rejectsSerializerCombinedWithSchemaDecoding() {
-        ConfigReader config = config(List.of(Map.of("topic", "orders", "flow", "f",
-                "serializer", "json", "schema.enabled", "true")));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidRoutingOrSerializerEntries")
+    void rejectsInvalidRoutingOrSerializerEntry(String name, Map<String, Object> entry) {
+        ConfigReader config = config(List.of(entry));
         assertThrows(IllegalArgumentException.class, () -> build(config));
     }
 
@@ -348,8 +340,8 @@ class KafkaFlowAdapterConfigTest {
 
     @Test
     void taskTtlUsesLongMathWithNoSilentWrap() {
-        // int arithmetic would wrap '50000d' (4.32e9 seconds) to a silently WRONG positive value;
-        // long math honors an absurd-but-accepted duration exactly as written
+        // integer arithmetic would wrap '50000d' (4.32e9 seconds) to a silently WRONG positive value.
+        // long math honors an absurd-but-accepted duration exactly as written.
         assertEquals(50000L * 86400 * 1000, KafkaFlowAdapter.parseTaskTtl("50000d"));
         assertEquals(86400000L, KafkaFlowAdapter.parseTaskTtl("1d"));
         assertEquals(3600000L, KafkaFlowAdapter.parseTaskTtl("1h"));

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterTest.java
@@ -92,7 +92,7 @@ class KafkaFlowAdapterTest {
         KafkaTestSupport.createTopic(kafka.bootstrapServers(), LEGACY_TOPIC);
         KafkaTestSupport.createTopic(kafka.bootstrapServers(), JSON_TOPIC);
         KafkaTestSupport.createTopic(kafka.bootstrapServers(), AVRO_TOPIC);
-        // created before AutoStart.main() starts the topic-pattern consumer's subscribe(Pattern), same as
+        // created before AutoStart.main() starts the topic-pattern consumer subscribe(Pattern), same as
         // the topics above - avoids a race against the adapter's first metadata fetch.
         KafkaTestSupport.createTopic(kafka.bootstrapServers(), PATTERN_TOPIC, 2);
         KafkaTestSupport.createTopic(kafka.bootstrapServers(), ROUTED_TOPIC);
@@ -410,8 +410,8 @@ class KafkaFlowAdapterTest {
     @SuppressWarnings("unchecked")
     void bodyRuleRoutesOnSchemaDecodedRecord() throws Exception {
         JsonSinkTask.RECEIVED.clear();
-        // on a schema-enabled binding, input.body rules match on the Confluent-decoded Map -
-        // the decode happens before rule evaluation, exactly as on the direct-routing path
+        // on a schema-enabled binding, input.body rules match on the Confluent-decoded Map
+        // and decode happens before rule evaluation, exactly as on the direct-routing path
         String subject = ROUTED_SCHEMA_TOPIC + "-value";
         KafkaRuntime.schemaCodec().client().register(subject, new JsonSchema(JSON_SCHEMA));
         String cid = Utility.getInstance().getUuid();
@@ -436,7 +436,7 @@ class KafkaFlowAdapterTest {
     void listBodyRuleRoutesTopLevelJsonArray() throws Exception {
         RoutedTaskSink.RECEIVED.clear();
         // a top-level JSON array decodes to a List and is addressable by an input.body[0] bracket rule
-        // (target selection between the list rule and the default is pinned at unit level - this proves
+        // (target selection between the list rule and the default is pinned at unit level. This proves
         // the wire-to-List decode and List delivery end-to-end through the real pipeline)
         KafkaRuntime.publisher().publishSync(ROUTED_TOPIC, null, Map.of(),
                 "[{\"type\":\"batch-order\"},{\"type\":\"noise\"}]".getBytes(StandardCharsets.UTF_8), 10000);
@@ -445,7 +445,7 @@ class KafkaFlowAdapterTest {
         assertNotNull(received, "the JSON-array record should reach the task target");
         List<Object> body = (List<Object>) assertInstanceOf(List.class, received.get("body"),
                 "serializer 'json' delivered the decoded List as the task's whole body");
-        assertEquals("batch-order", ((Map<String, Object>) body.get(0)).get("type"));
+        assertEquals("batch-order", ((Map<String, Object>) body.getFirst()).get("type"));
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowRoutingConsumerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowRoutingConsumerTest.java
@@ -178,9 +178,9 @@ class KafkaFlowRoutingConsumerTest {
         assertTrue(consumer.routeToFlow(inbound("x".getBytes(StandardCharsets.UTF_8), Map.of())),
                 "a durably dead-lettered message must allow the commit");
         assertEquals(1, dlq.history().size());
-        assertEquals("mixed-dlq", dlq.history().get(0).topic());
+        assertEquals("mixed-dlq", dlq.history().getFirst().topic());
         // the failure cause names the task target, not a flow
-        String dlqError = new String(dlq.history().get(0).headers().lastHeader("dlq.error").value(),
+        String dlqError = new String(dlq.history().getFirst().headers().lastHeader("dlq.error").value(),
                 StandardCharsets.UTF_8);
         assertTrue(dlqError.contains("task 'always.failing'"), dlqError);
     }
@@ -203,7 +203,7 @@ class KafkaFlowRoutingConsumerTest {
         assertTrue(consumer.routeToFlow(inbound("x".getBytes(StandardCharsets.UTF_8), Map.of())),
                 "a durably dead-lettered message must allow the commit");
         assertEquals(1, dlq.history().size());
-        String dlqError = new String(dlq.history().get(0).headers().lastHeader("dlq.error").value(),
+        String dlqError = new String(dlq.history().getFirst().headers().lastHeader("dlq.error").value(),
                 StandardCharsets.UTF_8);
         assertTrue(dlqError.contains("Route vanished.route not found"), dlqError);
     }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/RoutingRuleSetTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/RoutingRuleSetTest.java
@@ -139,7 +139,7 @@ class RoutingRuleSetTest {
     @Test
     void dollarPrefixedBodyKeysAreLiteralSegmentsNeverJsonPath() {
         // the body is evaluated under a synthetic root, so MultiLevelMap's '$'-JsonPath escape hatch
-        // (whose parser can throw at record time) is structurally unreachable - a '$'-prefixed key is
+        // (whose parser can throw at record time) is structurally unreachable - a '$' prefixed key is
         // an ordinary literal segment, and a JsonPath-looking key is a plain non-match, never an error
         RoutingRuleSet literal = compile("input.body.$kind(refund) -> flow://refund-flow", CATCH_ALL);
         assertEquals(flow("refund-flow"), literal.select(Map.of(), Map.of("$kind", "refund")));

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleKafkaNotificationTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleKafkaNotificationTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for the notification function's body handling - the outbound symmetry of the flow
  * adapter's inbound {@code serializer: 'json'}: a Map or List body auto-serializes to JSON bytes,
- * byte[] passes through verbatim, null stays null (a Kafka tombstone). The publish path itself is
+ * byte[] passes through verbatim, null stays null (a Kafka tombstone). The publishing path itself is
  * proven end-to-end in {@link KafkaFlowAdapterTest}.
  */
 class SimpleKafkaNotificationTest {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleRandomPartitionerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SimpleRandomPartitionerTest.java
@@ -38,10 +38,10 @@ class SimpleRandomPartitionerTest {
     private static final String TOPIC = "random-partitioner-test";
     private static final int PARTITIONS = 10;
 
-    private static Cluster cluster(int partitions, boolean withLeaders) {
+    private static Cluster cluster(boolean withLeaders) {
         Node node = new Node(1, "127.0.0.1", 9092);
         List<PartitionInfo> info = new ArrayList<>();
-        for (int i = 0; i < partitions; i++) {
+        for (int i = 0; i < PARTITIONS; i++) {
             // leader == null marks a partition unavailable for the availablePartitionsForTopic view
             info.add(new PartitionInfo(TOPIC, i, withLeaders ? node : null, new Node[]{node}, new Node[]{node}));
         }
@@ -53,7 +53,7 @@ class SimpleRandomPartitionerTest {
     void keylessRecordsSpreadAcrossPartitions() {
         SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
         partitioner.configure(Map.of());
-        Cluster cluster = cluster(PARTITIONS, true);
+        Cluster cluster = cluster(true);
         Set<Integer> seen = new HashSet<>();
         for (int i = 0; i < 500; i++) {
             int p = partitioner.partition(TOPIC, null, null, null, new byte[]{1}, cluster);
@@ -69,7 +69,7 @@ class SimpleRandomPartitionerTest {
     @SuppressWarnings("resource")
     void keyedRecordsMapDeterministically() {
         SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
-        Cluster cluster = cluster(PARTITIONS, true);
+        Cluster cluster = cluster(true);
         byte[] key = "profile-100".getBytes(StandardCharsets.UTF_8);
         int first = partitioner.partition(TOPIC, "profile-100", key, null, new byte[]{1}, cluster);
         for (int i = 0; i < 20; i++) {
@@ -79,10 +79,9 @@ class SimpleRandomPartitionerTest {
     }
 
     @Test
-    @SuppressWarnings("resource")
     void fallsBackToAllPartitionsWhenNoneAvailable() {
         SimpleRandomPartitioner partitioner = new SimpleRandomPartitioner();
-        Cluster cluster = cluster(PARTITIONS, false);
+        Cluster cluster = cluster(false);
         for (int i = 0; i < 50; i++) {
             int p = partitioner.partition(TOPIC, null, null, null, new byte[]{1}, cluster);
             assertTrue(p >= 0 && p < PARTITIONS, "must fall back to the full partition list");


### PR DESCRIPTION
## What

A behavior-preserving code-quality round combining IDE-recommended polish with
remediation of the SonarQube findings flagged in the IDE:

- **`TaskExecutor.executeTask` cognitive complexity 18 → well under 15** — the
  `flow://` and function dispatch branches extracted as `launchSubFlow` and
  `sendTaskEvent` (pure code movement, no logic change).
- **`KafkaFlowConsumer.deliver` 16 → under 15** — the nested ternary in the
  `ExecutionException` catch extracted as a `rootCause` helper.
- **`CompileFlows.validateTtlParameter`** — the duration parse + positivity check
  extracted as `getValidTtlSeconds`.
- **`KafkaFlowAdapterConfigTest`** — the family of 7 identical-shape routing/serializer
  rejection tests folded into one `@ParameterizedTest` with named cases (S5976);
  `junit-jupiter-params` added to the module via the existing junit-bom, mirroring
  platform-core.
- **`SimpleRandomPartitionerTest`** — dropped the always-constant `partitions` helper
  parameter.
- IDE wording/naming polish across the recently-merged surfaces (quoted model keys in
  javadoc, `record` → `restoredRecord` renames, `Utility.sleep` in tests, comment
  consistency).

## Why

The field DevOps quality gate holds the **whole codebase** (not just new code) to zero
blocker/critical/major findings, and cognitive-complexity violations are exactly what
failed past field scans (v4.9.1, v4.10.4). The two S3776 findings were introduced by
the recently merged deadline round (#250) — this applies the house lesson of
extracting-as-you-go near the threshold, before the next field scan sees them. The
parameterized fold removes the whole S5976 cluster rather than only the three flagged
members, so adjacent identical-shape tests cannot be re-flagged later.

**Verification:** event-script 185/185, minimalist-kafka 163/163 (the folded tests run
as 7 named parameterized cases — identical execution count, no coverage lost),
redis-state 10/10.

---

Co-Authored-By: Claude Code <noreply@anthropic.com>