### PR TITLE
chore(discovery): Sonar round + annotation cleanup for ai-contract-pr…

### DIFF
--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/AiContractProvider.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/AiContractProvider.java
@@ -118,8 +118,12 @@ public class AiContractProvider implements EntryPoint {
             log.error("Skill export failed - {}", output.get("message") == null
                     ? output : output.get("message"));
             return 1;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Skill export interrupted before completion");
+            return 1;
         } catch (Exception e) {
-            log.error("Skill export failed - {}", e.getMessage());
+            log.error("Unable to export skill - {}", e.getMessage());
             return 1;
         } finally {
             platform.release(EXPORT_CALLBACK);

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractCatalog.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractCatalog.java
@@ -23,6 +23,7 @@ import org.platformlambda.core.util.MultiLevelMap;
 import org.platformlambda.discovery.models.ContractEntry;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,10 @@ import java.util.regex.Pattern;
 public class ContractCatalog {
     private static final Pattern CONTRACT_ID = Pattern.compile("[a-z][a-z0-9-]{1,63}");
     private static final Pattern SUMMARY = Pattern.compile("[A-Za-z0-9][A-Za-z0-9 .,;:/()_+\\-]{0,239}");
-    private static final Pattern ANCHOR_CLASS = Pattern.compile("[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z0-9_$]+)*");
+    // possessive quantifiers: segments are dot-delimited, so no backtracking is ever
+    // needed and pathological inputs cannot trigger a regex stack overflow
+    private static final Pattern ANCHOR_CLASS =
+            Pattern.compile("[A-Za-z_$][A-Za-z0-9_$]*+(\\.[A-Za-z0-9_$]++)*+");
     private static final ContractCatalog INSTANCE = new ContractCatalog();
 
     private final List<ContractEntry> contracts;
@@ -80,7 +84,7 @@ public class ContractCatalog {
             validate(entry, ids);
             result.add(entry);
         }
-        result.sort((a, b) -> a.id().compareTo(b.id()));
+        result.sort(Comparator.comparing(ContractEntry::id));
         return List.copyOf(result);
     }
 

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractDetail.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractDetail.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Describe one installed contract: behavior anchors and packaged references. */
-@PreLoad(route = "v1.contract.detail", instances = 10, isPrivate = true)
+@PreLoad(route = "v1.contract.detail", instances = 10)
 public class ContractDetail implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractList.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ContractList.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** List the installed operational contracts (id, module, summary). */
-@PreLoad(route = "v1.contract.list", instances = 10, isPrivate = true)
+@PreLoad(route = "v1.contract.list", instances = 10)
 public class ContractList implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/DiscoveryIndex.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/DiscoveryIndex.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** The one URL an AI agent needs first: version, contract ids, and the endpoint map. */
-@PreLoad(route = "v1.discovery.index", instances = 10, isPrivate = true)
+@PreLoad(route = "v1.discovery.index", instances = 10)
 public class DiscoveryIndex implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ManifestGenerator.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ManifestGenerator.java
@@ -24,7 +24,7 @@ import org.platformlambda.core.models.TypedLambdaFunction;
 import java.util.Map;
 
 /** Serve the deterministic snapshot manifest: per-file SHA-256 plus a whole-snapshot hash. */
-@PreLoad(route = "v1.manifest.generator", instances = 10, isPrivate = true)
+@PreLoad(route = "v1.manifest.generator", instances = 10)
 public class ManifestGenerator implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ReferenceReader.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/ReferenceReader.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * references/guides/event-script/flow-grammar.md). There is no path arithmetic to get
  * wrong: anything that is not an exact member of the snapshot is HTTP-404.
  */
-@PreLoad(route = "v1.reference.reader", instances = 10, isPrivate = true)
+@PreLoad(route = "v1.reference.reader", instances = 10)
 public class ReferenceReader implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/SkillExporter.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/SkillExporter.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * mapped in rest.yaml - filesystem export is a local operator action, launched by the
  * application's --export mode through the export-skill flow.
  */
-@PreLoad(route = "v1.skill.exporter", instances = 1, isPrivate = true)
+@PreLoad(route = "v1.skill.exporter")
 public class SkillExporter implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
 
     @Override

