### PR TITLE
feat(event-script): f:setConfig plugin sets or overrides a config parameter at run-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    packaged-inventory test pins `files.list` to the real `docs/guides` tree. No framework
    module changes: the app depends on the runtime, never the reverse. (ADR-0015 proposed)
 
+2. **Event Script `f:setConfig` plugin — set or override a configuration parameter at
+   run-time.** The new built-in simple plugin stores a key-value pair as a system property,
+   which takes precedence over the base configuration on every subsequent read. Typical use:
+   a start-up flow hydrates secrets from a cloud secret manager before dependent components
+   consume them. The key must be a non-empty string; the value can be any object and is
+   converted to text. Invalid input returns false without side effect.
+
 ### Fixed
 
 1. **The OpenTelemetry forwarder no longer drops a span when a pooled connection dies

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1655,6 +1655,13 @@ For example:
 `validate`
 :   Perform simple field validation. See details below.
 
+#### Configuration
+
+`setConfig`
+:   A parameter name (non-empty string) and its value (any object, converted to text). Sets the
+    value as a system property so that it overrides the corresponding base configuration
+    parameter at run-time. Returns true when applied, false for invalid input. See details below.
+
 *DateTime plugins*
 
 - f:dateTime() will yield a timestamp with local timezone.
@@ -1715,6 +1722,33 @@ throwing an validation error. For example,
 - f:validate(input.body.id, text(id; String; evaluate))
 
 Please note that the validation rule uses semicolon as separator because comma is used for tokenization.
+
+*Configuration override plugin*
+
+The 'setConfig' plugin sets or overrides a configuration parameter at run-time by saving it as a
+system property. Since a system property takes precedence over the base application configuration,
+any subsequent configuration read — e.g. a `map(my.parameter)` constant in a data mapping statement
+or an `AppConfigReader` lookup inside a user function — will see the updated value.
+
+Syntax is "f:setConfig(key, value)". The key must be a non-empty string. The value can be any
+object — a text constant or a model variable — and it is converted to text with
+`String.valueOf(value)` because configuration parameter values are stored as strings.
+
+- f:setConfig(text(my.parameter), text(demo)) -> model.updated
+- f:setConfig(text(my.parameter), model.secret) -> model.updated
+
+It returns true when the parameter is set, or false when the key is missing or empty, or the
+value is null.
+
+The typical use case is secret hydration: a flow retrieves secrets from a cloud "secret manager"
+at start-up and sets them as configuration parameters for the rest of the application to consume.
+
+Please be careful about the application life cycle:
+
+1. The override applies to the whole application instance and stays effective until the
+   application restarts — not just for the calling flow instance.
+2. Components that have already consumed a parameter at start-up will not see the update.
+   Run the flow that sets the parameters before the dependent components read them.
 
 *JSON-Path helpers*
 

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -932,7 +932,7 @@ Arguments can be model variables, constant types, or nested plugin calls.
 | `f:subtract(a, b, ...)` | `a` minus remaining args | `f:subtract(model.total, model.fee) -> net` |
 | `f:multiply(a, b)` | Product | `f:multiply(model.price, model.qty) -> total` |
 | `f:div(a, b)` | Division (`a / b`) | `f:div(model.total, model.n) -> avg` |
-| `f:modulus(a, b)` | Remainder (`a % b`) | `f:modulus(model.n, int(2)) -> rem` |
+| `f:mod(a, b)` | Remainder (`a % b`) | `f:mod(model.n, int(2)) -> rem` |
 | `f:increment(a)` | `a + 1` | `f:increment(model.count) -> next_count` |
 | `f:decrement(a)` | `a - 1` | `f:decrement(model.count) -> prev_count` |
 
@@ -993,8 +993,18 @@ Arguments can be model variables, constant types, or nested plugin calls.
 | Function | Description | Example |
 |----------|-------------|---------|
 | `f:uuid()` | Generate a random UUID string | `f:uuid() -> id` |
