### PR TITLE
Keep the Kafka flow consumer alive through rebalances and long flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Fixed
+
+1. **The Kafka flow adapter's consumer thread no longer dies permanently on a transient rebalance
+   or commit failure.** From a field code review: the poll loop had no per-iteration guard, so a
+   routine post-rebalance `CommitFailedException`/`RebalanceInProgressException` escaped the loop,
+   was logged once, and the consumer closed — the binding was dead until the pod restarted. The
+   loop now logs known transients (including Kafka's retriable errors) at `WARN` and continues;
+   the uncommitted records redeliver after the group rejoin, preserving at-least-once delivery.
+   Any other unexpected exception keeps the binding alive with an escalating pause (1s doubling
+   to 30s) and an `ERROR` per occurrence — loud but alive.
+
+2. **`max.poll.interval.ms` is derived from each binding's worst-case processing envelope.** Also
+   from the field review: message processing happens on the poll thread (the flow's `ttl` is the
+   deadline) but nothing aligned that with Kafka's `max.poll.interval.ms` (default 5 minutes,
+   never set by the library) — a slow or slow-failing message could exceed the interval through
+   the retry envelope alone, getting the consumer evicted mid-processing and (before fix 1)
+   permanently killing the binding. The adapter now computes
+   `(kafka.flow.max.retries + 1) × slowest reachable flow/task ttl + retries × backoff`, times
+   `max.poll.records` plus headroom, and raises the interval to cover it (never below the Kafka
+   default). An explicit `max.poll.interval.ms` in the consumer template is respected as-is, with
+   a `WARN` when the envelope exceeds it. Documented in the Minimalist Kafka guide's new
+   "Consumer liveness" section.
+
+3. **Negative tests pin `json.fail.invalid.schema`.** The `schema.registry.serde.*` pass-through
+   delivers Confluent's validation flag to both serializer and deserializer, but no test asserted
+   that an invalid payload is actually rejected; now pinned on both sides (with a control proving
+   the default codec stays non-validating).
+
+---
 ## Version 4.11.2, 8/3/2026
 
 Security patch for field deployment quality gates. Java-only — the Maven dependency

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -371,6 +371,30 @@ On a **failure**, the message is retried up to `kafka.flow.max.retries` times (w
 **Reprocessing** (read the DLQ topic → fix → replay) is business-domain logic and is intentionally out of
 scope: the library guarantees durable capture (when a `dlq-topic` is configured and reachable), not replay.
 
+### Consumer liveness: rebalances and the processing deadline {#liveness}
+
+Two robustness behaviors keep a binding alive through the realities of consumer-group life:
+
+- **The poll loop survives transient consumer exceptions.** A group rebalance (scale-out, pod churn)
+  routinely makes an in-flight offset commit throw `CommitFailedException` or
+  `RebalanceInProgressException`. The loop logs a `WARN` and continues — the uncommitted records simply
+  redeliver to whichever consumer owns the partitions after the rejoin, preserving at-least-once delivery
+  (flows must be idempotent, as always). Kafka's own retriable errors get the same treatment. Any *other*
+  unexpected exception keeps the binding alive too, with an escalating pause (1s doubling to 30s) and an
+  `ERROR` per occurrence — loud but alive, instead of a consumer thread that dies silently until the pod
+  restarts.
+- **`max.poll.interval.ms` is derived from the binding's worst-case processing time.** Message processing
+  happens *on the poll thread* (the flow's `ttl` is the deadline), so the worst case between two polls is
+  the full retry envelope — `(kafka.flow.max.retries + 1) ×` the slowest reachable flow/task `ttl`
+  `+ retries × backoff` — times `max.poll.records`, plus headroom. If that exceeds Kafka's
+  `max.poll.interval.ms` (default 5 minutes), the group coordinator evicts the consumer mid-processing and
+  the subsequent commit fails. The adapter therefore computes the envelope per binding at startup and
+  raises `max.poll.interval.ms` to cover it (never lowering it below the Kafka default; the derivation is
+  logged). An explicit `max.poll.interval.ms` in the consumer template is an operator decision and is
+  respected as-is — with a `WARN` when the computed envelope exceeds it. Raising the interval is low-risk:
+  a crashed pod is still detected by heartbeats (`session.timeout.ms`); this setting only bounds time
+  between polls.
+
 ## Outbound: publishing to Kafka {#outbound}
 
 `simple.kafka.notification` is a composable function that publishes an event to a topic. Send it an

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
@@ -153,6 +153,10 @@ public class KafkaFlowAdapter implements AutoCloseable {
     private static final String DEFAULT_GROUP_PREFIX = "kafka-flow-adapter";
     private static final int MANUAL_COMMIT_MAX_POLL_RECORDS = 1;
     private static final int AUTO_COMMIT_MAX_POLL_RECORDS = 500;   // Kafka client's own default
+    // Kafka's own max.poll.interval.ms default - the floor for the derivation, which only ever raises it.
+    private static final long KAFKA_DEFAULT_MAX_POLL_INTERVAL_MS = 300000;
+    // margin on top of the computed worst-case processing envelope (poll overhead, DLQ confirm-write, GC)
+    private static final long POLL_INTERVAL_HEADROOM_MS = 10000;
 
     private final List<KafkaFlowConsumer> consumers = new ArrayList<>();
     private final Properties consumerProps;
@@ -228,7 +232,7 @@ public class KafkaFlowAdapter implements AutoCloseable {
         KafkaConsumerBinding binding = (topicPattern != null ? builder.topicPattern(topicPattern)
                 : builder.topic(topic)).build();
         logBinding(label, binding);
-        return new KafkaFlowConsumer(newConsumer(binding), binding, dlqTimeout, retryPolicy,
+        return new KafkaFlowConsumer(newConsumer(binding, retryPolicy), binding, dlqTimeout, retryPolicy,
                 schemaEnabled ? schemaCodec : null);
     }
 
@@ -562,12 +566,89 @@ public class KafkaFlowAdapter implements AutoCloseable {
      * that decides the commit contract, so there is no ambiguity with {@link KafkaClientConfig}'s base
      * template about which setting wins.
      */
-    private Consumer<String, byte[]> newConsumer(KafkaConsumerBinding binding) {
+    private Consumer<String, byte[]> newConsumer(KafkaConsumerBinding binding, RetryPolicy retryPolicy) {
         Properties p = new Properties();
         p.putAll(consumerProps);
         p.setProperty(ConsumerConfig.GROUP_ID_CONFIG, binding.groupId());
         applyDeliveryMode(p, binding);
+        applyPollInterval(p, binding, retryPolicy);
         return new KafkaConsumer<>(p);
+    }
+
+    /**
+     * Guard against poll-thread eviction. Message processing happens ON the poll thread (a flow's own
+     * {@code ttl} is its deadline), so the worst-case time between two {@code poll()} calls is the
+     * binding's full retry envelope - {@code (maxRetries+1) x} the slowest reachable target ttl
+     * {@code + maxRetries x backoff} - times {@code max.poll.records}, plus headroom. If that envelope
+     * exceeds Kafka's {@code max.poll.interval.ms} (default 5 minutes), the group coordinator evicts the
+     * consumer mid-processing and the subsequent commit fails. This derives the interval from the
+     * envelope, never lowering it below the Kafka default. An explicit {@code max.poll.interval.ms} in
+     * the consumer template is an operator decision and is respected as-is, with a {@code WARN} when the
+     * computed envelope exceeds it. Raising the interval is low-risk: crash liveness is detected by
+     * heartbeats/{@code session.timeout.ms} - this setting only bounds time between polls. Visible for
+     * testing.
+     */
+    static void applyPollInterval(Properties p, KafkaConsumerBinding binding, RetryPolicy retryPolicy) {
+        long maxPollRecords = Long.parseLong(p.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+        long envelopeMs;
+        try {
+            long perRecordMs = Math.addExact(
+                    Math.multiplyExact(retryPolicy.maxRetries() + 1L, maxTargetTtlMs(binding)),
+                    Math.multiplyExact((long) retryPolicy.maxRetries(), retryPolicy.backoffMs()));
+            envelopeMs = Math.addExact(Math.multiplyExact(perRecordMs, maxPollRecords),
+                    POLL_INTERVAL_HEADROOM_MS);
+        } catch (ArithmeticException e) {
+            envelopeMs = Integer.MAX_VALUE;   // an absurd configuration saturates at the config's int range
+        }
+        envelopeMs = Math.min(envelopeMs, Integer.MAX_VALUE);
+        String explicit = p.getProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
+        if (explicit != null) {
+            warnWhenEnvelopeExceedsExplicitInterval(binding, explicit, envelopeMs);
+            return;
+        }
+        long derived = Math.max(KAFKA_DEFAULT_MAX_POLL_INTERVAL_MS, envelopeMs);
+        p.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(derived));
+        if (derived > KAFKA_DEFAULT_MAX_POLL_INTERVAL_MS) {
+            log.info("Binding '{}' derives max.poll.interval.ms={} from its worst-case retry envelope "
+                    + "(slowest target ttl x retries x max.poll.records + headroom)",
+                    binding.topicOrPattern(), derived);
+        }
+    }
+
+    private static void warnWhenEnvelopeExceedsExplicitInterval(KafkaConsumerBinding binding,
+                                                                String explicit, long envelopeMs) {
+        try {
+            if (envelopeMs > Long.parseLong(explicit.trim())) {
+                log.warn("Binding '{}' sets max.poll.interval.ms={} but its worst-case retry envelope "
+                        + "is {} ms - a slow-failing message may get this consumer evicted from the "
+                        + "group mid-processing", binding.topicOrPattern(), explicit.trim(), envelopeMs);
+            }
+        } catch (NumberFormatException e) {
+            // a malformed template value is the Kafka client's to reject with its own config error
+        }
+    }
+
+    /**
+     * The slowest reachable target deadline for a binding: flow targets use the compiled flow's own ttl
+     * (every target was validated to exist at construction); {@code task://} targets use the binding's
+     * task ttl (default {@value KafkaFlowConsumer#DEFAULT_TASK_TTL_MS} ms).
+     */
+    private static long maxTargetTtlMs(KafkaConsumerBinding binding) {
+        long taskTtl = binding.taskTtlMs() != null ? binding.taskTtlMs() : KafkaFlowConsumer.DEFAULT_TASK_TTL_MS;
+        if (binding.routingRules() == null) {
+            return flowTtl(binding.flowId(), taskTtl);
+        }
+        long max = 0;
+        for (RoutingRuleSet.Target target : binding.routingRules().allTargets()) {
+            max = Math.max(max, target.task() ? taskTtl : flowTtl(target.destination(), taskTtl));
+        }
+        return max;
+    }
+
+    /** A compiled flow's ttl, or the fallback for a flow not in the registry (defensive; validated earlier). */
+    private static long flowTtl(String flowId, long fallback) {
+        var flow = Flows.getFlow(flowId);
+        return flow != null ? flow.ttl : fallback;
     }
 
     /**

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -20,11 +20,14 @@ package org.platformlambda.mini.kafka;
 
 import com.accenture.automation.EventScriptManager;
 import com.accenture.models.Flows;
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.serializers.SimpleMapper;
@@ -109,6 +112,15 @@ import java.util.regex.Pattern;
  * {@code ERROR} and the offset committed - see {@link #writeToDeadLetter} for why (avoiding a recovery
  * storm), the resulting data-loss caveat, and the planned alternative-path improvement.</p>
  *
+ * <p><b>Poll-loop resilience.</b> The loop survives the consumer exceptions that routinely follow a group
+ * rebalance ({@link CommitFailedException}, {@link RebalanceInProgressException}) and Kafka's own
+ * {@link RetriableException} family: the offending iteration is logged at {@code WARN} and the loop
+ * continues - uncommitted records simply redeliver to whichever consumer owns the partitions after the
+ * rejoin, preserving at-least-once delivery. Any other unexpected {@code RuntimeException} keeps the
+ * binding alive with an escalating pause (1s doubling to 30s) and an {@code ERROR} per occurrence, rather
+ * than silently killing the consumer thread until the pod restarts. Only shutdown ({@code close()} via
+ * {@code wakeup()}) exits the loop.</p>
+ *
  * <p><b>Partition pinning (opt-in).</b> When a {@code partition} is supplied for the binding, the consumer
  * <b>manually assigns</b> that one topic-partition ({@code assign}) instead of joining the consumer group
  * ({@code subscribe}). This bypasses group rebalancing - the pinned consumer reads exactly that partition -
@@ -127,6 +139,10 @@ public class KafkaFlowConsumer implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaFlowConsumer.class);
     private static final Duration POLL_TIMEOUT = Duration.ofMillis(500);
+    // Escalating pause after an UNEXPECTED poll-loop failure (known transients continue immediately):
+    // 1s doubling to a 30s ceiling, reset by the next successful iteration.
+    private static final long INITIAL_FAILURE_BACKOFF_MS = 1000;
+    private static final long MAX_FAILURE_BACKOFF_MS = 30000;
     private static final String ADAPTER_ROUTE = "kafka.flow.adapter";
     private static final String FLOW_ID = "flow_id";   // header key read by event.script.manager
     private static final String HEADER = "header";
@@ -139,8 +155,9 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private static final String METADATA_KEY = "key";
     private static final String DLQ_ERROR_HEADER = "dlq.error";
     private static final String DLQ_ORIGIN_TOPIC_HEADER = "dlq.origin.topic";
-    // deadline for a task:// invocation when the binding sets no 'ttl' (a bare function has no flow ttl)
-    private static final long DEFAULT_TASK_TTL_MS = 30000;
+    // deadline for a task:// invocation when the binding sets no 'ttl' (a bare function has no flow ttl);
+    // package-private: KafkaFlowAdapter reuses it when deriving max.poll.interval.ms from the retry envelope
+    static final long DEFAULT_TASK_TTL_MS = 30000;
     // Global inbound business correlation-id header (default "cid"); its value seeds the flow's model.cid.
     private static final String GLOBAL_CORRELATION_ID_HEADER = AppConfigReader.getInstance()
             .getProperty("kafka.correlation.id.header", KafkaHeaders.CORRELATION_ID);
@@ -205,20 +222,61 @@ public class KafkaFlowConsumer implements AutoCloseable {
     private void pollLoop() {
         try {
             subscribeOrAssign(consumer);
+            int consecutiveFailures = 0;
             while (running) {
-                ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
-                for (ConsumerRecord<String, byte[]> consumerRecord : records) {
-                    if (routeToFlow(consumerRecord) && !binding.autoCommit()) {
-                        commit(consumerRecord);   // commit only after the flow finished -> at-least-once
+                try {
+                    ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+                    for (ConsumerRecord<String, byte[]> consumerRecord : records) {
+                        if (routeToFlow(consumerRecord) && !binding.autoCommit()) {
+                            commit(consumerRecord);   // commit only after the flow finished -> at-least-once
+                        }
+                    }
+                    consecutiveFailures = 0;
+                } catch (WakeupException e) {
+                    throw e;   // close() breaking the poll - handled below, not a failure
+                } catch (CommitFailedException | RebalanceInProgressException e) {
+                    // Routine after a group rebalance: the partitions were revoked while a record was in
+                    // flight, so its offset cannot be committed. The uncommitted records redeliver to
+                    // whichever consumer now owns the partitions (at-least-once holds; flows are required
+                    // to be idempotent) and the next poll() rejoins the group.
+                    log.warn("Offset commit for {} failed after a rebalance; records will redeliver - {}",
+                            binding.topicOrPattern(), e.getMessage());
+                } catch (RetriableException e) {
+                    log.warn("Transient Kafka error on {}; retrying - {}",
+                            binding.topicOrPattern(), e.getMessage());
+                } catch (RuntimeException e) {
+                    // Unforeseen failure: stay alive (the alternative is a binding that is dead until the
+                    // pod restarts) but pause with escalating backoff so a persistent error cannot hot-loop.
+                    consecutiveFailures++;
+                    long pause = Math.min(MAX_FAILURE_BACKOFF_MS,
+                            INITIAL_FAILURE_BACKOFF_MS << Math.min(consecutiveFailures - 1, 5));
+                    log.error("Kafka flow consumer for {} caught an unexpected error (failure #{}); "
+                            + "pausing {} ms before it continues",
+                            binding.topicOrPattern(), consecutiveFailures, pause, e);
+                    if (!pause(pause)) {
+                        break;   // interrupted during shutdown
                     }
                 }
             }
         } catch (WakeupException e) {
             // expected: close() called wakeup() to break the poll
         } catch (RuntimeException e) {
+            // a failure outside the per-iteration guard (e.g. the initial subscribe) is fatal to this binding
             log.error("Kafka flow consumer for {} stopped unexpectedly", binding.topicOrPattern(), e);
         } finally {
             consumer.close();
+        }
+    }
+
+    /** Pause after an unexpected poll-loop failure. @return false if interrupted (shutting down). */
+    private boolean pause(long ms) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(ms);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            running = false;
+            return false;
         }
     }
 

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowAdapterConfigTest.java
@@ -251,6 +251,66 @@ class KafkaFlowAdapterConfigTest {
         assertEquals("50", p.getProperty("max.poll.records"));
     }
 
+    // ---- max.poll.interval.ms derivation (the poll-thread eviction guard) ----
+    // Flow 'f' is not in the compiled Flows registry in this unit context, so the derivation falls
+    // back to the binding's task ttl (default 30000) - the same fallback resolveTtl uses at runtime.
+
+    @Test
+    void smallRetryEnvelopeKeepsThePollIntervalAtKafkaDefault() {
+        Properties p = new Properties();
+        KafkaConsumerBinding binding = KafkaConsumerBinding.builder().topic("orders").flowId("f").build();
+        KafkaFlowAdapter.applyDeliveryMode(p, binding);   // manual commit -> max.poll.records = 1
+        KafkaFlowAdapter.applyPollInterval(p, binding, new RetryPolicy(3, 500, null));
+        // envelope = 4 x 30000 + 3 x 500 + 10000 headroom = 131500 < the 300000 floor
+        assertEquals("300000", p.getProperty("max.poll.interval.ms"));
+    }
+
+    @Test
+    void derivesPollIntervalFromTheRetryEnvelopeWhenItExceedsTheDefault() {
+        Properties p = new Properties();
+        KafkaConsumerBinding binding = KafkaConsumerBinding.builder().topic("orders").flowId("f")
+                .taskTtlMs(120000L).build();
+        KafkaFlowAdapter.applyDeliveryMode(p, binding);
+        KafkaFlowAdapter.applyPollInterval(p, binding, new RetryPolicy(3, 500, null));
+        // (3+1) x 120000 + 3 x 500 + 10000 headroom = 491500 - the coordinator no longer evicts a
+        // consumer that is legitimately waiting out its retry envelope
+        assertEquals("491500", p.getProperty("max.poll.interval.ms"));
+    }
+
+    @Test
+    void autoCommitBatchSizeMultipliesThePollIntervalEnvelope() {
+        Properties p = new Properties();
+        KafkaConsumerBinding binding = KafkaConsumerBinding.builder().topic("orders").flowId("f")
+                .autoCommit(true).maxPollRecords(100).build();
+        KafkaFlowAdapter.applyDeliveryMode(p, binding);
+        KafkaFlowAdapter.applyPollInterval(p, binding, new RetryPolicy(0, 0, null));
+        // a poll batch is processed sequentially on the poll thread: 100 x 30000 + 10000 = 3010000
+        assertEquals("3010000", p.getProperty("max.poll.interval.ms"));
+    }
+
+    @Test
+    void explicitPollIntervalFromTheConsumerTemplateIsRespected() {
+        Properties p = new Properties();
+        p.setProperty("max.poll.interval.ms", "60000");
+        KafkaConsumerBinding binding = KafkaConsumerBinding.builder().topic("orders").flowId("f")
+                .taskTtlMs(120000L).build();
+        KafkaFlowAdapter.applyDeliveryMode(p, binding);
+        KafkaFlowAdapter.applyPollInterval(p, binding, new RetryPolicy(3, 500, null));
+        // an operator's explicit value is a decision, not a bug - kept as-is (with a WARN in the log)
+        assertEquals("60000", p.getProperty("max.poll.interval.ms"));
+    }
+
+    @Test
+    void oversizedPollIntervalEnvelopeClampsToIntegerRange() {
+        Properties p = new Properties();
+        KafkaConsumerBinding binding = KafkaConsumerBinding.builder().topic("orders").flowId("f")
+                .taskTtlMs(Long.MAX_VALUE / 4).build();
+        KafkaFlowAdapter.applyDeliveryMode(p, binding);
+        KafkaFlowAdapter.applyPollInterval(p, binding, new RetryPolicy(3, 500, null));
+        // max.poll.interval.ms is an int config - the derivation must not overflow past it
+        assertEquals(String.valueOf(Integer.MAX_VALUE), p.getProperty("max.poll.interval.ms"));
+    }
+
     @Test
     void parsesPartitionWhenPresent() {
         assertEquals(3, KafkaFlowAdapter.parsePartition("3"));

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaFlowConsumerTest.java
@@ -18,6 +18,7 @@
 
 package org.platformlambda.mini.kafka;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -250,6 +251,59 @@ class KafkaFlowConsumerTest {
 
         assertNull(committed.get(tp), "auto-commit mode must not manually commit - Kafka's own "
                 + "periodic timer owns offset commits, not KafkaFlowConsumer");
+    }
+
+    @Test
+    void pollLoopSurvivesTransientRebalanceExceptions() {
+        MockConsumer<String, byte[]> mock = new MockConsumer<>("earliest");
+        AtomicInteger polls = new AtomicInteger();
+        // poll #1 throws the routine post-rebalance transient; the loop must log-and-continue, so
+        // poll #2 still happens - the old loop died here, leaving the binding dead until pod restart
+        mock.schedulePollTask(() -> {
+            polls.incrementAndGet();
+            mock.setPollException(new CommitFailedException());
+        });
+        mock.schedulePollTask(polls::incrementAndGet);
+        KafkaFlowConsumer consumer =
+                new KafkaFlowConsumer(mock, binding().build(), 1000, new RetryPolicy(0, 0, null), null);
+
+        consumer.start();
+        long deadline = System.currentTimeMillis() + 2000;
+        while (polls.get() < 2 && System.currentTimeMillis() < deadline) {
+            Utility.getInstance().sleep(10);
+        }
+        int reached = polls.get();
+        consumer.close();
+
+        assertTrue(reached >= 2, "the poll loop must survive a transient rebalance/commit exception");
+        assertTrue(mock.closed(), "close() still shuts the consumer down cleanly");
+    }
+
+    @Test
+    void pollLoopSurvivesUnexpectedErrorsWithBackoff() {
+        MockConsumer<String, byte[]> mock = new MockConsumer<>("earliest");
+        AtomicInteger polls = new AtomicInteger();
+        // an exception OUTSIDE the known-transient set (a bare KafkaException is neither
+        // CommitFailed/RebalanceInProgress nor Retriable) keeps the binding alive too, after the
+        // escalating pause (1s for the first failure) instead of hot-looping or dying
+        mock.schedulePollTask(() -> {
+            polls.incrementAndGet();
+            mock.setPollException(new org.apache.kafka.common.KafkaException("boom"));
+        });
+        mock.schedulePollTask(polls::incrementAndGet);
+        KafkaFlowConsumer consumer =
+                new KafkaFlowConsumer(mock, binding().build(), 1000, new RetryPolicy(0, 0, null), null);
+
+        consumer.start();
+        long deadline = System.currentTimeMillis() + 4000;   // covers the 1s first-failure pause
+        while (polls.get() < 2 && System.currentTimeMillis() < deadline) {
+            Utility.getInstance().sleep(10);
+        }
+        int reached = polls.get();
+        consumer.close();
+
+        assertTrue(reached >= 2, "the poll loop must pause and continue after an unexpected error");
+        assertTrue(mock.closed(), "close() still shuts the consumer down cleanly");
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/SchemaCodecTest.java
@@ -41,6 +41,8 @@ import org.platformlambda.mini.kafka.schema.SchemaType;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +113,41 @@ class SchemaCodecTest {
         assertEquals("world", ((Map<?, ?>) decoded).get("hello"));
 
         assertTrue(schemaCached(id), "schema cached in memory by id");
+    }
+
+    @Test
+    void failInvalidSchemaFlagRejectsNonConformingPayloads() throws Exception {
+        // The schema.registry.serde.* pass-through delivers Confluent's json.fail.invalid.schema to
+        // BOTH serializer and deserializer. This codec reads it from the isolated 'schema.strict'
+        // prefix in the test application.properties; a strict schema makes violations detectable.
+        String strictSchema = "{\"type\":\"object\",\"properties\":{\"hello\":{\"type\":\"string\"}},"
+                + "\"required\":[\"hello\"],\"additionalProperties\":false}";
+        int id = codec.client().register("strict-orders-value", new JsonSchema(strictSchema));
+        SchemaCodec strict = SchemaCodec.fromConfig(AppConfigReader.getInstance(),
+                registry.baseUrl(), "schema.strict");
+        SchemaCodec.Encoder strictEncoder = strict.newEncoder();
+        SchemaCodec.Decoder strictDecoder = strict.newDecoder();
+
+        // serializer side: a payload missing the required key is rejected before it is framed...
+        assertThrows(RuntimeException.class,
+                () -> strictEncoder.serialize(TOPIC, SchemaType.JSON, id, Map.of("wrong", "shape")),
+                "an invalid payload must not serialize when json.fail.invalid.schema=true");
+        // ...while a conforming payload passes - proving the rejection above is validation, not setup
+        byte[] conforming = strictEncoder.serialize(TOPIC, SchemaType.JSON, id, Map.of("hello", "world"));
+        assertInstanceOf(Map.class, strictDecoder.decode(TOPIC, conforming));
+
+        // deserializer side: hand-framed bytes carrying a non-conforming document under the strict id
+        byte[] invalid = frame(id, "{\"wrong\":\"shape\"}");
+        assertThrows(RuntimeException.class, () -> strictDecoder.decode(TOPIC, invalid),
+                "an invalid payload must not decode when json.fail.invalid.schema=true");
+        // the default (non-validating) decoder accepts the same bytes - the flag is what rejects
+        assertInstanceOf(Map.class, decoder.decode(TOPIC, invalid));
+    }
+
+    /** Confluent wire format by hand: magic byte 0 + 4-byte big-endian schema id + payload. */
+    private static byte[] frame(int schemaId, String json) {
+        byte[] payload = json.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(5 + payload.length).put((byte) 0).putInt(schemaId).put(payload).array();
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/resources/application.properties
+++ b/system/minimalist-kafka/src/test/resources/application.properties
@@ -34,3 +34,9 @@ kafka.flow.retry.backoff.ms=500
 # the custom name first with the standard header as fallback. Set here so the whole test suite runs
 # with the feature active, proving it is additive.
 kafka.traceparent.header=x-kafka-trace
+# Strict-validation codec used ONLY by SchemaCodecTest's negative test: the schema.registry.serde.*
+# pass-through (here under the isolated 'schema.strict' prefix) delivers Confluent's
+# json.fail.invalid.schema to BOTH serializer and deserializer, so non-conforming payloads are
+# rejected instead of silently framed/decoded. The default codec above stays non-validating.
+schema.strict.serde.json.fail.invalid.schema=true
+schema.strict.properties=classpath:/schema-registry.properties


### PR DESCRIPTION
## What

Three fixes to the Kafka flow adapter's consumer path, from a field code review:

- **The poll loop survives transient consumer exceptions.** It previously had no
  per-iteration guard: a routine post-rebalance `CommitFailedException` or
  `RebalanceInProgressException` escaped the loop, was logged once, and the consumer
  closed — the binding was dead until the pod restarted. Known transients (including
  Kafka's `RetriableException` family) now log `WARN` and continue; the uncommitted
  records redeliver after the group rejoin, preserving at-least-once delivery. Any other
  unexpected exception keeps the binding alive with an escalating pause (1s doubling to
  30s) and an `ERROR` per occurrence — loud but alive. Only shutdown exits the loop.
- **`max.poll.interval.ms` is derived from each binding's worst-case processing
  envelope.** Processing happens on the poll thread (the flow's `ttl` is the deadline),
  but nothing aligned that with Kafka's 5-minute default, which the library never set.
  The worst case is the full retry envelope — `(kafka.flow.max.retries + 1) × slowest
  reachable flow/task ttl + retries × backoff` — times `max.poll.records`, so with
  default settings a 75-second flow ttl already breaches the interval on a persistently
  failing message; the eviction's commit failure then triggered the first bug. The
  adapter now computes the envelope per binding at startup and raises the interval to
  cover it (never below the Kafka default, clamped to the config's int range). An
  explicit `max.poll.interval.ms` in the consumer template is respected as-is, with a
  `WARN` when the envelope exceeds it.
- **Negative tests pin `json.fail.invalid.schema`.** The `schema.registry.serde.*`
  pass-through delivers the flag to both serializer and deserializer, but no test
  asserted rejection; now pinned on both sides (hand-framed non-conforming document
  under a strict schema id), with a control proving the default codec stays
  non-validating.

## Why

A consumer binding that silently dies on the most common transient consumer exceptions —
or gets evicted mid-processing because its legitimate retry envelope exceeds an
unconfigured poll interval — turns a routine rebalance or one slow message into a
permanent outage requiring a pod restart. Both gaps compound: the eviction causes the
commit failure that killed the loop. The fixes make liveness the default while keeping
failures loud, and encode the flow-ttl/poll-interval coupling the library's blocking
processing model implies. Raising the interval is low-risk: crash liveness stays
heartbeat-based; the setting only bounds time between polls.

## Verification

8 new tests (poll-loop survival on both the transient and unexpected-error paths driven
through a live MockConsumer loop; five derivation cases including operator override and
overflow clamping; the schema negative test both sides). Full module suite 171/171 with
the JaCoCo coverage gate met. New "Consumer liveness" section in the Minimalist Kafka
guide documents both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>