### PR TITLE
fix(docs): rest.yaml flow binding requires both service and flow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the pool queues and delivers every span) and a thread-lifecycle test (provably no export
    threads without the owned pool, none leaked after close).
 
+3. **Documentation taught a broken rest.yaml flow binding.** Two guides showed a flow-backed
+   endpoint bound with `flow:` alone (one even advised using `flow:` *instead of* `service:`),
+   but the REST automation engine skips any entry without `service:` as invalid — a flow
+   binding requires **both** `service: 'http.flow.adapter'` and `flow: '<flow-id>'`. The guides
+   are corrected, and the worked example is now a single canonical fixture
+   (`guide-fixtures/rest-bindings.yaml`) embedded into the documentation by mkdocs **and**
+   loaded through the production `RoutingEntry` parser in a platform-core test, so the
+   documented example can no longer drift from what the router accepts.
+
 ---
 ## Version 4.11.9, 8/11/2026
 

--- a/docs/guides/ai-developer-guide.md
+++ b/docs/guides/ai-developer-guide.md
@@ -150,14 +150,14 @@ flows:
 location: 'classpath:/flows/'
 ```
 
-Wire to `rest.yaml` with `flow:` instead of `service:`:
+Wire to `rest.yaml` through the flow adapter. A flow binding needs **both** keys — `service:
+'http.flow.adapter'` selects the adapter and `flow:` selects the flow; an entry with `flow:`
+alone has no service and is skipped as invalid at startup. The canonical worked example below
+also shows the function and HTTP-relay binding forms, and this exact file is loaded through the
+production REST router in a platform-core test so it cannot drift from the parser:
 
 ```yaml
-rest:
-  - flow: "my-flow"
-    methods: ['POST']
-    url: "/api/my-flow-endpoint"
-    timeout: 10s
+--8<-- "system/platform-core/src/test/resources/guide-fixtures/rest-bindings.yaml"
 ```
 
 See [Event Script AI agent guide](event-script/ai-agent-guide.md) for the full flow grammar and

--- a/docs/guides/event-script/ai-agent-guide.md
+++ b/docs/guides/event-script/ai-agent-guide.md
@@ -27,7 +27,8 @@ A flow is not called directly:
 
 1. Write the flow YAML under `src/main/resources/flows/`.
 2. Register its file in the **`flows.yaml`** manifest.
-3. Map an HTTP endpoint to it in **`rest.yaml`** (`flow: {flow-id}`) — or trigger it by event.
+3. Map an HTTP endpoint to it in **`rest.yaml`** (`service: 'http.flow.adapter'` plus
+   `flow: {flow-id}` — both keys are required) — or trigger it by event.
 
 The engine compiles every registered flow at startup; a flow that violates the grammar fails to
 load. So correctness is checkable *before* runtime.

--- a/docs/guides/rest-automation/ai-agent-guide.md
+++ b/docs/guides/rest-automation/ai-agent-guide.md
@@ -44,45 +44,13 @@ Look up exact fields/values in [`rest-automation.json`](rest-automation.json); f
 
 ## Worked example {#example}
 
-A flow-backed endpoint plus a reusable CORS config:
+The canonical example below covers all three binding forms — a flow-backed endpoint with
+reusable CORS and response-header configs, a function-backed endpoint with a path parameter,
+and an HTTP relay with `url_rewrite`. This exact file is also loaded through the production
+`RoutingEntry` parser in a platform-core test, so the example cannot drift from the router:
 
 ```yaml
