### PR TITLE
docs(onboarding): root AGENTS.md forks contributors from Mercury consumers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@
 This project uses the **agent-memory** shared memory system. **Read these now, in order** — don't
 defer to a pointer chain (Copilot Ask/Plan modes won't follow it unless the files are attached):
 
-1. **`AGENTS.md`** — the one-line universal discovery shim.
+1. **`AGENTS.md`** — the universal discovery shim (forks contributors from Mercury consumers).
 2. **`memory/PROTOCOL.md`** — the memory protocol; follow it before substantive work.
 3. **`memory/instructions.md`** — persona, project rules, conventions.
 4. **`memory/continuity.md`** — current state, key decisions, open threads, the project's hard rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,13 @@
-Read [memory/PROTOCOL.md](memory/PROTOCOL.md) and follow it.
+**Contributing to this repository?** Read [memory/PROTOCOL.md](memory/PROTOCOL.md) and follow it.
+
+**Building an application WITH Mercury** (consuming it as a dependency or plugin)? Skip the
+memory protocol — it is for repository contributors. Start at [system/AGENTS.md](system/AGENTS.md)
+for the version-matched AI discovery surface.
+
+**Unsure which path is yours?** A session that already carries this repo's memory context is a
+contributor; an agent that arrived through `system/AGENTS.md`, the contract provider, or the
+exported `mercury-platform` skill is a consumer. Otherwise you are a fresh session: if the
+first instruction does not itself resolve the path (many questions are valid on both paths),
+ask before loading either: *"Am I contributing to Mercury itself, or building an application
+that uses it?"* The answer creates your path — every subsequent interaction lands on it.
+Headless with no signals: default to contributor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Event-driven Java framework (Maven reactor, `com.accenture.mercury`) — self-co
 This project uses the agent-memory shared memory system.
 
 **Full context:** follow [`memory/PROTOCOL.md`](./memory/PROTOCOL.md) — the memory
-protocol (root `AGENTS.md` is its one-line discovery shim) — then:
+protocol (root `AGENTS.md` is its discovery shim, forking contributors from Mercury consumers) — then:
 1. `memory/instructions.md`
 2. `memory/continuity.md`
 3. `memory/sessions/` (latest 2–3 files)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,8 +3,8 @@
 Event-driven Java framework (Maven reactor, `com.accenture.mercury`) — self-contained functions wired by YAML event flows.
 
 This project uses the agent-memory shared memory system. **Follow
-[`memory/PROTOCOL.md`](./memory/PROTOCOL.md) first.** Root `AGENTS.md` is its one-line
-universal discovery shim.
+[`memory/PROTOCOL.md`](./memory/PROTOCOL.md) first.** Root `AGENTS.md` is its universal
+discovery shim, forking contributors from Mercury consumers.
 
 The protocol and core memory files are imported below, so they are structurally present at
 session start (presence is guaranteed; *attending* to them is still the protocol). Imports


### PR DESCRIPTION
## What

The root `AGENTS.md` entry point now forks the two agent audiences explicitly, with a
role-resolution ladder:

- **Contributors** to this repository read `memory/PROTOCOL.md` and follow it, as before.
- **Consumers** — AI tools building an application WITH Mercury as a dependency or plugin —
  skip the memory protocol entirely and start at `system/AGENTS.md`, the version-matched AI
  discovery surface (contract-provider endpoints on port 8999, or the exported
  `mercury-platform` skill).
- **Resolution rule:** a session already carrying this repo's memory context is a
  contributor (never re-asked); an agent arriving through a consumer surface is a consumer
  by construction; a fresh interactive session whose first instruction does not itself
  resolve the path asks one question before loading either — *"Am I contributing to Mercury
  itself, or building an application that uses it?"* — because the answer creates the path
  and every subsequent interaction lands on it. Headless with no signals defaults to
  contributor.

In the same commit, the three vendor entry files (`CLAUDE.md`, `GEMINI.md`,
`.github/copilot-instructions.md`) update their now-stale description of the root file as a
"one-line shim" to describe the fork.

## Why

A fresh-agent assessment of the AI onboarding docs (2026-08-21) found the root shim routed
**every** agent into the contributor memory-activation path; an AI tool consuming Mercury as
a dependency only escaped if it happened to find `system/AGENTS.md` on its own. Consumers
were ingesting ~1000 lines of repository-maintainer memory they should never see.

The ask-on-unresolved rule exists because a zero-context agent's own inference is least
trustworthy exactly at activation, and many first questions ("how does data mapping work?")
are valid on both paths — while the human trivially knows the answer, and it is asked
roughly once per human-repo relationship.

The agent-memory tool preserves customized root instructions across upgrades
(its UPGRADE.md 4.37.0), so this local customization is upgrade-safe; the same design has
been proposed upstream for the tool's shim template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>