### PR TITLE
OTLP forwarder: retry every IOException so a dying connection cannot drop a span  Body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the fixed exporter recovers on the second connection; without the widened retry policy the
    span is provably lost.
 
+2. **The OpenTelemetry forwarder no longer drops a span when the export executor rejects the
+   call.** The very first CI run carrying the new cause-bearing warning exposed a second failure
+   class: `InterruptedIOException: executor rejected` — the sender's managed dispatcher runs a
+   zero-queue thread pool (`core=0`, `SynchronousQueue`) whose `execute()` rejects during
+   transient full-occupancy races, and a rejected call never reaches the retry interceptor, so
+   no retry policy can save it (retrying calls sleeping through backoff also widen that race
+   window). The exporter now runs on its own small fixed pool with an **unbounded queue** —
+   saturation means "later", never "lost" — and the pool's lifecycle is tied to the exporter so
+   a closed exporter leaks no threads. Pinned by a saturation-burst test (a burst far wider than
+   the pool queues and delivers every span) and a thread-lifecycle test (provably no export
+   threads without the owned pool, none leaked after close).
+
 ---
 ## Version 4.11.9, 8/11/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Fixed
+
+1. **The OpenTelemetry forwarder no longer drops a span when a pooled connection dies
+   mid-export.** The OTLP exporter's default retry covers only a whitelist of transport errors
+   (connect/socket timeouts, unknown host, `SocketException`); a keep-alive connection that the
+   collector closed at the moment of reuse surfaces as a plain
+   `IOException: unexpected end of stream`, which failed on the first attempt and silently
+   dropped the span (observed as an occasional CI failure of the flow-summary assertion — and
+   the same drop loses production spans in the field). The exporter now retries **every**
+   `IOException` under the SDK's default bounded backoff (5 attempts, 1s→5s); HTTP status
+   handling is unchanged (retry on 429/502/503/504 only). Telemetry delivery is at-least-once
+   by design: a rare duplicate span is tolerated by every backend, a dropped span is data loss.
+   The export-failure warning now includes the cause, so any future drop is self-diagnosing.
+   Pinned by a raw-socket test that kills the first connection after reading the request —
+   the fixed exporter recovers on the second connection; without the widened retry policy the
+   span is provably lost.
+
+---
 ## Version 4.11.9, 8/11/2026
 
 ### Changed

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -81,7 +82,11 @@ public class OtelForwarderContext {
         CompletableResultCode rc = exporter.export(Collections.singletonList(span));
         rc.whenComplete(() -> {
             if (!rc.isSuccess()) {
-                log.warn("OTLP export failed for span {} of trace {}", span.getSpanId(), span.getTraceId());
+                // the cause makes a dropped span diagnosable (a bare "failed" hid the reason
+                // behind an occasional CI flake for weeks)
+                Throwable cause = rc.getFailureThrowable();
+                log.warn("OTLP export failed for span {} of trace {} - {}", span.getSpanId(),
+                        span.getTraceId(), cause == null ? "no cause reported" : cause.toString());
             }
         });
     }
@@ -111,7 +116,15 @@ public class OtelForwarderContext {
                 .setEndpoint(endpoint)
                 .setTimeout(Duration.ofMillis(timeoutMs))
                 .setConnectTimeout(Duration.ofMillis(connectTimeoutMs))
-                .setCompression(encoding);
+                .setCompression(encoding)
+                // The SDK's default retry whitelists only a few IOException types (connect/socket
+                // timeouts, UnknownHost, SocketException); anything else - notably a pooled
+                // keep-alive connection the server closed as we reused it ("unexpected end of
+                // stream") - fails on the FIRST attempt and silently drops the span. Telemetry
+                // delivery is at-least-once by design: duplicates are tolerated, drops are what
+                // hurt, so every IOException is worth the default bounded backoff (5 attempts,
+                // 1s..5s). HTTP status handling is unchanged (retry on 429/502/503/504 only).
+                .setRetryPolicy(RetryPolicy.builder().setRetryExceptionPredicate(e -> true).build());
         headers.forEach(builder::addHeader);
         return builder.build();
     }

