### PR TITLE
Resolve field Sonar findings - third field remediation round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    that an invalid payload is actually rejected; now pinned on both sides (with a control proving
    the default codec stays non-validating).
 
+4. **Field Sonar rescan findings resolved (13 issues, third field remediation round), all
+   behavior-preserving.** Three methods refactored below the cognitive-complexity threshold via
+   helper extraction (the graph traveler's skill-response handler, the playground feature loader,
+   and platform-core's worker log-context registration — extracted synchronously on the same
+   worker thread, so the thread-keyed trace/log-context semantics are unchanged); the kafka-demo
+   catch-all task's duplicated literals extracted to constants; five prose comments whose
+   trailing semicolons pattern-match as commented-out code reworded; and test hygiene — one
+   assertThrows lambda reduced to a single invocation, a `record` variable renamed off the
+   restricted identifier, a fixed ttl-expiry sleep replaced by a deterministic expiry rewrite on
+   the stored record, and a 27-assertion companion test split into two focused tests.
+
 ---
 ## Version 4.11.2, 8/3/2026
 

--- a/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/CatchAllProcessor.java
+++ b/examples/kafka-demo/src/main/java/com/accenture/kafka/demo/tasks/CatchAllProcessor.java
@@ -41,33 +41,35 @@ import java.util.Map;
 @PreLoad(route = "demo.catch.all", instances = 10)
 public class CatchAllProcessor implements TypedLambdaFunction<Object, Map<String, Object>> {
     private static final Logger log = LoggerFactory.getLogger(CatchAllProcessor.class);
+    private static final String RECEIVED = "received";
+    private static final String SHAPE = "shape";
 
     @Override
     public Map<String, Object> handleEvent(Map<String, String> headers, Object input, int instance) {
         PostOffice po = new PostOffice(headers, instance);
         Map<String, Object> response = new HashMap<>();
-        // a raw byte[] means serializer: 'json' could not parse the record - show it as text;
-        // a Map/List is a well-formed JSON record that simply matched no routing rule
+        // A raw byte[] arrives when the best-effort JSON deserializer could not parse the record,
+        // so it is shown as text. A Map/List is a well-formed JSON record that matched no routing rule.
         switch (input) {
             case byte[] bytes -> {
-                response.put("received", new String(bytes, StandardCharsets.UTF_8));
-                response.put("shape", "raw bytes (not a JSON object/array)");
+                response.put(RECEIVED, new String(bytes, StandardCharsets.UTF_8));
+                response.put(SHAPE, "raw bytes (not a JSON object/array)");
             }
             case Map<?, ?> map -> {
-                response.put("received", map);
-                response.put("shape", "map (JSON object, no rule matched)");
+                response.put(RECEIVED, map);
+                response.put(SHAPE, "map (JSON object, no rule matched)");
             }
             case List<?> list -> {
-                response.put("received", list);
-                response.put("shape", "list (JSON array, no rule matched)");
+                response.put(RECEIVED, list);
+                response.put(SHAPE, "list (JSON array, no rule matched)");
             }
             case null, default -> {
-                response.put("received", String.valueOf(input));
-                response.put("shape", "other");
+                response.put(RECEIVED, String.valueOf(input));
+                response.put(SHAPE, "other");
             }
         }
         log.info("Unmatched record caught by the default rule (cid={}, traceId={}): {}",
-                po.getMyCorrelationId(), po.getTraceId(), response.get("shape"));
+                po.getMyCorrelationId(), po.getTraceId(), response.get(SHAPE));
         response.put("processedBy", "demo-catch-all-flow");
         response.put("routedBy", "default");
         response.put("traceId", po.getTraceId());

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphTraveler.java
@@ -204,51 +204,57 @@ public class GraphTraveler extends GraphLambdaFunction {
         // a late reply after the run reached a terminal (completed, aborted or timed
         // out) is dropped before any console send - the reply route may already be a
         // released companion capture route
-        if (graphInstance != null && !graphInstance.complete.get()) {
-            var stateMachine = graphInstance.stateMachine;
-            var target = stateMachine.getElement(nodeName + "." + TARGET);
-            // Unrecoverable error from the node itself
-            if (response.hasError()) {
-                if (target != null) {
-                    var eMap = getErrorMap(stateMachine.getElement(OUTPUT_BODY), target);
-                    stateMachine.setElement(OUTPUT_BODY, eMap);
-                }
-                handleErrorResponse(po, graphInstance, response);
-                return;
+        if (graphInstance == null || graphInstance.complete.get()) {
+            return;
+        }
+        var stateMachine = graphInstance.stateMachine;
+        var target = stateMachine.getElement(nodeName + "." + TARGET);
+        // Unrecoverable error from the node itself
+        if (response.hasError()) {
+            if (target != null) {
+                var eMap = getErrorMap(stateMachine.getElement(OUTPUT_BODY), target);
+                stateMachine.setElement(OUTPUT_BODY, eMap);
             }
-            var graph = graphInstance.graph;
-            var node = graph.findNodeByAlias(nodeName);
-            checkFrequency(po, graphInstance, nodeName);
-            // advise user that the node with skill has been executed
-            var skill = node.getProperty(SKILL);
-            var replyTo = graphInstance.getReplyTo();
-            po.send(new EventEnvelope().setTo(replyTo).setBody("Executed " + nodeName + " with skill " + skill +
-                    " in " +response.getExecutionTime() + " ms"));
-            // Skill handler would set status and error in its node properties
-            // e.g. the HTTP response status code to the API fetcher >= 400
-            var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
-            var resultError = stateMachine.getElement(nodeName + "." + ERROR);
-            // Mark the skill complete only when it did NOT fail (status + error set,
-            // e.g. an exception-routed fetcher): a join barrier consults skillRun,
-            // so a failed branch must not satisfy the barrier while it retries.
-            // GraphExecutor keeps identical semantics.
-            if (!(processStatus instanceof Integer && resultError != null)) {
-                graphInstance.skillRun.put(nodeName, true);
+            handleErrorResponse(po, graphInstance, response);
+            return;
+        }
+        handleSkillSuccess(po, graphInstance, nodeName, target, response);
+    }
+
+    private void handleSkillSuccess(PostOffice po, GraphInstance graphInstance, String nodeName,
+                                    Object target, EventEnvelope response) {
+        var stateMachine = graphInstance.stateMachine;
+        var node = graphInstance.graph.findNodeByAlias(nodeName);
+        checkFrequency(po, graphInstance, nodeName);
+        // advise user that the node with skill has been executed
+        var skill = node.getProperty(SKILL);
+        var replyTo = graphInstance.getReplyTo();
+        po.send(new EventEnvelope().setTo(replyTo).setBody("Executed " + nodeName + " with skill " + skill +
+                " in " +response.getExecutionTime() + " ms"));
+        // Skill handler would set status and error in its node properties
+        // e.g. the HTTP response status code to the API fetcher >= 400
+        var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
+        var resultError = stateMachine.getElement(nodeName + "." + ERROR);
+        // Mark the skill complete only when it did NOT fail (status + error set,
+        // e.g. an exception-routed fetcher): a join barrier consults skillRun,
+        // so a failed branch must not satisfy the barrier while it retries.
+        // GraphExecutor keeps identical semantics.
+        if (!(processStatus instanceof Integer && resultError != null)) {
+            graphInstance.skillRun.put(nodeName, true);
+        }
+        var errorHandler = node.getProperty(EXCEPTION);
+        if (processStatus instanceof Integer rc && resultError != null && errorHandler == null) {
+            if (claimTerminal(graphInstance)) {
+                var errorMap = getErrorMap(resultError, target);
+                var cid = graphInstance.getCorrelationId();
+                var error = new EventEnvelope().setTo(replyTo).setCorrelationId(cid)
+                                                .setBody(errorMap).setStatus(rc);
+                po.send(error);
+                emitAborted(po, graphInstance);
             }
-            var errorHandler = node.getProperty(EXCEPTION);
-            if (processStatus instanceof Integer rc && resultError != null && errorHandler == null) {
-                if (claimTerminal(graphInstance)) {
-                    var errorMap = getErrorMap(resultError, target);
-                    var cid = graphInstance.getCorrelationId();
-                    var error = new EventEnvelope().setTo(replyTo).setCorrelationId(cid)
-                                                    .setBody(errorMap).setStatus(rc);
-                    po.send(error);
-                    emitAborted(po, graphInstance);
-                }
-            } else if (!graphInstance.complete.get()) {
-                var next = String.valueOf(response.getBody());
-                decideNext(po, node, next, graphInstance);
-            }
+        } else if (!graphInstance.complete.get()) {
+            var next = String.valueOf(response.getBody());
+            decideNext(po, node, next, graphInstance);
         }
     }
 

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphJs.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphJs.java
@@ -94,8 +94,8 @@ public class GraphJs extends GraphLambdaFunction {
         // Two deliberate choices: (1) close(true) - a STICKY cancellation - not
         // interrupt(), which is non-destructive and only affects an eval in flight: a
         // node execution is many evals with host-code gaps between them, and a deadline
-        // landing in a gap would be silently consumed, leaving later evals unbounded;
-        // after close(true), any in-flight or subsequent eval throws isCancelled().
+        // landing in a gap would be silently consumed and leave later evals unbounded.
+        // After close(true), any in-flight or subsequent eval throws isCancelled().
         // (2) the close runs on a virtual thread, never the Vert.x event loop - it
         // blocks until the guest reaches a cancellation safepoint.
         var nodeTtl = node.getProperty(TTL);

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphStateSkill.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphStateSkill.java
@@ -78,8 +78,8 @@ abstract class GraphStateSkill extends GraphLambdaFunction {
 
     protected String getRequiredCorrelationId(GraphInstance graphInstance, String nodeName) {
         // trim: a business correlation ID (e.g. an order number) may be entered by an
-        // operator in a web UI - padding would otherwise split the store key space;
-        // both engines trim identically so the mixed-fleet key stays one key
+        // operator in a web UI, and padding would otherwise split the store key space.
+        // Both engines trim identically so the mixed-fleet key stays one key
         if (graphInstance.stateMachine.getElement(MODEL_CID) instanceof String value && !value.isBlank()) {
             return value.trim();
         }

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/start/PlaygroundLoader.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/start/PlaygroundLoader.java
@@ -63,29 +63,33 @@ public class PlaygroundLoader implements EntryPoint {
         List<ClassInfo> services = scanner.getAnnotatedClasses(eachPackage, FetchFeature.class);
         for (ClassInfo info : services) {
             try {
-                Class<?> cls = Class.forName(info.getName());
-                FetchFeature feature = cls.getAnnotation(FetchFeature.class);
-                if (Feature.isRequired(cls)) {
-                    Class<?> featureClass = Class.forName(info.getName());
-                    Object o = featureClass.getDeclaredConstructor().newInstance();
-                    if (o instanceof FeatureRunner runner) {
-                        if (features.containsKey(feature.value())) {
-                            log.warn("Reloading FetchFeature {} - please check duplicated feature name",
-                                        feature.value());
-                        }
-                        features.put(feature.value(), new FeatureDef(runner));
-                        log.info("Class {} loaded as API fetcher feature {}", o.getClass().getName(), feature.value());
-                    } else {
-                        log.error("Did you forget to implement FetchFeature interface for {}?", o.getClass().getName());
-                    }
-                } else {
-                    log.info("Skip optional {} - {}", cls, feature.value());
-                }
+                loadFeature(info);
             } catch (ClassNotFoundException e) {
                 log.error("Class {} not found", info.getName());
             } catch (Exception e) {
                 log.error("FetchFeature {} cannot be instantiated - {}", info.getName(), e.getMessage());
             }
+        }
+    }
+
+    private void loadFeature(ClassInfo info) throws ReflectiveOperationException {
+        Class<?> cls = Class.forName(info.getName());
+        FetchFeature feature = cls.getAnnotation(FetchFeature.class);
+        if (!Feature.isRequired(cls)) {
+            log.info("Skip optional {} - {}", cls, feature.value());
+            return;
+        }
+        Class<?> featureClass = Class.forName(info.getName());
+        Object o = featureClass.getDeclaredConstructor().newInstance();
+        if (o instanceof FeatureRunner runner) {
+            if (features.containsKey(feature.value())) {
+                log.warn("Reloading FetchFeature {} - please check duplicated feature name",
+                            feature.value());
+            }
+            features.put(feature.value(), new FeatureDef(runner));
+            log.info("Class {} loaded as API fetcher feature {}", o.getClass().getName(), feature.value());
+        } else {
+            log.error("Did you forget to implement FetchFeature interface for {}?", o.getClass().getName());
         }
     }
 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -104,51 +104,67 @@ class CompanionSyncTest {
                     .reduce("", (a, b) -> a + "\n" + b);
             assertTrue(teedText.contains("node root created"),
                     "sync output must be teed to the session's WS .out for the live human view: " + teed);
-
-            // 4) a traversal (`run`) is asynchronous - the handler replies before the
-            //    traveler streams its output. The sync response must carry the WHOLE
-            //    traversal, drained on the traveler's terminal line (emitted last), not a
-            //    raced sentinel that truncates it. Build a runnable graph and run it.
-            syncCommand(po, sid, "create node end");
-            syncCommand(po, sid, """
-                    create node mapper
-                    with type mapper
-                    with properties
-                    skill=graph.data.mapper
-                    mapping[]=input.body.id -> output.body""");
-            syncCommand(po, sid, "connect root to mapper with first");
-            syncCommand(po, sid, "connect mapper to end with second");
-            var instantiated = syncCommand(po, sid, "instantiate graph\ntext(hello world) -> input.body.id");
-            assertEquals(Boolean.TRUE, instantiated.get("ok"), "instantiate -> ok:true: " + instantiated);
-            // the instantiate command is the dry-run's edge: it guarantees a business
-            // correlation ID like the REST edge does, with a reminder when auto-created
-            var initOutput = ((List<?>) instantiated.get("output")).stream().map(String::valueOf).toList();
-            assertTrue(initOutput.stream().anyMatch(
-                            l -> l.startsWith("No business correlation ID given - this dry-run created model.cid = ")),
-                    "the dry-run edge must auto-create model.cid with a reminder: " + initOutput);
-            // an explicitly mapped model.cid is honored without the reminder
-            var withCid = syncCommand(po, sid,
-                    "instantiate graph\ntext(hello world) -> input.body.id\ntext(dry-run-77) -> model.cid");
-            assertEquals(Boolean.TRUE, withCid.get("ok"), "instantiate with cid -> ok:true: " + withCid);
-            var withCidOutput = ((List<?>) withCid.get("output")).stream().map(String::valueOf).toList();
-            assertTrue(withCidOutput.stream().noneMatch(l -> l.contains("created model.cid")),
-                    "a supplied model.cid must be honored without the reminder: " + withCidOutput);
-
-            var ran = syncCommand(po, sid, "run");
-            assertEquals(Boolean.TRUE, ran.get("ok"), "sync run -> ok:true: " + ran);
-            var runOutput = ((List<?>) ran.get("output")).stream().map(String::valueOf).toList();
-            assertTrue(runOutput.stream().anyMatch("Walk to root"::equals),
-                    "sync run captures the traversal start: " + runOutput);
-            assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Executed mapper with skill graph.data.mapper")),
-                    "sync run captures mid-traversal skill execution: " + runOutput);
-            assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Graph traversal completed in")),
-                    "sync run must capture the traversal terminal (drain waited for it): " + runOutput);
-            assertNotNull(ran.get("result"), "sync run returns the output.body as structured result: " + ran);
-            assertTrue(String.valueOf(ran.get("result")).contains("hello world"),
-                    "structured result carries the run's output.body: " + ran.get("result"));
         } finally {
             platform.release(outRoute);
         }
+    }
+
+    /**
+     * A traversal ({@code run}) is asynchronous - the handler replies before the traveler streams
+     * its output. The sync response must carry the WHOLE traversal, drained on the traveler's
+     * terminal line (emitted last), not a raced sentinel that truncates it - and the dry-run edge
+     * guarantees a business correlation ID exactly like the REST edge does.
+     */
+    @Test
+    void syncRunDrainsWholeTraversalWithStructuredResult() throws Exception {
+        var po = EventEmitter.getInstance();
+        var sid = "ws-990007-2";
+        var inRoute = "ws.990007.2.in";
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", inRoute)));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+        // build a runnable graph on this session
+        syncCommand(po, sid, "create node root\nwith type Root");
+        syncCommand(po, sid, "create node end");
+        syncCommand(po, sid, """
+                create node mapper
+                with type mapper
+                with properties
+                skill=graph.data.mapper
+                mapping[]=input.body.id -> output.body""");
+        syncCommand(po, sid, "connect root to mapper with first");
+        syncCommand(po, sid, "connect mapper to end with second");
+        var instantiated = syncCommand(po, sid, "instantiate graph\ntext(hello world) -> input.body.id");
+        assertEquals(Boolean.TRUE, instantiated.get("ok"), "instantiate -> ok:true: " + instantiated);
+        // the instantiate command is the dry-run's edge: it guarantees a business
+        // correlation ID like the REST edge does, with a reminder when auto-created
+        var initOutput = ((List<?>) instantiated.get("output")).stream().map(String::valueOf).toList();
+        assertTrue(initOutput.stream().anyMatch(
+                        l -> l.startsWith("No business correlation ID given - this dry-run created model.cid = ")),
+                "the dry-run edge must auto-create model.cid with a reminder: " + initOutput);
+        // an explicitly mapped model.cid is honored without the reminder
+        var withCid = syncCommand(po, sid,
+                "instantiate graph\ntext(hello world) -> input.body.id\ntext(dry-run-77) -> model.cid");
+        assertEquals(Boolean.TRUE, withCid.get("ok"), "instantiate with cid -> ok:true: " + withCid);
+        var withCidOutput = ((List<?>) withCid.get("output")).stream().map(String::valueOf).toList();
+        assertTrue(withCidOutput.stream().noneMatch(l -> l.contains("created model.cid")),
+                "a supplied model.cid must be honored without the reminder: " + withCidOutput);
+
+        var ran = syncCommand(po, sid, "run");
+        assertEquals(Boolean.TRUE, ran.get("ok"), "sync run -> ok:true: " + ran);
+        var runOutput = ((List<?>) ran.get("output")).stream().map(String::valueOf).toList();
+        assertTrue(runOutput.stream().anyMatch("Walk to root"::equals),
+                "sync run captures the traversal start: " + runOutput);
+        assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Executed mapper with skill graph.data.mapper")),
+                "sync run captures mid-traversal skill execution: " + runOutput);
+        assertTrue(runOutput.stream().anyMatch(l -> l.startsWith("Graph traversal completed in")),
+                "sync run must capture the traversal terminal (drain waited for it): " + runOutput);
+        assertNotNull(ran.get("result"), "sync run returns the output.body as structured result: " + ran);
+        assertTrue(String.valueOf(ran.get("result")).contains("hello world"),
+                "structured result carries the run's output.body: " + ran.get("result"));
     }
 
     /**

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/skills/GraphStateSkillTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/skills/GraphStateSkillTest.java
@@ -41,11 +41,12 @@ class GraphStateSkillTest {
         // in a web UI with accidental padding - the cid is the store key, and both
         // engines trim identically so the mixed-fleet key space stays one key per id
         var graphInstance = new GraphInstance("unit-test");
+        var skill = new TestSkill();
         graphInstance.stateMachine.setElement("model.cid", "  order-1001  ");
-        assertEquals("order-1001", new TestSkill().getRequiredCorrelationId(graphInstance, "suspend"));
+        assertEquals("order-1001", skill.getRequiredCorrelationId(graphInstance, "suspend"));
         // blank remains a missing correlation ID, not an empty key
         graphInstance.stateMachine.setElement("model.cid", "   ");
         assertThrows(IllegalArgumentException.class,
-                () -> new TestSkill().getRequiredCorrelationId(graphInstance, "suspend"));
+                () -> skill.getRequiredCorrelationId(graphInstance, "suspend"));
     }
 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/start/CompileGraphTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/start/CompileGraphTest.java
@@ -78,11 +78,11 @@ class CompileGraphTest {
 
     @Test
     void staticValidatorRejectsEveryInvalidSuspendResumeShape() {
-        // direct coverage of every static rule, independent of the manifest:
-        // err1 graph.suspend node not named 'suspend'; err2 suspend=true on graph.math;
-        // err3 suspensible node without a suspend node; err4 suspend node without ttl;
-        // err5 suspensible node without a drawn edge to 'suspend'; err6 suspend node
-        // without an outgoing connection; err7 suspension point without a
+        // Direct coverage of every static rule, independent of the manifest. The fixtures cover
+        // err1 a graph.suspend node not named 'suspend', err2 the suspend marker on graph.math,
+        // err3 a suspensible node without a suspend node, err4 a suspend node without ttl,
+        // err5 a suspensible node without a drawn edge to 'suspend', err6 a suspend node
+        // without an outgoing connection, and err7 a suspension point without a
         // continuation edge (a resumed run could not continue)
         for (var id : List.of("unit-test-suspend-err1", "unit-test-suspend-err2", "unit-test-suspend-err3",
                               "unit-test-suspend-err4", "unit-test-suspend-err5", "unit-test-suspend-err6",
@@ -100,10 +100,10 @@ class CompileGraphTest {
         // valid: a graph.task node may declare a child-call deadline (ttl in the suspend grammar)
         var ok = importGraph("unit-test-ttl-ok");
         GraphModelValidator.validate(ok);
-        // err1: ttl on a skill without child-call deadline semantics (graph.math);
-        // err2: malformed duration on a deadline skill;
-        // err3: a data mapping writing to reserved model metadata (model.ttl);
-        // err4: the same metadata write embedded as a MAPPING: line in a graph.math statement
+        // The err fixtures cover err1 a ttl on a skill without child-call deadline semantics
+        // (graph.math), err2 a malformed duration on a deadline skill, err3 a data mapping
+        // writing to reserved model metadata (model.ttl), and err4 the same metadata write
+        // embedded as a MAPPING line inside a graph.math statement
         for (var id : List.of("unit-test-ttl-err1", "unit-test-ttl-err2", "unit-test-ttl-err3",
                               "unit-test-ttl-err4")) {
             var graph = importGraph(id);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/suspend/GraphSuspendResumeTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/suspend/GraphSuspendResumeTest.java
@@ -81,16 +81,16 @@ class GraphSuspendResumeTest {
         // into every skill and task - not the engine's internal callback IDs
         assertEquals(cid, CountingStepTask.getBusinessCid("one", cid));
         // the persisted record has the documented envelope shape and no reserved model keys
-        var record = readStoredRecord(cid);
-        assertEquals("step-1", record.getElement("data.node"));
-        assertEquals(cid, record.getElement("data.cid"));
-        assertEquals(1, record.getElement("data.model.step1_count"));
-        assertNull(record.getElement("data.model.cid"), "reserved model keys must not persist");
-        assertNull(record.getElement("data.model.instance"), "reserved model keys must not persist");
-        assertNull(record.getElement("data.model.flow"), "reserved model keys must not persist");
-        assertNull(record.getElement("data.model.trace"), "reserved model keys must not persist");
-        assertNull(record.getElement("data.model.run"), "the fresh/resume run flag must not persist");
-        assertEquals(true, record.getElement("data.run.step-1"));
+        var stored = readStoredRecord(cid);
+        assertEquals("step-1", stored.getElement("data.node"));
+        assertEquals(cid, stored.getElement("data.cid"));
+        assertEquals(1, stored.getElement("data.model.step1_count"));
+        assertNull(stored.getElement("data.model.cid"), "reserved model keys must not persist");
+        assertNull(stored.getElement("data.model.instance"), "reserved model keys must not persist");
+        assertNull(stored.getElement("data.model.flow"), "reserved model keys must not persist");
+        assertNull(stored.getElement("data.model.trace"), "reserved model keys must not persist");
+        assertNull(stored.getElement("data.model.run"), "the fresh/resume run flag must not persist");
+        assertEquals(true, stored.getElement("data.run.step-1"));
         // run 2 with the same correlation ID: resume continues past the checkpoint
         var second = runGraph("unit-test-suspend-1", cid);
         assertEquals(200, second.getStatus());
@@ -163,13 +163,13 @@ class GraphSuspendResumeTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void expiredRecordFallsBackToFreshRun() throws TimeoutException, InterruptedException {
+    void expiredRecordFallsBackToFreshRun() throws TimeoutException, IOException {
         var cid = Utility.getInstance().getUuid();
         var r1 = runGraph("unit-test-suspend-5", cid);
         assertEquals("suspended", new MultiLevelMap((Map<String, Object>) r1.getBody()).getElement("type"));
         assertEquals(1, CountingStepTask.getCount("expiry", cid));
-        Thread.sleep(1300);
-        // the 1s record has expired: the resume falls back to a fresh run and suspends again
+        expireStoredRecord(cid);
+        // the record's expiry has passed: the resume falls back to a fresh run and suspends again
         var r2 = runGraph("unit-test-suspend-5", cid);
         assertEquals("suspended", new MultiLevelMap((Map<String, Object>) r2.getBody()).getElement("type"));
         assertEquals(2, CountingStepTask.getCount("expiry", cid), "an expired record means a fresh run");
@@ -281,6 +281,19 @@ class GraphSuspendResumeTest {
     private MultiLevelMap readStoredRecord(String cid) throws IOException {
         var wrapper = (Map<String, Object>) new MsgPack().unpack(Files.readAllBytes(storedFile(cid).toPath()));
         return new MultiLevelMap(wrapper);
+    }
+
+    /**
+     * Rewrite the stored record's expiry into the past - a deterministic stand-in for waiting out
+     * the ttl. The store enforces expiry at retrieval time, so an expired stamp behaves exactly
+     * like elapsed wall-clock time, without a sleep in the test.
+     */
+    @SuppressWarnings("unchecked")
+    private void expireStoredRecord(String cid) throws IOException {
+        var file = storedFile(cid);
+        var wrapper = (Map<String, Object>) new MsgPack().unpack(Files.readAllBytes(file.toPath()));
+        wrapper.put("expires_at", System.currentTimeMillis() - 1000);
+        Files.write(file.toPath(), new MsgPack().pack(wrapper));
     }
 
     private File storedFile(String cid) {

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/WorkerHandler.java
@@ -106,25 +106,8 @@ public class WorkerHandler {
         String rpc = event.getTag(EventEmitter.RPC);
         EventEmitter po = EventEmitter.getInstance();
         String ref = tracing? po.startTracing(parentRoute, event.getTraceId(), event.getTracePath(), event.getSpanId(), instance) : "?";
-        // Register the application log context for this worker thread, in lockstep with the trace
-        // bracket. The JSON appenders look it up by thread id at log time. Gated on a real trace
-        // having been created and on the log-context feature being enabled.
         long threadId = Thread.currentThread().threadId();
-        if (tracing && LogContextConfig.getInstance().isEnabled()) {
-            // tracing defaults on for every function, but a context only makes sense once a real
-            // traceId is available (trace.id != null), per the log-context contract.
-            TraceInfo logTrace = po.getTrace(parentRoute, instance);
-            if (logTrace != null && logTrace.id != null) {
-                // the log context 'cid' is the BUSINESS correlation-id only, resolved exactly
-                // like the injected my_correlation_id: the engine's my_cid tag, else a legacy
-                // pre-4.10.2 peer's transported header. When no business context exists the
-                // token stays unset and the context block omits it - an internal routing id
-                // under the 'cid' label would mislead log aggregation
-                String businessCid = event.getTag(EventEmitter.BUSINESS_CID_TAG) != null?
-                        event.getTag(EventEmitter.BUSINESS_CID_TAG) : event.getHeaders().get(MY_CORRELATION_ID);
-                LogContextManager.register(threadId, new LogContext(logTrace, businessCid));
-            }
-        }
+        registerLogContext(po, event, threadId);
         ProcessStatus ps = processEvent(event, rpc);
         TraceInfo trace = po.stopTracing(ref);
         // processEvent never throws (it has a catch-all), so this always runs - no leak. Cheap no-op
@@ -147,6 +130,30 @@ public class WorkerHandler {
          */
         if (!ps.isReactive()) {
             Platform.getInstance().getEventSystem().send(def.getRoute(), READY + route);
+        }
+    }
+
+    /**
+     * Register the application log context for this worker thread, in lockstep with the trace
+     * bracket. The JSON appenders look it up by thread id at log time. Gated on tracing, on the
+     * log-context feature being enabled, and on a real traceId being available (trace.id != null),
+     * per the log-context contract - tracing defaults on for every function, but a context only
+     * makes sense once a real trace was created. Runs synchronously on the worker thread, before
+     * {@code processEvent}, so the thread-id key matches the executing function.
+     */
+    private void registerLogContext(EventEmitter po, EventEnvelope event, long threadId) {
+        if (tracing && LogContextConfig.getInstance().isEnabled()) {
+            TraceInfo logTrace = po.getTrace(parentRoute, instance);
+            if (logTrace != null && logTrace.id != null) {
+                // the log context 'cid' is the BUSINESS correlation-id only, resolved exactly
+                // like the injected my_correlation_id: the engine's my_cid tag, else a legacy
+                // pre-4.10.2 peer's transported header. When no business context exists the
+                // token stays unset and the context block omits it - an internal routing id
+                // under the 'cid' label would mislead log aggregation
+                String businessCid = event.getTag(EventEmitter.BUSINESS_CID_TAG) != null?
+                        event.getTag(EventEmitter.BUSINESS_CID_TAG) : event.getHeaders().get(MY_CORRELATION_ID);
+                LogContextManager.register(threadId, new LogContext(logTrace, businessCid));
+            }
         }
     }
 


### PR DESCRIPTION
## What

Thirteen findings from a field SonarQube scan of the 4.11.x line, all behavior-preserving:

- **Cognitive complexity (3× S3776):** `GraphTraveler.handleSkillResponse` gains an
  early-return late-reply guard and a `handleSkillSuccess` helper;
  `PlaygroundLoader.prepareFeatures` extracts the per-class `loadFeature`;
  `WorkerHandler.executeFunction` extracts `registerLogContext` — called synchronously on
  the same worker thread, before `processEvent`, so the thread-keyed trace/log-context
  semantics are unchanged.
- **Literals and comments:** the kafka-demo catch-all task extracts its duplicated
  `"received"`/`"shape"` literals to constants (2× S1192); five prose comments whose
  trailing semicolons pattern-match as commented-out code are reworded (5× S125).
- **Test hygiene:** one `assertThrows` lambda reduced to a single invocation (S5778); a
  `record` variable renamed off the restricted identifier (S6213); the ttl-expiry test
  replaces `Thread.sleep` with a deterministic expiry rewrite on the stored record — the
  store enforces expiry at retrieval time, so an expired stamp behaves exactly like
  elapsed wall-clock time, without the race or the 1.3s wait (S2925); the 27-assertion
  companion sync test splits into two focused tests on separate sessions (S5961).

## Why

The field DevSecOps quality gate holds the whole codebase to zero blocker/critical/major
issues, and the latest scan of the 4.11.x line failed on 5 Critical + 9 Major new issues.
This is the third remediation round of this shape; fixes follow the same
behavior-preserving playbook as the previous two (helper extraction, constants, prose
rewording, test splits), so the field can rescan clean without any functional change.

## Verification

kafka-demo 8/8, minigraph-playground-engine 99/99 (one more test from the split),
platform-core 425 green (3 pre-existing skips). All three modules' coverage gates met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>