### PR TITLE
Release v4.11.2 - lz4 CVE exclusion fix + Kafka 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.11.2, 8/3/2026
+
+Security patch for field deployment quality gates. Java-only — the Maven dependency
+surface has no Rust counterpart, so the Rust engine stays at v4.11.1.
+
+### Security
+
+1. **The unused lz4 codec library is excluded again — the old exclusion had silently
+   expired.** Field Snyk scans reject deployments over CVE-2026-59949 (NULL pointer
+   dereference, CWE-125; Snyk CVSS 8.3 High) in `at.yawk.lz4:lz4-java` 1.10.x, which
+   `kafka-clients` pulls transitively with no upstream remediation path. This project has
+   always excluded the lz4 codec — no framework module enables Kafka compression; codecs
+   load lazily and the producer default is `none` — but the exclusion was pinned to the
+   library's former coordinate `org.lz4:lz4-java` and became a silent no-op when Apache
+   Kafka moved to the maintained `at.yawk.lz4` fork. All six declaration sites
+   (kafka-connector, minimalist-kafka's client and embedded test broker, twin-kafka,
+   sync-over-async, kafka-standalone) now exclude the current coordinate, so no module's
+   resolved dependency tree carries lz4-java. An application that deliberately enables
+   `compression.type=lz4` must declare `at.yawk.lz4:lz4-java` itself — the same contract
+   as before the fork switch.
+
+### Changed
+
+1. **`kafka.version` 4.2.0 → 4.3.1 across the reactor.** Executes the previously deferred
+   client upgrade and lands on Confluent Platform 8.3.x's own tested pairing (Apache
+   Kafka 4.3.x). The embedded KRaft broker used by kafka-standalone and the integration
+   tests moves in lock-step — kafka-standalone's `kafka_2.13` now references
+   `${kafka.version}` instead of a hardcoded literal — and kotlin-example's inert
+   `kafka.version` property was aligned. Validated by the full reactor build and test
+   suite against the 4.3.1 client and broker.
+
+---
 ## Version 4.11.1, 8/1/2026
 
 ### Fixed

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
             <artifactId>kafka-clients</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -21,7 +21,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -21,7 +21,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -27,7 +27,7 @@
              pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
              Confluent chain must override the property itself - see minimalist-kafka's pom. -->
         <httpcore5.version>5.4.3</httpcore5.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -21,7 +21,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <kotlin.version>2.1.21</kotlin.version>
         <java.version>21</java.version>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -19,7 +19,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>    
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -27,7 +27,7 @@
              pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
              Confluent chain must override the property itself - see minimalist-kafka's pom. -->
         <httpcore5.version>5.4.3</httpcore5.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -27,7 +27,7 @@
              pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
              Confluent chain must override the property itself - see minimalist-kafka's pom. -->
         <httpcore5.version>5.4.3</httpcore5.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -21,7 +21,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -34,7 +34,7 @@
         <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Embedded broker (kafka_2.13) version for tests. Matches the kafka-clients version pinned by
              minimalist-kafka so there is no client/broker protocol skew. -->
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
     </properties>
 
     <dependencyManagement>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava
@@ -108,7 +108,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
                 <exclusion>

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,16 +50,16 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
-            <version>4.2.0</version>
+            <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
                 <exclusion>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -36,14 +36,12 @@
         <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Pin the Kafka client to the same version as the embedded broker used in tests
              (kafka_2.13) to avoid client/broker protocol skew. -->
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <!-- Provides the out-of-the-box Schema Registry serializers (interop with existing client
-             projects). Confluent Platform 8.3.x's own tested pairing is Apache Kafka 4.3.x, but we
-             deliberately pin our own kafka-clients (above) rather than follow that pairing - the
-             serializers implement the stable Serializer/Deserializer contract, so they are tolerant of a
-             different Kafka client version. Bumping kafka.version to 4.3.x is a separate, deferred
-             decision (broader blast radius: 24 modules, embedded broker behavior, no CVE driver) -
-             see the project backlog. -->
+             projects). Confluent Platform 8.3.x's own tested pairing is Apache Kafka 4.3.x, matching
+             the kafka.version pinned above. We still pin our own kafka-clients rather than inherit a
+             version - the serializers implement the stable Serializer/Deserializer contract, so they
+             are tolerant of a different Kafka client version. -->
         <confluent.version>8.3.0</confluent.version>
     </properties>
 
@@ -85,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava
@@ -105,7 +103,7 @@
             <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>
@@ -198,7 +196,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
                 <exclusion>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <name>Mercury platform-core module</name>
 
     <parent>
@@ -22,7 +22,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -24,7 +24,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -24,7 +24,7 @@
         <netty.version>4.2.16.Final</netty.version>
         <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>
     </properties>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.11.1</version>
+    <version>4.11.2</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -36,7 +36,7 @@
              Confluent chain must override the property itself - see minimalist-kafka's pom. -->
         <httpcore5.version>5.4.3</httpcore5.version>
         <!-- Same pinning rationale as minimalist-kafka: match the embedded test broker. -->
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.1</kafka.version>
     </properties>
 
     <repositories>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.1</version>
+            <version>4.11.2</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with
@@ -71,7 +71,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
                 <exclusion>


### PR DESCRIPTION
## What

Security patch for field deployment quality gates. Java-only — the Maven dependency
surface has no Rust counterpart, so the Rust engine stays at v4.11.1.

- **Restores the lz4 codec exclusion under its current coordinate.** The long-standing
  exclusion of the unused lz4 library was pinned to the former `org.lz4:lz4-java`
  coordinate and became a silent no-op when Apache Kafka moved to the maintained
  `at.yawk.lz4` fork. All six declaration sites (kafka-connector, minimalist-kafka's
  client and embedded test broker, twin-kafka, sync-over-async, kafka-standalone) now
  exclude `at.yawk.lz4:lz4-java`; no module's resolved dependency tree carries lz4-java.
- **Bumps `kafka.version` 4.2.0 → 4.3.1 across the reactor**, executing the previously
  deferred client upgrade and landing on Confluent Platform 8.3.x's own tested pairing.
  kafka-standalone's `kafka_2.13` now references `${kafka.version}` instead of a
  hardcoded literal (broker and `kafka-metadata` can no longer skew), and
  kotlin-example's inert property was aligned.
- Version sweep to 4.11.2 (33 poms) + CHANGELOG.

## Why

Field Snyk scans reject deployments over CVE-2026-59949 (NULL pointer dereference,
Snyk CVSS 8.3 High) in `at.yawk.lz4:lz4-java` 1.10.x, pulled transitively by
kafka-clients with no upstream remediation path — both kafka-clients 4.2.0 and 4.3.1
depend on vulnerable fork versions (1.10.1 / 1.10.2, below the fixed 1.11.1), so the
exclusion is the remediation. lz4 compression is an exception rather than a norm: no
framework module enables Kafka compression (codecs load lazily; the producer default is
`none`), and a field installation that requires lz4 adds the dependency itself — the
same contract that held before the fork switch.

## Verification

- Full reactor build and test suite green against the 4.3.1 client and embedded KRaft
  broker.
- `dependency:tree` across every module: zero lz4-java (including verbose/conflict
  view on kafka-standalone); all fourteen Kafka artifacts uniformly at 4.3.1.
- Live kafka-demo regression against the 4.3.1 kafka-standalone broker, per the demo
  README procedure: direct routing with end-to-end trace continuity; all four
  second-level routing rules (exact / wildcard / body-rule → `task://` / default);
  JSON auto-serialization symmetry; the failure path (3 retries then dead-letter to
  `demo.orders.dlq` with origin/error headers, body preserved verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>