### PR TITLE
Polish the consumer resilience round per IDE Sonar findings

### DIFF
--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowAdapter.java
@@ -594,7 +594,7 @@ public class KafkaFlowAdapter implements AutoCloseable {
         try {
             long perRecordMs = Math.addExact(
                     Math.multiplyExact(retryPolicy.maxRetries() + 1L, maxTargetTtlMs(binding)),
-                    Math.multiplyExact((long) retryPolicy.maxRetries(), retryPolicy.backoffMs()));
+                    Math.multiplyExact(retryPolicy.maxRetries(), retryPolicy.backoffMs()));
             envelopeMs = Math.addExact(Math.multiplyExact(perRecordMs, maxPollRecords),
                     POLL_INTERVAL_HEADROOM_MS);
         } catch (ArithmeticException e) {
@@ -618,10 +618,11 @@ public class KafkaFlowAdapter implements AutoCloseable {
     private static void warnWhenEnvelopeExceedsExplicitInterval(KafkaConsumerBinding binding,
                                                                 String explicit, long envelopeMs) {
         try {
-            if (envelopeMs > Long.parseLong(explicit.trim())) {
+            String configured = explicit.trim();
+            if (envelopeMs > Long.parseLong(configured)) {
                 log.warn("Binding '{}' sets max.poll.interval.ms={} but its worst-case retry envelope "
                         + "is {} ms - a slow-failing message may get this consumer evicted from the "
-                        + "group mid-processing", binding.topicOrPattern(), explicit.trim(), envelopeMs);
+                        + "group mid-processing", binding.topicOrPattern(), configured, envelopeMs);
             }
         } catch (NumberFormatException e) {
             // a malformed template value is the Kafka client's to reject with its own config error

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaFlowConsumer.java
@@ -224,39 +224,7 @@ public class KafkaFlowConsumer implements AutoCloseable {
             subscribeOrAssign(consumer);
             int consecutiveFailures = 0;
             while (running) {
-                try {
-                    ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
-                    for (ConsumerRecord<String, byte[]> consumerRecord : records) {
-                        if (routeToFlow(consumerRecord) && !binding.autoCommit()) {
-                            commit(consumerRecord);   // commit only after the flow finished -> at-least-once
-                        }
-                    }
-                    consecutiveFailures = 0;
-                } catch (WakeupException e) {
-                    throw e;   // close() breaking the poll - handled below, not a failure
-                } catch (CommitFailedException | RebalanceInProgressException e) {
-                    // Routine after a group rebalance: the partitions were revoked while a record was in
-                    // flight, so its offset cannot be committed. The uncommitted records redeliver to
-                    // whichever consumer now owns the partitions (at-least-once holds; flows are required
-                    // to be idempotent) and the next poll() rejoins the group.
-                    log.warn("Offset commit for {} failed after a rebalance; records will redeliver - {}",
-                            binding.topicOrPattern(), e.getMessage());
-                } catch (RetriableException e) {
-                    log.warn("Transient Kafka error on {}; retrying - {}",
-                            binding.topicOrPattern(), e.getMessage());
-                } catch (RuntimeException e) {
-                    // Unforeseen failure: stay alive (the alternative is a binding that is dead until the
-                    // pod restarts) but pause with escalating backoff so a persistent error cannot hot-loop.
-                    consecutiveFailures++;
-                    long pause = Math.min(MAX_FAILURE_BACKOFF_MS,
-                            INITIAL_FAILURE_BACKOFF_MS << Math.min(consecutiveFailures - 1, 5));
-                    log.error("Kafka flow consumer for {} caught an unexpected error (failure #{}); "
-                            + "pausing {} ms before it continues",
-                            binding.topicOrPattern(), consecutiveFailures, pause, e);
-                    if (!pause(pause)) {
-                        break;   // interrupted during shutdown
-                    }
-                }
+                consecutiveFailures = pollOnce(consecutiveFailures);
             }
         } catch (WakeupException e) {
             // expected: close() called wakeup() to break the poll
@@ -268,15 +236,59 @@ public class KafkaFlowConsumer implements AutoCloseable {
         }
     }
 
-    /** Pause after an unexpected poll-loop failure. @return false if interrupted (shutting down). */
-    private boolean pause(long ms) {
+    /**
+     * One guarded poll iteration: poll, dispatch, commit - surviving the consumer exceptions that
+     * routinely follow a group rebalance, so the binding stays alive. Only {@link WakeupException}
+     * (shutdown) escapes to the caller.
+     *
+     * @param consecutiveFailures the current unexpected-failure streak
+     * @return the streak for backoff pacing: 0 after a clean iteration, unchanged on a known
+     *         transient, incremented after an unexpected error (which also pauses with backoff)
+     */
+    private int pollOnce(int consecutiveFailures) {
         try {
-            TimeUnit.MILLISECONDS.sleep(ms);
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            ConsumerRecords<String, byte[]> records = consumer.poll(POLL_TIMEOUT);
+            for (ConsumerRecord<String, byte[]> consumerRecord : records) {
+                if (routeToFlow(consumerRecord) && !binding.autoCommit()) {
+                    commit(consumerRecord);   // commit only after the flow finished -> at-least-once
+                }
+            }
+            return 0;
+        } catch (WakeupException e) {
+            throw e;   // close() breaking the poll - handled by the poll loop, not a failure
+        } catch (CommitFailedException | RebalanceInProgressException e) {
+            // Routine after a group rebalance: the partitions were revoked while a record was in
+            // flight, so its offset cannot be committed. The uncommitted records redeliver to
+            // whichever consumer now owns the partitions (at-least-once holds; flows are required
+            // to be idempotent) and the next poll() rejoins the group.
+            log.warn("Offset commit for {} failed after a rebalance; records will redeliver - {}",
+                    binding.topicOrPattern(), e.getMessage());
+            return consecutiveFailures;
+        } catch (RetriableException e) {
+            log.warn("Transient Kafka error on {}; retrying - {}",
+                    binding.topicOrPattern(), e.getMessage());
+            return consecutiveFailures;
+        } catch (RuntimeException e) {
+            // Unforeseen failure: stay alive (the alternative is a binding that is dead until the
+            // pod restarts) but pause with escalating backoff so a persistent error cannot hot-loop.
+            // An interrupted pause sets running=false, so the poll loop exits on its next check.
+            int failures = consecutiveFailures + 1;
+            long pause = Math.min(MAX_FAILURE_BACKOFF_MS,
+                    INITIAL_FAILURE_BACKOFF_MS << Math.min(failures - 1, 5));
+            log.error("Kafka flow consumer for {} caught an unexpected error (failure #{}); "
+                    + "pausing {} ms before it continues",
+                    binding.topicOrPattern(), failures, pause, e);
+            pause(pause);
+            return failures;
+        }
+    }
+
+    /** Pause after an unexpected poll-loop failure; an interruption stops the loop via running=false. */
+    private void pause(long ms) {
+        Utility.getInstance().sleep(ms);
+        // Utility.sleep restores the interrupt flag instead of throwing - honor a shutdown interrupt
+        if (Thread.currentThread().isInterrupted()) {
             running = false;
-            return false;
         }
     }
 
@@ -523,14 +535,13 @@ public class KafkaFlowConsumer implements AutoCloseable {
         if (retryPolicy.backoffMs() <= 0) {
             return true;
         }
-        try {
-            TimeUnit.MILLISECONDS.sleep(retryPolicy.backoffMs());
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        Utility.getInstance().sleep(retryPolicy.backoffMs());
+        // Utility.sleep restores the interrupt flag instead of throwing - honor a shutdown interrupt
+        if (Thread.currentThread().isInterrupted()) {
             running = false;
             return false;
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
## What

Four small, behavior-preserving cleanups on the recently merged poll-loop resilience
work (#255), caught by a local SonarQube-for-IDE scan:

- **`KafkaFlowConsumer.pollLoop` extracts the guarded iteration into `pollOnce`** —
  clearing both the cognitive-complexity finding (S3776, 20 > 15) and the nested-try
  finding (S1141). Fidelity is exact: the unexpected-failure streak resets on a clean
  iteration, stays unchanged on a known transient (rebalance/commit/retriable), and
  increments with escalating backoff on an unexpected error; only `WakeupException`
  (shutdown) escapes to the loop.
- **The `pause` and `backoff` helpers sleep via `Utility.getInstance().sleep`** instead
  of `TimeUnit.sleep`. `Utility.sleep` restores the interrupt flag instead of throwing,
  so both helpers honor a shutdown interrupt by checking `isInterrupted()` afterward —
  `pause` becomes void (interruption already stops the loop via `running=false`) and
  `backoff` keeps its load-bearing boolean (`false` = interrupted = caller must not
  commit).
- **`warnWhenEnvelopeExceedsExplicitInterval` hoists `explicit.trim()`** into a local
  used by both the parse and the log call, so the log arguments need no evaluation
  (S2629).
- **`applyPollInterval` drops a redundant `(long)` cast** on `maxRetries()` — the `int`
  promotes to `long` in `multiplyExact`.

## Why

Same-day follow-through on the field Sonar quality bar: the resilience round's new code
should hold to the identical standard the third remediation round (#256) just restored
across the codebase — fixing it now keeps the field's next scan clean rather than
minting a fourth round.

## Verification

Full minimalist-kafka suite 172/172 with the coverage gate met. The two poll-loop
survival tests (transient and unexpected-error paths, driven through a live MockConsumer
loop) pin the refactor's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>