--- a/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/SkillSnapshot.java
+++ b/system/ai-contract-provider/src/main/java/org/platformlambda/discovery/services/SkillSnapshot.java
@@ -67,13 +67,13 @@ public class SkillSnapshot {
     private static final SkillSnapshot INSTANCE = new SkillSnapshot();
 
     private final Map<String, byte[]> rendered;
-    private final Map<String, Object> manifest;
+    private final Map<String, Object> snapshotManifest;
     private final String mercuryVersion;
 
     private SkillSnapshot() {
         this.mercuryVersion = dependencyVersion(PLATFORM_CORE_POM_PROPERTIES);
         this.rendered = render();
-        this.manifest = buildManifest(rendered);
+        this.snapshotManifest = buildManifest(rendered);
     }
 
     public static SkillSnapshot getInstance() {
@@ -97,7 +97,7 @@ public class SkillSnapshot {
 
     /** Deterministic manifest: per-file SHA-256 and a whole-snapshot hash. */
     public Map<String, Object> getManifest() {
-        return manifest;
+        return snapshotManifest;
     }
 
     /** Read one snapshot file as text, or throw HTTP-404 for anything else. */
@@ -184,25 +184,26 @@ public class SkillSnapshot {
 
     private static void validateLinks(Map<String, byte[]> files) {
         for (var entry : files.entrySet()) {
-            if (!entry.getKey().endsWith(".md")) {
-                continue;
-            }
-            var links = MARKDOWN_LINK.matcher(new String(entry.getValue(), StandardCharsets.UTF_8));
-            while (links.find()) {
-                var target = links.group(1).trim();
-                if (target.isEmpty() || target.startsWith("#") || target.startsWith("//")
-                        || URI_SCHEME.matcher(target).matches()) {
-                    continue;
-                }
-                var local = target.split("#", 2)[0].split("\\?", 2)[0];
-                var parent = Path.of(entry.getKey()).getParent();
-                var resolved = (parent == null ? Path.of(local) : parent.resolve(local)).normalize();
-                if (resolved.isAbsolute() || resolved.startsWith("..")
-                        || !files.containsKey(resolved.toString().replace('\\', '/'))) {
-                    throw new IllegalArgumentException("Broken relative link in "
-                            + entry.getKey() + " -> " + target);
+            if (entry.getKey().endsWith(".md")) {
+                var links = MARKDOWN_LINK.matcher(new String(entry.getValue(), StandardCharsets.UTF_8));
+                while (links.find()) {
+                    validateLink(files, entry.getKey(), links.group(1).trim());
                 }
             }
+        }
+    }
+
+    private static void validateLink(Map<String, byte[]> files, String source, String target) {
+        if (target.isEmpty() || target.startsWith("#") || target.startsWith("//")
+                || URI_SCHEME.matcher(target).matches()) {
+            return;
+        }
+        var local = target.split("#", 2)[0].split("\\?", 2)[0];
+        var parent = Path.of(source).getParent();
+        var resolved = (parent == null ? Path.of(local) : parent.resolve(local)).normalize();
+        if (resolved.isAbsolute() || resolved.startsWith("..")
+                || !files.containsKey(resolved.toString().replace('\\', '/'))) {
+            throw new IllegalArgumentException("Broken relative link in " + source + " -> " + target);
         }
     }
 


### PR DESCRIPTION
## What

Post-merge review round for `system/ai-contract-provider` (PR #286): a maintainer
annotation cleanup plus fixes for every SonarQube finding in the three flagged files.

- **Annotation cleanup** — the six service functions drop redundant `@PreLoad` attributes
  (`isPrivate = true` and `instances = 1` are the annotation defaults; all functions
  remain private).
- **SkillSnapshot** — the `manifest` field is renamed `snapshotManifest` (name differed
  from the `MANIFEST` constant only by case), and `validateLinks` is back under the
  cognitive-complexity limit via an extracted per-link `validateLink` helper.
- **ContractCatalog** — the anchor-class regex uses possessive quantifiers
  (`[A-Za-z_$][A-Za-z0-9_$]*+(\.[A-Za-z0-9_$]++)*+`); segments are dot-delimited so
  backtracking was never needed, which removes the stack-overflow-on-large-input pattern.
  The catalog sort uses `Comparator.comparing(ContractEntry::id)`.
- **AiContractProvider** — `InterruptedException` is caught separately and re-interrupts
  the thread (S2142; the blanket `catch (Exception)` had swallowed it), and the two
  export-failure log messages are now distinct.

## Why

The field Sonar gate holds the whole codebase — not just new code — to zero
blocker/critical/major issues, so the new module must enter the field-scan clean. All
changes are behavior-preserving: the regex accepts exactly the same class-name grammar
(deterministic segment matching, no backtracking), the rename is internal, and the
interrupt handling makes the one-shot CLI exit path correct under thread interruption
instead of silently mislabeling it as an export failure. Module test gate: 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>