### PR TITLE
Post-merge polish: IDE cosmetics + S3776 split in GraphExecutor

### DIFF
--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/common/GraphLambdaFunction.java
@@ -222,7 +222,7 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
 
     /**
      * A suspension point with NO drawn edge to the suspend node reached the checkpoint
-     * by an IF-THEN-ELSE jump (jump mode) - by construction only a routing skill can
+     * by an IF-THEN-ELSE jump (jump mode). By construction only a routing skill can
      * jump, so the node is a decision and a resumed run RE-EXECUTES it against the new
      * request input instead of continuing past it. An edge-mode suspension point
      * (drawn edge present) is never re-executed - the resumed run continues along its
@@ -423,7 +423,7 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
 
     /**
      * Stage the generic exception context for an exception-handler jump: Event Script
-     * parity names (error.code/message/stack) plus the originating node in error.source,
+     * parity names (error.code/message/stack) plus the originating node in 'error.source',
      * so one island-anchored handler can serve every node's exception= route without
      * naming the failing node in its data mapping. Reads the failing node's scratch
      * entries staged by the skill. Inspectable in a dry-run session via 'inspect error'.
@@ -456,13 +456,13 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
      * The deadline (ms) for a child call made by this node: the node's optional 'ttl' property
      * (duration syntax, e.g. 10s - the suspend-node grammar) overrides the propagated model.ttl.
      * A SHORTER child deadline lets a sub-flow, sub-graph or API call time out FIRST, so this
-     * graph's error path can catch the timeout and retry within its remaining budget - with plain
+     * graph's error path can catch the timeout and retry within its remaining budget. With plain
      * propagation, parent and child carry the same value and the parent always expires first.
      * (graph.js also honors a node ttl for its script-execution deadline, but resolves its own
      * default of 5s instead of model.ttl - scripts are meant for very simple computation.)
      *
      * @param instance the graph instance
-     * @param node     the calling node (graph.extension, graph.api.fetcher or graph.task)
+     * @param node     the calling node (graph.extension, graph.api.fetcher or 'graph.task')
      * @return the node ttl in milliseconds when declared, else the propagated model.ttl
      */
     protected long getEffectiveTtl(GraphInstance instance, SimpleNode node) {
@@ -665,7 +665,7 @@ public abstract class GraphLambdaFunction implements TypedLambdaFunction<EventEn
     /**
      * Reject a write target inside engine-managed model metadata. Every runtime path that can
      * write a {@code model.*} target calls this - data-mapping RHS validation, the fetcher-family
-     * input and output mappings, and for_each expansion - in BOTH walker lanes (executor and
+     * input and output mappings, and for_each expansion. In BOTH walker lanes (executor and
      * traveler), so dry-run drafts and single-node execution are covered as well as full runs.
      */
     protected void assertMutableModelTarget(String nodeName, String rhs) {

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
@@ -150,40 +150,45 @@ public class GraphExecutor extends GraphLambdaFunction {
                 handleErrorResponse(po, graphInstance, response, parentSpanId);
                 return;
             }
-            var graph = graphInstance.graph;
-            var node = graph.findNodeByAlias(nodeName);
-            checkFrequency(po, graphInstance, nodeName, parentSpanId);
-            // Skill handler can also set status and error in its node properties instead of throwing exception
-            var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
-            var resultError = stateMachine.getElement(nodeName + "." + ERROR);
-            // Mark the skill complete only when it did NOT fail (status + error set,
-            // e.g. an exception-routed fetcher): a join barrier consults skillRun,
-            // so a failed branch must not satisfy the barrier while it retries.
-            // GraphTraveler keeps identical semantics.
-            if (!(processStatus instanceof Integer && resultError != null)) {
-                graphInstance.skillRun.put(nodeName, true);
+            handleSkillSuccess(po, graphInstance, nodeName, target, response, parentSpanId);
+        }
+    }
+
+    private void handleSkillSuccess(PostOffice po, GraphInstance graphInstance, String nodeName,
+                                    Object target, EventEnvelope response, String parentSpanId) {
+        var stateMachine = graphInstance.stateMachine;
+        var node = graphInstance.graph.findNodeByAlias(nodeName);
+        checkFrequency(po, graphInstance, nodeName, parentSpanId);
+        // Skill handler can also set status and error in its node properties instead of throwing exception
+        var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
+        var resultError = stateMachine.getElement(nodeName + "." + ERROR);
+        // Mark the skill complete only when it did NOT fail (status + error set,
+        // e.g. an exception-routed fetcher): a join barrier consults skillRun,
+        // so a failed branch must not satisfy the barrier while it retries.
+        // GraphTraveler keeps identical semantics.
+        if (!(processStatus instanceof Integer && resultError != null)) {
+            graphInstance.skillRun.put(nodeName, true);
+        }
+        // Skill handler would set status and error in its node properties
+        // e.g. the HTTP response status code to the API fetcher >= 400
+        var errorHandler = node.getProperty(EXCEPTION);
+        if (processStatus instanceof Integer rc && resultError != null && errorHandler == null) {
+            var errorMap = getErrorMap(resultError, target);
+            var replyTo = graphInstance.getReplyTo();
+            var cid = graphInstance.getCorrelationId();
+            var error = new EventEnvelope().setTo(replyTo).setCorrelationId(cid).setBody(errorMap)
+                    .setStatus(rc).setSpanId(parentSpanId);
+            po.send(error);
+            graphInstance.complete.set(true);
+        } else if (!graphInstance.complete.get()) {
+            if (processStatus instanceof Integer && resultError != null) {
+                // the node failed and routed to its exception= handler ('next' is the
+                // handler's alias): stage the generic exception context so one handler
+                // can serve any node. GraphTraveler keeps identical semantics.
+                stageErrorContext(stateMachine, nodeName);
             }
-            // Skill handler would set status and error in its node properties
-            // e.g. the HTTP response status code to the API fetcher >= 400
-            var errorHandler = node.getProperty(EXCEPTION);
-            if (processStatus instanceof Integer rc && resultError != null && errorHandler == null) {
-                var errorMap = getErrorMap(resultError, target);
-                var replyTo = graphInstance.getReplyTo();
-                var cid = graphInstance.getCorrelationId();
-                var error = new EventEnvelope().setTo(replyTo).setCorrelationId(cid).setBody(errorMap)
-                        .setStatus(rc).setSpanId(parentSpanId);
-                po.send(error);
-                graphInstance.complete.set(true);
-            } else if (!graphInstance.complete.get()) {
-                if (processStatus instanceof Integer && resultError != null) {
-                    // the node failed and routed to its exception= handler ('next' is the
-                    // handler's alias): stage the generic exception context so one handler
-                    // can serve any node. GraphTraveler keeps identical semantics.
-                    stageErrorContext(stateMachine, nodeName);
-                }
-                var next = String.valueOf(response.getBody());
-                decideNext(po, node, next, graphInstance, parentSpanId);
-            }
+            var next = String.valueOf(response.getBody());
+            decideNext(po, node, next, graphInstance, parentSpanId);
         }
     }
 

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphExtension.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphExtension.java
@@ -246,7 +246,7 @@ public class GraphExtension extends GraphLambdaFunction {
 
     private void inheritBusinessCid(EventEnvelope forward, GraphInstance graphInstance) {
         // the child flow or graph inherits the parent's business correlation-id (model.cid),
-        // exactly like an Event Script sub-flow launch - so a subgraph that suspends can be
+        // exactly like an Event Script sub-flow launch. Therefore, a subgraph that suspends can be
         // resumed under the same business transaction id (its store record is keyed by
         // graph + cid, never by a per-call random id)
         if (graphInstance.stateMachine.getElement(MODEL_CID) instanceof String businessCid


### PR DESCRIPTION
Post-merge polish: IDE cosmetics + S3776 split in GraphExecutor

The walker's exception-context staging pushed handleSkillResponse to
cognitive complexity 18 (> 15). The executor now adopts GraphTraveler's
existing handleSkillResponse -> handleSkillSuccess split - behavior-
preserving, same-thread synchronous, and the two walker twins are more
symmetric. Comment cosmetics per IDE recommendation. Engine 112/112.

Co-Authored-By: Claude Code <noreply@anthropic.com>