### PR TITLE
chore(release): v4.11.10 - version sweep and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.11.10, 8/21/2026
 
 ### Added
 

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Spring Boot 3 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-3</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 3 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.11.9</version>
+    <version>4.11.10</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.9</version>
+            <version>4.11.10</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Release cut for v4.11.10: the 34-pom sweep 4.11.9 → 4.11.10 and the CHANGELOG Unreleased
section becomes **Version 4.11.10, 8/21/2026**.

## Why

Ships four merged items: the `system/ai-contract-provider` AI discovery app (ADR-0015) with
its version-matched contract endpoints and offline Agent Skill export; the Event Script
`f:setConfig` plugin (run-time configuration override for secret hydration); the two
OpenTelemetry forwarder span-loss fixes (IOException retry + the exporter's own pool); and
the rest.yaml flow-binding documentation fix with its canonical parser-loaded fixture.
The Rust engine releases v4.11.10 in lock-step (`f:setConfig` + its own
`system/ai-contract-provider` edition).

**Gate:** full reactor build green (all modules, all tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>