### PR TITLE
fix(test): make ObjectStreamTest expiry tests deterministic

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -18,7 +18,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-08-21 | agent: Claude Code (2026-08-21-005515)
+- **last_session:** 2026-08-21 | agent: Claude Code (2026-08-21-195149)
 - **last_review:** 2026-08-21 | through 2026-08-21-005515.md
 - **last_invariant_check:** 2026-08-21 | 2026-08-21-005515.md (all 15 confirmed by Eric — one-by-one walkthrough with live-tree evidence; stack-messaging-kafka wording refreshed to name the grown Kafka family; ot-reverify-invariants-20260821 closed)
 
@@ -205,6 +205,26 @@
   approve → production), so models promote to production as standard endpoints. → serves: vision-mercury-composable
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-08-14 | uses: 2 | tier: working -->
 ## Open Threads
+
+- [ ] (fix — test-only; on worktree branch `claude/compassionate-wing-aa6098`, platform-core
+  gate green 426/426; **awaiting Eric's commit/PR gate, not pushed**) **ObjectStreamTest
+  expiry tests made deterministic — the PR #286 CI flake was a designed-in race.**
+  The 408 "Event stream expired" comes from a per-publisher one-shot Vert.x timer (NOT the
+  30s ObjectStreamIO housekeeper, which only CLOSEs idle streams), and
+  `FluxPublisher.publish()`'s `doFinally` CANCELS that timer on flux completion — so the old
+  shape (ttl=1000, sleep(1100), publish an instantly-completing flux) raced a 100ms margin:
+  late timer → publish cancels it → normal completion (CI signature "expected: <false> but
+  was: <true>"; mechanism proven locally by shrinking the sleep to 800ms). Rewrite (both
+  sleep-margin siblings, fluxPublisherExpiryTest + eventPublisherExpiryTest): no sleep — the
+  consumer attaches immediately and waits; the source never delivers (`Flux.never()` /
+  never-publishing EventPublisher); consumer patience 10s ≫ publisher ttl 1s so a broken
+  build fails with a crisp message mismatch ("Consumer expired"), never a silent pass. Flux
+  variant now also exercises the timer's mid-flight dispose branch (previously unreachable).
+  **Mutation-proven**: each timer body neutralized → its test fails at the message assert.
+  expiryTest/CacheTest/PostOfficeTest sleeps checked — no change needed (timer-vs-timer
+  ordering / safe-direction margins). Follows the S2925 deterministic-expiry precedent
+  ([[thread-sonar-4-11-x-field-round-3]]). Full detail: origin log.
+  <!-- id: thread-objectstream-expiry-test-determinism | created: 2026-08-21 | last_used: 2026-08-21 | uses: 1 | tier: working | origin: 2026-08-21-195149 -->
 
 - [x] **Re-verify invariants (due):** confirm stack-language-java21, stack-build-maven,
   stack-integration-spring, stack-messaging-kafka, stack-ci-gha, functions-decoupled-routes,

--- a/memory/sessions/2026-08-21-195149.md
+++ b/memory/sessions/2026-08-21-195149.md
@@ -1,0 +1,70 @@
+# Session (2026-08-21T19:51:49.000Z)
+
+**Agent:** Claude Code
+
+## Summary
+
+Investigated and fixed the CI flake in platform-core's
+`ObjectStreamTest#fluxPublisherExpiryTest` (observed on PR #286's CI run 32519040655:
+`expected: <false> but was: <true>` at line 259, on a memory-only commit whose identical
+tree had passed 40 minutes earlier). Diagnosis proven before fixing; both sleep-margin
+expiry tests rewritten deterministically (the house S2925 precedent: deterministic expiry
+over sleep tuning); pins mutation-proven; full module gate green. Test-only change on
+worktree branch `claude/compassionate-wing-aa6098` — awaiting Eric's commit/PR gate.
+
+## Root cause (durable engine facts)
+
+1. **The 408 "Event stream expired" comes from a per-publisher one-shot Vert.x timer set at
+   construction** (`FluxPublisher`/`EventPublisher` constructors), NOT from
+   `ObjectStreamIO`'s 30-second housekeeper. The housekeeper only garbage-collects idle
+   streams by sending CLOSE (releases routes; a waiting consumer would see its own
+   "Consumer expired", never the publisher-side 408).
+2. **`FluxPublisher.publish()`'s `doFinally` cancels the expiry timer when the flux
+   completes** (FluxPublisher.java:107-110). So the old test shape — ttl=1000, sleep(1100),
+   then publish a 3-event flux that completes instantly — raced the sleep against the
+   timer with a 100ms margin. On a loaded runner the timer hadn't fired when the sleep
+   returned; publish → instant completion → timer cancelled → the 408 never exists →
+   consumer gets data + completion. **Mechanism proven locally**: shrinking the sleep to
+   800ms reproduced the exact CI signature deterministically.
+3. **Stream events are retained FIFO in the manager queue** (`ServiceQueue`/`ElasticQueue`)
+   and delivered one per consumer READ — an expiry EXCEPTION queued before the consumer
+   attaches is retained (why the old `eventPublisherExpiryTest` shape usually passed), and
+   a consumer waiting on an empty stream receives the next queued event on arrival.
+
+## The deterministic rewrite (both sleep-margin siblings)
+
+`fluxPublisherExpiryTest` and `eventPublisherExpiryTest` now share one shape: **no sleep;
+the consumer attaches immediately and waits; the source never delivers** (`Flux.never()` /
+an EventPublisher that never publishes), so the publisher TTL is the only possible
+publisher-side outcome and the test is insensitive to when the timer fires. Consumer
+patience (10s) deliberately dwarfs the publisher ttl (1s) so the publisher-side message
+wins — and on a broken build the failure is a crisp message mismatch
+(`expected: <Event stream expired> but was: <Consumer expired>`), never a silent pass.
+Bonus coverage: the flux variant now publishes before expiry, exercising the timer's
+mid-flight `disposable.dispose()` branch (previously unreachable — the old shape always
+had `disposable == null` at fire time). `expiryTest` needs no change (timer-vs-timer
+deadline ordering, no sleep); CacheTest's `sleep(1050)` is safe-direction (a slow runner
+makes the item more expired); PostOfficeTest's `sleep(1000)` is a port-readiness retry.
+
+## Gates
+
+- Rewritten tests green (2/2), then full platform-core suite: **426 tests, 0 failures,
+  0 errors, 3 pre-existing skips, BUILD SUCCESS**.
+- **Mutation-proven**: neutralizing each publisher's expiry-timer body made its test fail
+  at the message assertion via the consumer's 10s backstop (both mutations killed, then
+  reverted; production files verified restored via git).
+
+## Observations (not acted on)
+
+- `FluxPublisher.disposable` is a plain field written by `publish()` (caller thread) and
+  read by the expiry timer (event-loop thread) — formally a data race; benign in practice
+  (worst case the timer skips disposing an inert subscription; the 408 still goes out).
+- The Rust port has its own object-stream implementation; if its expiry tests share the
+  sleep-margin shape, the same deterministic rewrite would apply (test internals are not
+  the cross-engine contract, so no lock-step obligation — Eric's call).
+
+## Memory References
+
+- referenced: thread-sonar-4-11-x-field-round-3 (the S2925 deterministic-expiry precedent
+  that set the fix direction)
+- created: thread-objectstream-expiry-test-determinism (tier: working)

--- a/system/platform-core/src/test/java/org/platformlambda/core/ObjectStreamTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/ObjectStreamTest.java
@@ -220,16 +220,21 @@ class ObjectStreamTest extends TestBase {
     @Test
     void eventPublisherExpiryTest() throws InterruptedException {
         final long timeToLive = 1000;
+        // the publisher never publishes anything so its TTL is the only possible outcome.
+        // The consumer attaches immediately and waits - no sleep margin - so the test is
+        // deterministic no matter how late the expiry timer fires on a loaded machine.
         EventPublisher publisher = new EventPublisher(timeToLive);
-        Utility.getInstance().sleep(1100);
         final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
         final List<Object> messages = new ArrayList<>();
-        FluxConsumer<String> fc = new FluxConsumer<>(publisher.getStreamId(), timeToLive);
+        // consumer patience must be much larger than the publisher TTL so the consumer sees
+        // the publisher-side "Event stream expired" and not its own "Consumer expired"
+        // (expiryTest covers the inverse case where the consumer expires first)
+        FluxConsumer<String> fc = new FluxConsumer<>(publisher.getStreamId(), 10000);
         fc.consume(messages::add, e -> {
             messages.add(e);
             bench.add(false);
         }, () -> bench.add(true));
-        Object signal = bench.poll(5, TimeUnit.SECONDS);
+        Object signal = bench.poll(15, TimeUnit.SECONDS);
         assertEquals(false, signal);
         assertEquals(1, messages.size());
         assertInstanceOf(AppException.class, messages.getFirst());
@@ -241,21 +246,22 @@ class ObjectStreamTest extends TestBase {
     @Test
     void fluxPublisherExpiryTest() throws InterruptedException {
         final long timeToLive = 1000;
-        Flux<String> source = Flux.create(emitter -> {
-            emitter.next("hello world");
-            emitter.complete();
-        });
-        FluxPublisher<String> publisher = new FluxPublisher<>(source, timeToLive);
-        Utility.getInstance().sleep(1100);
+        // a Flux that never emits or completes: the publisher's TTL must expire the stream
+        // and dispose the subscription. The consumer attaches immediately and waits - no
+        // sleep margin - so the test is deterministic no matter how late the expiry timer
+        // fires on a loaded machine. (A source that completes would cancel the expiry timer.)
+        FluxPublisher<String> publisher = new FluxPublisher<>(Flux.never(), timeToLive);
         String streamId = publisher.publish();
         final BlockingQueue<Boolean> bench = new ArrayBlockingQueue<>(1);
         final List<Object> messages = new ArrayList<>();
-        FluxConsumer<String> fc = new FluxConsumer<>(streamId, timeToLive);
+        // consumer patience must be much larger than the publisher TTL so the consumer sees
+        // the publisher-side "Event stream expired" and not its own "Consumer expired"
+        FluxConsumer<String> fc = new FluxConsumer<>(streamId, 10000);
         fc.consume(messages::add, e -> {
             messages.add(e);
             bench.add(false);
         }, () -> bench.add(true));
-        Object signal = bench.poll(5, TimeUnit.SECONDS);
+        Object signal = bench.poll(15, TimeUnit.SECONDS);
         assertEquals(false, signal);
         assertEquals(1, messages.size());
         assertInstanceOf(AppException.class, messages.getFirst());


### PR DESCRIPTION
## What

Rewrite the two sleep-margin expiry tests in platform-core's `ObjectStreamTest`
(`fluxPublisherExpiryTest`, `eventPublisherExpiryTest`) into a deterministic shape:
no fixed sleep — the consumer attaches immediately and waits, and the source never
delivers (`Flux.never()` / an `EventPublisher` that never publishes), so the
publisher's TTL expiry is the only possible publisher-side outcome no matter when
the expiry timer fires. Consumer patience (10s) deliberately dwarfs the publisher
TTL (1s), so a broken build fails with a crisp message mismatch
(`Consumer expired` vs `Event stream expired`), never a silent pass. Test-only
change; no production code touched.

## Why

`fluxPublisherExpiryTest` is flaky on loaded CI runners (PR #286, run 32519040655:
`expected: <false> but was: <true>` on a memory-only commit whose identical tree
had passed 40 minutes earlier). The old shape raced a 1000ms one-shot Vert.x expiry
timer against a 1100ms sleep — and `FluxPublisher.publish()`'s `doFinally` cancels
that timer when the flux completes. On a runner where the timer hadn't fired when
the sleep returned, the instantly-completing flux cancelled its own expiry, so the
408 never existed and the consumer saw normal completion. The mechanism was proven
locally before fixing: shrinking the sleep below the TTL reproduces the exact CI
failure signature deterministically.

## Verification

- Both rewritten tests green; full platform-core suite green (426 tests, 0 failures,
  3 pre-existing skips).
- Pins mutation-proven: neutralizing each publisher's expiry-timer body makes its
  test fail at the message assertion via the consumer's 10s backstop.
- Bonus coverage: the flux variant now exercises the timer's mid-flight
  `disposable.dispose()` branch, unreachable under the old shape.
- Sibling patterns audited: `expiryTest` (timer-vs-timer deadline ordering) and the
  sleeps in `CacheTest`/`PostOfficeTest` are load-safe and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>