### PR TITLE
Kafka flow adapter: group.protocol=auto adopts KIP-848 when the cluster supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. **`group.protocol=auto`: the Kafka flow adapter can adopt the KIP-848 consumer rebalance
+   protocol automatically.** Kafka's classic rebalance protocol is client-driven with a group-wide
+   synchronization barrier — an infrastructure interruption makes every member of a consumer group
+   stop, rejoin, and re-sync, and a flapping member repeats that storm (reported from the field as
+   high CPU during unscheduled rebalances). The KIP-848 protocol (GA since Apache Kafka 4.0) is
+   broker-driven and fully incremental: only the interrupted member's partitions move. Setting
+   `group.protocol=auto` in `kafka-consumer.properties` now probes the cluster's finalized
+   `group.version` feature flag once at startup — via the `ApiVersions` handshake, which brokers
+   answer pre-authentication and never ACL-gate, so no grant is needed beyond the connection
+   credentials already in the template — and resolves to `consumer` when the cluster supports the
+   new protocol, `classic` otherwise (older brokers, probe failures, and Kafka-compatible endpoints
+   that do not report features all resolve to `classic`, the safe default). If the template also
+   sets client tuning that the consumer protocol forbids (`session.timeout.ms`,
+   `heartbeat.interval.ms`, `partition.assignment.strategy`), `auto` keeps `classic` and warns
+   instead of failing. One probe per cluster (twin-kafka's secondary cluster resolves
+   independently); the decision is stated in the startup log. Explicit `consumer`/`classic`
+   template values pass through verbatim as before.
+
+---
 ## Version 4.11.6, 8/10/2026
 
 ### Changed

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -392,8 +392,53 @@ Two robustness behaviors keep a binding alive through the realities of consumer-
   raises `max.poll.interval.ms` to cover it (never lowering it below the Kafka default; the derivation is
   logged). An explicit `max.poll.interval.ms` in the consumer template is an operator decision and is
   respected as-is — with a `WARN` when the computed envelope exceeds it. Raising the interval is low-risk:
