### PR TITLE
Present the tutorial-14 walkthrough as a mermaid diagram

### DIFF
--- a/docs/guides/knowledge-graph/workflow-suspension.md
+++ b/docs/guides/knowledge-graph/workflow-suspension.md
@@ -99,10 +99,12 @@ colors in the Playground; the skill defines the behavior.
 app) is the complete multi-checkpoint pattern — **three human checkpoints, four short
 runs, one correlation ID**:
 
-```text
-root → resume → order (suspend=true) → check-approval → approval (suspend=true) → delivery (suspend=true) → ship → end
-                                        ↑        ↘ manager-reject → end
-                                        └─ await-decision (suspend=true)
+```mermaid
+flowchart LR
+    root(["root"]) --> resume --> order["order<br>(suspend=true)"] --> check{"check-approval"}
+    check -->|approved| approval["approval<br>(suspend=true)"] --> delivery["delivery<br>(suspend=true)"] --> ship --> done(["end"])
+    check -->|rejected| reject["manager-reject"] --> done
+    check -->|waiting| await["await-decision<br>(suspend=true)"] --> check
 ```
 
 A customer orders, the store manager approves **or rejects with a reason**, the delivery


### PR DESCRIPTION
## What

Replace the ASCII text box in the workflow-suspension guide's walkthrough section
with a mermaid flowchart: the workflow spine from root to end, the three-way
check-approval decision with labeled approved/rejected/waiting edges, the
await-decision wait loop, and suspend=true marked on each checkpoint node.

## Why

The text box overflowed horizontally on the published page and the branching was
hard to read. The docs site renders mermaid natively (Material theme), so the same
topology now reads at a glance in both light and dark themes.

Co-Authored-By: Claude Code <noreply@anthropic.com>