### PR TITLE
Dry-run graph identity: an unnamed draft is scoped 'untitled' instead of rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Changed
+
+1. **A dry-run graph whose root node has no `name` is scoped as `untitled` instead of being
+   rejected.** v4.11.8 required a suspend/resume model to carry a root `name` before the playground
+   would instantiate it, because the fallback identity was a per-instantiation handle that no later
+   run could read. What the state store actually needs is an identity that is *stable across
+   instantiations*, not one derived from the model name — so an unnamed draft now falls back to the
+   stable constant `untitled` and simply works: it suspends and resumes like any named model,
+   sharing the `graph:untitled:{cid}` scope. Naming the root node (which the export path does
+   automatically, keeping it in sync with the graph's file/deployment id) still gives a draft its
+   own scope and remains the recommendation for anything you intend to deploy.
+
+---
 ## Version 4.11.8, 8/10/2026
 
 ### Fixed

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -59,16 +59,11 @@ public class GraphCommandService extends GraphLambdaFunction {
     private static final ManagedCache cachedMessage = ManagedCache.createCache("last.ws.message", 1000);
     private static final String DEFAULT_TEMP_DIR = "/tmp/graph";
     private static final String OUTCOME = "outcome";
-    private static final String PLAYGROUND = "playground";
+    private static final String UNTITLED = "untitled";
     private static final String NODES = "nodes";
     private static final String PROPERTIES = "properties";
     private static final String TOTAL = "Total ";
     private static final String INVALID_GRAPH_NAME = "Invalid filename - must be a-z, A-Z, 0-9 with optional hyphen";
-    private static final String GRAPH_SUSPEND_SKILL = "graph.suspend";
-    private static final String GRAPH_RESUME_SKILL = "graph.resume";
-    private static final String UNNAMED_SUSPEND_GRAPH =
-            "This graph model uses suspend/resume, so its workflow state needs a stable identity. "
-            + "Add a 'name' property to the root node (name=<graph-name>), then instantiate again.";
     private static final String SESSION_TAG = "Session ";
     private static final long EXPIRY = 20 * 1000L;
     private static final String[] MAPPING_PROPERTIES = {"mapping", "input", "output", "for_each"};
@@ -1369,50 +1364,18 @@ public class GraphCommandService extends GraphLambdaFunction {
         }
     }
 
-    /**
-     * The suspend/resume store contract scopes records by graph + cid, so a dry-run instance must
-     * carry the model's STABLE identity - the root node's {@code name} property, which the export
-     * path keeps in sync with the graph's file/deployment id - never a per-instantiation handle
-     * (an ephemeral id makes every resume look up a key no suspend ever wrote, so a suspended
-     * dry-run workflow could only ever restart fresh). A draft whose root has no name yet has no
-     * stable identity to scope by: it keeps a unique playground handle, and
-     * {@code handleInstantiateGraph} REJECTS it when the model uses suspend/resume - a silent
-     * ephemeral fallback there would break the resume mechanism invisibly.
-     */
-    private String stableGraphIdentity(MiniGraph graph) {
-        var name = rootName(graph);
-        return name != null ? name : PLAYGROUND + "-" + util.getUuid();
-    }
-
-    /** @return the root node's non-blank {@code name} property, or {@code null} */
-    private String rootName(MiniGraph graph) {
-        var root = graph.getRootNode();
-        return root != null && root.getProperty(NAME) instanceof String name && !name.isBlank()
-                ? name : null;
-    }
-
-    /** True when any node carries the 'graph.suspend' or 'graph.resume' skill. */
-    private boolean usesSuspension(MiniGraph graph) {
-        return graph.getNodes().stream().map(n -> n.getProperty(SKILL))
-                .anyMatch(s -> GRAPH_SUSPEND_SKILL.equals(s) || GRAPH_RESUME_SKILL.equals(s));
-    }
-
     private void handleInstantiateGraph(PostOffice po, String inRoute, String outRoute, List<String> lines) {
         var graph = graphModels.get(inRoute);
         if (graph == null) {
             return;
         }
-        // a suspend/resume model without a stable identity cannot be dry-run: its
-        // suspension record would be invisible to every later instantiation
-        if (rootName(graph) == null && usesSuspension(graph)) {
-            po.send(new EventEnvelope().setTo(outRoute).setBody(UNNAMED_SUSPEND_GRAPH));
-            return;
-        }
-        instantiateGraph(po, inRoute, outRoute, lines, graph);
+        var root = graph.getRootNode();
+        var graphId = root != null && root.getProperty(NAME) instanceof String name && !name.isBlank()? name : UNTITLED;
+        instantiateGraph(po, inRoute, outRoute, lines, graph, graphId);
     }
 
     private void instantiateGraph(PostOffice po, String inRoute, String outRoute,
-                                  List<String> lines, MiniGraph graph) {
+                                  List<String> lines, MiniGraph graph, String graphId) {
         var currentInstance = graphInstances.get(inRoute);
         if (currentInstance != null) {
             graphInstances.remove(inRoute);
@@ -1424,7 +1387,7 @@ public class GraphCommandService extends GraphLambdaFunction {
         util.str2file(file, text);
         // use config reader to resolve environment variables
         var reader = new ConfigReader(FILE_PREFIX+file.getPath());
-        var graphInstance = new GraphInstance(stableGraphIdentity(graph));
+        var graphInstance = new GraphInstance(graphId);
         graphInstance.graph.importGraph(reader.getMap());
         // map node properties to state machine
         var nodeCount = initializeWithNodeProperties(graphInstance);

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -211,8 +211,8 @@ class CompanionSyncTest {
         for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
             Utility.getInstance().sleep(20);
         }
-        // the root carries a name so the STABLE-IDENTITY instantiate guard passes and the
-        // run reaches the pre-run check this test pins
+        // the root name doubles as the dry-run graph id; incidental here - this test pins the
+        // pre-run check, and neither assertion below depends on the identity
         syncCommand(po, sid, "create node root\nwith type Root\nwith properties\nname=unit-test-prerun-check");
         syncCommand(po, sid, "create node end\nwith type End");
         syncCommand(po, sid,
@@ -619,9 +619,10 @@ class CompanionSyncTest {
      * The dry-run twin of the field regression that surfaced on tutorial-14: a suspended dry-run
      * workflow must RESUME when the graph is re-instantiated with the same business correlation
      * ID. The store contract scopes records by graph + cid, so the dry-run instance must present
-     * the model's stable identity (the root node's name) - a per-instantiation handle writes the
-     * suspension under a key no later instantiation can ever read, and every resume silently
-     * restarts fresh.
+     * an identity that is STABLE across instantiations - here the root node's name - because a
+     * per-instantiation handle writes the suspension under a key no later instantiation can ever
+     * read, and every resume silently restarts fresh. The nameless twin is
+     * {@link #unnamedDraftResumesAcrossInstantiations()}.
      */
     @Test
     void dryRunResumesAcrossInstantiations() throws Exception {
@@ -676,38 +677,95 @@ class CompanionSyncTest {
     }
 
     /**
-     * A suspend/resume model whose root has no {@code name} is REJECTED at instantiation
-     * (ruling on the dry-run graph-scope regression): a silent ephemeral fallback would break
-     * the resume mechanism invisibly, so the guard teaches instead. A nameless model WITHOUT
-     * suspension keeps working - scratch drafts need no stable identity.
+     * The nameless twin of {@link #dryRunResumesAcrossInstantiations()}: a draft sketched in the
+     * playground has no root {@code name} yet, and must still suspend and resume - the dry-run
+     * lane scopes such a draft under the stable constant {@code untitled}. This is the branch the
+     * regression lived in: the identity only has to be STABLE across instantiations, so anything
+     * per-instantiation (a UUID handle) writes a suspension no later run can read and silently
+     * restarts fresh instead of resuming.
      */
     @Test
-    void unnamedSuspendGraphIsRejectedAtInstantiation() throws Exception {
+    void unnamedDraftResumesAcrossInstantiations() throws Exception {
         var po = EventEmitter.getInstance();
-        var sid = "ws-990015-2";
-        var inRoute = "ws.990015.2.in";
+        var sid = "ws-990016-2";
+        var inRoute = "ws.990016.2.in";
         po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
                 .setBody(Map.of("type", "open", "in", inRoute)));
         for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
             Utility.getInstance().sleep(20);
         }
         assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
-        syncCommand(po, sid, "create node root\nwith type Root");
-        syncCommand(po, sid, "create node end\nwith type End");
-        syncCommand(po, sid, """
+        var cid = "dry-run-untitled-1";
+        // consume-on-retrieve makes a leftover record indistinguishable from this test's own
+        var storedRecord = new File("/tmp/suspend-resume", "untitled_" + cid);
+        if (storedRecord.exists()) {
+            assertTrue(storedRecord.delete(), "stale store record removed");
+        }
+        // sketch a suspend/resume draft with NO name on the root - the edge-mode shape:
+        // a drawn edge into the suspend node, plus the mandatory continuation edge
+        for (var command : List.of(
+                "create node root\nwith type Root",
+                "create node end\nwith type End",
+                """
                 create node resume
                 with type Resume
                 with properties
                 skill=graph.resume
-                task=v1.file.state.store""");
-        syncCommand(po, sid, "connect root to resume with then");
-        syncCommand(po, sid, "connect resume to end with then");
-        var rejected = syncCommand(po, sid, "instantiate graph");
-        var lines = ((List<?>) rejected.get("output")).stream().map(String::valueOf).toList();
-        assertTrue(lines.stream().anyMatch(l -> l.contains("needs a stable identity")),
-                "the guard must teach the fix (name the root node): " + lines);
-        assertTrue(lines.stream().noneMatch(l -> l.startsWith("Graph instance created")),
-                "no instance may be created for an unnamed suspend/resume model: " + lines);
+                task=v1.file.state.store""",
+                """
+                create node step-1
+                with type Suspensible
+                with properties
+                skill=graph.task
+                task=v1.counting.step
+                input[]=text(u-one) -> step
+                input[]=model.cid -> cid
+                output[]=result.count -> model.step1_count""",
+                """
+                create node suspend
+                with type Suspend
+                with properties
+                skill=graph.suspend
+                task=v1.file.state.store
+                ttl=30s""",
+                """
+                create node step-2
+                with type Task
+                with properties
+                skill=graph.task
+                task=v1.counting.step
+                input[]=text(u-two) -> step
+                input[]=model.cid -> cid
+                input[]=model.step1_count -> prior
+                output[]=result -> output.body""",
+                "connect root to resume with test",
+                "connect resume to step-1 with test",
+                "connect step-1 to suspend with checkpoint",
+                "connect step-1 to step-2 with approved",
+                "connect suspend to end with test",
+                "connect step-2 to end with test")) {
+            syncCommand(po, sid, command);
+        }
+
+        // run 1: the nameless draft suspends at the checkpoint
+        var instantiated = syncCommand(po, sid, "instantiate graph\ntext(" + cid + ") -> model.cid");
+        assertEquals(Boolean.TRUE, instantiated.get("ok"), "a nameless draft must instantiate: " + instantiated);
+        var first = syncCommand(po, sid, "run");
+        assertEquals(Boolean.TRUE, first.get("ok"), "run 1: " + first);
+        assertEquals(1, CountingStepTask.getCount("u-one", cid), "step-1 executes on the fresh run");
+        assertEquals(0, CountingStepTask.getCount("u-two", cid), "the suspension stops before step-2");
+        assertTrue(storedRecord.exists(),
+                "a nameless draft must persist under the stable 'untitled' scope, not a "
+                        + "per-instantiation handle: " + storedRecord);
+
+        // run 2: a NEW instantiation with the same business cid resumes past the checkpoint
+        var again = syncCommand(po, sid, "instantiate graph\ntext(" + cid + ") -> model.cid");
+        assertEquals(Boolean.TRUE, again.get("ok"), "re-instantiate: " + again);
+        var second = syncCommand(po, sid, "run");
+        assertEquals(Boolean.TRUE, second.get("ok"), "run 2: " + second);
+        assertEquals(1, CountingStepTask.getCount("u-one", cid), "the checkpoint must not re-execute");
+        assertEquals(1, CountingStepTask.getCount("u-two", cid), "the continuation must run on resume");
+        assertFalse(storedRecord.exists(), "the record is consumed on resume (at-most-once)");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What

Simplifies the dry-run graph-id resolution to a single rule: the graph id is the root node's
`name` property, or the stable constant `untitled` when the draft has not been named yet.
v4.11.8's rejection guard, its two helper methods and its teaching message go away, along with
the ephemeral `playground-{uuid}` fallback they were defending against.

Adds the pin the unnamed branch never had: a nameless suspend/resume draft, sketched through
companion commands in the edge-mode shape, must suspend and then resume across a second
`instantiate graph`. The test is mutation-proven — restoring a per-instantiation handle fails it
on the store-key assertion — so the stability invariant is enforced rather than implied. The Rust
engine is updated in lock-step (mercury PR of the same name). Engine module 118/118.

## Why

v4.11.8 fixed the dry-run resume regression but required a suspend/resume model to carry a root
`name` before the playground would instantiate it at all. That requirement was an artifact of the
fix, not of the contract: what the state store needs is an identity that is **stable across
instantiations**, not one derived from the model name. A constant satisfies that, so the guard was
only ever protecting against the unstable fallback that shipped beside it — and it charged a real
cost, refusing to dry-run a draft at exactly the moment a developer is sketching one. An unnamed
draft now simply works, sharing the `graph:untitled:{cid}` scope.

A global constant is also deliberately preferred over anything session-derived: the playground
session handle is derived from the WebSocket route and changes on reconnect, which would
reintroduce the silent fresh-restart across the ordinary leave-and-come-back flow that
long-running workflows invite. Naming the root — which the export path does automatically, keeping
it in sync with the graph's file/deployment id — still gives a draft its own scope and remains the
recommendation for anything destined for deployment.

Co-Authored-By: Claude Code <noreply@anthropic.com>