### PR TITLE
Fix piped-mode behavior of the kafka-demo publish helpers

### DIFF
--- a/examples/kafka-demo/node/publish-inbound.js
+++ b/examples/kafka-demo/node/publish-inbound.js
@@ -17,32 +17,49 @@ const { Kafka, Partitioners } = kafkajs;
     `[${cfg.ts()}] connected. Type a message + Enter to publish to '${cfg.inboundTopic}' (Ctrl-C to quit).`
   );
 
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' });
-  rl.prompt();
+  async function publishOne(text) {
+    const cid = randomUUID();
+    // W3C traceparent: 00-<32-hex trace-id>-<16-hex span-id>-01. The Kafka flow adapter adopts this
+    // trace-id, so the whole flow (and the message it publishes to demo.outbound) shares it - making
+    // the end-to-end trace continuity visible.
+    const traceId = randomBytes(16).toString('hex');
+    const traceparent = `00-${traceId}-${randomBytes(8).toString('hex')}-01`;
+    try {
+      await producer.send({
+        topic: cfg.inboundTopic,
+        messages: [{ value: text, headers: { cid, traceparent } }],
+      });
+      console.log(`[${cfg.ts()}] -> ${cfg.inboundTopic} cid=${cid} traceId=${traceId} ${text}`);
+    } catch (e) {
+      console.error(`[${cfg.ts()}] publish failed:`, e.message);
+    }
+  }
 
-  rl.on('line', async (line) => {
+  // Show the interactive prompt only on a TTY - piped input otherwise gets '>' characters
+  // glued onto the log lines.
+  const interactive = process.stdin.isTTY === true;
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: interactive ? process.stdout : undefined,
+    prompt: '> ',
+  });
+  if (interactive) rl.prompt();
+
+  // chain the sends so they stay ordered and can be awaited on close - the script then works both
+  // interactively AND with piped input for scripted regression runs, e.g.
+  //   echo 'hello composable kafka' | node publish-inbound.js
+  let inflight = Promise.resolve();
+
+  rl.on('line', (line) => {
     const text = line.trim();
     if (text.length > 0) {
-      const cid = randomUUID();
-      // W3C traceparent: 00-<32-hex trace-id>-<16-hex span-id>-01. The Kafka flow adapter adopts this
-      // trace-id, so the whole flow (and the message it publishes to demo.outbound) shares it - making
-      // the end-to-end trace continuity visible.
-      const traceId = randomBytes(16).toString('hex');
-      const traceparent = `00-${traceId}-${randomBytes(8).toString('hex')}-01`;
-      try {
-        await producer.send({
-          topic: cfg.inboundTopic,
-          messages: [{ value: text, headers: { cid, traceparent } }],
-        });
-        console.log(`[${cfg.ts()}] -> ${cfg.inboundTopic} cid=${cid} traceId=${traceId} ${text}`);
-      } catch (e) {
-        console.error(`[${cfg.ts()}] publish failed:`, e.message);
-      }
+      inflight = inflight.then(() => publishOne(text));
     }
-    rl.prompt();
+    if (interactive) rl.prompt();
   });
 
   rl.on('close', async () => {
+    await inflight;
     await producer.disconnect();
     process.exit(0);
   });

--- a/examples/kafka-demo/node/publish-orders.js
+++ b/examples/kafka-demo/node/publish-orders.js
@@ -124,8 +124,15 @@ function toRecord(line) {
     }
   }
 
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' });
-  rl.prompt();
+  // Show the interactive prompt only on a TTY - piped input otherwise gets '>' characters
+  // glued onto the log lines.
+  const interactive = process.stdin.isTTY === true;
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: interactive ? process.stdout : undefined,
+    prompt: '> ',
+  });
+  if (interactive) rl.prompt();
 
   // chain the sends so they stay ordered and can be awaited on close - the script then works both
   // interactively AND with piped input for scripted regression runs, e.g.