-  a crashed pod is still detected by heartbeats (`session.timeout.ms`); this setting only bounds time
-  between polls.
+  a crashed pod is still detected by heartbeats (`session.timeout.ms`; broker-side group configuration
+  under the [KIP-848 consumer protocol](#rebalance-protocol)); this setting only bounds time between
+  polls.
+
+### Consumer rebalance protocol (KIP-848) {#rebalance-protocol}
+
+Kafka's *classic* rebalance protocol is client-driven with a group-wide synchronization barrier: when
+cloud infrastructure interrupts one pod, **every** member of the group stops, rejoins, and re-syncs —
+and a flapping member repeats that storm. The **KIP-848 consumer rebalance protocol** (GA since Apache
+Kafka 4.0) moves coordination to the broker's group coordinator and makes reassignment fully
+incremental: only the interrupted member's partitions move, survivors keep consuming. On clusters that
+support it, this materially reduces rebalance time and the CPU churn of unscheduled rebalances.
+
+The protocol is selected per cluster in `kafka-consumer.properties` via `group.protocol`:
+
+| Value | Behavior |
+|-------|----------|
+| *(unset)* / `classic` | Kafka's classic protocol — works on every broker. |
+| `consumer` | The KIP-848 protocol, unconditionally. Fails at runtime if the cluster does not support it. |
+| `auto` | The adapter probes the cluster once at startup and picks `consumer` when available, `classic` otherwise. |
+
+**How `auto` decides.** KIP-848 enablement is a *finalized feature flag* (`group.version >= 1`) —
+controller-managed and cluster-wide, so it is authoritative even during a rolling broker upgrade. The
+probe reads it via the `ApiVersions` handshake that every Kafka client performs on connect: the broker
+answers it before authentication completes and never applies an ACL to it, so the probe **needs no
+grant** beyond the connection credentials already in the template. One probe per cluster per
+application instance; the decision is stated in the startup log. Any probe failure — an older broker,
+an unreachable cluster, a Kafka-compatible endpoint that does not report features — resolves to
+`classic`, the safe default.
+
+**Client tuning that conflicts.** Under the consumer protocol, `session.timeout.ms`,
+`heartbeat.interval.ms` and `partition.assignment.strategy` move to broker-side group configuration —
+a client that sets them together with `group.protocol=consumer` fails fast with a `ConfigException`.
+When the template sets any of them, `auto` therefore resolves to `classic` with a `WARN` naming the
+conflicting keys: remove them to let `auto` upgrade. Everything the adapter itself manages —
+`group.id`, the delivery-mode overlay, the [derived `max.poll.interval.ms`](#liveness) — is valid
+under both protocols.
+
+**Prerequisites and managed services.** The cluster must run Apache Kafka 4.0+ with the
+`group.version` feature enabled (new 4.0+ clusters enable it at format time; upgraded clusters enable
+it explicitly — check with `kafka-features.sh describe`). Confluent Platform 8.x carries the Apache
+4.x core and reports the flag; for other managed or Kafka-compatible services (Confluent Cloud, AWS
+MSK, Azure Event Hubs), verify against your actual cluster — wherever the flag is not reported,
+`auto` simply keeps `classic`. Migration is online: a group converts when members join with the
+consumer protocol (mixed members interoperate during a rolling deploy) and reverts if all
+new-protocol members leave. To force the classic protocol regardless of cluster support, set
+`group.protocol=classic` explicitly.
 
 ## Outbound: publishing to Kafka {#outbound}
 

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -55,7 +55,10 @@ cluster's schema-id cache is isolated (Confluent global ids are only unique with
 
 All secondary templates follow the same mechanics as the primary ones: loaded from the bundled
 classpath template by default, `${ENV_VAR:default}` substitution, and OAuth token endpoint URLs
-auto-registered on the JVM allow-list. Externalization of configuration is opt-in - point the
+auto-registered on the JVM allow-list. That includes the
+[consumer rebalance protocol](minimalist-kafka.md#rebalance-protocol): each cluster resolves
+`group.protocol=auto` independently, so the primary may run the KIP-848 consumer protocol while the
+secondary stays classic (or vice versa). Externalization of configuration is opt-in - point the
 location key at a file rendered by the devops pipeline (e.g. `file:/tmp/config/...`), optionally
 with a classpath fallback as a comma-separated list. The default bootstrap is
 `${SECONDARY_KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:8092}` - matching the

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/GroupProtocolResolver.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/GroupProtocolResolver.java
@@ -1,0 +1,156 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DescribeFeaturesOptions;
+import org.apache.kafka.clients.admin.FeatureMetadata;
+import org.apache.kafka.clients.admin.FinalizedVersionRange;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resolves the adapter-level {@code group.protocol=auto} consumer template value into a concrete
+ * Kafka {@code group.protocol} ({@code consumer} or {@code classic}) by probing the cluster's
+ * finalized {@code group.version} feature flag - the flag that gates the KIP-848 consumer
+ * rebalance protocol.
+ *
+ * <p><b>How the probe works.</b> {@link Admin#describeFeatures()} rides the {@code ApiVersions}
+ * handshake that every Kafka client performs on connect: the broker answers it before
+ * authentication completes and never applies an ACL to it (version negotiation must work before a
+ * session exists), so the probe needs no grant beyond the connection credentials already present
+ * in the consumer template. The <i>finalized</i> {@code group.version} is controller-managed and
+ * cluster-wide - it only turns on when every broker supports it - so it is authoritative even
+ * during a rolling broker upgrade.</p>
+ *
+ * <p><b>Resolution rules.</b> Finalized {@code group.version >= 1} resolves to {@code consumer};
+ * an absent or zero feature level, or any probe failure (older broker, unreachable cluster, a
+ * Kafka-compatible endpoint that does not report features), resolves to {@code classic} - the
+ * safe default on any Kafka. One probe per {@code bootstrap.servers} per JVM; the decision and
+ * its evidence are stated in the startup log. An explicit {@code consumer} or {@code classic} in
+ * the template is passed through verbatim, no probe.</p>
+ *
+ * <p><b>Conflict guard.</b> {@code session.timeout.ms}, {@code heartbeat.interval.ms} and
+ * {@code partition.assignment.strategy} are client-side tuning that cannot be set together with
+ * {@code group.protocol=consumer} (the Kafka client fails fast with a {@code ConfigException} -
+ * their roles move to broker-side group configuration under KIP-848). When the template sets any
+ * of them, {@code auto} resolves to {@code classic} with a warning naming the conflicting keys:
+ * respecting the operator's explicit tuning is safer than silently discarding it.</p>
+ */
+final class GroupProtocolResolver {
+    private static final Logger log = LoggerFactory.getLogger(GroupProtocolResolver.class);
+
+    private static final String AUTO = "auto";
+    private static final String CONSUMER = "consumer";
+    private static final String CLASSIC = "classic";
+    private static final String GROUP_VERSION_FEATURE = "group.version";
+    /** Client-side tuning that cannot be combined with {@code group.protocol=consumer}. */
+    private static final List<String> CONSUMER_PROTOCOL_CONFLICTS = List.of(
+            ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG,
+            ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG,
+            ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG);
+    /** One resolution per cluster per JVM, keyed by the template's bootstrap.servers. */
+    private static final ConcurrentMap<String, String> RESOLVED = new ConcurrentHashMap<>();
+    static int probeTimeoutMs = 10_000;     // visible for testing
+
+    private GroupProtocolResolver() {}
+
+    /**
+     * Resolve {@code group.protocol=auto} in place. Any other value (or none) is left untouched.
+     *
+     * @param p the consumer properties assembled from the template
+     */
+    static void resolve(Properties p) {
+        String protocol = p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG);
+        if (protocol == null || !AUTO.equalsIgnoreCase(protocol.trim())) {
+            return;
+        }
+        List<String> conflicts = CONSUMER_PROTOCOL_CONFLICTS.stream()
+                .filter(p::containsKey).toList();
+        if (!conflicts.isEmpty()) {
+            p.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, CLASSIC);
+            log.warn("group.protocol=auto resolved to classic - {} cannot be used with the consumer "
+                    + "rebalance protocol; remove the setting(s) to let auto upgrade", conflicts);
+            return;
+        }
+        String bootstrap = p.getProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
+        if (bootstrap == null || bootstrap.isBlank()) {
+            p.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, CLASSIC);
+            log.warn("group.protocol=auto resolved to classic - no bootstrap.servers to probe");
+            return;
+        }
+        p.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG,
+                RESOLVED.computeIfAbsent(bootstrap, b -> probe(p, b)));
+    }
+
+    /**
+     * One-time feature probe against the cluster, using only the template's connection and
+     * security settings (filtered to the Admin client's own config surface, so consumer-only
+     * keys are not passed along).
+     */
+    private static String probe(Properties template, String bootstrap) {
+        Properties adminProps = new Properties();
+        template.stringPropertyNames().stream()
+                .filter(AdminClientConfig.configNames()::contains)
+                .forEach(k -> adminProps.setProperty(k, template.getProperty(k)));
+        adminProps.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(probeTimeoutMs));
+        adminProps.setProperty(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, String.valueOf(probeTimeoutMs));
+        Admin admin = Admin.create(adminProps);
+        try {
+            FeatureMetadata meta = admin.describeFeatures(
+                            new DescribeFeaturesOptions().timeoutMs(probeTimeoutMs))
+                    .featureMetadata().get(probeTimeoutMs + 1000L, TimeUnit.MILLISECONDS);
+            FinalizedVersionRange groupVersion = meta.finalizedFeatures().get(GROUP_VERSION_FEATURE);
+            if (groupVersion != null && groupVersion.maxVersionLevel() >= 1) {
+                log.info("Kafka cluster ({}) finalizes group.version={} - group.protocol=auto resolved "
+                        + "to consumer (KIP-848 consumer rebalance protocol)",
+                        bootstrap, groupVersion.maxVersionLevel());
+                return CONSUMER;
+            }
+            log.info("Kafka cluster ({}) does not finalize group.version - group.protocol=auto "
+                    + "resolved to classic", bootstrap);
+            return CLASSIC;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Kafka feature probe interrupted ({}) - group.protocol=auto resolved to classic",
+                    bootstrap);
+            return CLASSIC;
+        } catch (Exception e) {
+            log.warn("Unable to probe Kafka cluster features ({}) - group.protocol=auto resolved to "
+                    + "classic: {}", bootstrap, e.getMessage());
+            return CLASSIC;
+        } finally {
+            admin.close(Duration.ofSeconds(5));
+        }
+    }
+
+    /** Forget cached cluster resolutions - for tests that probe the same bootstrap twice. */
+    static void clearCachedResolutions() {
+        RESOLVED.clear();
+    }
+}

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaClientConfig.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaClientConfig.java
@@ -92,7 +92,9 @@ public final class KafkaClientConfig {
     /**
      * Base consumer config from the template, with only the wire-contract deserializers pinned. The caller
      * ({@code KafkaFlowAdapter.newConsumer}) adds a per-topic {@code group.id} and the binding's
-     * delivery-mode overlay ({@code enable.auto.commit} / {@code max.poll.records}).
+     * delivery-mode overlay ({@code enable.auto.commit} / {@code max.poll.records}). A template
+     * {@code group.protocol=auto} is resolved here to {@code consumer} or {@code classic} from the
+     * cluster's finalized {@code group.version} feature - see {@link GroupProtocolResolver}.
      */
     public static Properties consumerProperties(ConfigBase appConfig) {
         return consumerProperties(appConfig, CONSUMER_LOCATION, DEFAULT_CONSUMER);
@@ -112,6 +114,9 @@ public final class KafkaClientConfig {
         Properties p = load(appConfig.getProperty(locationKey, defaultLocations));
         p.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         p.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        // a template's group.protocol=auto becomes consumer|classic from the cluster's own
+        // finalized group.version feature (KIP-848) - one probe per cluster, stated in the log
+        GroupProtocolResolver.resolve(p);
         return p;
     }
 

--- a/system/minimalist-kafka/src/main/resources/kafka-consumer.properties
+++ b/system/minimalist-kafka/src/main/resources/kafka-consumer.properties
@@ -23,6 +23,17 @@ bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS:127.0.0.1:9092}
 # --- Where a brand-new consumer group starts reading ---
 auto.offset.reset=${KAFKA_AUTO_OFFSET_RESET:earliest}
 
+# --- Consumer rebalance protocol (KIP-848) ---
+# Unset (or 'classic') = Kafka's classic protocol, works on every broker.
+# 'consumer' = the KIP-848 broker-driven incremental protocol (needs Kafka 4.0+ with the
+#              group.version feature enabled) - faster, less disruptive rebalances.
+# 'auto'     = probe the cluster once at startup and pick 'consumer' when available, else 'classic'.
+#              The probe rides the ApiVersions handshake (answered pre-authentication, never
+#              ACL-gated), so it needs no grant beyond the connection credentials above. Note:
+#              session.timeout.ms / heartbeat.interval.ms / partition.assignment.strategy cannot be
+#              combined with the consumer protocol - if set here, 'auto' keeps 'classic' and warns.
+# group.protocol=${KAFKA_GROUP_PROTOCOL:auto}
+
 # --- Enterprise security: uncomment and complete for your installation ---
 # security.protocol=${KAFKA_SECURITY_PROTOCOL:SASL_SSL}
 # sasl.mechanism=${KAFKA_SASL_MECHANISM:OAUTHBEARER}

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedKafka.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/EmbeddedKafka.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -55,11 +56,22 @@ final class EmbeddedKafka implements AutoCloseable {
     private final Path logDir;
 
     EmbeddedKafka() {
+        this(BROKER_PORT, CONTROLLER_PORT, LOG_DIR, Map.of());
+    }
+
+    /**
+     * Variant broker on its own ports and log directory, with storage formatted at pinned feature
+     * levels - e.g. {@code Map.of("group.version", (short) 0)} boots a broker whose cluster does
+     * NOT finalize the KIP-848 consumer rebalance protocol (the normal state of an upgraded
+     * cluster whose feature flag has not been enabled yet).
+     */
+    EmbeddedKafka(int brokerPort, int controllerPort, String logDirLocation, Map<String, Short> featureLevels) {
         try {
-            this.bootstrapServers = "127.0.0.1:" + BROKER_PORT;
-            this.logDir = prepareLogDir();
-            formatStorage(logDir);
-            this.server = new KafkaRaftServer(new KafkaConfig(brokerConfig(logDir)), Time.SYSTEM);
+            this.bootstrapServers = "127.0.0.1:" + brokerPort;
+            this.logDir = prepareLogDir(logDirLocation);
+            formatStorage(logDir, featureLevels);
+            this.server = new KafkaRaftServer(
+                    new KafkaConfig(brokerConfig(logDir, brokerPort, controllerPort)), Time.SYSTEM);
             this.server.startup();
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to start embedded Kafka", e);
@@ -70,21 +82,21 @@ final class EmbeddedKafka implements AutoCloseable {
         return bootstrapServers;
     }
 
-    private static Path prepareLogDir() throws IOException {
-        Path dir = Path.of(LOG_DIR);
+    private static Path prepareLogDir(String logDirLocation) throws IOException {
+        Path dir = Path.of(logDirLocation);
         cleanup(dir);
         Files.createDirectories(dir);
         return dir;
     }
 
-    private static Properties brokerConfig(Path logDir) {
+    private static Properties brokerConfig(Path logDir, int brokerPort, int controllerPort) {
         Properties p = new Properties();
         p.setProperty("process.roles", "broker,controller");
         p.setProperty("node.id", Integer.toString(NODE_ID));
-        p.setProperty("controller.quorum.voters", NODE_ID + "@127.0.0.1:" + CONTROLLER_PORT);
+        p.setProperty("controller.quorum.voters", NODE_ID + "@127.0.0.1:" + controllerPort);
         p.setProperty("listeners",
-                "PLAINTEXT://127.0.0.1:" + BROKER_PORT + ",CONTROLLER://127.0.0.1:" + CONTROLLER_PORT);
-        p.setProperty("advertised.listeners", "PLAINTEXT://127.0.0.1:" + BROKER_PORT);
+                "PLAINTEXT://127.0.0.1:" + brokerPort + ",CONTROLLER://127.0.0.1:" + controllerPort);
+        p.setProperty("advertised.listeners", "PLAINTEXT://127.0.0.1:" + brokerPort);
         p.setProperty("inter.broker.listener.name", "PLAINTEXT");
         p.setProperty("controller.listener.names", CONTROLLER_LISTENER);
         p.setProperty("listener.security.protocol.map", "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT");
@@ -99,15 +111,16 @@ final class EmbeddedKafka implements AutoCloseable {
         return p;
     }
 
-    private static void formatStorage(Path logDir) {
+    private static void formatStorage(Path logDir, Map<String, Short> featureLevels) {
         try (PrintStream quiet = new PrintStream(OutputStream.nullOutputStream(), true, StandardCharsets.UTF_8)) {
-            new Formatter()
+            Formatter formatter = new Formatter()
                     .setNodeId(NODE_ID)
                     .setClusterId(Uuid.randomUuid().toString())
                     .setDirectories(List.of(logDir.toString()))
                     .setControllerListenerName(CONTROLLER_LISTENER)
-                    .setPrintStream(quiet)
-                    .run();
+                    .setPrintStream(quiet);
+            featureLevels.forEach(formatter::setFeatureLevel);
+            formatter.run();
         } catch (Exception e) {
             throw new IllegalStateException("Unable to format embedded Kafka storage", e);
         }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/GroupProtocolResolverTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/GroupProtocolResolverTest.java
@@ -1,0 +1,201 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The {@code group.protocol=auto} resolution matrix, pinned against LIVE brokers on both sides of
+ * the feature flag: the default embedded broker finalizes {@code group.version=1} (KIP-848 on),
+ * and a variant broker is storage-formatted with {@code group.version=0} - the normal state of a
+ * cluster whose brokers are upgraded but whose consumer-rebalance-protocol feature has not been
+ * enabled. Fallback and guard branches use unreachable bootstrap addresses (nothing listens on
+ * the probe ports), so no probe can accidentally succeed.
+ */
+class GroupProtocolResolverTest {
+
+    private static final String CONSUMER = "consumer";
+    private static final String CLASSIC = "classic";
+    private static final String DEAD_BOOTSTRAP_1 = "127.0.0.1:65531";
+    private static final String DEAD_BOOTSTRAP_2 = "127.0.0.1:65530";
+    private static final String E2E_TOPIC = "group-protocol-auto-topic";
+    private static final int DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+    private static EmbeddedKafka kafka;
+    private static EmbeddedKafka classicKafka;
+
+    @BeforeAll
+    static void boot() {
+        kafka = new EmbeddedKafka();
+        classicKafka = new EmbeddedKafka(19094, 19095, "/tmp/mini-kafka-classic",
+                Map.of("group.version", (short) 0));
+    }
+
+    @AfterAll
+    static void shutdown() {
+        GroupProtocolResolver.probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS;
+        GroupProtocolResolver.clearCachedResolutions();
+        if (kafka != null) {
+            kafka.close();
+        }
+        if (classicKafka != null) {
+            classicKafka.close();
+        }
+    }
+
+    @BeforeEach
+    void isolate() {
+        GroupProtocolResolver.probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS;
+        GroupProtocolResolver.clearCachedResolutions();
+    }
+
+    private static Properties autoTemplate(String bootstrap) {
+        Properties p = new Properties();
+        p.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+        p.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, "auto");
+        return p;
+    }
+
+    @Test
+    void autoResolvesToConsumerWhenClusterFinalizesGroupVersion() {
+        Properties p = autoTemplate(kafka.bootstrapServers());
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CONSUMER, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    void autoResolvesToClassicWhenClusterDoesNotFinalizeGroupVersion() {
+        Properties p = autoTemplate(classicKafka.bootstrapServers());
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CLASSIC, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    void conflictingClientTuningResolvesToClassicWithoutProbing() {
+        Properties p = autoTemplate(DEAD_BOOTSTRAP_1);
+        p.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "45000");
+        long started = System.currentTimeMillis();
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CLASSIC, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        // guard resolution is local - an attempted network probe would spend the full timeout
+        assertTrue(System.currentTimeMillis() - started < 2000, "conflict guard must not probe");
+        // the operator's tuning stays untouched
+        assertEquals("45000", p.getProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG));
+    }
+
+    @Test
+    void probeFailureResolvesToClassic() {
+        GroupProtocolResolver.probeTimeoutMs = 1500;
+        Properties p = autoTemplate(DEAD_BOOTSTRAP_2);
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CLASSIC, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    void explicitProtocolPassesThroughVerbatimWithoutProbing() {
+        Properties p = new Properties();
+        p.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, DEAD_BOOTSTRAP_1);
+        p.setProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG, CONSUMER);
+        long started = System.currentTimeMillis();
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CONSUMER, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        assertTrue(System.currentTimeMillis() - started < 2000, "explicit value must not probe");
+    }
+
+    @Test
+    void absentGroupProtocolIsLeftUntouched() {
+        Properties p = new Properties();
+        p.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, DEAD_BOOTSTRAP_1);
+        GroupProtocolResolver.resolve(p);
+        assertNull(p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+    }
+
+    @Test
+    void secondResolutionForTheSameClusterUsesTheCachedAnswer() {
+        Properties first = autoTemplate(kafka.bootstrapServers());
+        GroupProtocolResolver.resolve(first);
+        assertEquals(CONSUMER, first.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        long started = System.currentTimeMillis();
+        Properties second = autoTemplate(kafka.bootstrapServers());
+        GroupProtocolResolver.resolve(second);
+        assertEquals(CONSUMER, second.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        assertTrue(System.currentTimeMillis() - started < 2000, "cached resolution must not re-probe");
+    }
+
+    /**
+     * The resolved properties are real: a consumer built from an auto-resolved template joins the
+     * group under the KIP-848 consumer protocol and consumes a record end-to-end.
+     */
+    @Test
+    void autoResolvedConsumerProtocolConsumesEndToEnd() throws Exception {
+        KafkaTestSupport.createTopic(kafka.bootstrapServers(), E2E_TOPIC);
+        Properties p = autoTemplate(kafka.bootstrapServers());
+        GroupProtocolResolver.resolve(p);
+        assertEquals(CONSUMER, p.getProperty(ConsumerConfig.GROUP_PROTOCOL_CONFIG));
+        p.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        p.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        p.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "group-protocol-auto-e2e");
+        p.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        Properties producerProps = new Properties();
+        producerProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers());
+        producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        try (KafkaProducer<String, byte[]> producer = new KafkaProducer<>(producerProps);
+             Consumer<String, byte[]> consumer = new KafkaConsumer<>(p)) {
+            producer.send(new ProducerRecord<>(E2E_TOPIC,
+                    "hello kip-848".getBytes(StandardCharsets.UTF_8))).get();
+            consumer.subscribe(List.of(E2E_TOPIC));
+            String received = null;
+            long deadline = System.currentTimeMillis() + 20_000;
+            while (received == null && System.currentTimeMillis() < deadline) {
+                ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(500));
+                if (!records.isEmpty()) {
+                    received = new String(records.iterator().next().value(), StandardCharsets.UTF_8);
+                }
+            }
+            assertNotNull(received, "record must arrive under the consumer protocol");
+            assertEquals("hello kip-848", received);
+        }
+    }
+}


### PR DESCRIPTION
## What

A consumer template may now set `group.protocol=auto`: the flow adapter probes the
cluster's finalized `group.version` feature flag once at startup and resolves to
`consumer` (the KIP-848 consumer rebalance protocol, GA since Apache Kafka 4.0) when the
cluster supports it, `classic` otherwise. The probe rides the `ApiVersions` handshake —
answered pre-authentication and never ACL-gated — so it needs no grant beyond the
template's connection credentials, honoring the same convention that keeps
`KafkaHealthCheck` off Cluster-Describe-gated admin APIs. Resolution happens at the
single choke point `KafkaClientConfig.consumerProperties(...)`, covering adapter
bindings, the health check, and twin-kafka's secondary cluster (independent per-cluster
resolution by construction). Client tuning that the consumer protocol forbids
(`session.timeout.ms`, `heartbeat.interval.ms`, `partition.assignment.strategy`)
resolves `auto` to `classic` with a WARN naming the keys instead of crashing with
Kafka's `ConfigException`; explicit `consumer`/`classic` values pass through verbatim.
Every decision path states its evidence in the startup log. The shipped template keeps
`group.protocol` commented out — behavior is unchanged unless a team opts in.

Tests pin the matrix against live brokers on both sides of the flag: `EmbeddedKafka`
gained a feature-pinned variant constructor (`Formatter.setFeatureLevel`), so the suite
boots a real `group.version=0` broker alongside the default `group.version=1` one —
plus an end-to-end consume under the resolved protocol, the conflict guard, probe
failure, passthrough, and cache behavior. Docs: a new `#rebalance-protocol` section in
the minimalist-kafka guide, a per-cluster note in the twin-kafka guide, and the
template's comment block.

## Why

A field team reported high CPU during unscheduled consumer rebalances caused by cloud
infrastructure interruptions. Kafka's classic rebalance protocol is client-driven with a
group-wide synchronization barrier: one interrupted pod makes every member of the group
stop, rejoin, and re-sync — and a flapping member repeats that storm across every
binding's consumer group. KIP-848 is broker-driven and fully incremental — only the
interrupted member's partitions move — which directly addresses the reported symptom.
Investigation proved the adapter runs the new protocol with zero code change (the full
e2e suite passed with the template value, including topic-pattern bindings), so the
remaining gap was safe adoption across a fleet of enterprise clusters whose broker
versions and feature states are outside our control: `auto` gives the field one template
value that upgrades where the cluster allows it and stays on `classic` everywhere else —
the same detect-once-per-connection posture as the Redis version-aware consume strategy.

Co-Authored-By: Claude Code <noreply@anthropic.com>