-rest:
-  - service: 'http.flow.adapter'
-    flow: 'order-status'
-    methods: ['POST']
-    url: '/api/orders/{order_id}/status'
-    timeout: 30s
-    cors: cors_1
-    headers: header_1
-    tracing: true
-
-cors:
-  - id: cors_1
-    options:
-      - 'Access-Control-Allow-Origin: *'
-      - 'Access-Control-Allow-Methods: GET, POST, OPTIONS'
-      - 'Access-Control-Allow-Headers: Origin, Authorization, Content-Type'
-    headers:
-      - 'Access-Control-Allow-Origin: *'
-
-headers:
-  - id: header_1
-    response:
-      add:
-        - 'x-powered-by: mercury'
-      drop:
-        - 'server'
-```
-
-A function-backed endpoint with a path parameter:
-
-```yaml
-rest:
-  - service: 'profile.lookup'
-    methods: ['GET']
-    url: '/api/profile/{id}'
-    timeout: 10s
+--8<-- "system/platform-core/src/test/resources/guide-fixtures/rest-bindings.yaml"
 ```
 
 A traced endpoint serving a legacy caller that uses its own trace/correlation header names

--- a/system/platform-core/src/test/java/org/platformlambda/automation/RoutingEntryGuideFixtureTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/RoutingEntryGuideFixtureTest.java
@@ -1,0 +1,109 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.automation.config.RoutingEntry;
+import org.platformlambda.automation.models.AssignedRoute;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.util.ConfigReader;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Loads the documentation guides' canonical rest.yaml worked example
+ * (guide-fixtures/rest-bindings.yaml, embedded into the guides by mkdocs) through the
+ * production RoutingEntry parser. The docs once taught a flow binding with {@code flow:}
+ * alone - a form the parser silently skips because {@code service:} is mandatory - so this
+ * test pins the documented example to what the router actually accepts.
+ */
+class RoutingEntryGuideFixtureTest extends TestBase {
+    private static final String FIXTURE = "classpath:/guide-fixtures/rest-bindings.yaml";
+    private static final String APPLICATION_REST_CONFIG = "classpath:/rest.yaml";
+    private static final String FLOW_ADAPTER = "http.flow.adapter";
+    private static final String PROFILE_FUNCTION = "profile.lookup";
+
+    @Test
+    void guideWorkedExampleLoadsThroughTheProductionParser() {
+        Platform platform = Platform.getInstance();
+        // the fixture's service routes must exist when RoutingEntry validates the entries
+        boolean stubFlowAdapter = registerIfMissing(platform, FLOW_ADAPTER);
+        boolean stubProfile = registerIfMissing(platform, PROFILE_FUNCTION);
+        RoutingEntry routing = RoutingEntry.getInstance();
+        try {
+            routing.load(new ConfigReader(FIXTURE));
+
+            // flow-backed: 'service' selects the flow adapter and 'flow' selects the flow
+            AssignedRoute flow = requireRoute(routing, "POST", "/api/orders/1001/status");
+            assertEquals(FLOW_ADAPTER, flow.info.primary);
+            assertEquals("order-status", flow.info.flowId);
+            assertEquals(List.of("POST", "OPTIONS"), flow.info.methods);
+            assertEquals(30, flow.info.timeoutSeconds);
+            assertTrue(flow.info.tracing);
+            assertEquals("1001", flow.arguments.get("order_id"));
+            // the reusable cors/headers configs resolved by id
+            assertEquals("cors_1", flow.info.corsId);
+            assertEquals("header_1", flow.info.responseTransformId);
+
+            // function-backed endpoint with a path parameter
+            AssignedRoute function = requireRoute(routing, "GET", "/api/profile/8300");
+            assertEquals(PROFILE_FUNCTION, function.info.primary);
+            assertEquals(10, function.info.timeoutSeconds);
+            assertEquals("8300", function.arguments.get("id"));
+
+            // HTTP relay: 'service' is a URL and url_rewrite maps the path prefix
+            AssignedRoute relay = requireRoute(routing, "GET", "/api/upstream/orders");
+            assertEquals("https://example.org", relay.info.host);
+            assertEquals(List.of("/api/upstream", "/v1"), relay.info.urlRewrite);
+            assertEquals(20, relay.info.timeoutSeconds);
+            assertTrue(relay.info.tracing);
+        } finally {
+            // RoutingEntry is a process-wide singleton and load() is additive - re-load the
+            // application config so its routes stay authoritative for later test classes.
+            // The fixture's paths are distinct from rest.yaml's, so nothing collides.
+            routing.load(new ConfigReader(APPLICATION_REST_CONFIG));
+            if (stubFlowAdapter) {
+                platform.release(FLOW_ADAPTER);
+            }
+            if (stubProfile) {
+                platform.release(PROFILE_FUNCTION);
+            }
+        }
+    }
+
+    private static boolean registerIfMissing(Platform platform, String route) {
+        if (platform.hasRoute(route)) {
+            return false;
+        }
+        platform.registerPrivate(route, (headers, input, instance) -> input, 1);
+        return true;
+    }
+
+    private static AssignedRoute requireRoute(RoutingEntry routing, String method, String url) {
+        AssignedRoute route = routing.getRouteInfo(method, url);
+        assertNotNull(route, () -> method + " " + url + " was not registered");
+        assertNotNull(route.info, () -> method + " " + url + " did not resolve for this method");
+        return route;
+    }
+}

--- a/system/platform-core/src/test/resources/guide-fixtures/rest-bindings.yaml
+++ b/system/platform-core/src/test/resources/guide-fixtures/rest-bindings.yaml
@@ -1,0 +1,50 @@
+# The canonical rest.yaml worked example for the documentation guides.
+#
+# This exact file is included into the guides by mkdocs AND loaded through the production
+# RoutingEntry parser in RoutingEntryGuideFixtureTest, so the documented example can never
+# drift from what the REST automation engine actually accepts.
+
+rest:
+  # A flow-backed endpoint needs BOTH keys: 'service' selects the flow adapter and
+  # 'flow' selects the flow. An entry with 'flow' alone has no service and is
+  # skipped as invalid at startup.
+  - service: 'http.flow.adapter'
+    flow: 'order-status'
+    methods: ['POST']
+    url: '/api/orders/{order_id}/status'
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
+  # A function-backed endpoint with a path parameter
+  - service: 'profile.lookup'
+    methods: ['GET']
+    url: '/api/profile/{id}'
+    timeout: 10s
+
+  # An HTTP relay: 'service' is a single URL and 'url_rewrite' maps the inbound
+  # path prefix to the upstream path
+  - service: 'https://example.org'
+    methods: ['GET']
+    url: '/api/upstream/orders'
+    url_rewrite: ['/api/upstream', '/v1']
+    timeout: 20s
+    tracing: true
+
+cors:
+  - id: cors_1
+    options:
+      - 'Access-Control-Allow-Origin: *'
+      - 'Access-Control-Allow-Methods: GET, POST, OPTIONS'
+      - 'Access-Control-Allow-Headers: Origin, Authorization, Content-Type'
+    headers:
+      - 'Access-Control-Allow-Origin: *'
+
+headers:
+  - id: header_1
+    response:
+      add:
+        - 'x-powered-by: mercury'
+      drop:
+        - 'server'


### PR DESCRIPTION
## What

Fixes the rest.yaml flow-binding documentation and pins the worked example to the
production parser.

- Two guides taught a flow-backed endpoint bound with `flow:` alone — one even advised
  using `flow:` *instead of* `service:` — but `RoutingEntry` skips any entry without
  `service:` as invalid, so the documented form never registered. A flow binding requires
  **both** `service: 'http.flow.adapter'` and `flow: '<flow-id>'`.
- The worked example is now one canonical fixture
  (`system/platform-core/src/test/resources/guide-fixtures/rest-bindings.yaml`) covering
  all three binding forms — flow-backed with reusable CORS/response-header configs,
  function-backed with a path parameter, and an HTTP relay with `url_rewrite`.
- The guides embed that exact file via the mkdocs snippet include (already configured with
  `check_paths: true` and built `--strict`), and `RoutingEntryGuideFixtureTest` loads the
  same file through the production `RoutingEntry` parser, asserting route resolution,
  flow id, methods, timeouts, path arguments, and the cors/headers wiring.

## Why

The documented example and the runtime had no shared artifact, so the docs drifted into
teaching a form the router silently rejects (credit to @eugeneacn, whose PR #284
investigation surfaced this). With the fixture as the single source — rendered into the
docs by mkdocs and loaded by the parser in a test — the documented example can no longer
drift from what the router accepts. The finding and design intent originate from PR #284;
this PR extracts that fix as an independent, minimal unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>