-| `f:dateTime()` | Current date-time (ISO-8601) | `f:dateTime() -> now` |
-| `f:date(format)` | Formatted date string | `f:date(text(yyyy-MM-dd)) -> today` |
+| `f:now()` | Current UTC time — ISO-8601 by default, `text(ms)` for epoch milliseconds, `text(local)` for local date-time | `f:now(text(ms)) -> ts` |
+| `f:dateTime(format?)` | Current date-time with local timezone, optionally formatted | `f:dateTime(text(yyyy-MM-dd)) -> today` |
+
+### Configuration
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `f:setConfig(key, value)` | Set or override a configuration parameter (stored as a system property; key = non-empty string, value = any object converted to text) | `f:setConfig(text(my.parameter), model.secret) -> updated` |
+
+> `f:setConfig` changes run-time state for the whole application instance, not just the calling
+> flow. The typical use case is hydrating secrets from a secret manager at start-up; components
+> that already consumed a parameter will not see a later override.
 
 > Plugins are validated at compile time. They may only use classes from `java.lang`,
 > `java.util`, `java.math`, `java.time`, and Mercury framework packages.

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/SetConfigParameter.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/SetConfigParameter.java
@@ -1,0 +1,60 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+@SimplePlugin
+public class SetConfigParameter implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "setConfig";
+    }
+
+    /**
+     * Set or override configuration parameter using system property
+     * <p>
+     * input data mapping statement example:
+     * 'f:setConfig(text(my.parameter), text(demo)) -> config_updated'
+     * In this example, the value 'demo' is set as config parameter 'my.parameter'.
+     * The second argument can be a model variable. It may be any object that
+     * will be converted to text using String.valueOf(value).
+     * <p>
+     * Please be careful about life cycle for your application start up sequence.
+     * If your MainApplication needs the updated parameter, you must run a flow
+     * to invoke this plugin first. The typical use case is to retrieve secrets
+     * from a cloud "secret manager" and then set the secrets in the base
+     * configuration - since System properties would override a configuration
+     * parameter at run-time.
+     *
+     * @param input key and value
+     * @return value of true if success or false if syntax error or invalid data
+     */
+    @Override
+    public Object calculate(Object... input) {
+        if (input.length == 2 && input[0] instanceof String key && !key.isBlank() && input[1] != null) {
+            System.setProperty(key, String.valueOf(input[1]));
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -2065,6 +2065,41 @@ class FlowTests extends TestBase {
 
     @SuppressWarnings("unchecked")
     @Test
+    void shouldSetConfigParameterWithPluggableFunction() throws InterruptedException, ExecutionException {
+        final long timeout = 8000;
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host)
+                .setMethod("GET")
+                .setHeader("accept", "application/json")
+                .setUrl("/api/pluggableFunctions/set-config");
+        EventEmitter po = EventEmitter.getInstance();
+        EventEnvelope req = EventEnvelope.of().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope res = po.request(req, timeout).get();
+        assertNotNull(res);
+        assertInstanceOf(Map.class, res.getBody());
+        Map<String, Object> result = (Map<String, Object>) res.getBody();
+        assertNotNull(result);
+        // the plugin sets the parameter as a system property
+        assertEquals(true, result.get("updated"));
+        assertEquals("from-config-plugin", System.getProperty("unit.test.config.override"));
+        // a system property overrides base configuration at run-time, so a later task
+        // reading the parameter with the map(key) constant sees the updated value
+        assertEquals("from-config-plugin", result.get("value_from_config"));
+        assertEquals("from-config-plugin",
+                AppConfigReader.getInstance().getProperty("unit.test.config.override"));
+        // a non-string value is converted to text with String.valueOf(value)
+        assertEquals(true, result.get("numeric_value"));
+        assertEquals("8088", System.getProperty("unit.test.config.numeric"));
+        assertEquals("8088", result.get("numeric_from_config"));
+        // invalid usage returns false and sets nothing - missing 2nd argument
+        assertEquals(false, result.get("one_argument"));
+        assertNull(System.getProperty("unit.test.config.incomplete"));
+        // invalid usage returns false - empty parameter name
+        assertEquals(false, result.get("empty_key"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     void inputConversionTest() throws ExecutionException, InterruptedException {
         AsyncHttpRequest request = new AsyncHttpRequest();
         request.setTargetHost(host).setMethod("POST")

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/SetConfigParameterTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/SetConfigParameterTest.java
@@ -1,0 +1,65 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.util.AppConfigReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SetConfigParameterTest {
+
+    private final SetConfigParameter plugin = new SetConfigParameter();
+
+    @Test
+    void shouldUseSetConfigAsPluginName() {
+        assertEquals("setConfig", plugin.getName());
+    }
+
+    @Test
+    void shouldSetConfigParameterAsSystemProperty() {
+        assertNull(System.getProperty("set.config.plugin.direct"));
+        assertEquals(true, plugin.calculate("set.config.plugin.direct", "hello"));
+        assertEquals("hello", System.getProperty("set.config.plugin.direct"));
+        // a system property overrides base configuration at run-time
+        assertEquals("hello", AppConfigReader.getInstance().getProperty("set.config.plugin.direct"));
+        // setting the same parameter again overrides the previous value
+        assertEquals(true, plugin.calculate("set.config.plugin.direct", "world"));
+        assertEquals("world", System.getProperty("set.config.plugin.direct"));
+        // a non-string value is converted to text with String.valueOf(value)
+        assertEquals(true, plugin.calculate("set.config.plugin.number", 8088));
+        assertEquals("8088", System.getProperty("set.config.plugin.number"));
+        assertEquals(true, plugin.calculate("set.config.plugin.flag", true));
+        assertEquals("true", System.getProperty("set.config.plugin.flag"));
+    }
+
+    @Test
+    void shouldReturnFalseForInvalidInputWithoutSideEffect() {
+        assertEquals(false, plugin.calculate());
+        assertEquals(false, plugin.calculate("key.only"));
+        assertEquals(false, plugin.calculate("too", "many", "arguments"));
+        assertEquals(false, plugin.calculate(100, "non-string-key"));
+        assertEquals(false, plugin.calculate(null, "value"));
+        assertEquals(false, plugin.calculate("", "empty-key"));
+        assertEquals(false, plugin.calculate("   ", "blank-key"));
+        assertEquals(false, plugin.calculate("set.config.plugin.null.value", (Object) null));
+        assertNull(System.getProperty("set.config.plugin.null.value"));
+    }
+}

--- a/system/event-script-engine/src/test/resources/flows.yaml
+++ b/system/event-script-engine/src/test/resources/flows.yaml
@@ -44,6 +44,7 @@ flows:
   - 'autostart.yml'
   - 'pluggableFunctions/arithmetic.yml'
   - 'pluggableFunctions/types.yml'
+  - 'pluggableFunctions/set-config.yml'
   - 'input-validation-1.yml'
   - 'input-validation-2.yml'
   - 'input-validation-3.yml'

--- a/system/event-script-engine/src/test/resources/flows/pluggableFunctions/set-config.yml
+++ b/system/event-script-engine/src/test/resources/flows/pluggableFunctions/set-config.yml
@@ -1,0 +1,36 @@
+flow:
+  id: 'set-config-parameter'
+  description: 'Set or override configuration parameter plugin test'
+  ttl: 10s
+
+first.task: 'set.config.task'
+
+tasks:
+  - name: 'set.config.task'
+    input:
+      - 'f:setConfig(text(unit.test.config.override), text(from-config-plugin)) -> model.updated'
+      - 'int(8088) -> model.port'
+      - 'f:setConfig(text(unit.test.config.numeric), model.port) -> model.numeric_value'
+      - 'f:setConfig(text(unit.test.config.incomplete)) -> model.one_argument'
+      - 'f:setConfig(text(), text(no-key)) -> model.empty_key'
+    process: 'no.op'
+    description: 'Set config parameters and exercise invalid usages'
+    output: []
+    execution: sequential
+    next:
+      - 'read.config.task'
+
+  - name: 'read.config.task'
+    input:
+      - 'model.updated -> updated'
+      - 'model.numeric_value -> numeric_value'
+      - 'model.one_argument -> one_argument'
+      - 'model.empty_key -> empty_key'
+      - 'map(unit.test.config.override) -> value_from_config'
+      - 'map(unit.test.config.numeric) -> numeric_from_config'
+    process: 'no.op'
+    description: 'Read back the overridden parameters through app configuration'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    execution: end

--- a/system/event-script-engine/src/test/resources/rest.yaml
+++ b/system/event-script-engine/src/test/resources/rest.yaml
@@ -392,6 +392,15 @@ rest:
     tracing: true
 
   - service: "http.flow.adapter"
+    methods: [ 'GET' ]
+    url: "/api/pluggableFunctions/set-config"
+    flow: 'set-config-parameter'
+    timeout: 10s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+
+  - service: "http.flow.adapter"
     methods: [ 'POST' ]
     url: "/api/wildcard-conversion/test"
     flow: 'wildcard-conversion-test'


### PR DESCRIPTION
## What

A new built-in Event Script simple plugin, `f:setConfig(key, value)` (`SetConfigParameter`),
that sets or overrides a configuration parameter at run-time by saving it as a system
property — plus its flow-based test, a direct unit test, and documentation on both plugin
reference surfaces.

- **Plugin contract:** the key must be a non-empty string; the value can be any object and
  is converted to text with `String.valueOf(value)`. Invalid input returns `false` without
  side effect.
- **Flow test** (`set-config-parameter`, `/api/pluggableFunctions/set-config`): task one
  sets parameters through `f:setConfig`; task two reads them back through `map(key)`
  constants — proving the override is visible to configuration reads at run-time, including
  a numeric model variable coerced to text (`8088` → `"8088"`). Invalid usages (missing
  second argument, empty key) return `false` and set nothing.
- **Direct unit test** (`SetConfigParameterTest`) pins the plugin name and the
  `calculate()` argument contract, following the per-plugin test convention.
- **Docs:** Built-in Plugins catalog entry + a "Configuration override plugin" detail
  section in `event-script/syntax.md` (with application life-cycle cautions); a new
  Configuration table in `flow-schema-reference.md`; CHANGELOG Unreleased.
- **In passing:** fixed two wrong plugin names in `flow-schema-reference.md` tables —
  `f:modulus` → `f:mod`, and the nonexistent `f:date` → `f:dateTime(format?)` with the
  missing `f:now` row added. Both would fail `CompileFlows` for an AI agent generating
  flows from that page.

## Why

Since a system property takes precedence over the base application configuration on every
read, a flow can now update configuration at run-time by configuration alone. The typical
use case is secret hydration: a start-up flow retrieves secrets from a cloud secret manager
and sets them as configuration parameters before dependent components consume them —
previously this required custom code.

The rest of the surface keeps the review rulings: the value coercion (`String.valueOf`)
makes numeric model variables work naturally; the empty-key guard returns `false` instead
of surfacing a raw JDK `IllegalArgumentException` mid-flow; and the name `setConfig` reads
as the setter it is (with `map(key)` as the reading side).

The Rust engine ships the same plugin in lock-step (Accenture/mercury PR), keeping flow
files engine-portable: the test fixture is byte-identical on both engines.

**Gates:** event-script-engine 189/189 exit 0; ai-contract-provider 18/18 (the edited
guides ship in its skill snapshot — render + link validation green); mkdocs strict exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>