### PR TITLE
graph.task reaches declarative Event-over-HTTP targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Added
+
+1. `graph.task` accepts a task route declared as a declarative Event-over-HTTP target
+   (`yaml.event.over.http`) - a knowledge graph can invoke remote engine instances and
+   polyglot (python/node.js) function hosts as graph tasks. New
+   `PostOffice.getEventHttpTarget(route)` API exposes the declarative map lookup.
+
+---
 ## Version 4.11.10, 8/21/2026
 
 ### Added

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphTask.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/skills/GraphTask.java
@@ -71,7 +71,10 @@ public class GraphTask extends GraphLambdaFunction {
         if (route == null) {
             throw new IllegalArgumentException(NODE_NAME + nodeName + " does not have a 'task' route");
         }
-        if (!po.exists(route)) {
+        // a task route is reachable when registered locally or in the cloud (po.exists),
+        // or when declared as a declarative Event-over-HTTP target - the way python/
+        // node.js polyglot functions and remote engine instances join a graph
+        if (!po.exists(route) && po.getEventHttpTarget(route) == null) {
             throw new IllegalArgumentException(NODE_NAME + nodeName + " - task '" + route + "' does not exist");
         }
         // reset result to ensure execution is idempotent

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tasks/GraphTaskTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tasks/GraphTaskTest.java
@@ -198,7 +198,7 @@ class GraphTaskTest {
     void foreignRouteViaEventOverHttp() throws TimeoutException {
         // 'polyglot.stub.function' is not registered locally - it resolves through the
         // declarative event-over-http map (yaml.event.over.http) to the stub peer, the
-        // way python/node.js polyglot functions join a knowledge graph
+        // way python/node.js polyglot functions join a 'knowledge graph'
         var response = runGraph("unit-test-task-7", Map.of("text", "polyglot"), Map.of());
         assertEquals(200, response.getStatus());
         assertInstanceOf(Map.class, response.getBody());

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tasks/GraphTaskTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/tasks/GraphTaskTest.java
@@ -19,6 +19,8 @@
 package com.accenture.minigraph.tasks;
 
 import com.accenture.minigraph.start.PlaygroundLoader;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.platformlambda.core.models.AsyncHttpRequest;
@@ -26,9 +28,12 @@ import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.system.PostOffice;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.MultiLevelMap;
+import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -45,13 +50,45 @@ class GraphTaskTest {
     private static final String ASYNC_HTTP_CLIENT = "async.http.request";
     private static final long TIMEOUT = 8000;
     private static String target;
+    private static HttpServer stubPeer;
 
     @BeforeAll
-    static void beforeAll() {
+    static void beforeAll() throws IOException {
         PlaygroundLoader.main(new String[0]);
         var config = AppConfigReader.getInstance();
         var port = config.getProperty("rest.server.port");
         target = "http://localhost:" + port;
+        startStubPeer(Utility.getInstance().str2int(config.getProperty("stub.peer.port", "8391")));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (stubPeer != null) {
+            stubPeer.stop(0);
+        }
+    }
+
+    /**
+     * A minimal polyglot peer: an /api/event endpoint that decodes the relayed
+     * event envelope and answers with a standard-format reply envelope - the
+     * same wire contract a python or node.js function host speaks.
+     */
+    private static void startStubPeer(int port) throws IOException {
+        stubPeer = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+        stubPeer.createContext("/api/event", exchange -> {
+            var request = new EventEnvelope(exchange.getRequestBody().readAllBytes());
+            var reply = new EventEnvelope().setBody(Map.of(
+                    "language", "stub",
+                    "route", String.valueOf(request.getTo()),
+                    "echo", request.getBody() instanceof Map? request.getBody() : Map.of()));
+            var payload = reply.toBytes(EventEnvelope.Format.STANDARD);
+            exchange.getResponseHeaders().set("Content-Type", "application/octet-stream");
+            exchange.sendResponseHeaders(200, payload.length);
+            try (var out = exchange.getResponseBody()) {
+                out.write(payload);
+            }
+        });
+        stubPeer.start();
     }
 
     @SuppressWarnings("unchecked")
@@ -154,6 +191,22 @@ class GraphTaskTest {
         assertEquals("recovered", mm.getElement("message"));
         assertEquals(400, mm.getElement("status"));
         log.info("graph.task exception handler routing works");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void foreignRouteViaEventOverHttp() throws TimeoutException {
+        // 'polyglot.stub.function' is not registered locally - it resolves through the
+        // declarative event-over-http map (yaml.event.over.http) to the stub peer, the
+        // way python/node.js polyglot functions join a knowledge graph
+        var response = runGraph("unit-test-task-7", Map.of("text", "polyglot"), Map.of());
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        var mm = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("stub", mm.getElement("language"));
+        assertEquals("polyglot.stub.function", mm.getElement("route"));
+        assertEquals("polyglot", mm.getElement("echo.text"));
+        log.info("graph.task reached a foreign route through the event-over-http map");
     }
 
     @Test

--- a/system/minigraph-playground-engine/src/test/resources/application.properties
+++ b/system/minigraph-playground-engine/src/test/resources/application.properties
@@ -8,6 +8,12 @@ rest.server.port=8090
 rest.automation=true
 yaml.rest.automation=classpath:/rest.yaml
 #
+# Event-over-HTTP declarative map for the graph.task foreign-route pin (GraphTaskTest);
+# the stub peer binds stub.peer.port in the test
+#
+yaml.event.over.http=classpath:/event-over-http.yaml
+stub.peer.port=8391
+#
 # Event script configuration file location
 #
 yaml.flow.automation=classpath:/flows.yaml

--- a/system/minigraph-playground-engine/src/test/resources/event-over-http.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/event-over-http.yaml
@@ -1,0 +1,3 @@
+event.http:
+  - route: 'polyglot.stub.function'
+    target: 'http://127.0.0.1:${stub.peer.port}/api/event'

--- a/system/minigraph-playground-engine/src/test/resources/graph/unit-test-task-7.json
+++ b/system/minigraph-playground-engine/src/test/resources/graph/unit-test-task-7.json
@@ -1,0 +1,59 @@
+{
+  "nodes": [
+    {
+      "types": [
+        "UnitTest"
+      ],
+      "alias": "end",
+      "properties": {}
+    },
+    {
+      "types": [
+        "Task"
+      ],
+      "alias": "foreign-task",
+      "properties": {
+        "task": "polyglot.stub.function",
+        "input": [
+          "input.body -> *"
+        ],
+        "output": [
+          "result -> output.body"
+        ],
+        "skill": "graph.task"
+      }
+    },
+    {
+      "types": [
+        "UnitTest"
+      ],
+      "alias": "root",
+      "properties": {
+        "purpose": "graph.task reaches a foreign route through the declarative event-over-http map",
+        "name": "unit-test-task-7"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "source": "foreign-task",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    },
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "test",
+          "properties": {}
+        }
+      ],
+      "target": "foreign-task"
+    }
+  ]
+}

--- a/system/minigraph-playground-engine/src/test/resources/graphs.yaml
+++ b/system/minigraph-playground-engine/src/test/resources/graphs.yaml
@@ -32,6 +32,8 @@ graphs:
   # deliberately invalid: an input mapping targets reserved model metadata
   # (model.ttl) - CompileGraph must reject it and requests answer 404
   - 'unit-test-task-6'
+  # foreign route: the task exists only as a declarative event-over-http target
+  - 'unit-test-task-7'
   - 'unit-test-join-retry'
   - 'unit-test-join-chain'
   - 'unit-test-cache-key'

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/PostOffice.java
@@ -233,6 +233,18 @@ public class PostOffice {
     }
 
     /**
+     * Check if a route resolves to an Event-over-HTTP target declared in the
+     * optional "yaml.event.over.http" configuration - the way remote engine
+     * instances and polyglot function hosts are addressed as if local
+     *
+     * @param route name of the target service
+     * @return the target URL or null if the route is not configured
+     */
+    public String getEventHttpTarget(String route) {
+        return po.getEventHttpTarget(route);
+    }
+
+    /**
      * User application may add key-values to a trace using this method
      * <p>
      * Please note that trace annotation feature is available inside a user function

--- a/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/PostOfficeTest.java
@@ -1017,7 +1017,6 @@ class PostOfficeTest extends TestBase {
         assertTrue(multi.exists("trace.span_id"));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     void accidentalMetadataEchoIsSanitizedAtExit() throws InterruptedException, ExecutionException {
         // Eric's scenario: a function accidentally copies its input headers - including the
@@ -1110,6 +1109,7 @@ class PostOfficeTest extends TestBase {
                 "the legacy carrier is scrubbed from the delivered envelope view");
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void rpcTelemetryCarriesSpanLineage() throws InterruptedException {
         // Regression: the RPC trace record (the one with round_trip) must chain like a


### PR DESCRIPTION
## What

- `graph.task`'s existence guard accepts a task route that is not registered locally when
  it is declared in the declarative Event-over-HTTP map (`yaml.event.over.http`). The
  teaching error for genuinely unknown routes is unchanged.
- New `PostOffice.getEventHttpTarget(route)` API - a passthrough to EventEmitter's
  declarative-map lookup, alongside `exists()`.
- Pin: `unit-test-task-7` + `GraphTaskTest.foreignRouteViaEventOverHttp` - a graph.task
  node reaches a route that exists ONLY as an event-over-http target, served by a stub
  `/api/event` peer that decodes the relayed envelope and replies in the standard wire
  format (the same contract a python/node.js function host speaks). Proven failing
  against the unfixed guard first (same "does not exist" signature with the map
  demonstrably loaded). The existing `missingTaskRouteFailsFast` pin keeps the negative
  path honest.
- CHANGELOG Unreleased entry; IDE cosmetics follow-up commit (comment quoting +
  @SuppressWarnings placement).

## Why

This is the only engine change of the ratified polyglot initiative (D5): Event Script
flows already reach declarative Event-over-HTTP targets with zero code (the shipped
composable-example demo), but MiniGraph's `graph.task` pre-checks route existence and
`routeExists()` consults only the local registry and cloud routes - so knowledge graphs
could not call the new python/node.js polyglot function hosts (or remote engine
instances) that flows already can. The surgical guard relaxation closes that gap without
touching global `exists()` semantics, keeping graphs and flows symmetric on the polyglot
surface. `graph.suspend`'s store-task guard deliberately stays local-only - state stores
over HTTP are not part of this feature.

## Verification

- New e2e proven against unfixed code first, green after the fix.
- minigraph-playground-engine: 119/119. platform-core: 426 green. Re-gated after the
  cosmetics commit (GraphTaskTest 10/10, PostOfficeTest 78/78).
- Rust lock-step: the mercury repo carries the identical guard relaxation with a
  byte-identical `unit-test-task-7` fixture (companion PR).

Co-Authored-By: Claude Code <noreply@anthropic.com>