### PR TITLE
Expose partition metadata on KafkaRequestPublisher for routing bound checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## Unreleased
 
+### Added
+
+1. **`KafkaRequestPublisher.partitions(topic)` — partition metadata for application-side
+   partition routing.** Field requirement: an application deriving an explicit partition from
+   an encoded record header needs the topic's partition count to validate the encoded value
+   (partition ids are contiguous, so `0..size-1` is the valid range). The method exposes the
+   producer's own metadata view — no AdminClient — and is reachable through the shared
+   `KafkaRuntime.publisher()` singleton, complementing the content-based partitioning pattern
+   (selector function → explicit `partition` header). Validating up front matters: an
+   out-of-range explicit partition does not fail fast on send — the producer blocks up to
+   `max.block.ms` before erroring.
+
 ### Fixed
 
 1. **The Kafka flow adapter's consumer thread no longer dies permanently on a transient rebalance

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaRequestPublisher.java
@@ -20,10 +20,12 @@ package org.platformlambda.mini.kafka;
 
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -80,6 +82,31 @@ public class KafkaRequestPublisher implements AutoCloseable {
         });
         return Mono.fromFuture(ack)
                 .doOnError(e -> log.error("Failed to publish to topic {}: {}", topic, e.getMessage()));
+    }
+
+    /**
+     * Obtain partition metadata for a topic from the producer's own metadata view - no AdminClient
+     * involved. The first call for a topic not yet in the client's metadata cache blocks up to
+     * {@code max.block.ms} fetching it; subsequent calls are served from the cache, which the client
+     * refreshes in the background (every {@code metadata.max.age.ms}).
+     *
+     * <p>Partition ids are contiguous {@code 0..size-1}, so the returned list's size bounds an
+     * application-supplied partition number - e.g. a routing function validating an encoded partition
+     * header before publishing with an explicit partition. Validating up front matters: an
+     * out-of-range explicit partition does not fail fast on send - the producer blocks up to
+     * {@code max.block.ms} waiting for that partition to appear in metadata, then errors. A stale
+     * cache is conservative for this check, because a partition count only ever grows.</p>
+     *
+     * <p>Cautions: throws Kafka's unchecked {@link org.apache.kafka.common.errors.TimeoutException}
+     * when metadata cannot be obtained within {@code max.block.ms} (e.g. the topic does not exist and
+     * auto-creation is off); and on brokers with {@code auto.create.topics.enable=true}, requesting
+     * metadata for a nonexistent topic may <b>create</b> it - mind topic-name typos in routing code.</p>
+     *
+     * @param topic name
+     * @return partition metadata for the topic
+     */
+    public List<PartitionInfo> partitions(String topic) {
+        return producer.partitionsFor(topic);
     }
 
     /**

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaRequestPublisherTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaRequestPublisherTest.java
@@ -20,12 +20,17 @@ package org.platformlambda.mini.kafka;
 
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,6 +83,26 @@ class KafkaRequestPublisherTest {
         producer.errorNext(new RuntimeException("broker down"));
         Exception ex = assertThrows(Exception.class, publish::block);
         assertTrue(ex.getMessage().contains("broker down"));
+    }
+
+    @Test
+    void partitionsExposeTopicMetadataForBoundChecks() {
+        Node broker = new Node(0, "127.0.0.1", 9092);
+        Node[] replicas = {broker};
+        List<PartitionInfo> orders = List.of(
+                new PartitionInfo("orders", 0, broker, replicas, replicas),
+                new PartitionInfo("orders", 1, broker, replicas, replicas),
+                new PartitionInfo("orders", 2, broker, replicas, replicas));
+        Cluster cluster = new Cluster("mock-cluster", List.of(broker), orders, Set.of(), Set.of());
+        MockProducer<String, byte[]> producer =
+                new MockProducer<>(cluster, true, null, new StringSerializer(), new ByteArraySerializer());
+        try (KafkaRequestPublisher publisher = new KafkaRequestPublisher(producer)) {
+            List<PartitionInfo> partitions = publisher.partitions("orders");
+            // partition ids are contiguous 0..size-1, so size() bounds an encoded partition number
+            assertEquals(3, partitions.size());
+            assertEquals(List.of(0, 1, 2),
+                    partitions.stream().map(PartitionInfo::partition).sorted().toList());
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

Adds `KafkaRequestPublisher.partitions(topic)` — a thin accessor over the producer's own
metadata view (`producer.partitionsFor`), plus the operational-contract javadoc, a
MockProducer test pinning the count and contiguous-id contract, and a CHANGELOG entry.

- No AdminClient involved: partition counts are ordinary metadata that every Kafka client
  maintains; the first call for an uncached topic blocks up to `max.block.ms`, after
  which reads are served from the client's background-refreshed cache.
- Partition ids are contiguous `0..size-1`, so the returned list's size is the complete
  bound for validating an application-supplied partition number.
- Reachable through the shared `KafkaRuntime.publisher()` singleton, and `KafkaProducer`
  is thread-safe — no lifecycle or concurrency changes.
- Javadoc cautions: Kafka's unchecked `TimeoutException` when metadata cannot be
  obtained, and broker-side topic auto-creation on metadata requests for nonexistent
  topics (mind topic-name typos in routing code).

## Why

Field requirement for custom partition routing: an application derives an explicit
partition from a record header that carries an encoded partition number, and must
validate the encoded value against the topic's real partition count before publishing.
This complements the approved content-based partitioning pattern (selector function →
explicit `partition` header). Validating up front matters: an out-of-range explicit
partition does not fail fast on send — the producer blocks up to `max.block.ms` (default
60s) waiting for that partition to appear in metadata before erroring, so a pre-check
turns a one-minute stall per bad message into an immediate application decision.

## Verification

New `partitionsExposeTopicMetadataForBoundChecks` test (seeded-cluster MockProducer:
count matches, ids run 0..N-1). Full minimalist-kafka suite 172/172 on the branch
(rebased onto current main), JaCoCo coverage gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>