@@ -137,7 +144,7 @@ function toRecord(line) {
     if (text.length > 0) {
       inflight = inflight.then(() => publishOne(text));
     }
-    rl.prompt();
+    if (interactive) rl.prompt();
   });
 
   rl.on('close', async () => {

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -18,7 +18,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-08-02 | agent: Claude Code (2026-08-02-013842)
+- **last_session:** 2026-08-03 | agent: Claude Code (2026-08-03-155225)
 - **last_review:** 2026-07-31 | through 2026-07-31-001057.md
 - **last_invariant_check:** 2026-07-27 | 2026-07-27-215011.md (all 15 confirmed by Eric — one-by-one walkthrough with live-tree evidence; thread-reverify-invariants-2026q2 closed)
 
@@ -404,6 +404,28 @@
   Relates [[thread-kafka-2nd-level-routing]].
   <!-- id: thread-kafka-header-casing-mismatch | created: 2026-07-30 | last_used: 2026-07-30 | uses: 1 | tier: working | origin: 2026-07-30-233623 -->
 
+- [x] (release — SHIPPED 2026-08-03, **Java only by nature — the Maven dependency surface
+  has no Rust counterpart; Rust stays at 4.11.1**) **v4.11.2 — the field lz4-CVE security
+  patch + Kafka 4.3.1.** Field Snyk rejected a deployment over CVE-2026-59949 in
+  `at.yawk.lz4:lz4-java` (transitive via kafka-clients, no upstream remediation path).
+  [PR #253](https://github.com/Accenture/mercury-composable/pull/253), squash `08a31cfa`,
+  CI green, tag on the verified squash commit. **Durable lessons:** (1) the repo had
+  always excluded the unused lz4 codec, but the exclusions pinned the library's FORMER
+  coordinate `org.lz4:lz4-java` and became silent no-ops when Kafka switched to the
+  maintained `at.yawk.lz4` fork — **a groupId-pinned exclusion silently expires when
+  upstream renames a coordinate**; fixed at all six declaration sites. (2) **lz4 contract
+  (Eric):** LZ4 compression is an exception rather than a norm — a field installation
+  that needs it adds the dependency itself; the framework ships codec-free. Also executed
+  and closed the deferred kafka.version 4.2.0→4.3.1 upgrade (Confluent 8.3.x's tested
+  pairing; kafka-standalone's kafka_2.13 now on `${kafka.version}`, no broker/metadata
+  skew). Pre-release gates Eric asked for: per-module dependency-tree sweep (zero lz4,
+  all 14 Kafka artifacts uniform 4.3.1) + live kafka-demo regression against the 4.3.1
+  standalone broker (all routing rules, trace continuity, retries→DLQ — the README
+  procedure). Residual observation: the demo's publish helpers have two piped-mode-only
+  display/EOF quirks (interactive use unaffected; candidate two-line fix). Full detail:
+  origin log.
+  <!-- id: thread-release-4-11-2 | created: 2026-08-03 | last_used: 2026-08-03 | uses: 1 | tier: working | origin: 2026-08-03-155225 -->
+
 - [x] (release — SHIPPED 2026-08-01, **Java only — the first Java-ahead-of-Rust release
   since the 4.8.x line, deliberate**) **v4.11.1 — the second-level routing + deadline
   release.** [PR #252](https://github.com/Accenture/mercury-composable/pull/252), squash
@@ -655,11 +677,13 @@
   `GraphModelValidator` ([[compilegraph-mandatory-gate]]).
   <!-- id: thread-compilegraph-syntax-validation | created: 2026-07-02 | last_used: 2026-07-29 | uses: 4 | tier: working | origin: 2026-07-02-004606 -->
 
-- [ ] (planned — backlog, no ETA, no CVE driver) **Upgrade `kafka.version` (4.2.0 → 4.3.x) across
-  the 24 pom.xml files that pin it.** Deferred alongside the `confluent.version` 8.2.0→8.3.0 bump
-  — see [[minimalist-kafka-confluent-8-3-0]]. Scope when picked up: verify kafka-clients 4.3.x +
-  the embedded KRaft broker behavioral compatibility across all 24 files — a materially larger
-  test surface than a serializer-library bump.
+- [x] (planned — **CLOSED 2026-08-03: executed by the v4.11.2 release**, which gained a CVE
+  driver after all — see [[thread-release-4-11-2]]; all poms now pin 4.3.1, validated by the
+  full reactor + embedded KRaft broker + a live kafka-demo drive) **Upgrade `kafka.version`
+  (4.2.0 → 4.3.x) across the 24 pom.xml files that pin it.** Deferred alongside the
+  `confluent.version` 8.2.0→8.3.0 bump — see [[minimalist-kafka-confluent-8-3-0]]. Scope when
+  picked up: verify kafka-clients 4.3.x + the embedded KRaft broker behavioral compatibility
+  across all 24 files — a materially larger test surface than a serializer-library bump.
   <!-- id: thread-kafka-client-version-upgrade | created: 2026-07-01 | last_used: 2026-07-01 | uses: 1 | tier: working | origin: 2026-07-01-230246 -->
 
 - [ ] (planned — Eric, 2026-06-24) **Add Gradle build support** alongside the existing Maven reactor

--- a/memory/sessions/2026-08-03-155225.md
+++ b/memory/sessions/2026-08-03-155225.md
@@ -1,0 +1,67 @@
+# Session (2026-08-03T15:52:25.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.11.2 SHIPPED — the field lz4-CVE security patch + the deferred Kafka client upgrade.**
+Field Snyk scans rejected a v4.11.0 deployment over CVE-2026-59949 (NULL pointer
+dereference, Snyk CVSS 8.3 High) in `at.yawk.lz4:lz4-java` 1.10.x, transitive via
+kafka-clients with no upstream remediation path. Eric supplied the pattern edit in
+kafka-connector's pom; verified acceptable and applied across the reactor.
+[PR #253](https://github.com/Accenture/mercury-composable/pull/253), squash `08a31cfa`,
+CI green (Build & Unit Tests 7m43s), tag `v4.11.2` on the verified squash commit.
+Java-only release — the Maven dependency surface has no Rust counterpart; Rust stays at
+v4.11.1.
+
+**Root cause (the durable lesson):** the repo had ALWAYS excluded the unused lz4 codec,
+but the exclusions were pinned to the library's former coordinate `org.lz4:lz4-java` and
+became silent no-ops when Apache Kafka switched to the maintained `at.yawk.lz4` fork
+(kafka-clients 4.2.0 and 4.3.1 both depend on vulnerable fork versions 1.10.1/1.10.2,
+below the fixed 1.11.1 — so the exclusion, not the version bump, is the remediation).
+**A groupId-pinned exclusion is a silent-expiry hazard: when upstream renames a
+coordinate, the exclusion keeps "passing" while the artifact re-enters the tree.**
+
+**What shipped:**
+- Exclusion coordinate `org.lz4` → `at.yawk.lz4` at all six declaration sites
+  (kafka-connector, minimalist-kafka client + embedded test broker, twin-kafka,
+  sync-over-async, kafka-standalone). All twelve Snyk-flagged projects clear —
+  demo/example modules inherit through these.
+- `kafka.version` 4.2.0 → 4.3.1 across the reactor — **executes and closes the deferred
+  [[thread-kafka-client-version-upgrade]]** (and lands on Confluent 8.3.x's own tested
+  pairing with Apache Kafka 4.3.x; the minimalist-kafka comment documenting the deferral
+  rewritten). kafka-standalone's `kafka_2.13` now references `${kafka.version}` instead
+  of a hardcoded literal (broker/kafka-metadata can no longer skew); kotlin-example's
+  inert 3.9.1 pin aligned.
+- **lz4 contract (Eric's ruling):** LZ4 compression is an exception rather than a norm —
+  a field installation that requires it adds the `at.yawk.lz4:lz4-java` dependency
+  itself. The framework ships codec-free (codecs load lazily; producer default `none`;
+  zstd-jni/snappy-java remain, never excluded, no CVE). Stated in the CHANGELOG.
+
+**Verification (Eric asked for two extra gates before release):**
+- Full reactor build + tests green against the 4.3.1 client and embedded KRaft broker;
+  `dependency:tree` on every module: zero lz4-java (kafka-standalone also checked in
+  verbose/conflict view), all fourteen Kafka artifacts uniformly 4.3.1.
+- **Live kafka-demo regression against the 4.3.1 kafka-standalone broker** per the demo
+  README procedure: direct routing with end-to-end trace continuity (same traceId at
+  publisher/Java/listener, new span per hop); all four second-level routing rules (exact,
+  wildcard with matched key named, body rule → task:// direct with nothing on outbound,
+  default with raw-bytes shape); JSON auto-serialization symmetry; failure path = 3
+  retries then dead-letter to demo.orders.dlq with origin/error headers, body verbatim.
+
+**Minor observation (not fixed, piped-mode only; interactive use unaffected):**
+`publish-inbound.js` can drop a piped message (EOF races the async send —
+`publish-orders.js` already chains sends and is immune); `publish-orders.js` under piped
+input prints cid/traceId confirmations shifted by one record (display closure race; wire
+truth verified via the Java log). Candidate two-line fix if Eric wants it.
+
+## Memory References
+
+- referenced: thread-kafka-client-version-upgrade (closed by this release),
+  thread-kafka-2nd-level-routing (its demo README doubled as the regression procedure),
+  release-4-8-1-shipped (pom-sweep digit-lookahead lesson applied, no substring hazards),
+  thread-release-4-11-1 (release-rhythm precedent; Rust divergence note),
+  conv-helpers-docker-less (kafka-standalone as the live test broker),
+  thread-minimalist-kafka-protobuf-revival (checked: Confluent stays 8.3.0, not affected)
+- created: thread-release-4-11-2
+- Superseded: (none)


### PR DESCRIPTION
## What

Two fixes to the kafka-demo Node publish helpers, affecting piped (scripted) use only —
interactive behavior is unchanged:

- **`publish-inbound.js` could drop a piped message.** Its async `line` handler raced the
  `close` handler's `producer.disconnect()` on EOF. It now chains sends on an `inflight`
  promise awaited at close — the same pattern `publish-orders.js` already used — so it
  works both interactively and piped (`echo 'hello' | node publish-inbound.js`).
- **Both publishers show the readline prompt only when stdin is a TTY.** Piped input
  previously accumulated `> ` prompt characters that glued onto the first confirmation
  line, which could make filtered/scripted output appear misaligned. (The cid/traceId
  pairing in the confirmations was always correct — the apparent off-by-one during the
  v4.11.2 regression drive turned out to be a capture artifact of that prompt glue, not
  a script bug.)

## Why

The kafka-demo README doubles as the manual-regression procedure for the second-level
routing feature, and `publish-orders.js` was deliberately made pipe-friendly for scripted
regression runs. These fixes bring `publish-inbound.js` up to the same contract and make
piped output from both helpers clean and trustworthy, so scripted drives can assert on it
directly.

## Verification

Live against the kafka-standalone (Kafka 4.3.1) broker: a piped inbound message publishes
without any workaround and arrives at the app with the identical cid/traceId; all four
piped routing commands (exact, wildcard, body-rule, default) print clean confirmations
that pair one-to-one with the Java-side receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>