--- a/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
+++ b/extensions/opentelemetry-forwarder/src/main/java/org/platformlambda/opentelemetry/support/OtelForwarderContext.java
@@ -34,6 +34,9 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Holds the OTLP exporter, OpenTelemetry {@link Resource} and instrumentation scope used by the
@@ -112,11 +115,22 @@ public class OtelForwarderContext {
     public static SpanExporter buildExporter(String endpoint, long timeoutMs, long connectTimeoutMs,
                                              String compression, Map<String, String> headers) {
         String encoding = (compression == null || compression.isBlank()) ? NO_COMPRESSION : compression.trim();
+        // Exports must never be REJECTED at enqueue: the sender's managed dispatcher runs a
+        // zero-queue thread pool (core=0, SynchronousQueue) whose execute() rejects during
+        // transient full-occupancy races - surfaced in CI as InterruptedIOException
+        // "executor rejected", dropping the span before any interceptor (and therefore any
+        // retry policy) could run. A small fixed pool with an UNBOUNDED queue makes
+        // saturation mean "later", never "lost"; the wrapper below ties the pool's lifecycle
+        // to the exporter so a closed exporter leaks no threads.
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(2, 2, 30, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(), OtelForwarderContext::exportThread);
+        pool.allowCoreThreadTimeOut(true);
         var builder = OtlpHttpSpanExporter.builder()
                 .setEndpoint(endpoint)
                 .setTimeout(Duration.ofMillis(timeoutMs))
                 .setConnectTimeout(Duration.ofMillis(connectTimeoutMs))
                 .setCompression(encoding)
+                .setExecutorService(pool)
                 // The SDK's default retry whitelists only a few IOException types (connect/socket
                 // timeouts, UnknownHost, SocketException); anything else - notably a pooled
                 // keep-alive connection the server closed as we reused it ("unexpected end of
@@ -126,7 +140,45 @@ public class OtelForwarderContext {
                 // 1s..5s). HTTP status handling is unchanged (retry on 429/502/503/504 only).
                 .setRetryPolicy(RetryPolicy.builder().setRetryExceptionPredicate(e -> true).build());
         headers.forEach(builder::addHeader);
-        return builder.build();
+        return new PooledSpanExporter(builder.build(), pool);
+    }
+
+    private static Thread exportThread(Runnable r) {
+        Thread t = new Thread(r, "otlp-export");
+        t.setDaemon(true);
+        return t;
+    }
+
+    /**
+     * Ties the export thread pool's lifecycle to the exporter: the SDK treats a caller-supplied
+     * {@code ExecutorService} as unmanaged and leaves it running on shutdown, which would leak
+     * two threads per exporter (tests build many). Everything else delegates verbatim.
+     */
+    private static final class PooledSpanExporter implements SpanExporter {
+        private final SpanExporter delegate;
+        private final ThreadPoolExecutor pool;
+
+        private PooledSpanExporter(SpanExporter delegate, ThreadPoolExecutor pool) {
+            this.delegate = delegate;
+            this.pool = pool;
+        }
+
+        @Override
+        public CompletableResultCode export(java.util.Collection<SpanData> spans) {
+            return delegate.export(spans);
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return delegate.flush();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            CompletableResultCode rc = delegate.shutdown();
+            pool.shutdown();
+            return rc;
+        }
     }
 
     /**

--- a/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
+++ b/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
@@ -73,6 +73,64 @@ class OtlpExportRetryTest {
         }
     }
 
+    /**
+     * The second failure class from CI: the sender's managed dispatcher runs a zero-queue pool
+     * whose {@code execute()} REJECTS during transient full-occupancy races
+     * ({@code InterruptedIOException: executor rejected}) - and a rejected call never reaches the
+     * retry interceptor, so no retry policy can save it. With the exporter's own unbounded-queue
+     * pool, a burst far wider than the pool must queue and deliver every span, never reject.
+     */
+    @Test
+    void saturationBurstQueuesEveryExportInsteadOfRejecting() throws Exception {
+        try (HealthyOtlpServer server = new HealthyOtlpServer()) {
+            String endpoint = "http://127.0.0.1:" + server.port() + "/v1/traces";
+            try (SpanExporter exporter = OtelForwarderContext.buildExporter(endpoint, 10_000, Map.of())) {
+                List<CompletableResultCode> results = new java.util.ArrayList<>();
+                for (int i = 0; i < 16; i++) {
+                    results.add(exporter.export(List.of(sampleSpan())));
+                }
+                CompletableResultCode all = CompletableResultCode.ofAll(results);
+                all.join(30, TimeUnit.SECONDS);
+                assertTrue(all.isSuccess(), "a burst wider than the export pool must queue, never "
+                        + "be rejected at enqueue");
+                assertTrue(server.requests() >= 16,
+                        "every span of the burst must reach the collector (got "
+                                + server.requests() + ")");
+            }
+        }
+    }
+
+    /**
+     * Closing the exporter must also stop its export pool - tests build many exporters.
+     * Baseline-relative: the app's own forwarder (booted by sibling test classes in this JVM)
+     * runs identically-named threads, so the pin counts only the DELTA this test creates.
+     */
+    @Test
+    void closingTheExporterStopsItsExportThreads() throws Exception {
+        try (HealthyOtlpServer server = new HealthyOtlpServer()) {
+            String endpoint = "http://127.0.0.1:" + server.port() + "/v1/traces";
+            long baseline = liveExportThreads();
+            SpanExporter exporter = OtelForwarderContext.buildExporter(endpoint, 10_000, Map.of());
+            exporter.export(List.of(sampleSpan())).join(10, TimeUnit.SECONDS);
+            assertTrue(liveExportThreads() > baseline,
+                    "an active exporter runs at least one export thread of its own");
+            exporter.close();
+            long deadline = System.currentTimeMillis() + 5000;
+            while (liveExportThreads() > baseline && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50);
+            }
+            assertTrue(liveExportThreads() <= baseline,
+                    "the export pool must shut down with the exporter (threads leaked)");
+        }
+    }
+
+    private long liveExportThreads() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(Thread::isAlive)
+                .filter(t -> "otlp-export".equals(t.getName()))
+                .count();
+    }
+
     private SpanData sampleSpan() {
         Map<String, Object> trace = new HashMap<>();
         trace.put("id", "4bf92f3577b34da6a3ce929d0e0e4736");
@@ -133,9 +191,64 @@ class OtlpExportRetryTest {
             }
         }
 
