### PR TITLE
test: cover the offline skill export failure path (field new-code coverage gate)

### DIFF
--- a/system/ai-contract-provider/src/test/java/org/platformlambda/discovery/OfflineSkillWriterTest.java
+++ b/system/ai-contract-provider/src/test/java/org/platformlambda/discovery/OfflineSkillWriterTest.java
@@ -26,15 +26,22 @@ import org.platformlambda.discovery.export.OfflineSkillWriter;
 import org.platformlambda.discovery.services.SkillSnapshot;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class OfflineSkillWriterTest {
 
@@ -80,6 +87,31 @@ class OfflineSkillWriterTest {
         var e = assertThrows(AppException.class, () -> writer.export(exportRoot));
         assertEquals(409, e.getStatus());
         assertArrayEquals(original, Files.readAllBytes(marker), "existing snapshot untouched");
+    }
+
+    @Test
+    void wrapsAnExportFailureWithContextAndCause() throws IOException {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+                "needs a POSIX file system to force the I/O failure");
+        var writer = new OfflineSkillWriter();
+        var readOnlyRoot = Files.createDirectory(temp.resolve("read-only-root"));
+        var originalPermissions = Files.getPosixFilePermissions(readOnlyRoot);
+        Files.setPosixFilePermissions(readOnlyRoot,
+                Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE));
+        try {
+            assumeFalse(Files.isWritable(readOnlyRoot),
+                    "environment ignores directory permissions - cannot force the failure");
+            var exportRoot = readOnlyRoot.toString();
+            var e = assertThrows(AppException.class, () -> writer.export(exportRoot));
+            assertEquals(500, e.getStatus());
+            assertInstanceOf(IOException.class, e.getCause(),
+                    "the underlying cause must survive for the ultimate handler");
+            assertTrue(e.getMessage().contains(
+                    "Skill export to " + readOnlyRoot.resolve(OfflineSkillWriter.SKILL_DIRECTORY)),
+                    "the message must name the export target: " + e.getMessage());
+        } finally {
+            Files.setPosixFilePermissions(readOnlyRoot, originalPermissions);
+        }
     }
 
     @Test


### PR DESCRIPTION
**What**

One new test in `system/ai-contract-provider` - `wrapsAnExportFailureWithContextAndCause`:
forces a real I/O failure inside `export()`'s try block (POSIX read-only export root ->
`Files.createDirectory` throws) and pins the failure contract of the #296 S2139 fix -
`AppException` status 500, the message names the export target, and the underlying
`IOException` survives as the cause. Assumption-guarded for non-POSIX file systems and
permission-ignoring environments (e.g. running as root), with permissions restored in
`finally` so `@TempDir` cleanup works.

**Why**

The field's follow-up Sonar scan cleared all six issues from #296, and the dependency
security scan passed - but the quality gate now fails on **new-code coverage: 0.0%
(required >= 80%) on exactly 1 new line**: the S2139 rethrow in `OfflineSkillWriter`.
The catch path was never exercised (every existing test fails before the try block), so
the old log-and-rethrow lines were equally uncovered - but they were old code; the
replacement line counts as new. This test covers that line with real value: it is the
only pin on the fix's promise that context and cause survive the rethrow.

**Gates:** module 19/19; jacoco marks the rethrow line fully covered -> new-code coverage
1/1 = 100%; **mutation-proven** - with the cause dropped from the rethrow, the test fails
on the "cause must survive" assertion (expected IOException, was null); restored green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>