-        /** Read the full request (headers, then content-length body) so the client is
-         *  waiting on the RESPONSE when the first connection closes. */
-        private void drainRequest(InputStream in) throws IOException {
+        @Override
+        public void close() throws IOException {
+            running = false;
+            server.close();
+        }
+    }
+
+    /**
+     * A raw-socket OTLP endpoint that answers every request with an empty 200 and counts them -
+     * the healthy counterpart of {@link FlakyOtlpServer} for the saturation and lifecycle pins.
+     */
+    private static final class HealthyOtlpServer implements AutoCloseable {
+        private final ServerSocket server;
+        private final AtomicInteger requests = new AtomicInteger();
+        private volatile boolean running = true;
+
+        HealthyOtlpServer() throws IOException {
+            this.server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+            Thread acceptor = new Thread(this::acceptLoop, "healthy-otlp-server");
+            acceptor.setDaemon(true);
+            acceptor.start();
+        }
+
+        int port() {
+            return server.getLocalPort();
+        }
+
+        int requests() {
+            return requests.get();
+        }
+
+        private void acceptLoop() {
+            while (running) {
+                try (Socket socket = server.accept()) {
+                    drainRequest(socket.getInputStream());
+                    requests.incrementAndGet();
+                    OutputStream out = socket.getOutputStream();
+                    out.write(("HTTP/1.1 200 OK\r\n"
+                            + "content-type: application/x-protobuf\r\n"
+                            + "content-length: 0\r\n"
+                            + "connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                    out.flush();
+                } catch (IOException e) {
+                    // server socket closed on shutdown, or a client went away - both fine
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            running = false;
+            server.close();
+        }
+    }
+
+    /** Read the full request (headers, then content-length body) so the client is
+     *  waiting on the RESPONSE after the server has consumed its input. */
+    private static void drainRequest(InputStream in) throws IOException {
             StringBuilder head = new StringBuilder();
             int prev3 = -1;
             int prev2 = -1;
@@ -168,12 +281,5 @@ class OtlpExportRetryTest {
                 }
                 remaining -= skipped;
             }
-        }
-
-        @Override
-        public void close() throws IOException {
-            running = false;
-            server.close();
-        }
     }
 }

--- a/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
+++ b/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
@@ -1,0 +1,179 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.opentelemetry.support;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the widened export retry against the exact transport failure that dropped a span in CI:
+ * the collector end closes the connection after reading the request but before answering, so the
+ * client sees a bare EOF - a plain {@link IOException} ("unexpected end of stream") that the
+ * OpenTelemetry SDK's <b>default</b> retry predicate does NOT retry (its whitelist covers only
+ * connect/socket-timeout, UnknownHost and SocketException). With the widened predicate the second
+ * attempt lands on a healthy connection and the span survives.
+ * <p>
+ * Mutation check: removing {@code setRetryPolicy(...)} from
+ * {@link OtelForwarderContext#buildExporter} makes this test fail on the first-attempt drop.
+ */
+class OtlpExportRetryTest {
+
+    @Test
+    void widenedRetryRecoversTheSpanWhenTheServerKillsTheFirstConnection() throws Exception {
+        try (FlakyOtlpServer server = new FlakyOtlpServer()) {
+            String endpoint = "http://127.0.0.1:" + server.port() + "/v1/traces";
+            try (SpanExporter exporter = OtelForwarderContext.buildExporter(endpoint, 10_000, Map.of())) {
+                CompletableResultCode rc = exporter.export(List.of(sampleSpan()));
+                // first attempt fails on the killed connection; the retry backoff starts at ~1s
+                rc.join(20, TimeUnit.SECONDS);
+                assertTrue(rc.isSuccess(),
+                        "the widened retry must recover a span from a killed connection "
+                                + "instead of dropping it");
+                assertTrue(server.connections() >= 2,
+                        "success requires a SECOND connection - the first was deliberately killed "
+                                + "after reading the request (got " + server.connections() + ")");
+            }
+        }
+    }
+
+    private SpanData sampleSpan() {
+        Map<String, Object> trace = new HashMap<>();
+        trace.put("id", "4bf92f3577b34da6a3ce929d0e0e4736");
+        trace.put("span_id", "00f067aa0ba902b7");
+        trace.put("service", "retry.pin");
+        trace.put("start", "2026-06-24T10:00:00Z");
+        trace.put("exec_time", 1.0);
+        trace.put("success", true);
+        Map<String, Object> ds = new HashMap<>();
+        ds.put("trace", trace);
+        Resource resource = Resource.create(
+                Attributes.of(AttributeKey.stringKey("service.name"), "mercury-otel-demo"));
+        return TraceMetricsSpanData.map(ds, resource, InstrumentationScopeInfo.create("test"));
+    }
+
+    /**
+     * A minimal raw-socket HTTP endpoint that fully reads each request, then KILLS the first
+     * connection without a response (the client observes EOF where the status line should be)
+     * and answers an empty OTLP 200 on every later connection.
+     */
+    private static final class FlakyOtlpServer implements AutoCloseable {
+        private final ServerSocket server;
+        private final AtomicInteger connections = new AtomicInteger();
+        private volatile boolean running = true;
+
+        FlakyOtlpServer() throws IOException {
+            this.server = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+            Thread acceptor = new Thread(this::acceptLoop, "flaky-otlp-server");
+            acceptor.setDaemon(true);
+            acceptor.start();
+        }
+
+        int port() {
+            return server.getLocalPort();
+        }
+
+        int connections() {
+            return connections.get();
+        }
+
+        private void acceptLoop() {
+            while (running) {
+                try (Socket socket = server.accept()) {
+                    int n = connections.incrementAndGet();
+                    drainRequest(socket.getInputStream());
+                    if (n > 1) {
+                        OutputStream out = socket.getOutputStream();
+                        out.write(("HTTP/1.1 200 OK\r\n"
+                                + "content-type: application/x-protobuf\r\n"
+                                + "content-length: 0\r\n"
+                                + "connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                        out.flush();
+                    }
+                    // n == 1: close without responding - the deliberate mid-exchange kill
+                } catch (IOException e) {
+                    // server socket closed on shutdown, or a client went away - both fine
+                }
+            }
+        }
+
+        /** Read the full request (headers, then content-length body) so the client is
+         *  waiting on the RESPONSE when the first connection closes. */
+        private void drainRequest(InputStream in) throws IOException {
+            StringBuilder head = new StringBuilder();
+            int prev3 = -1;
+            int prev2 = -1;
+            int prev1 = -1;
+            int b;
+            while ((b = in.read()) != -1) {
+                head.append((char) b);
+                if (prev3 == '\r' && prev2 == '\n' && prev1 == '\r' && b == '\n') {
+                    break;
+                }
+                prev3 = prev2;
+                prev2 = prev1;
+                prev1 = b;
+            }
+            int contentLength = 0;
+            for (String line : head.toString().split("\r\n")) {
+                String lower = line.toLowerCase();
+                if (lower.startsWith("content-length:")) {
+                    contentLength = Integer.parseInt(line.substring(line.indexOf(':') + 1).trim());
+                }
+            }
+            long remaining = contentLength;
+            while (remaining > 0) {
+                long skipped = in.skip(remaining);
+                if (skipped <= 0) {
+                    if (in.read() == -1) {
+                        break;
+                    }
+                    skipped = 1;
+                }
+                remaining -= skipped;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            running = false;
+            server.close();
+        }
+    }
+}

--- a/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
+++ b/extensions/opentelemetry-forwarder/src/test/java/org/platformlambda/opentelemetry/support/OtlpExportRetryTest.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.junit.jupiter.api.Test;
+import org.platformlambda.core.util.Utility;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,6 +35,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +56,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@link OtelForwarderContext#buildExporter} makes this test fail on the first-attempt drop.
  */
 class OtlpExportRetryTest {
+    // HTTP requires CRLF line endings: the \r escapes pair with the text block's own \n
+    private static final String OTLP_200 = """
+            HTTP/1.1 200 OK\r
+            content-type: application/x-protobuf\r
+            content-length: 0\r
+            connection: close\r
+            \r
+            """;
 
     @Test
     void widenedRetryRecoversTheSpanWhenTheServerKillsTheFirstConnection() throws Exception {
@@ -85,7 +95,7 @@ class OtlpExportRetryTest {
         try (HealthyOtlpServer server = new HealthyOtlpServer()) {
             String endpoint = "http://127.0.0.1:" + server.port() + "/v1/traces";
             try (SpanExporter exporter = OtelForwarderContext.buildExporter(endpoint, 10_000, Map.of())) {
-                List<CompletableResultCode> results = new java.util.ArrayList<>();
+                List<CompletableResultCode> results = new ArrayList<>();
                 for (int i = 0; i < 16; i++) {
                     results.add(exporter.export(List.of(sampleSpan())));
                 }
@@ -117,7 +127,7 @@ class OtlpExportRetryTest {
             exporter.close();
             long deadline = System.currentTimeMillis() + 5000;
             while (liveExportThreads() > baseline && System.currentTimeMillis() < deadline) {
-                Thread.sleep(50);
+                Utility.getInstance().sleep(50);
             }
             assertTrue(liveExportThreads() <= baseline,
                     "the export pool must shut down with the exporter (threads leaked)");
@@ -178,10 +188,7 @@ class OtlpExportRetryTest {
                     drainRequest(socket.getInputStream());
                     if (n > 1) {
                         OutputStream out = socket.getOutputStream();
-                        out.write(("HTTP/1.1 200 OK\r\n"
-                                + "content-type: application/x-protobuf\r\n"
-                                + "content-length: 0\r\n"
-                                + "connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                        out.write(OTLP_200.getBytes(StandardCharsets.US_ASCII));
                         out.flush();
                     }
                     // n == 1: close without responding - the deliberate mid-exchange kill
@@ -228,10 +235,7 @@ class OtlpExportRetryTest {
                     drainRequest(socket.getInputStream());
                     requests.incrementAndGet();
                     OutputStream out = socket.getOutputStream();
-                    out.write(("HTTP/1.1 200 OK\r\n"
-                            + "content-type: application/x-protobuf\r\n"
-                            + "content-length: 0\r\n"
-                            + "connection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                    out.write(OTLP_200.getBytes(StandardCharsets.US_ASCII));
                     out.flush();
                 } catch (IOException e) {
                     // server socket closed on shutdown, or a client went away - both fine


### PR DESCRIPTION
## What

Fixes the occasional CI failure of `OtlpFlowTraceTest` ("missing the synthetic flow-summary
span") at its root: the span was being DROPPED, not delivered slowly. The OTLP exporter's
default retry policy whitelists only a few IOException types (connect/socket timeouts,
`UnknownHost`, `SocketException`), so a pooled keep-alive connection that the collector closed
at the moment of reuse — `IOException: unexpected end of stream` — failed on the first attempt,
and the fire-and-forget `forward()` lost the span with a cause-less warning. The test's
generous 30-second await can never recover a dropped export.

The exporter now sets an explicit `RetryPolicy` that retries **every** `IOException` under the
SDK's default bounded backoff (5 attempts, 1s→5s); HTTP status handling is unchanged (retry on
429/502/503/504 only). The export-failure warning now includes the cause
(`getFailureThrowable`), so any future drop is self-diagnosing. `OtlpFlowTraceTest` itself is
unchanged — its await design was sound; the flake lived beneath it.

Pinned by the new `OtlpExportRetryTest`: a raw-socket server reads the full request, kills the
first connection without responding (reproducing the exact failure — the mutation run confirmed
`IOException: unexpected end of stream` on the wire), and serves an OTLP 200 on the retry.
Without the widened policy the pin provably fails on the first-attempt drop. Module 24/24.

## Why

The flake was diagnosed from a failure on a memory-only commit, so it was demonstrably
environmental — but the root cause is a production defect, not a test artifact: the same
single-attempt drop silently loses real spans in the field whenever a collector-side load
balancer or keep-alive timeout closes a pooled connection mid-reuse, which is routine in
enterprise networks. OTLP delivery is at-least-once by design — every tracing backend tolerates
a rare duplicate span, while a dropped span is unrecoverable data loss. Widening the retry
predicate to all IOExceptions (with the same bounded backoff) closes that gap for CI and
production alike, and the cause-bearing warning ends the era of undiagnosable "failed for span"
messages. Java-only: the Rust port has no OpenTelemetry forwarder.

Co-Authored-By: Claude Code <noreply@anthropic.com>