### PR TITLE
Progressive SSE consumption in AsyncHttpClient; design specs go public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,8 @@ __pycache__/
 *.pyc
 site/
 
-# Work-in-progress design drafts — kept local until finalized (not for commit)
-draft-design-specs/
+# Design specs (draft-design-specs/) are committed by design: they are the living
+# work-in-progress journal of how this project evolves — transparent, for human readers
 .interop-mercury
 
 # === agent-memory: AI infrastructure (personal / per-machine — do not commit) ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    plus the `scripts/sse-client.mjs` progressive-rendering client). See the
    HTTP Response Streaming guide (ADR-0018).
 
+2. **Progressive SSE consumption in the HTTP client** - `async.http.request` can
+   consume a `text/event-stream` response progressively (an LLM provider's token
+   stream, another engine's streaming endpoint, any SSE API), relaying one
+   `x-event-stream: data` envelope per upstream event to the caller's reply route,
+   then `eof` - the same streaming protocol the HTTP edge consumes, which makes an
+   SSE-to-SSE relay a pure configuration exercise. Activation is explicit: the
+   request must declare `Accept: text/event-stream`, the response must be SSE, and
+   the request must carry a reply route; anything else keeps the buffered single-shot
+   behavior. For streams, the request timeout acts as the idle allowance between
+   reads (keep-alive comments reset it); idle expiry and mid-stream disconnects fail
+   the stream in-band. (ADR-0019)
+
 ### Changed
 
 1. The `/info/routes` actuator endpoint renders pool-style route families compactly:

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -22,6 +22,47 @@ in that ADR's own *Rationale* section.
 
 ---
 
+## ADR-0019 — The HTTP client consumes SSE progressively; Event-over-HTTP streams on the same call {#adr-0019}
+**Status:** Proposed · **Date:** 2026-08-29 · **Serves:** vision-mercury-composable · **Formalizes:** async-http-client-sse-streaming-design
+<!-- id: adr-0019 | status: proposed -->
+
+**Abstract.** `async.http.request` consumes a `text/event-stream` response progressively
+and relays it as the platform's own streaming protocol: one `x-event-stream: data`
+envelope per upstream SSE event to the caller's reply route (the event's data as body,
+`event:` name as `x-event-name`, head control - upstream status plus the SSE content
+type - on the first envelope), `eof` on a clean end, and an in-band `exception` on idle
+expiry or a mid-stream disconnect. Activation is explicit and standard: the request must
+declare `Accept: text/event-stream`, the response must actually be SSE, and the request
+must carry a `reply_to`; anything else keeps the buffered single-shot behavior. For a
+stream, the request timeout becomes the per-read idle allowance (any upstream bytes,
+keep-alive comments included, reset it). Payloads are never interpreted - provider
+conventions such as `data: [DONE]` forward verbatim, keeping the client vendor-neutral.
+Because the streaming producer contract is the one the HTTP edge already consumes, a
+streaming endpoint's function can forward its own `reply_to` and correlation id into the
+client call and the application becomes an SSE-to-SSE relay by configuration. The same
+enhancement is the transport for Event-over-HTTP peer streaming (python/node wrapper
+functions and engine⇄engine): the peer's `/api/event` answers the SAME call with an SSE
+response using a hybrid control/data framing - control signals (the head, `eof`,
+`exception`, and any segment that cannot round-trip as text) ride base64-encoded MsgPack
+envelope frames under the reserved SSE event name `envelope`, while token segments ride
+raw SSE frames with near-zero overhead - negotiated by the same Accept contract, so
+version skew degrades explicitly, never silently.
+
+**Rationale.** Progressive delivery had reached the HTTP edge (ADR-0018) but not the two
+consumption paths AI-era workloads need: an engine function consuming an LLM provider's
+token stream, and a polyglot wrapper function streaming results back to the engine. One
+mechanism closes both because the Event-over-HTTP relay already flows through
+AsyncHttpClient. Alternatives rejected: an on-demand WebSocket channel (breaks the
+wrapper scope fence, grows four codebases, historically gateway-hostile, and drifts
+toward the standing-connection mesh the framework keeps opt-in); per-segment POSTs back
+to the reply lane (FIFO forces serialized posts - one round trip per token - and opens
+an inbound path to reply lanes); gRPC/HTTP-2 push (a foreign dependency stack); and
+long-polling (chatty and stateful). Streaming on the response of the engine's own
+request adds no inbound surface, is ordered by TCP for free, and rides the wire shape
+gateways already accommodate for LLM traffic.
+
+---
+
 ## ADR-0018 — HTTP response streaming rides the multi-shot reply route; the wire stays standards-only {#adr-0018}
 **Status:** Proposed · **Date:** 2026-08-28 · **Serves:** vision-mercury-composable · **Formalizes:** http-response-streaming-design
 <!-- id: adr-0018 | status: proposed -->

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -169,6 +169,63 @@ The `-N` (`--no-buffer`) flag matters: curl receives the events progressively ei
 way, but without `-N` it holds output in an internal buffer, so the messages would
 appear all at once when the stream ends.
 
+## Consume an SSE stream (HTTP client)
+
+The other direction: `async.http.request` can consume a Server-Sent Events response
+progressively - an LLM provider's token stream, another engine's streaming endpoint, or
+any SSE API - and relay each event to your reply route using the same streaming
+protocol.
+
+Activation is explicit and standard - all three must hold:
+
+1. the request declares `Accept: text/event-stream`,
+2. the response actually arrives as `Content-Type: text/event-stream`, and
+3. the request event carries a `reply_to` (a multi-shot-capable consumer).
+
+Anything else keeps the buffered single-shot behavior exactly as before.
+
+Each upstream SSE event becomes one `x-event-stream: data` envelope to your reply
+route: the event's data is the body (multi-line data joins with newline per the SSE
+specification), an `event:` name maps to `x-event-name`, and comment/id/retry fields
+are consumed by the client, never forwarded. The first envelope carries the head
+(upstream status and the SSE content type). A clean upstream end sends `eof`; a
+mid-stream failure sends an in-band `exception`. Payloads are never interpreted -
+provider conventions such as `data: [DONE]` are forwarded verbatim for your function
+to handle, keeping the client vendor-neutral.
+
+For a stream, the request's timeout is the *idle* allowance between reads rather than
+a total limit: any upstream bytes - keep-alive comments included - reset it, and on
+expiry the client fails the stream in-band with status 408 and closes the upstream
+connection.
+
+The composition this enables: a streaming endpoint's function can forward its own
+`reply_to` and correlation id into the client call, turning the application into an
+SSE-to-SSE relay with no imperative streaming code -
+
+```java
+@PreLoad(route = "v1.sse.relay", instances = 50)
+@EventInterceptor
+public class SseRelay implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        AsyncHttpRequest upstream = new AsyncHttpRequest();
+        upstream.setMethod("GET");
+        upstream.setTargetHost("https://api.example.com");
+        upstream.setUrl("/v1/tokens");
+        upstream.setHeader("accept", "text/event-stream");
+        upstream.setTimeoutSeconds(30);
+        // the caller's reply lane becomes the client's reply route:
+        // upstream tokens render progressively out the HTTP edge
+        EventEmitter.getInstance().send(new EventEnvelope()
+                .setTo("async.http.request").setBody(upstream.toMap())
+                .setReplyTo(request.getReplyTo())
+                .setCorrelationId(request.getCorrelationId()));
+        return null;
+    }
+}
+```
+
 ## Relation to `x-stream-id`
 
 The existing `x-stream-id` relay (object streams, file downloads, `Flux` results) is

--- a/draft-design-specs/README.md
+++ b/draft-design-specs/README.md
@@ -1,0 +1,16 @@
+# Design specs — a work-in-progress journal
+
+The documents in this folder are **working design specs**: they are written and refined
+during the design and implementation of a feature, capturing the problem, the options
+considered, the decisions taken (and revised), and the implementation status as the work
+unfolds.
+
+**After a feature ships, a spec is a journal record for reference only.** It is kept as
+history — transparent, in the open-source spirit — so a human reader can understand how
+the project evolved and why decisions were made at the time.
+
+**Source code is the source of truth.** A shipped feature's authoritative description
+lives in the code, its tests, and the published guides (`docs/guides/`); durable
+architecture decisions live in the ADR ledger (`docs/arch-decisions/ADR.md`). Where a
+design spec and the code disagree, the code is right — the spec records what was
+planned and learned, not what necessarily holds today.

--- a/draft-design-specs/ai-agent-orchestration.md
+++ b/draft-design-specs/ai-agent-orchestration.md
@@ -1,0 +1,247 @@
+# AI agent orchestration on the Active Knowledge Graph — design concept
+
+**Status:** CONCEPT — direction ratified by Eric 2026-08-25; experiments queued after the
+AI workshop. This paper captures the thesis, the architecture concept, the open design
+questions (Q-series), and the staged experiment plan (E-series). Numbered design
+decisions (D-series) will be proposed against experiment evidence, not up front.
+**Blueprint:** `bp-agent-orchestration` → serves `vision-mercury-composable`.
+**Repo scope:** no engine surface at concept stage — everything below attaches at the
+function tier (wrapper-side Python/Node functions), so no Java↔Rust lock-step is
+triggered until/unless a built-in skill emerges (then `conv-telemetry-presentation-parity`
+applies in full).
+
+---
+
+## 1. Context and driver
+
+The industry is converging on **"graph engineering" as the next iteration of the agent
+loop**: get the control flow of a multi-step AI application out of the model's implicit
+`while(true)` and into an explicit, inspectable graph — nodes for reasoning and tool
+calls, edges for transitions, checkpoints for human authority. LangGraph popularized the
+shape; Anthropic's own "workflows vs agents" guidance points the same way for production
+systems.
+
+Mercury already made exactly this move for microservice orchestration: code → Event
+Script → Active Knowledge Graph. The thesis of this concept is therefore not "build an
+agent framework" but:
+
+> **MiniGraph already is a graph-engineering runtime. The only missing piece is the AI
+> node type — and the polyglot Event-over-HTTP work (shipped v4.11.11 + wrapper repos)
+> makes that node type a user-land function, not an engine change.**
+
+The pitch to enterprises inverts the usual one: agent orchestration is **just another
+workload for the same governed runtime** that runs their integration flows — not a new
+bespoke agent silo beside it. Changing what an agent does becomes *refining the model,
+certifying it, and deploying the model* — the Vision sentence verbatim, with "agent"
+substituted for "system".
+
+## 2. Capability mapping — what the agent loop needs vs what is already shipped
+
+| Agent-loop requirement | Shipped Mercury capability |
+| --- | --- |
+| Explicit, bounded control flow | Graph model + CompileGraph mandatory gate ("compiled or 404", ADR-0011) |
+| Model-driven branching | Decision routing (`graph.math` IF/THEN/ELSE; Event Script `decision`) on an LLM's returned verdict/label |
+| Iterative loops (reflect → act → check) | Wait-loop RESET pattern (tutorial-14; seen-marks + self-RESET), dynamic statement targets (v4.11.6) for generic retry/escalation handlers |
+| Human-in-the-loop checkpoints | `graph.suspend`/`graph.resume` (ADR-0010/0012/0013): external state store, TTL, at-most-once resume, graph-scoped keys, jump-mode re-evaluation against new input — **production-proven by field multi-suspension approval workflows** |
+| Tool calling | Composable functions: every Layer 1/2 capability (HTTP, Kafka, DB, whole flows) is a route-addressed, traced, concurrency-managed, mockable tool; `graph.task` reaches all of it |
+| Polyglot AI ecosystem access | Event-over-HTTP wrappers (mercury-python / mercury-nodejs); graph.task's route guard consults `yaml.event.over.http` since v4.11.11 |
+| Agent state / memory | State machine `model` namespace — explicit, inspectable (`inspect`), persisted across suspensions |
+| Error handling around flaky calls | Walker-staged `error.source/code/message/stack` + recovery semantics (resolved/outstanding) + dynamic `{error.source}` targets |
+| Concurrency economics for slow LLM I/O | Virtual threads (ADR-0002): thousands of blocked LLM RPCs suspend cheaply |
+| Deadline propagation | flow/graph `ttl` bounds the event call; `headers.x-ttl` (ms) rides the wire end-to-end (tutorial-13 pattern) |
+| Observability | OTel end-to-end incl. trace-id propagation into wrapper processes (proven live 2026-08-22, flow → python) |
+| Token-free testing | Route decoupling → the LLM node mocks out by config (tutorial-13 `mock.mdm.profile` shape); dry-run lane simulates without spending |
+
+**Evidence discipline (honest-evidence rule):** flows → python function is proven live
+(2026-08-22 flagship drive, my_correlation_id + engine trace_id in the python log).
+graph.task → wrapper function is pinned by engine tests on both engines (v4.11.11,
+unit-test-task-7) but has **no live drive yet** — E0 below produces the first one. No
+LLM or MCP call has run through Mercury yet; that is what the experiments are for.
+Nothing in this section may be claimed in public docs beyond what has actually run.
+
+## 3. Architecture concept
+
+### 3.1 Attachment point: the function tier, engine stays neutral
+
+All AI capability attaches as **functions**, never as engine features:
+
+- The engine core stays LLM-free and vendor-neutral (Vision non-goal: "not locked to one
+  LLM vendor"; posture precedent: `kafka-mesh-opt-in` — heavyweight integrations live in
+  optional modules).
+- The wrapper **scope fence is untouched** ("NO orchestration" in wrappers): the adapters
+  below are *user-land functions built ON the wrappers* — demo-app or contrib-package
+  code — not wrapper-core features.
+- Taste precedent: `graphjs-phase-out-direction` — bounded, declarative capability beats
+  embedded arbitrary power. The graph owns control flow; models advise within it.
+
+### 3.2 Adapter family A — the LLM node (`llm.chat`)
+
+A provider-neutral wrapper-side function (Python first; the LLM ecosystem lives there).
+Illustrative contract sketch (Q2 refines it):
+
+```
+route: llm.chat                      (registered in a wrapper app; reached via
+                                      yaml.event.over.http + graph.task / a flow task)
+input (Map):
+  messages | prompt                  conversation turns or single-turn text
+  system                             optional system prompt
+  schema                             optional JSON schema -> function enforces
+                                     structured output (the graph needs parseable verdicts)
+  params: model, max_tokens, temperature, ...
+output (Map):
+  text | data                        completion text, or schema-validated object
+  usage: input_tokens, output_tokens
+  stop_reason
+errors:  provider/rate-limit errors ride the standard envelope status (portable to the
+         graph's error context: error.source/code/message)
+ttl:     function maps its remaining budget onto the provider SDK timeout (x-ttl pattern)
+```
+
+### 3.3 Adapter family B — MCP client (route-per-tool)
+
+The official MCP SDKs are Python and TypeScript — exactly the two shipped wrappers.
+Two integration shapes considered:
+
+1. **Generic dispatcher** (`mcp.request` + `{server, tool, arguments}`) — quick, but the
+   compile gate sees one opaque route; "read a file" and "send an email" are
+   indistinguishable to governance. Not preferred.
+2. **Route-per-tool** (preferred): the wrapper app connects to configured MCP servers and
+   registers each **allowlisted** tool as its own route (`mcp.github.create.issue`, …).
+   The graph names exactly which external capabilities it touches; the gate validates
+   them; each call traces under its own route; **the allowlist itself is the
+   certification artifact** ("what can this agent reach?" answered by config).
+
+Security seam: MCP servers, their stdio child processes, and their credentials live in
+the wrapper's process/environment, never the JVM. (This does not contradict the shelved
+stdio-subprocess ruling — that ruling was about the *function transport*; an MCP client
+managing its own children is internal library business.)
+
+### 3.4 Adapter family C — agent-as-node (graphs of agents)
+
+For genuinely open-ended agency: one node's function runs a classic inner tool-use loop
+(e.g., Claude Agent SDK / API tool runner inside the Python wrapper) and returns an
+outcome envelope. The graph orchestrates at the macro level — sequencing, approvals,
+compensation — while open agency stays encapsulated in the node. This mirrors the
+emerging "multi-agent = graph of agents" industry shape.
+
+### 3.5 Reverse direction — Mercury as MCP *server*
+
+Expose certified flows and deployed graphs as MCP tools so any external agent (Claude
+Code/Desktop, any MCP client) can invoke Mercury capabilities with the governance gate
+intact. Nearer than it looks: `system/ai-contract-provider` (ADR-0015) already serves
+machine-readable discovery/contracts at :8999; an MCP facade over that discovery surface
+plus the Event API is a thin adapter (Q7). Result: a certified graph becomes a tool in
+every agent's toolbox — governed in both directions.
+
+## 4. Orchestration patterns
+
+1. **Bounded agency** (the graph decides, the model advises): LLM nodes classify /
+   extract / judge; decision nodes route among *enumerated* branches. Fits the engine
+   today and fits the enterprise story best — the certified toolset IS the graph.
+2. **Agent-as-node**: macro-orchestration + checkpoints in the graph; inner loop
+   encapsulated (3.4).
+3. **Human-in-the-loop**: `graph.suspend` before any irreversible/side-effectful action;
+   resume with approval; jump-mode re-evaluates the decision against the new input. The
+   field's existing approval workflows are literally this pattern.
+4. **Agentic loop, made visible**: reflect → act → check → loop-until-done via the
+   wait-loop RESET idiom — bounded and inspectable instead of implicit.
+
+## 5. Governance and security posture
+
+- **"Governed nondeterminism" — never "deterministic agents."** The graph bounds the
+  blast radius (only enumerated branches/tools reachable), makes decisions inspectable,
+  and gates changes; it does not make model reasoning deterministic. Say exactly that.
+- Promotion lifecycle (`bp-graph-governance-lifecycle`: dry-run → certify → stage →
+  approve → production) is the differentiator no agent-loop framework offers.
+- MCP's known risk class is prompt/tool injection via tool descriptions and results.
+  Bounded-agency graphs structurally shrink it (tool results feed data mapping, not an
+  open loop's next-tool choice); agent-as-node keeps the usual exposure inside the node —
+  document the difference honestly.
+- Audit: prompt/completion capture (trace annotations) needs a PII/redaction policy
+  before any enterprise claim (Q4).
+- Dry-run without tokens: mock the LLM/MCP routes by config; GraphTraveler simulates the
+  agent for free.
+
+## 6. Open design questions (Q-series — need rulings, mostly per experiment evidence)
+
+- **Q1 — dynamic dispatch.** Should a model ever pick an arbitrary route at runtime?
+  Today the gate validates routes statically; the working stance is
+  *constraint-as-feature* (bounded agency), with agent-as-node as the escape hatch.
+  Ruling needed only if a field case demands open dispatch.
+- **Q2 — `llm.chat` production contract.** Streaming (engine supports Flux; the pattern
+  to the REST edge needs design — Q8), token/usage accounting, structured-output
+  enforcement, provider neutrality/pluggability, rate-limit retry semantics vs the
+  graph's own retry handlers (avoid double-retry).
+- **Q3 — MCP registration timing.** Static tool declaration vs boot-time enumeration of
+  the server's tool list; allowlist config shape; failure behavior when a listed tool is
+  absent at boot (fail-fast per the compiled-or-404 taste?).
+- **Q4 — audit capture.** What of prompts/completions lands in trace annotations; PII
+  redaction policy; retention.
+- **Q5 — context economics.** Conversation history lives in the `model` namespace and is
+  persisted on suspend — size management conventions (summarize-then-carry? cap?) before
+  long-running agents.
+- **Q6 — where adapters live.** Wrapper demo apps (E0) → a named contrib package
+  (mercury-python extras?) → `extensions/`? Decide after E0–E2 show the shapes.
+- **Q7 — Mercury-as-MCP-server facade.** Transport (HTTP), auth, and which surface is
+  exposed: deployed graphs only? flows? individual functions? (Gate-respecting default:
+  deployed graphs + explicitly exported flows.)
+- **Q8 — streaming to the edge.** Token streaming from an LLM node through a graph run
+  to the HTTP response — pattern using Flux/ObjectStream, or explicitly out of scope for
+  v1 (request-response per node).
+
+## 7. Experiment plan (E-series — post-workshop; each produces evidence for D-rulings)
+
+- **E0 — the AI node exists (hours).** `llm.chat` in the mercury-python demo app
+  (Anthropic SDK) + a bounded-agency demo graph: fetch → `llm.chat` (classify with
+  `schema`) → decision node routes → respond. Zero engine change. **Also the first live
+  graph.task → wrapper drive** (closes that evidence gap incidentally).
+  *Evidence out:* the demo graph JSON, the live trace (engine trace_id in the python
+  log), token usage surfaced in `model`.
+- **E1 — human authority.** Insert `graph.suspend` before a side-effectful step; approve
+  → resume; reject → re-suspend loop (tutorial-14 shape, LLM verdict as the decision
+  input). *Evidence out:* suspension record contents with conversation context (feeds Q5).
+- **E2 — MCP reach.** Route-per-tool prototype against one well-known MCP server
+  (e.g., filesystem or github) with an explicit allowlist; graph calls two of its tools.
+  *Evidence out:* registration timing findings (Q3), ttl mapping behavior, trace shape.
+- **E3 — agent-as-node.** One node runs a bounded inner tool-use loop (Claude Agent
+  SDK in the python wrapper), returns an outcome envelope; graph handles the approval
+  checkpoint. *Evidence out:* envelope contract for "agent outcome", injection-surface
+  notes.
+- **E4 (stretch) — Mercury as MCP server.** Thin facade over ai-contract-provider
+  discovery + Event API exposing one deployed graph as an MCP tool; drive it from Claude
+  Code. *Evidence out:* Q7 answers.
+
+After E0–E2: propose the D-series rulings + an ADR ("AI agent orchestration attaches at
+the function tier; the engine stays neutral") and decide the public-docs story. Public
+docs claim only drives that ran.
+
+## 8. Relationship to existing blueprints / decisions
+
+- **Distinct from `bp-ai-companion-llm-backend`** — that is AI at *design time*
+  (co-authoring graphs); this is AI at *run time* (graphs orchestrating agents). They
+  compound: the companion authors the agent graph; the graph governs the agent.
+- **Builds on `bp-polyglot-functions`** — the wrappers are the enabler; this is their
+  first strategic payload beyond parity demos.
+- **Compounds `bp-graph-governance-lifecycle`** — promotion is the enterprise agent
+  governance answer; this blueprint gives it a second, high-urgency customer.
+- Precedents honored: `polyglot-event-over-http-design` (scope fence),
+  `kafka-mesh-opt-in` (opt-in posture), `graphjs-phase-out-direction` (bounded > embedded
+  power), `conv-telemetry-presentation-parity` (lock-step only if engine surface appears).
+
+## 9. Non-goals
+
+- Not a new agent framework silo; not a LangGraph clone — the runtime is the existing
+  governed graph engine.
+- No LLM SDK, MCP client, or vendor coupling in engine core — ever (Vision non-goal).
+- No orchestration in wrappers (fence intact); adapters are functions on top.
+- No determinism claims for model reasoning — the claim is governed nondeterminism.
+- Not (yet) a streaming UX platform — Q8 may defer streaming out of v1.
+
+## 10. Competitive positioning (one paragraph for future docs)
+
+LangGraph is code-first graphs with checkpointing; Temporal is durable execution for
+developers; Step Functions/Bedrock Flows are declarative but vendor-locked. Mercury's
+angle: **declarative, zero-code-default agent graphs with a mandatory compile gate, a
+promotion lifecycle, production-hardened suspend/resume, route-decoupled polyglot tools,
+full OTel, and virtual-thread economics — on the same runtime that already runs your
+integration flows.** One platform, both workloads, governed the same way.

--- a/draft-design-specs/ai-contract-provider-plan.md
+++ b/draft-design-specs/ai-contract-provider-plan.md
@@ -1,0 +1,208 @@
+# Plan: AiContractProvider — composable AI-discovery app
+
+- **Status:** DRAFT — awaiting Eric's ratification (this file is gitignored; an ADR is
+  proposed only at implementation-PR time, per protocol)
+- **Supersedes:** PR #284 (closed unmerged; essence extracted, implementation discarded)
+- **Decision driver (Eric, 2026-08-21):** the contract capability must adopt the
+  Composable design pattern — a standalone app under `system/`, functions + Event Script
+  flows + `rest.yaml`, REST discovery on port 8999 (and/or CLI) — not a library module
+  that core depends on, and not commands grafted into the playground.
+
+---
+
+## 1. Essence extracted from PR #284 (what we keep as *requirements*)
+
+1. **Version-matched truth**: an AI agent asks a *running Mercury* for its operational
+   contract and gets answers that provably match the runtime version — not stale web docs.
+2. **Anchored claims**: each contract names the behavior classes that implement it, so a
+   refactor surfaces drift deterministically (in CI, before release).
+3. **Offline skill export**: a deterministic `mercury-platform` snapshot (SKILL.md +
+   linked guide closure + machine catalogs + `security.json`) with per-file SHA-256 and a
+   snapshot hash, for agents with no repo and no network. Two exports are byte-identical.
+4. **Read-only remote surface**: discovery over HTTP never writes; export is a local
+   operator action only.
+5. **The real docs bug**: `rest.yaml` flow bindings require BOTH `service:
+   'http.flow.adapter'` AND `flow:` — the old `flow:`-only example never registered
+   (`RoutingEntry` skips entries without `service`). Fix the guides and pin the corrected
+   example through the production parser.
+6. **Anti-drift in CI**: the packaged closure and the catalog cannot silently diverge from
+   `docs/` or the code.
+7. **Advisory-only skill posture**: `security.json` + SKILL.md instruction boundaries
+   (no network/shell/write authority claimed; packaged references are immutable vendor
+   material). Content rewritten fresh — no text copied from the PR.
+
+## 2. What we deliberately drop (and why)
+
+| Dropped | Why |
+| --- | --- |
+| `ServiceLoader` provider framework + `platform-contracts` library | Inverted the dependency arrow: platform-core/event-script/minigraph all gained a new compile dependency. All modules release under one version anyway, so a static catalog verified at build time gives the same guarantee with zero framework changes. |
+| Playground commands (`help mercury`, `list contracts`, `describe contract`) + webapp/catalog/help edits | The playground surface is mirrored on the Rust engine (shared webapp bundle, byte-identical catalog). Java-only commands there break cross-engine parity at the next sync. A dedicated discovery endpoint removes the entire problem. |
+| `CodeSource`-based resource reading | Live-proven broken under Spring Boot nested-jar packaging (`help mercury` failed in the real packaged playground). All resource reads go through `getResourceAsStream`. |
+| The 658-line TOCTOU exporter (fileKey reservation loops, hook seams, 6 telescoping constructors, hard-link publication) | Security posture beyond the threat model at the cost of readability. We keep the *properties* (§6) with a straightforward implementation. |
+| Compile-time `MERCURY_VERSION` constant + hard-coded version in an IT | Two new release-sweep sites outside the 33-pom sed sweep. Replaced by manifest-derived versions (§7) — zero new sweep sites; the new pom rides the existing sweep (33 → 34 poms, note in the release runbook). |
+| Committed `docs/specs/` convention, self-accepted ADR, "Orca" reference | House convention: plans live in gitignored `draft-design-specs/`; ADRs are Proposed until the maintainer's gate; no unexplained external references in public docs. |
+
+## 3. The app
+
+**Module:** `system/ai-contract-provider` · artifact `ai-contract-provider-<version>.jar`
+**Main:** `AiContractProvider implements EntryPoint`, `@MainApplication`, launched by
+`AutoStart.main(args)` — the standard app shape.
+
+**Runtime dependencies:** `platform-core` (REST automation, event system) and
+`event-script-engine` (flows). **`minigraph-playground-engine` at TEST scope only** —
+needed to verify anchor classes, but a compile/runtime dependency would auto-preload the
+playground's own `@PreLoad` functions into this app (jar on classpath = routes). At
+runtime, minigraph anchors are strings; the module's tests resolve every anchor via
+`Class.forName` so a rename still fails the reactor deterministically.
+
+**Zero diffs to existing modules.** The dependency arrow points INTO the app.
+
+**Modes (one binary, two entrypoints):**
+- Default: REST discovery server on **port 8999** (`rest.server.port=8999`).
+- `--export <dir>`: one-shot CLI export of the offline skill, then exit. The EntryPoint
+  triggers the export *flow* via `FlowExecutor.request(...)` — orchestration stays in
+  YAML even in CLI mode (`event-script-over-code`).
+
+**Build section:** mirrored from an existing standalone app (kafka-standalone) — pinned
+plugins, sources JAR at build time, jacoco. (The PR's module lacked all three.)
+
+## 4. Composable wiring (functions → flows → rest.yaml)
+
+Functions — `TypedLambdaFunction` + `@PreLoad`, app-local routes (no reserved-name changes):
+
+| Route | Purpose |
+| --- | --- |
+| `v1.discovery.index` | JSON index: app name, `mercury_version`, endpoint list, contract ids — the one URL an agent needs first |
+| `v1.contract.list` | catalog summary (id — summary, deterministic order) |
+| `v1.contract.detail` | one contract: id, module, summary, anchors, references; unknown id → `AppException(404)` |
+| `v1.skill.entrypoint` | `SKILL.md` text (`content-type: text/markdown`) |
+| `v1.reference.reader` | serve one packaged reference file; the path must be an exact member of the packaged inventory (no traversal logic to get wrong — membership lookup only) |
+| `v1.manifest.generator` | inventory + per-file SHA-256 + snapshot hash (computed once, cached) |
+| `v1.skill.exporter` | offline snapshot writer — **not mapped in rest.yaml** |
+
+Flows (one per endpoint + `export-skill.yml`), registered in `flows.yaml`. Each flow is a
+legible statement of the endpoint: input mapping → task → output mapping (incl. the
+content-type header). The app thereby doubles as a small reference implementation of the
+pattern it documents.
+
+`rest.yaml` (all GET, all flow-bound with `service: 'http.flow.adapter'` — eating the
+corrected docs example's own cooking):
+
+```
+GET /api/discovery          -> flow: discovery-index
+GET /api/contracts          -> flow: contract-list
+GET /api/contracts/{id}     -> flow: contract-detail
+GET /api/skill              -> flow: skill-entrypoint
+GET /api/references/*       -> flow: reference-fetch      (wildcard suffix; confirm against rest grammar during build)
+GET /api/manifest           -> flow: manifest
+```
+
+`/info` and `/health` come free from platform-core.
+
+## 5. Contract catalog — configuration over code
+
+`src/main/resources/contracts.yaml` — one file, four contracts (platform-core,
+rest-automation, event-script, minigraph): `id`, `module`, `summary`,
+`anchors` (fully-qualified class names), `references` (paths into the packaged closure).
+
+Validation is test-time, deterministic, in this module:
+- every anchor resolves (`Class.forName`; minigraph via test-scope dependency);
+- every reference is a member of the packaged closure;
+- ids/summaries match the same bounded character rules as the PR (no markdown injection).
+
+No ServiceLoader, no build-id handshake — the reactor builds everything at one version and
+the tests bind the catalog to the code.
+
+## 6. Export — same properties, simple implementation
+
+Kept properties: target is `<dir>/mercury-platform`; refuse if it already exists; reject a
+symlinked destination; CREATE_NEW writes only; expand the one known mkdocs `--8<--`
+fixture include and fail closed if any other include marker remains; validate that every
+relative markdown link resolves inside the snapshot; write `manifest.json` LAST (its
+absence marks an incomplete snapshot); per-file SHA-256 + snapshot hash over
+`path\nhash\n` in sorted order; on failure, best-effort cleanup of the partial directory;
+messages never contain exception text or absolute paths (but the underlying cause is
+LOGGED — the OTLP lesson).
+
+Dropped: fileKey reservation re-checks, hard-link publication, injectable failure seams.
+Target size: a focused class ≤ ~200 lines plus direct tests.
+
+Packaged closure (same as the PR — it is the guides' actual link closure):
+`docs/index.md`, `docs/arch-decisions/ADR.md`, `docs/guides/**`,
+`docs/test-reports/event-over-http-interop.md`, plus `SKILL.md`, `security.json`,
+the REST fixture, and a checked-in `files.list`. The `llms.txt` link in `index.md` is
+replaced by a local note (llms.txt stays excluded — it points off-snapshot).
+
+`files.list` discipline (soft form of the PR's docs tax): a unit test in THIS module walks
+`docs/guides` on the filesystem at test time and asserts equality with `files.list` — a
+new guide page fails this module's tests with a message telling the author the one-line
+fix. No separate python gate needed for the inventory; `docs.yml` optionally gains a thin
+`check-ai-contract-provider.py` for PR-time feedback without a Maven run (decision D4).
+
+## 7. Version matching — no new sweep sites
+
+- The app's pom version rides the existing release sed sweep (pom count 33 → 34; runbook
+  note only).
+- Served payloads report `mercury_version` from the app jar's `Implementation-Version`
+  (`Utility.getVersion()` pattern).
+- Fail-closed startup check: the app compares its own version with platform-core's jar
+  manifest version; mismatched assembly → log + refuse to start.
+- A unit test pins pom version == served version, so CI catches drift without a
+  hard-coded constant anywhere.
+
+## 8. Cross-engine position
+
+Java-only by design (minimalist-kafka precedent) — no Rust lock-step obligation because no
+shared surface is touched (no webapp, no catalog, no help pages, no playground grammar).
+The REST discovery API itself is engine-portable; if a Rust twin is ever wanted, the same
+endpoints + flows are the contract.
+
+## 9. Testing & gates (deterministic)
+
+Module tests: catalog validation (anchors + references + bounds); files.list ↔ filesystem
+equality; link-closure validation; endpoint e2e (TestBase boots the app; AsyncHttpClient
+hits every endpoint incl. 404 and traversal-shaped reference paths); export determinism
+(two exports byte-identical — the PR's best pin, kept), existing-target refusal
+(mutation-proven), manifest re-verification (recompute all hashes); version-mismatch
+fail-closed; startup smoke.
+
+Pre-PR gates (house standard): full reactor `mvn clean install` exit 0; live boot of the
+built jar (`java -jar`, port 8999) + curl of every endpoint — **explicitly under the real
+packaging**, the lesson PR #284's tests missed; one real `--export` with independent hash
+verification; `mkdocs build --strict`; Sonar hygiene pass (no unused imports, S3776 within
+bounds).
+
+## 10. Delivery
+
+- **PR A (small, independent): the docs fix.** Correct the flow-binding example in
+  `ai-developer-guide.md`, `event-script/ai-agent-guide.md`,
+  `rest-automation/ai-agent-guide.md`; add the canonical fixture
+  `rest-bindings.yaml` under **platform-core test resources** (the module that owns
+  `RoutingEntry` proves its own docs example) + `RoutingEntryGuideFixtureTest`
+  (singleton restored in `finally`); guides embed the fixture via the existing mkdocs
+  snippet include (single source; `check_paths: true` + `--strict` already guard it);
+  fixture gains `cors:`/`headers:` blocks so the worked CORS example survives — asserted
+  by the test; CHANGELOG Unreleased.
+- **PR B: the app** (module, catalog, flows, endpoints, export, tests, README,
+  ADR-NNNN *Proposed*, CHANGELOG Unreleased, optional thin CI script). The app packages
+  PR A's fixture into the closure by relative resource include.
+- PR #284: closed unmerged by Eric; both PR bodies credit the original find and design
+  motivation to its author.
+
+## 11. Decision points (recommendation first)
+
+- **D1 — Modes:** hybrid (REST server default, `--export` one-shot CLI) ✅ recommended;
+  alternatives: REST-only or CLI-only.
+- **D2 — PR A separate from PR B:** yes ✅ (small, independently correct, mergeable now).
+- **D3 — Fixture include in docs:** keep the mkdocs snippet include (one source of
+  truth) ✅; alternative: plain inline YAML (drifts again).
+- **D4 — CI script:** rely on the module's own tests only ✅ (reactor already gates);
+  optional extra: a thin python check in docs.yml for fast PR feedback on docs-only
+  changes.
+- **D5 — minigraph at test scope:** yes ✅ (no preload pollution; anchors still
+  build-verified). Alternative: runtime dependency + config to silence the playground
+  (fragile).
+- **D6 — Who implements PR A:** good first-arc candidate for Eu Gene under this plan
+  (their find; the fixture test is theirs in spirit) — Eric's call.
+- **D7 — Closure scope:** same as the PR (guides' true link closure) ✅; trimming would
+  break link validation or force link rewrites.

--- a/draft-design-specs/annotation-macro-interop-design.md
+++ b/draft-design-specs/annotation-macro-interop-design.md
@@ -1,0 +1,265 @@
+# Annotation → Macro → Decorator: the Registration-Metadata Interop Design
+
+Date: 2026-07-25 (draft for maintainer review)
+Scope: Java (reference) → Rust (refine now) → Python, Node.js (future ports)
+Inputs: two deliberately context-free external reviews
+(`annotation-macro-fidelity-report-2026-07-25.md`, `preload-interop-blueprint.md`),
+verified line-by-line against both codebases by an 8-agent survey (2026-07-25).
+
+Goals (maintainer):
+1. Developers see consistent, decoupled annotations/macros — Java scans the classpath at
+   runtime, Rust collects at link time, but the code style reads the same.
+2. The Rust port becomes the best-practice template for the Python and Node.js ports.
+
+Out of short-term scope (maintainer): minimalist-kafka and sync-over-async ports — the
+Kafka-facing annotations ride that future iteration.
+
+---
+
+## 1. Ground truth (verified, with citations)
+
+### 1.1 The Java annotation surface (reference)
+
+Core package `org.platformlambda.core.annotations` — 10 annotations, all
+`@Target(TYPE) @Retention(RUNTIME)`:
+
+| Annotation | Payload | Consumed by |
+|---|---|---|
+| `@PreLoad` | `route` (comma-separated aliases), `customSerializer=Void.class`, `inputPojoClass=Void.class`, `instances=1`, `envInstances=""`, `isPrivate=true`, `inputStrategy/outputStrategy=DEFAULT` (enum SNAKE/CAMEL/DEFAULT) | AppStarter.preload → Platform.register (AppStarter.java:363-447) |
+| `@BeforeApplication` | `sequence=10` (0 reserved, 2 Event Script) | AppStarter.prepareApp (ascending) |
+| `@MainApplication` | `sequence=10` | AppStarter (after preload + web) |
+| `@WebSocketService` | `value` (name), `namespace="ws"` | AppStarter.prepareWebsocketServices |
+| `@OptionalService` | `value` — OR-list of `key`, `!key`, `key=value` | `Feature.isRequired` (Feature.java:35-76), honored by BeforeApp/MainApp/PreLoad/WebSocket scan + rest-spring WebLoader + minigraph PlaygroundLoader |
+| `@ZeroTracing` | marker | WorkerDispatcher:40 — suppresses trace start, log-context, telemetry |
+| `@EventInterceptor` | marker | ServiceDef:62 — raw envelope in, response swallowed, hygiene-scrub exempt |
+| `@KernelThreadRunner` | marker | ServiceDef:63-67 — kernel executor instead of virtual threads |
+| `@CloudConnector` | `name`, `original=""` | Platform.connectToCloud — only the Kafka mesh stack uses it |
+| `@CloudService` | `name`, `original=""` | Platform.startCloudServices — Kafka mesh only |
+
+Module-local extension annotations:
+
+| Annotation | Module | Shape | Loader |
+|---|---|---|---|
+| `@SimplePlugin` (marker) | event-script-engine | class implements `PluginFunction` (`getName()` default = class-name→camelCase; `Object calculate(Object...)`) | SimplePluginLoader, `@BeforeApplication(seq=3)` — before CompileFlows (seq 5) so `f:` names validate at compile time |
+| `@FetchFeature("name")` | minigraph-playground-engine | class implements `FeatureRunner` | PlaygroundLoader, `@MainApplication(seq=8)`; gates every class through `Feature.isRequired` |
+
+Operational companion: **`yaml.preload.override`** (AppStarter.java:289-434) — config files
+that rename / fan out / re-tune `instances` of any preloaded route without recompiling
+(entries: `original`, `routes`, `instances`, `keep-original`; multiple files merge:
+route-sets union, first-set instances wins).
+
+Conflict semantics in Java today (inconsistent — see §4.3):
+- Platform.register: **warn + reload** (Platform.java:555) — but the javadoc *claims* it
+  throws on duplicates (Platform.java:382, 396) — a documentation bug.
+- PlaygroundLoader features: **silent replace** (ConcurrentHashMap.put, PlaygroundLoader.java:72).
+- SimplePluginLoader: warns on duplicates.
+- Cloud services: duplicate names in `cloud.services` rejected with an error (Platform.java:258).
+
+### 1.2 The Rust macro surface (current)
+
+Three proc-macro crates; all entries collected via link-time `inventory`:
+
+| Macro | Args | Target | Entry struct |
+|---|---|---|---|
+| `#[preload]` | `route` (comma aliases, compile-validated), `instances=1` (clamped 1..=1000 like ServiceDef), `env_instances` (config KEY, resolved at boot), `is_private=true`, `typed`, `zero_tracing`, `interceptor` | struct | `PreloadEntry{route, instances, env_instances, optional_service, zero_tracing, interceptor, is_private, factory}` |
+| `#[before_application]` / `#[main_application]` | `sequence=10` | struct (EntryPoint) | `BeforeAppEntry` / `MainAppEntry` (+ optional_service) |
+| `#[websocket_service]` | name, `namespace="ws"` | struct | `WsServiceEntry` (+ optional_service) |
+| `#[optional_service("cond")]` | condition | **first-class stackable attribute**, consumed by the four platform macros; compile error if used alone | folded into the primary's entry |
+| `#[simple_plugin]` | `name` (default = camelCase of fn name — deliberately mirrors PluginFunction.getName) | **free fn** `fn(&[rmpv::Value]) -> Result<rmpv::Value, String>` | `SimplePluginEntry{name, body}` |
+| `#[fetch_feature("name")]` | name only — **any other arg is a compile error** | struct (FeatureRunner) | `FetchFeatureEntry{name, factory}` — **no optional_service field** |
+
+Marker stacking already mirrors Java: `#[zero_tracing]`, `#[event_interceptor]`,
+`#[optional_service]` may be written as separate stacked attributes; `#[preload]` strips
+and consumes them (platform-macros/src/lib.rs:144-147). Documented in
+macros-reference.md "Stacked markers".
+
+Collectors/lifecycle: AutoStart::main iterates BeforeApp → PreLoad → MainApp inventories;
+`env_instances` resolved at **boot** (app_starter.rs:426-430) with the same
+digits-else-fallback semantics as Java's getInstancesFromEnv; `optional_service`
+evaluated by `util::feature::is_required` (feature.rs:32-53 — same OR-list/!/= grammar as
+Java's Feature) for BeforeApp/PreLoad/MainApp/Ws entries. Event-script plugins load at
+`before_application(seq=3)`; knowledge-graph features at `before_application(seq=1)`.
+
+Conflict semantics in Rust today: preload = **warn + reload** (platform.rs:238-244, the
+F10 Java-parity fix); websocket = silent replace; simple plugins = **silent replace —
+a user plugin can silently shadow a built-in** (plugins.rs:78-83); fetch features =
+**skip/first-wins** on the declarative path (features.rs:74) but replace on explicit
+`register()`.
+
+### 1.3 Adoption reality
+
+- `#[preload]` ×43, `#[before_application]` ×6, `#[main_application]` ×3,
+  `#[websocket_service]` ×2, `#[optional_service]` ×17 in production Rust code.
+- `#[simple_plugin]` and `#[fetch_feature]`: **zero production usages** — all 46 built-in
+  mapping plugins are hard-coded in `builtin_registrations()` (plugins.rs:350-410,
+  incl. the PR #220 trio isEmpty/getFirst/getLast at :402-404), both built-in fetch
+  features hard-coded in `register_builtins()` (features.rs:157-164).
+- Java, by contrast: **all 47 built-in plugins are `@SimplePlugin` classes** under
+  `com.accenture.services.plugins/` and **both built-in features are `@FetchFeature`
+  classes** — Java's engine dogfoods its own extension points; Rust's does not.
+
+---
+
+## 2. Evaluation of the two external reports
+
+### 2.1 Fidelity report — verdict-by-verdict
+
+| Report claim | Verified outcome |
+|---|---|
+| FetchFeature is the least faithful port | **CONFIRMED** — hard-wired builtins, no OptionalService path (macro rejects extra args), first-wins vs Java's last-wins |
+| SimplePlugin mostly faithful; builtins hard-wired; test-only adoption | **CONFIRMED** — incl. the Java half (46/47 annotation-driven) the report could not have known to double-check |
+| Rust plugin = free fn vs Java class | **CONFIRMED** — assessed here as a *correct* per-language idiom, not a defect (§4.4) |
+| zero_tracing/event_interceptor "do not exist as standalone attributes" | **OVERSTATED** — they already stack as separate marker attributes below `#[preload]`, mirroring Java's annotation stacking; they are consumed by preload rather than independent proc-macros, which is the right Rust mechanic. Goal 1 is already met here. |
+| KernelThreadRunner/CloudConnector/CloudService unported | **CONFIRMED — and already documented as deliberate** (macros-reference.md:324-330, function-execution.md, port-scope.md). The report asked us to "decide explicitly"; the decision exists in writing. |
+| P2 "deterministic conflict policy" | **VALID — and bigger than the report knew**: Java itself is internally inconsistent and its Platform javadoc contradicts the implementation. This is a cross-engine contract item, not a Rust patch. |
+
+What the context-free reviewers missed (the intentional blind spots):
+1. **`yaml.preload.override`** — a whole operational surface of the Java annotation model
+   (config-driven rename/fan-out/instance-tuning), unported in Rust (documented), unknown
+   to the blueprint.
+2. **`#[optional_service]` is already first-class and stackable** in Rust — the platform
+   pattern the report recommends inventing for fetch_feature already exists to reuse.
+3. **Java's SimplePluginLoader does NOT honor @OptionalService** (only FetchFeature's
+   loader does) — so "gate everything" would *exceed* Java, a lock-step decision, not a
+   parity fix.
+4. Lifecycle nuance: Java loads fetch features at `@MainApplication(seq 8)`; Rust at
+   `before_application(seq 1)`. Both satisfy "features ready before graph execution";
+   noted as an accepted difference.
+5. Two **stale Rust docs** contradicting shipped behavior: event-script/syntax.md:354-360
+   claims `#[preload]` takes a single route (comma aliases ARE supported and used in
+   production); api-overview.md:28-36 claims no public/private distinction (is_private +
+   the /api/event 403 exist).
+
+### 2.2 Blueprint report — what to keep, what to replace
+
+Keep (the reusable skeleton): one-schema-many-mechanisms; **resolve late, register
+early**; string enums on the wire; explicit per-language discovery; the 6-step boot
+sequence; conformance-by-golden-JSON. All of this matches how we already proved the
+envelope wire format (golden vectors + normalize-and-diff), so it fits the project's
+established parity method.
+
+Replace: the entire placeholder schema — §3 below carries the real model. Its §3.2
+"known gap: customSerializer/inputPojoClass may be silently broken in Rust macros" is
+**refuted**: the four serialization-related @PreLoad fields are *intentionally absent*
+(serde is the single compile-time serializer; `TypedFunction<I,O>` + `body_as::<Vec<T>>()`
+subsumes inputPojoClass, which exists only to defeat JVM type erasure). One genuine
+residual: Java can flip snake/camel per route or via `snake.case.serialization` at
+runtime; Rust cannot without recompiling — carried in the capability matrix, not a bug.
+
+---
+
+## 3. The registration-metadata contract (real model, v1 proposal)
+
+One canonical, language-agnostic metadata model; per-language carriers (annotation /
+proc-macro / decorator) are idioms; **semantics are fixed**:
+
+```json
+{
+  "kind": "function | websocket | entrypoint-before | entrypoint-main | plugin | feature",
+  "route": "string (functions; comma-separated aliases allowed)",
+  "name": "string (websocket/plugin/feature)",
+  "namespace": "string, websocket only, default \"ws\"",
+  "sequence": "integer, entrypoints only, default 10 (0 framework-reserved)",
+  "instances": "integer, default 1, clamped 1..1000 at registration",
+  "envInstances": "string config KEY, default \"\" — resolved at BOOT: numeric value wins, else instances",
+  "isPrivate": "boolean, default true",
+  "zeroTracing": "boolean marker, default false",
+  "eventInterceptor": "boolean marker, default false",
+  "optionalService": "string | null — OR-list of key, !key, key=value against app config, evaluated at BOOT",
+  "capabilities": {
+    "customSerializer": "type name | null — JVM-family capability; N/A where serialization is compile-time (Rust)",
+    "inputPojoClass": "type name | null — JVM type-erasure workaround; N/A in monomorphized/duck-typed runtimes",
+    "serializationStrategy": "\"SNAKE\"|\"CAMEL\"|\"DEFAULT\" in/out — runtime-flippable in Java/Python/Node; compile-time (serde rename_all) in Rust",
+    "executionHint": "\"default\" | \"blocking\" — Java=@KernelThreadRunner, Rust=reserved (tokio spawn_blocking, unimplemented), Python/Node=TBD (GIL/worker-threads)"
+  }
+}
+```
+
+Fixed semantics (every port MUST):
+1. **Attach at definition, resolve at boot** — env keys and optional-service conditions
+   are never evaluated at decoration/expansion/import time.
+2. **Optional-service grammar** is exactly Java's Feature grammar: comma = OR, `!` = NOT,
+   `key=value` case-insensitive, bare `key` means `key=true`.
+3. **Conflict policy** (see D2): identical across all registries and all languages,
+   logged with both sources.
+4. **Boot sequence**: discover → register → *override (config)* → resolve (env) →
+   validate (unique routes, non-empty registry) → route table. The `override` step is
+   Java's `yaml.preload.override`; ports carry it (D4).
+5. **Lifecycle anchors**: plugins load before flow compilation; features before graph
+   execution; entrypoint sequences ascend; sequence 0 is framework-reserved.
+6. **Wire form for tooling**: JSON, camelCase keys, enums as strings — never ordinals.
+7. **Discovery is explicit per language** and must fail loudly when a registry that
+   should be populated is empty: Java = classpath scan (free); Rust = link-time
+   inventory (+ startup count assertion); Python = package walk + import before resolve;
+   Node = glob + dynamic import before resolve.
+
+Extension-point shape guidance for Python/Node (from the Rust experience):
+- **Plugins are named pure functions** — Rust's free-fn form is the better template than
+  Java's class+interface (a decorator on a function is the natural Python/Node idiom);
+  the *name derivation* rule (camelCase of the declared name, overridable) is the
+  portable part. Java's class shape stays as-is (reference does not churn).
+- **Features are small stateful runners** — struct/class with before/after hooks; the
+  annotation carries the feature name explicitly.
+
+Conformance: each engine exports its resolved demo-app registry (hello-world fixture set)
+to canonical JSON; a shared golden file must match after key-sorting — the
+golden-vector method that already guards the envelope wire format.
+
+---
+
+## 4. The Rust refinement plan (P1 — this iteration)
+
+### 4.1 Dogfood the extension points (goal 1's biggest visible gap)
+Convert all 46 built-in mapping plugins from `builtin_registrations()` to
+`#[simple_plugin]` fns (same bodies, same names — isEmpty/getFirst/getLast keep exact
+Java error-message parity), and both built-in fetch features to `#[fetch_feature]`
+structs. Delete `builtin_registrations()` / `register_builtins()`; replace the
+`include!("plugins_e8.rs")` textual include with a proper module. Add the startup
+assertion (registry count) so a linker-elision regression fails loudly in CI.
+
+### 4.2 fetch_feature reaches parity with the platform macros
+Accept stacked `#[optional_service("...")]` (reuse the existing platform strip/fold
+pattern), add `optional_service: Option<&'static str>` to `FetchFeatureEntry`, evaluate
+via the existing `util::feature::is_required` in `load_declared_features()` with the
+same "Skip optional …" log line as Java's PlaygroundLoader.
+
+### 4.3 One conflict policy, both engines (D2)
+Proposed: **explicit register() wins over declarative; within a registry, duplicate
+names = WARN with both sources + last-wins reload** — Java Platform's actual behavior,
+extended everywhere. Rust: features skip→warn+replace; plugins/websocket add the WARN.
+Java (small lock-step PR): fix the Platform.register javadoc (says "throws", actually
+reloads); add the WARN to PlaygroundLoader's silent put. Regression tests both engines,
+including "user plugin shadows built-in emits a warning naming both".
+
+### 4.4 Documented divergences (no code change; contract text)
+Plugin carrier shape (Java class / Rust fn), fetch-feature load anchor
+(MainApplication-8 vs before_application-1), serialization capability matrix,
+KernelThreadRunner→tokio posture. Fix the two stale Rust doc claims (syntax.md
+single-route; api-overview public/private).
+
+## 5. P2 (same arc, gated separately)
+- **Port `yaml.preload.override` to Rust** (D4): a boot-time transform over the collected
+  PreloadEntry set between inventory iteration and registration — rename/fan-out/
+  instances with Java's merge rules; removes the one operational annotation-surface gap.
+- **Publish the contract** (D5): spec page in the Java repo (reference), adapted in the
+  Rust docs like the macros-reference; golden conformance fixture; propose
+  ADR "Registration metadata is a cross-language contract; carriers are per-language
+  idioms" (Java ADR-0009 / Rust ADR-0008).
+
+## 6. Deferred (explicitly)
+- `@KernelThreadRunner` analog (`executionHint: blocking` → spawn_blocking): reserved in
+  the contract, unimplemented — revisit when a field workload needs it.
+- `@CloudConnector`/`@CloudService` + Kafka adapter annotations: ride the future
+  minimalist-kafka / sync-over-async port iteration (maintainer direction).
+- Whether `@SimplePlugin` should honor `@OptionalService` (would exceed Java — a
+  both-engines enhancement, not parity): proposed DEFER unless wanted now (D3b).
+
+## 7. Decision points for the maintainer
+- **D1** Convert Rust built-ins to declarative macros (46 plugins + 2 features). [rec: yes]
+- **D2** Conflict policy = warn + last-wins everywhere, explicit register() > declarative;
+  incl. the small Java javadoc/log lock-step fixes. [rec: yes; alternative: startup error]
+- **D3a** fetch_feature gains optional_service (Java parity). [rec: yes]
+  **D3b** simple_plugin too (exceeds Java, needs Java-side change in lock-step). [rec: defer]
+- **D4** Port yaml.preload.override to Rust. [rec: yes, P2]
+- **D5** Contract spec page + golden conformance fixture + ADR pair. [rec: yes, P2]
+- **D6** executionHint reserved-only for now. [rec: defer implementation]

--- a/draft-design-specs/async-http-client-sse-streaming.md
+++ b/draft-design-specs/async-http-client-sse-streaming.md
@@ -1,0 +1,215 @@
+# SSE consumption in AsyncHttpClient + Event-over-HTTP peer streaming — design spec
+
+**Status:** APPROVED — option 2 ratified by Eric 2026-08-29 (SSE response on the same
+call; WebSocket and multi-POST alternatives rejected — see §2); **D1–D9 approved as
+recommended 2026-08-29, with D5 REVISED to Eric's hybrid framing** (envelope frames only
+where envelope semantics matter; raw frames on the hot path — see D5). Phasing
+directive: **start with the AsyncHttpClient enhancement (Phase 1)**.
+**Phase 1 IMPLEMENTED (Java) 2026-08-29:** the SSE-candidate branch in AsyncHttpClient
+(responseTimeout exempted for candidates; per-read idle timer with in-band 408 "Timeout
+for N seconds"; lock-serialized relay per the drain-handler lesson), incremental
+byte-level SSE parser (UTF-8-safe line split, comment/id/retry suppression, multi-line
+data join), buffered fallback for non-SSE responses on the candidate path, and the
+self-relay demo endpoint (/api/hello/relay in the test app). Gates: 9 new tests
+(mapping, multi-field frames, 50-event FIFO burst, idle 408, comment-reset,
+mid-stream disconnect, buffered fallback, no-Accept backward-compat pin, progressive
+self-relay e2e) — platform-core 459/459. ADR-0019 Proposed.
+**Serves:** `bp-agent-orchestration` (an `llm.chat` node consuming provider token streams)
+and `bp-polyglot-functions` (wrapper functions streaming back to the engine) — the two
+remaining gaps after [[thread-http-response-streaming]] closed the engine→HTTP-edge leg.
+**Engine parity:** AsyncHttpClient and Event-over-HTTP are engine surface → Java + Rust
+lock-step with engine-identical vocabulary and messages (Java is the reference); the
+wrapper halves land in mercury-python / mercury-nodejs with their own twins.
+
+---
+
+## 1. Problem
+
+Progressive rendering now exists on the HTTP **service** side (both engines): a callee
+streams `x-event-stream: data | eof | exception` envelopes to the caller's reply lane and
+the edge renders SSE/chunked progressively. Two consumption gaps remain:
+
+1. **Engine as SSE client.** `async.http.request` aggregates the whole response before
+   replying (`responseSingle` on reactor-netty; body collect on hyper). An engine
+   function calling an LLM provider's SSE API (OpenAI/Anthropic/Gemini-compatible —
+   `text/event-stream` responses) receives everything buffered at completion — no
+   token-by-token relay is possible.
+2. **Wrapper functions cannot stream to the engine.** Event-over-HTTP is drop-n-forget
+   (`x-async: true` → 202) or request-response (RPC — the reply rides the single HTTP
+   response body). A python/node function has no channel for a segment sequence.
+
+Both gaps close with ONE mechanism because the Event-over-HTTP relay already flows
+through AsyncHttpClient (`EventEmitter.asyncRequest(event, timeout, headers, endpoint,
+rpc)` wraps the envelope as a POST via `async.http.request`): teach the client to consume
+a `text/event-stream` response progressively, and the wrapper's `/api/event` host becomes
+just another SSE producer.
+
+## 2. Decision record (option analysis ratified 2026-08-29)
+
+- **CHOSEN — SSE response on the same call.** One request → one ordered stream (TCP
+  ordering is FIFO for free); the terminal signal is in-band (the `eof`/`exception`
+  envelope — the protocol both engines already implement); no new inbound surface on the
+  engine (segments ride the response of a request the engine itself made); the most
+  middleware-survivable wire (gateways handle SSE because LLM traffic forced them to);
+  and the same client capability is needed anyway for direct LLM-provider calls.
+- **REJECTED — on-demand WebSocket engine⇄wrapper.** Breaks the wrapper scope fence
+  (D0–D8: codec + /api/event host + thin client — no connection-lifecycle machinery);
+  four codebases grow a WS surface + conformance vectors; historically gateway-hostile;
+  a standing engine⇄wrapper connection drifts toward the presence/mesh architecture the
+  framework deliberately keeps opt-in (`kafka-mesh-opt-in`).
+- **REJECTED — per-segment POSTs back to the reply lane** (the earlier v1.1 sketch).
+  Zero new machinery, but FIFO forces the wrapper to serialize posts (per-segment
+  latency = one network RTT — fatal for token streams) and it requires letting remote
+  peers address reply lanes (a new inbound trust surface the chosen option avoids).
+- **REJECTED — gRPC/HTTP-2 push** (foreign dependency stack), **long-polling** (chatty,
+  stateful), **the legacy `x-stream-id` relay** (Reactor/JVM-shaped; absent from the
+  Rust port; already rejected in the D1 round of the edge feature).
+
+## 3. The model
+
+```
+consumer function ──send──▶ async.http.request ──POST──▶ upstream (SSE server)
+        │ reply_to + cid                                     │ text/event-stream
+        ▼                                                    ▼
+reply route (e.g. the HTTP edge's reply lane) ◀── x-event-stream envelopes,
+                                                   one per SSE event, then eof
+```
+
+The client becomes a **streaming producer** toward the caller's `reply_to` — exactly the
+producer contract the edge already consumes. Composition falls out with zero new code:
+a `stream: true` endpoint whose function forwards its own `reply_to`/`cid` into the
+`async.http.request` event turns the engine into an **SSE-to-SSE relay by
+configuration** (upstream tokens → client → reply lane → SSE out the edge).
+
+Two consumption modes, selected by context:
+
+- **Raw mode** (Phase 1, user-facing): the upstream is any SSE API. Each SSE event maps
+  to one `x-event-stream: data` envelope (body = the event's data text; `event:` name →
+  `x-event-name`). For LLM providers and arbitrary SSE sources.
+- **Envelope mode** (Phase 2, the Event-over-HTTP relay): the upstream is a peer's
+  `/api/event`. HYBRID framing per D5: envelope frames (`event: envelope` +
+  base64 MsgPack) for the head, the terminals, and non-text segments; raw frames for
+  text segments. The client decodes/constructs and forwards each event to the original
+  `reply_to` with the original correlation id. Mode selection is structural: the relay
+  path (internal `x-event-api` context) uses envelope mode; user calls to
+  `async.http.request` use raw mode.
+
+## 4. Proposed decisions (D-series — for ruling)
+
+- **D1 — Activation is explicit and standard: the caller's Accept header.** Progressive
+  mode activates only when (a) the request declared `Accept: text/event-stream` AND
+  (b) the response arrives with `Content-Type: text/event-stream` AND (c) the request
+  event carries a `reply_to`. Anything else keeps today's buffered single-shot behavior
+  — fully backward compatible (existing callers that hit SSE endpoints and buffer them
+  keep working; an RPC caller who accidentally opts in would consume only the first
+  segment, hence the explicit Accept requirement). Recommended over a proprietary
+  opt-in header: "you asked for SSE, you receive SSE semantics" — and it follows the
+  house lesson that Accept must always be declared explicitly.
+- **D2 — Raw-mode event mapping.** One upstream SSE event → one `data` envelope:
+  multi-line `data:` fields joined with `\n` (SSE spec), `event:` → `x-event-name`,
+  comment lines (`: ping`) and `id:`/`retry:` fields consumed by the client, never
+  forwarded. The FIRST forwarded envelope carries head control: upstream HTTP status +
+  `content-type: text/event-stream` — so a relay to the edge opens SSE mode there
+  automatically. Stream end → `eof` envelope (empty body). Mid-stream transport error →
+  `exception` envelope `{status: 500, message}` — in-band, matching the edge contract.
+  A non-2xx upstream head with an SSE body still streams (status rides the first
+  envelope); a non-2xx non-SSE head is today's single-shot error reply.
+- **D3 — No payload interpretation in raw mode.** The client does NOT parse provider
+  conventions (OpenAI's `data: [DONE]`, JSON deltas, etc.) — data text is forwarded
+  verbatim and the consumer (an `llm.chat`-style function or the end client) owns
+  provider semantics. Keeps the client vendor-neutral (the AI-companion non-goal:
+  never locked to one LLM vendor).
+- **D4 — Idle allowance replaces total timeout for streams.** Today the request's
+  `x-ttl` bounds the whole exchange. In progressive mode it becomes the per-read idle
+  allowance (edge parity: each arriving event resets it); on idle expiry the client
+  forwards an in-band `exception` envelope `{status: 408, message: "Timeout for N
+  seconds"}` (engine-identical message) and aborts the upstream connection. Upstream
+  keep-alive comments DO reset the client's idle timer (they prove upstream liveness —
+  LLM providers ping during long tool-use pauses) but are never forwarded; a relay
+  flow should therefore set the producer-side idle override (`x-ttl` on the first
+  event, or a generous endpoint timeout) to cover quiet-but-alive upstreams
+  end-to-end. *(This asymmetry — upstream pings feed the client's timer but nothing
+  reaches the edge's timer — is the one nuance to confirm.)*
+- **D5 (REVISED — Eric's hybrid, 2026-08-29) — Envelope-mode framing is a HYBRID:
+  envelope frames only where envelope semantics matter; raw frames on the hot path.**
+  Rationale: pure envelope-per-frame repeats the whole envelope structure (cid, route,
+  headers, marker) plus base64 on EVERY token — ~200+ wire bytes for a 5-byte token;
+  raw frames cut the hot path to `data: <text>` (~90% reduction). One request = one
+  stream = one cid, so per-frame addressing carries no information.
+  **Eric's formulation (2026-08-29): control plane vs data plane — all control signals
+  ride as key-value headers in envelope frames (the first envelope carries the head:
+  status, content-type, idle allowance; the terminals ARE control signals — end of
+  transmission and in-band failure); subsequent blocks are tokens (raw frames).**
+  The dialect (self-describing, no sniffing):
+  - Reserved SSE event name **`event: envelope`** marks a frame whose `data:` is one
+    base64-encoded MsgPack envelope (the one codec; golden vectors still the gate).
+  - **First frame** = envelope frame (head control: status, content-type, x-ttl).
+  - **Terminal frames** (`eof` / `exception`) = envelope frames — one per stream, so
+    zero meaningful cost, and trailing metadata / {status,message} keep exact Map
+    types end-to-end (matters when the consumer is a function, not the edge).
+  - **Text segments** = raw frames: `data: <text>`, optional user `event: <name>` →
+    `x-event-name` (SSE's native field; the same grammar the edge renders).
+  - **Adaptive escape hatch**: the writer emits an envelope frame for any segment that
+    cannot round-trip raw — Map or byte bodies, text containing `\r` (SSE normalizes
+    line endings), or a user event name equal to the reserved word. Deterministic,
+    checked per segment, never lossy.
+  Keep-alive comments allowed, ignored. The raw dialect adds one small frame-mapping
+  conformance fixture, mirrored from the edge rendering both engines already pin.
+- **D6 — Envelope-mode capability negotiation (version skew).** The engine relay
+  advertises `Accept: text/event-stream` on `/api/event` calls once it can consume
+  progressively. A peer streams ONLY when the request accepts SSE and the target
+  function actually streams; a streaming function invoked by a non-accepting (older)
+  caller receives an explicit error envelope ("Streaming function requires a caller
+  that accepts text/event-stream" — engine-identical wording TBD) rather than a
+  silently buffered or truncated reply. Old wrappers ignore the Accept header and
+  behave exactly as today.
+- **D7 — Correlation and tracing across the hop.** The relayed segments are forwarded
+  to the ORIGINAL `reply_to` with the ORIGINAL `cid` (the client rewrites, exactly as
+  the edge's lane consumes them); trace context propagates on the outbound POST as
+  today (X-Trace-Id + traceparent); the client's forwarding leg is the visible span.
+- **D8 — Ordering guarantee.** One streaming call is consumed by ONE client worker
+  reading one HTTP response sequentially → per-stream FIFO into the reply route by
+  construction (no lane needed on the client side; the reply route's own discipline —
+  e.g. the edge lane — preserves order downstream).
+- **D9 — Phasing.** Phase 1 (START, this repo then Rust): raw-mode SSE consumption in
+  AsyncHttpClient + the self-relay proof (see §6). Phase 2 (both engines): envelope
+  mode on the Event-over-HTTP relay + `/api/event` SSE production on the ENGINE side
+  (engine⇄engine streaming works before wrappers move). Phase 3 (wrapper repos):
+  `/api/event` SSE production + `EventStreamWriter` twins in mercury-python and
+  mercury-nodejs, conformance-tested against the engines. Java-first with vocabulary
+  pinned; Rust immediately after each phase (D7 precedent).
+
+## 5. Implementation sketch (Phase 1)
+
+- **Java** (`AsyncHttpClient`): branch after response head — if progressive conditions
+  hold (D1), switch from `responseSingle` to `response((head, content) -> ...)` /
+  `responseContent()` (reactor-netty's streaming `ByteBufFlux`), feed an incremental
+  SSE frame parser (buffer split on `\n\n`, tolerate `\r\n`, partial-frame carry),
+  and emit envelopes to `reply_to` via `po.send` as frames complete; idle timer per
+  D4; cancellation on downstream failure (reply route gone → abort upstream).
+- **Rust** (`automation/http_client.rs`): same branch; hyper's `Incoming` body is
+  already frame-streaming — feed the same incremental parser (the test-side
+  de-chunking reader from `tests/event_stream.rs` is the shape, production-hardened).
+- Reuse the pinned SSE vocabulary end-to-end; no new config keys in Phase 1.
+
+## 6. Test plan (Phase 1)
+
+- **The self-relay e2e (flagship):** one app, no external dependency — a `stream: true`
+  endpoint whose function forwards its own `reply_to`/`cid` into an
+  `async.http.request` aimed at the app's OWN SSE demo endpoint. Proves consumption,
+  mapping, ordering, and edge re-rendering in a single process (progressive timing
+  asserted with the timed-line reader).
+- Raw-mode unit/e2e set against a mock SSE upstream: event mapping (data/multi-line/
+  named), comment and id/retry suppression, head-status propagation, eof on clean end,
+  in-band 408 on idle stall (with comment-reset case), in-band exception on mid-stream
+  disconnect, non-SSE response unchanged (backward-compat pin), Accept-not-declared →
+  buffered (backward-compat pin), burst FIFO through the relay.
+- Mutation-proof the idle timer and the terminal mapping (kill the fix, watch it fail).
+
+## 7. Follow-ups staged (not this spec's scope)
+
+- Phase 2/3 detail rounds (envelope-mode relay internals; wrapper host/writer twins;
+  interop report round per `conv-telemetry-presentation-parity`).
+- Event Script flow handoff (`model.http.*` reserved keys) — unchanged from the edge
+  spec's v1.1 list.
+- graph-run streaming (bp-agent-orchestration).

--- a/draft-design-specs/event-envelope-interop-design.md
+++ b/draft-design-specs/event-envelope-interop-design.md
@@ -1,0 +1,247 @@
+# Design: Common Event Envelope Wire Format for Cross-Language Interoperability
+
+**Status:** DRAFT for review (Eric)
+**Date:** 2026-07-21
+**Scope:** Event over HTTP interoperability between mercury-composable (Java) and the
+official Rust port (github.com/Accenture/mercury), extensible to future Node.js, Python,
+and Go ports.
+**Testbed:** the Rust port (read-only for this session; its `/api/event` implementation is
+a separate workstream).
+
+---
+
+## 1. Problem
+
+`POST /api/event` (Event over HTTP) carries a serialized `EventEnvelope` as
+`application/octet-stream`. The Java implementation serializes with **proprietary
+single-character map keys** before MsgPack encoding:
+
+| Compact key | Meaning | | Compact key | Meaning |
+|---|---|---|---|---|
+| `0` | id | | `S` | status |
+| `T` | to | | `H` | headers |
+| `F` | from | | `B` | body |
+| `R` | reply_to | | `7` | tags |
+| `t` | trace_id | | `6` | annotations |
+| `p` | trace_path | | `4` | exception (bytes) |
+| `s` | span_id | | `5` | stack |
+| `X` | cid | | `O` | obj_type |
+| `1` | exec_time | | `2` | round_trip |
+
+The Rust port encodes the same envelope with **full field names** via serde
+(`rmp_serde::to_vec_named`): `id`, `to`, `from`, `reply_to`, `cid`, `trace_id`,
+`trace_path`, `span_id`, `status`, `headers`, `body`, `exec_time`.
+
+The two cannot interoperate today, and the compact keys are undocumented outside the Java
+source — a barrier for every future port.
+
+**Key observation:** Java already maintains BOTH representations. `toBytes()`/`load()` use
+the compact flags; `toMap()`/`fromMap()` use descriptive keys that are almost exactly the
+Rust field names. The common format below is therefore not an invention — it is the
+promotion of the existing descriptive form to a documented, normative wire contract.
+
+## 2. Goals / non-goals
+
+**Goals**
+1. A language-neutral, self-describing serialized envelope any MsgPack-capable language
+   can encode/decode with its idiomatic tooling (serde, msgpack-java, msgpack-lite,
+   msgpack-python, vmihailenco/msgpack…) — no custom codec required.
+2. Backward compatible: existing Java↔Java Event over HTTP (compact keys) keeps working
+   through the transition, with no flag-day.
+3. Documented as a spec page that passes the fresh-agent test: a new port implements the
+   format from the page alone.
+
+**Non-goals**
+- Changing the in-memory `EventEnvelope` API in any language.
+- The Kafka service-mesh wire format (same-language mesh; can migrate later).
+- Cross-language transport of language-native exception objects (impossible by
+  definition; see §3.4).
+- Byte-identical encodings across languages (MsgPack map ordering is unspecified; the
+  contract is semantic round-trip, not binary equality).
+
+## 3. The interchange format ("standard envelope", v1)
+
+A single MsgPack **map with string keys**. Field registry:
+
+### 3.1 Core fields (all implementations)
+
+| Key | MsgPack type | Encode | Decode | Semantics |
+|---|---|---|---|---|
+| `id` | str | REQUIRED | REQUIRED | Event instance id (opaque string; UUID recommended) |
+| `to` | str | when set | optional | Target route name |
+| `from` | str | when set | optional | Sender route name |
+| `reply_to` | str | when set | optional | Reply route name |
+| `cid` | str | when set | optional | Business correlation id |
+| `trace_id` | str | when set | optional | Distributed trace id |
+| `trace_path` | str | when set | optional | Trace path, e.g. `GET /api/hello` |
+| `span_id` | str | when set | optional | Sender's span id (receiver's parent span) |
+| `status` | int | when set | optional, default 200 | HTTP-style status code |
+| `headers` | map<str,str> | REQUIRED (may be empty) | REQUIRED | User parameters |
+| `body` | any | when set (absent = nil) | optional, default nil | Payload — see §3.3 |
+| `exec_time` | float | when set | optional | Function execution ms |
+| `round_trip` | float | when set | optional | End-to-end ms |
+
+### 3.2 Extension fields (currently Java-only; optional everywhere)
+
+| Key | MsgPack type | Semantics |
+|---|---|---|
+| `tags` | map<str,str> | Routing metadata (`optional`, `json`, `broadcast`) |
+| `annotations` | map<str,any> | Trace annotations |
+| `stack` | str | Stack-trace text — the **portable** error detail |
+| `obj_type` | str | Language-specific payload type hint (PoJo class for Java). Advisory; receivers MAY ignore |
+
+### 3.3 Encoding rules
+
+1. **Map keys are strings.** Body maps must also use string keys (Java already
+   auto-converts integer keys; other languages must not emit them).
+2. **Optional fields:** encoders SHOULD omit unset optional fields; encoding them as nil
+   is equally valid. Decoders MUST treat *absent* and *nil* identically.
+3. **Required-on-encode:** `id` and `headers` are always present (empty map when there
+   are no headers) — this helps statically-typed decoders. `body` is emitted when set;
+   decoders default a missing body to nil. (Implementation finding: Java's `MsgPack.packMap`
+   skips null map values unless `serializer.null.transport=true`, so a nil body cannot be
+   emitted by default — the Rust decoder needs a serde default on `body`.)
+4. **Unknown keys MUST be ignored** by decoders (forward compatibility). This is serde's
+   default and trivial in dynamic languages.
+5. **Numbers:** encoders use the smallest natural MsgPack width; decoders MUST accept any
+   integer width for integer fields and float32/float64 for float fields. (Java's
+   documented Long→Integer downcast on small values is within spec.)
+6. **Binary:** `body` (or any nested value) may be MsgPack `bin`. Strings are UTF-8 `str`.
+7. **No MsgPack extension types** in v1 — timestamps travel as ISO-8601 UTC strings with
+   millisecond precision (the existing Java `Date`/`Instant` convention), keeping every
+   decoder trivial.
+8. The envelope is self-contained: no headers/metadata outside the MsgPack bytes are
+   required to decode it.
+
+### 3.4 The exception field (deliberately not in the spec)
+
+Java's `exception` ("4") is a Java `ObjectOutputStream` blob — meaningful only to another
+JVM. It is **excluded from the standard format**. The portable error contract is:
+`status` (≥400) + `body` (error message) + optional `stack` (text). Java keeps the
+exception blob working for compact-mode Java↔Java exchanges; when encoding standard mode
+it is dropped (the stack text and status carry the diagnosis).
+
+## 4. Compatibility & negotiation
+
+The compact and standard key namespaces are **disjoint** (compact keys are exactly one
+character; standard keys are all ≥2). Decoding is therefore unambiguous without any
+out-of-band signal:
+
+- map contains `0`, `T`, `H` or `B` → compact
+- map contains `id`, `to`, `headers` or `body` → standard
+
+**Decode: sniff everywhere.** Java's `load(byte[])` gains the sniff and routes compact
+maps through the existing flag decoder and standard maps through the existing
+`fromMap()`. Every 4.10+ Java node then accepts BOTH formats forever.
+
+**Encode: requester chooses, responder mirrors.** The Event-over-HTTP *service* replies
+in the same format the request arrived in (it knows — it sniffed). The *client* picks the
+request format:
+
+- `event.over.http.format = compact | standard` in application.properties
+  (global default), overridable per call via the existing headers parameter of
+  `po.asyncRequest(event, timeout, headers, endpoint, rpc)` with
+  `x-event-format: compact | standard`.
+- **Default: `standard`** (CONFIRMED by maintainer, 2026-07-21). Event over HTTP is a
+  transient transport — no payload is stored after transmission — so there is no
+  serialized-data migration concern; caller and callee upgrade together in practice.
+  `compact` is the explicit **fallback** for installations that are slow to upgrade one
+  side (the FIFO-vs-BDB elastic-queue precedent: the new format is the default, the old
+  one remains selectable).
+
+This gives: Rust ↔ new-Java (standard, zero config), new-Java → old-Java (set
+`event.over.http.format=compact` globally or `x-event-format: compact` per target until
+the old side upgrades). No handshake, no version headers on the wire, no flag-day.
+
+## 5. Implementation plan
+
+**Phase 1 — Java (this repo, feature release):**
+
+*Agreed API shape (maintainer + agent review, 2026-07-21).* Inbound decoding is automatic
+at the lowest level; outbound format is transport policy passed explicitly. No-arg
+defaults preserve today's behavior at both API levels, so every existing caller —
+in-process `toMap()` cloning (EventEmitter), mesh/stream `toBytes()` — is untouched:
+
+```java
+public enum Format { COMPACT, STANDARD }
+
+public Map<String, Object> toMap(Format format)   // explicit selection
+public Map<String, Object> toMap()                // = toMap(Format.STANDARD)  (today's toMap)
+public byte[] toBytes(Format format)              // = msgPack.pack(toMap(format))
+public byte[] toBytes()                           // = toBytes(Format.COMPACT) (today's wire)
+public void load(byte[] bytes)                    // sniffs compact vs standard automatically
+```
+
+The enum (not a boolean selector) is deliberate: call-site readability
+(`toMap(Format.STANDARD)` vs `toMap(true)`), Sonar java:S2301 avoidance, 1:1 mapping to
+the config string, and room for future representations. This lays the groundwork for
+other event-to-bytes transports (Redis, S3, …): each transport picks its `Format` and
+packs — the envelope owns representations, transports own policy.
+
+1. Implement the API above — `toMap(STANDARD)` is today's `toMap()` plus the
+   required-on-encode rule (`id`/`headers`/`body` always present) and the exception-blob
+   drop (§3.4); `toMap(COMPACT)` is the flag map extracted from today's `toBytes()`.
+2. `load()` sniffs (§4) — `fromMap()` already implements standard decode.
+3. `EventApiService` mirrors the request format in its response.
+4. `EventEmitter`/`PostOffice` remote path: `event.over.http.format` config (default
+   `standard`) + per-call `x-event-format` header selection.
+5. Docs: new reference page **"Event Envelope wire format"** carrying §3 verbatim
+   (the language-neutral spec), linked from the Event-over-HTTP guide and `llms.txt`.
+6. Config reference: `event.over.http.format` key.
+
+**Phase 2 — Rust (separate session, the testbed):**
+- Implement `/api/event` + client with the standard format (its envelope already IS the
+  §3.1 core, minus `round_trip`; needs `#[serde(default)]`-style tolerance checks and
+  the required-on-encode rule).
+- Optional: adopt extension fields as needed (`stack` for error reporting first).
+
+**Phase 3 — future ports (Node.js re-port, Python, Go):** implement from the spec page.
+
+## 6. Interoperability test plan (Rust as testbed)
+
+1. **Golden vectors** (shared fixtures, checked into both repos): canonical envelopes —
+   minimal, full-metadata, nested map body, list body, binary body, unicode strings,
+   ISO-8601 timestamp strings, 4xx error with stack — as base64 MsgPack files with a JSON
+   sidecar describing expected decoded values. Each repo has a decode-assert test and an
+   encode→decode round-trip test (semantic comparison, not byte comparison).
+2. **Live two-runtime exchange** (after Phase 2): Java app + Rust app;
+   (a) Java→Rust RPC and async (`x-ttl`, `x-async` honored), (b) Rust→Java both modes,
+   (c) trace continuity: `trace_id`/`span_id` propagate and telemetry chains across the
+   language boundary, (d) Java↔Java compact regression unchanged.
+3. **Fresh-agent test** on the spec page (per docs convention): an agent implements an
+   encoder/decoder in a scripting language from the page alone and passes the golden
+   vectors.
+
+## 7. Proposed ADR (human gate — for docs/arch-decisions/ADR.md if approved)
+
+> **ADR-NNNN: Standard event envelope wire format for cross-language interop**
+> Event over HTTP exchanges a MsgPack map with descriptive string keys (spec §3) as the
+> language-neutral envelope encoding. Compact single-character keys remain supported for
+> backward compatibility (decode always, encode by config) but are frozen — new fields
+> are added to the standard format only. Language-native artifacts (Java exception blobs)
+> never cross the wire in standard mode; portable errors are status + message + stack
+> text. Decoders ignore unknown keys.
+
+## 8. Review decisions (maintainer, 2026-07-21)
+
+1. **Default at introduction** — RESOLVED: **standard**, with compact as the explicit
+   fallback for slow-to-upgrade installations. Rationale: Event over HTTP is transport,
+   not storage — nothing serialized outlives the exchange, so both parties upgrading
+   together removes the compatibility concern.
+2. **Config + override** — CONFIRMED: `event.over.http.format = compact | standard`
+   (global) + `x-event-format: compact | standard` (per-request header).
+
+Still open (do not block Phase 1):
+
+3. **Version bump** — this is a feature: 4.10.0?
+4. **Kafka mesh** — migrate `cloud.connector` payloads to standard in a later release, or
+   leave compact indefinitely (same-language assumption)?
+   *Investigated 2026-07-21: the mesh IS compact today on every hop — event transport
+   (kafka-connector `EventConsumer.load`, platform-core `MultipartPayload.toBytes` incl.
+   large-payload segmentation blocks), presence reporting (`PresenceConnector`), and the
+   service monitor (`TopicController`). The Rust port has no mesh, so the same-language
+   assumption holds by construction. Note: `MultipartPayload` segmentation is a second
+   proprietary layer — any future cross-language mesh needs that spec'd too, so v1
+   correctly keeps the mesh out of scope.*
+5. **Golden-vector home** — `system/platform-core/src/test/resources/envelope-vectors/`
+   mirrored into the Rust repo, or a dedicated top-level `interop/` folder?

--- a/draft-design-specs/field-followups-graph-scoped-state-and-error-context.md
+++ b/draft-design-specs/field-followups-graph-scoped-state-and-error-context.md
@@ -1,0 +1,144 @@
+# Field follow-ups: graph-scoped workflow state + generic exception context
+
+Status: RATIFIED by Eric 2026-08-10 (rulings R1–R5 below) — implementation in progress
+Driver: field team demo review 2026-08-10 — a complex multi-suspension use case built on
+the first iteration (checkpoint-only) of suspend/resume surfaced two structural asks.
+Scope: Java reference engine first, then full Rust lock-step (regression-critical field core).
+
+---
+
+## Rulings (Eric, 2026-08-10)
+
+- **R1** — No back-compat machinery for the store-key change: suspend/resume use cases are
+  in the dev phase, no legacy production data. Document the breaking change in release notes.
+- **R2** — Business-cid propagation everywhere: flow→subflow (already shipped,
+  TaskExecutor), flow→graph (rides sub-flow launch), graph→subgraph and graph→subflow
+  (this change, GraphExtension). Consistency improves the overall system.
+- **R3** — Error-context naming follows Event Script parity: `error.source`, `error.code`,
+  `error.message`, plus `error.stack` when available.
+- **R4** — Reserve the node alias `error` at the gate: a small price to pay.
+- **R5** — Orchestrator pattern: illustrate and validate with a unit test; mention the
+  pattern in docs. No tutorial-14 change (keep it straightforward).
+
+## Feature A — graph-scoped store reference + business-cid propagation
+
+### Problem (field-confirmed, two independent root causes)
+
+1. The store key is `graph:state:{cid}` (RedisStateConnection.KEY_PREFIX + cid). One
+   business cid = one record globally: collisions across domains sharing a Redis, and
+   between a parent graph and its subgraphs.
+2. GraphExtension invokes a subgraph as a separate flow instance with
+   `setCorrelationId(util.getUuid())` and no business-cid header, so the subgraph's
+   `model.cid` is a random UUID per call — its resume can never find a record even with
+   scoped keys.
+
+### Design
+
+- **Persistence contract gains `graph`** (the running graph's id, from
+  `graphInstance.graphId`):
+  - put body: `{cid, graph, node, ttl, model, seen, run}`
+  - get body: `{cid, graph}`
+  - Key composition stays store-internal. The Redis reference implementation composes
+    `graph:{graph_id}:{cid}` (Eric's format) and REQUIRES `graph` (fail-fast teaching;
+    no cid-only fallback per R1). FileStateStore (test mock) mirrors.
+- **GraphExtension stamps `EventScriptManager.BUSINESS_CORRELATION_ID`** from the parent's
+  `model.cid` on the forward event — both branches (single call + for_each fork-join),
+  both protocols (`graph://` and `flow://`). This mirrors TaskExecutor's sub-flow launch
+  ("sub-flow inherits the parent's business correlation-id").
+- **Deliberate non-change:** the extension call does NOT set the `parent` header — an
+  extension is a request/response delegation, not a nested lifecycle (`model.parent` and
+  teardown listeners stay flow-only semantics).
+- **Self-containment is now by construction:** a record written under one graph id is
+  invisible to every other graph. You cannot suspend in one subgraph and resume in another.
+- **Direct path resume:** a subgraph is a deployed graph, so a suspended path may also be
+  resumed directly via `POST /api/graph/{subgraph-id}` with the same cid (document with
+  the cid-as-capability note).
+- **Documented caveat:** same subgraph × same cid = one record. A for_each fan-out of a
+  suspending subgraph under one cid would last-write-wins; invoke a suspendable subgraph
+  once per cid per run.
+- **Breaking change (release note):** records persisted under the old key are invisible
+  after upgrade — resume behaves as fresh (consistent with "absent and expired look the
+  same"). Custom stores must adopt the `graph` field.
+
+### Orchestrator pattern (R5)
+
+Parent graph = orchestrator; each processing path = a subgraph that may suspend/resume
+independently under `graph:{subgraph_id}:{cid}`. A suspending subgraph returns
+`{"type": "suspended", "cid": ...}` (or its staged output) to the parent extension node's
+`result`, so the parent can route on it — or pause itself under its own record. Validated
+by unit test; mentioned in the workflow-suspension guide; tutorial-14 untouched.
+
+## Feature B — generic exception handler context
+
+### Problem (field-confirmed)
+
+`exception=` routing already spans the whole family — graph.api.fetcher, graph.task
+(pinned by unit-test-task-4), graph.extension, and the suspend/resume store skills — and a
+handler may continue to further nodes (pinned by unit-test-join-retry). But the engine
+stages only `{failing-node}.status` / `{failing-node}.error`, so a handler's input mapping
+must name the failing node statically → one cloned handler per fetcher.
+
+### Design
+
+- **Walker-staged generic context** at the two exception choke points
+  (GraphExecutor.handleSkillResponse, GraphTraveler.handleSkillSuccess), immediately
+  before jumping to the handler:
+  - `error.source`  = failing node alias
+  - `error.code`    = `{node}.status` (int)
+  - `error.message` = `{node}.error`
+  - `error.stack`   = `{node}.stack` when present
+  One staging site per walker covers every skill with no per-skill routing edits. For an
+  extension node, `source` is the extension node in the parent graph; a subgraph's internal
+  failures route to the subgraph's own handlers (composes with self-containment).
+- **`{node}.stack`**: the skills' setError family (GraphTask, GraphApiFetcher,
+  GraphExtension, GraphStateSkill) additionally stages `response.getStackTrace()` when the
+  failing envelope carries one (Event Script parity: TaskExecutor stages `stack`).
+- **`{node}.status` / `{node}.error` staging is unchanged** — existing handlers keep
+  working.
+- **Reserved alias `error` (R4):** new GraphModelValidator whole-graph rule (shared by the
+  CompileGraph gate and the dry-run pre-run check): a node aliased `error` is rejected
+  with a teaching error — the alias is reserved for the exception context namespace;
+  suggest renaming (e.g. `on-error`) and mention `inspect error`.
+- **`inspect error` needs no engine change:** the inspect command is a raw state-machine
+  viewer (`stateMachine.getElement(key)`), so `inspect error` / `inspect error.source`
+  work by construction once staging lands — same mechanics as `inspect model`. Docs teach it.
+- **Documented rule:** a shared handler is jumped into at most once per run (nodeSeen
+  dedup) — concurrent-branch failures collapse into the first jump; deliberate re-entry
+  loops use the RESET idiom (see unit-test-join-retry).
+- `exception=suspend` stays rejected (existing R7 gate rule).
+
+## Test plan (Java)
+
+- Redis module: graph-scoped key composition; two records same cid × different graph ids
+  are isolated (consume one leaves the other); missing `graph` rejected; existing
+  suite updated to the new contract.
+- Engine: suspend persistence-envelope pin (`graph` field present); FileStateStore scoping.
+- Orchestrator e2e: parent graph (graph.extension) → subgraph suspends at a checkpoint →
+  parent receives suspended reply; re-invoke with same cid → subgraph resumes past the
+  checkpoint; asserts subgraph saw the parent's business cid (cid propagation).
+- Generic handler e2e: one island-anchored handler serving two failure sources — a
+  graph.task with `task=async.http.request` (HTTP 404) and another failing node — asserts
+  `error.source` distinguishes them, plus code/message (+stack presence where thrown).
+- Gate: node aliased `error` rejected in both lanes with the teaching message.
+- Dry-run twin: traveler stages error.*; `inspect error` returns the context.
+- Back-compat: unit-test-task-4 and unit-test-join-retry pass unmodified.
+
+## Docs plan
+
+- workflow-suspension guide: store contract/key format update + BREAKING note;
+  "Orchestrator pattern" section (per-graph records, direct subgraph resume, for_each
+  caveat, suspended-reply routing in the parent).
+- help pages: graph-api-fetcher / graph-task / graph-extension (error.* contract +
+  generic-handler pattern), graph-suspend / graph-resume (contract `graph` field),
+  inspect (`inspect error`); skills-reference; minigraph-commands.json AI catalog;
+  reserved-names docs (`error` alias + namespace, `graph` contract field).
+- CHANGELOG: Added (error context, orchestrator support) / Changed (store contract —
+  BREAKING, cid propagation). Release note wording for the flag-day.
+- Webapp bundle regeneration after help edits (`npm run release`).
+
+## Rust lock-step scope (after Java merges)
+
+`crates/knowledge-graph`: suspend.rs (envelope + get body), extension.rs (cid header),
+executor.rs + traveler.rs (error.* staging), model_validator.rs (alias rule), tests;
+`extensions/minigraph-state-redis`: key composition + tests; docs mirror (known port
+divergences preserved); CHANGELOG + INCREMENTS.

--- a/draft-design-specs/graph-suspend-resume-implementation-plan.md
+++ b/draft-design-specs/graph-suspend-resume-implementation-plan.md
@@ -1,0 +1,349 @@
+# Graph suspend/resume — design review + implementation plan
+
+**Status:** RATIFIED design, plan ready for P1 — 2026-07-28, Claude Code
+**Concept:** Eric's `graph-suspend-resume-concept.md` (2026-07-28) + ratified rulings:
+(R1) dedicated skills `graph.suspend` / `graph.resume` encapsulate persistence I/O — no
+node-level data mapping, skills are a superset of `graph.task`; (R2) **skill defines
+behavior, type is visual** — types `Suspend`/`Resume`/`Suspensible` are convention/best
+practice only; suspensibility of a skilled node is the reserved node property
+`suspend=true`; (R3) **`suspend` is a reserved node ALIAS** (the root/end pattern: a
+special alias resolved by name because traversal jumps to it — the routing vocabulary is
+`"next" | node-alias`, so the suspensible override is a plain jump to the well-known
+name). Bidirectional: alias `suspend` ⇔ `skill=graph.suspend`; exactly one suspend node
+per graph. The `resume` NAME stays convention (it is reached by normal traversal — no
+mechanism rides its name). (R4) The Redis store is a self-contained module/crate imported
+by the PLAYGROUND EXAMPLE APP, never by the engine (both repos); engine unit tests use a
+temp-file mock store under `/tmp/suspend-resume` implementing the same contract.
+Decisions D1-D6 ratified as recommended (D3: not-found = normal first-run case,
+default `next`).
+**Grounding:** five-agent code study of the live tree (engine core, state machine, entry
+paths, Redis/TTL precedents, Rust parity), file:line anchors below are from that study.
+
+---
+
+## 1. Verdict
+
+**The design is sound and viable.** It fits the engine's architecture unusually well:
+
+- **Jump-to-node already exists** — a skill's reply body naming a node alias jumps there
+  (`GraphExecutor.nextOrJump`, GraphExecutor.java:286-300). Resume rides an existing
+  primitive, not a new traversal mode.
+- **Suspension converts a long-lived workflow into a sequence of short-lived runs.** Each
+  run stays inside the normal flow ttl (rest.yaml timeout); only the persisted record is
+  long-lived (its own `ttl`, e.g. `2d`). No engine timer, no parked instance, no memory
+  pinned between runs — the in-memory `GraphInstance` lifecycle (created per run, reaped by
+  `graph.housekeeper` at flow end) is untouched.
+- **The pluggable store has an exact in-repo precedent**: sync-over-async's
+  `ReturnRouteStore` (SETEX/GET/DEL keyed by cid, TTL as crash safety net, explicit delete
+  as fast path — ReturnRouteStore.java:36-69), including embedded-redis tests and the
+  `RedisConfig` record with `${ENV_VAR:default}` support.
+- The two rulings (R1/R2) already dissolved the concept's three worst gaps (resume
+  jump-target channel, CompileGraph mapping special cases, persist-envelope
+  under-specification).
+
+The one hard constraint the code imposes: **traversal position is not a pointer.** The
+executor's state is a set of pending event callbacks (`<flowInstanceId>@<node>` cids) plus
+`nodeSeen`/`skillRun` maps; `walkNext` fans out to ALL forward links unconditionally
+(GraphExecutor.java:302-310), and there is no registry of in-flight branches. Suspension
+is therefore only well-defined when the suspending path is the graph's sole active branch
+(§4-D5). Everything else in the concept survives contact with the code.
+
+## 2. Corrections to the concept doc (verified against the tree)
+
+1. **"CompileGraph will reject `result -> model`" is wrong.** CompileGraph does only
+   deprecated-syntax conversion + structural import + root-purpose check
+   (CompileGraph.java:97-161). The bare-`model` RHS rejection is a *runtime* check in the
+   skills' output-mapping path (GraphLambdaFunction.setFetcherOutputEntry:478-481), and it
+   only fires when the mapped value is non-null. Conversely, `model -> *` as a graph.task
+   INPUT is *already allowed today* and ships the whole model (incl. copied reserved keys).
+   Under R1 both points become moot for this feature (no mapping on the new nodes), but the
+   doc's claims should be corrected.
+2. **`root`/`end` are not "reserved names" in the code's sense** — they are special aliases
+   outside `MiniGraph.RESERVED_NAMES` (which holds input/output/model/response/result/
+   parameter/none/next/api/error, MiniGraph.java:42-43). Under R2, `suspend`/`resume` names
+   stay unreserved (convention), so no change to either list is needed for *names*.
+3. **Reserved-property scope (ruled):** `suspend` and `missing` join `RESERVED_PARAMETERS`
+   (engine-routing configuration, the `for_each`/`concurrency` precedent). `ttl` is
+   deliberately NOT reserved — Eric's ruling: it is a task parameter (the store's expiry
+   timer) with no collision anywhere, so it keeps the standard node-parameter behavior
+   (echoes into the state machine as `suspend.ttl`, harmless).
+4. **Kafka-initiated graphs don't work directly today**: the kafka-flow-adapter dataset has
+   no `path_parameter.graph_id`, so `graph-executor` rejects it ("Missing graph ID in
+   header", GraphExecutor.java:103-105; KafkaFlowConsumer.toDataset:429-435). A wrapper
+   flow (or programmatic `FlowExecutor.launch` with a hand-built dataset) is required.
+   Resume-from-Kafka works the same way — with the business cid arriving via the
+   configured Kafka correlation header. Worth one sentence in the feature docs.
+5. Nits: "Suspensbile" (typo); the concept's `skill.math`/`skill.js` should read
+   `graph.math`/`graph.js`; the resume-node example's `purpose` says "Persist…" where it
+   means "Retrieve…"; the concept's dual mechanisms ("type contains Suspensible" vs the
+   example's `suspend=true`) are resolved by R2 in the property's favor.
+
+## 3. Feature specification (post-rulings)
+
+### 3.1 New reserved surface
+
+| Item | Kind | Notes |
+|---|---|---|
+| `graph.suspend` | skill route (built-in, minigraph engine) | superset of graph.task; instances=300 like peers |
+| `graph.resume` | skill route (built-in, minigraph engine) | superset of graph.task |
+| `suspend` | reserved node property (`true`) | on skilled nodes; routes to the suspend path after skill + output mapping |
+| `ttl` | node parameter (NOT reserved — Eric's ruling: it is a task parameter, the store's expiry timer, colliding with nothing) | on `graph.suspend` nodes; **mandatory, no default** (a checkpoint may wait a minute or days — only the designer knows); `Utility.getDurationInSeconds` format (`20s/5m/2h/2d`, bare number = seconds — Utility.java:1185-1203; NOT the rest.yaml 1s-5min clamp) |
+| `missing` | reserved node property (optional) | on `graph.resume` nodes; not-found behavior (§4-D3) |
+| Types `Suspend`/`Resume`/`Suspensible` | convention only | UI colors; engine never reads types (verified: traversal reads only `skill`) |
+
+### 3.2 graph.suspend (persist + terminate)
+
+Node shape (no input/output mapping — R1):
+
+```text
+create node suspend
+with type Suspend
+with properties
+purpose=Persist workflow state to the external state store
+skill=graph.suspend
+task=v1.redis.persist.model
+ttl=2d
+```
+
+Behavior:
+1. Validates `task` route exists (GraphTask precedent, GraphTask.java:68-74) and `ttl`
+   parses; reads business cid from state machine `model.cid` — **error 400 if absent**
+   (playground instances without an init-mapped model.cid fail loudly, §4-D6).
+2. Builds the persistence envelope itself (no mapping):
+   - `model`: deep-copied model namespace **minus reserved keys**
+     (`model.flow/instance/trace/ttl/parent/root` excluded; `model.cid` excluded from the
+     blob — it IS the key). Deep copy via `Utility.deepCopy`; the state machine map is
+     live (`MultiLevelMap.getMap()` returns the underlying map), so the copy is mandatory.
+   - `node`: the suspension point — the node that routed here (the `from` provenance,
+     §3.5).
+   - bookkeeping per §4-D2 (recommended: `nodeSeen` + `skillRun` snapshots).
+3. Invokes the `task=` function **synchronously** (`po.eRequest` + Mono, the GraphTask
+   pattern at GraphTask.java:142-164) and treats a non-2xx reply as a node error
+   (`exception` property honored like any skill). **Deliberately NOT the fire-and-forget
+   `ext:` external-state-machine contract** (TaskExecutor.java:1155-1183) — suspension is
+   a durability promise; it must not report success before the store acks.
+4. Default response staging (§4-D4): if state-machine `output.body` is still empty, stage
+   `{"type":"suspended","cid":"<cid>"}` so the caller of the suspended run gets a
+   meaningful 200 body instead of an empty 200 (verified: null output.body → empty 200,
+   AsyncHttpResponse.handleContent:212-236). Designers override by staging `output.*`
+   before the suspend node.
+5. Returns `next` → traversal proceeds along its forward link(s) to `end` →
+   `executionComplete` → normal flow response. No new termination mechanics.
+
+### 3.3 graph.resume (retrieve + jump)
+
+```text
+create node resume
+with type Resume
+with properties
+purpose=Restore workflow state from the external state store
+skill=graph.resume
+task=v1.redis.retrieve.model
+```
+
+Behavior:
+1. Reads `model.cid`; invokes `task=` synchronously with `{cid}`.
+2. **Found:** merges the persisted `model` blob into the state machine model namespace
+   (fresh reserved keys — seeded by the new FlowInstance — are never overwritten; the blob
+   contains none by construction). Restores bookkeeping per §4-D2 and marks the suspension
+   node `nodeSeen`+`skillRun` (so a downstream `graph.join` counts it as a completed
+   predecessor — GraphJoin.java:66-76 gates on exactly those maps). Replies with the new
+   directive **`resume:<node>`**.
+3. **Not found** (fresh transaction or TTL-expired): default replies `next` — the resume
+   node's normal forward links ARE the fresh path, so first-run pass-through falls out of
+   the existing NEXT directive with zero extra mechanics. Optional `missing=<node-alias>`
+   property jumps to a designer-chosen handler instead (§4-D3).
+
+### 3.4 Executor changes (GraphExecutor + GraphTraveler, kept identical)
+
+1. **`resume:<alias>` directive** in `nextOrJump` (GraphExecutor.java:286-300): resolve
+   the alias, do **not** execute it — mark it seen/run and `walkNext(alias)` traversing
+   its forward links, **skipping the link whose target alias is `suspend`** (trivial
+   name-based exclusion under R3). `:` is outside the alias charset
+   (GraphProperties.validateName:53-70), so the directive cannot collide with a node name.
+2. **Suspensible routing = a plain jump to the reserved alias `suspend` (R3).** A node
+   with `suspend=true`, on first execution: after its skill completes with `next`, the
+   executor jumps to `suspend` — the existing directive mechanism, no link classification
+   needed. The drawn edge `<suspensible> → suspend` is still REQUIRED (CompileGraph §3.6)
+   so the visual model stays truthful — the graph is the documentation. A plain edge into
+   the `suspend` node (the concept's island example) remains an unconditional suspension
+   with no property needed. `getSuspendNode()` resolves by alias, the root/end pattern
+   (MiniGraph.getRootNode/getEndNode precedent).
+3. **`from` provenance**: thread the walking-from alias through
+   `walk/walkTo/executeSkill` and deliver it as skill header `from`. This is how
+   `graph.suspend` learns the suspension point; it's also generically useful diagnostics.
+   (Today's headers: in/type/node — GraphExecutor.java:277-280.)
+4. **Reserved property additions**: `suspend` and `missing` join `RESERVED_PARAMETERS`
+   (GraphLambdaFunction.java:149-151) — engine-routing configuration. `ttl` stays a plain
+   node parameter (mandatory on the suspend node, validated by the skill; no default).
+5. `suspend=true` runtime guard: reject on nodes whose skill is `graph.math`/`graph.js`
+   (routing skills — suspension point must be deterministic), mirroring the concept.
+
+### 3.5 The persistence-store contract (the pluggable seam)
+
+Documented as a contract page (the registration-metadata-contract precedent — a spec page
+developers implement against):
+
+**Persist** — request to `task=` route of the suspend node:
+- headers: `type=put`
+- body: `{ "cid": "<business cid>", "node": "<suspension node alias>",
+  "ttl": <seconds:int>, "model": {…}, "seen": {…}, "run": {…} }`
+- reply: 2xx = durably stored; anything else = suspension fails (node error path).
+
+**Retrieve** — request from the resume node:
+- headers: `type=get`
+- body: `{ "cid": "<business cid>" }`
+- reply body: the persisted map (as stored) or null/404 for absent-or-expired.
+- Consume semantics per §4-D1 (recommended default: atomic consume — Redis `GETDEL`).
+
+Serialization is the store's concern; the reference Redis implementation stores the map as
+MsgPack bytes (byte[] round-trips; known caveats documented: Integer/Long width, PoJos
+already arrive as maps on the graph state machine since skill results transit the bus,
+Date/Instant→ISO strings, null values dropped unless `serializer.null.transport=true` —
+MsgPack.java:156-190, 260-274, 292-311). Stores without native TTL implement expiry
+themselves (concept doc; contract page states it).
+
+### 3.6 CompileGraph additions (structural only, opt-in graphs)
+
+- Alias `suspend` ⇔ `skill=graph.suspend`, bidirectional (a node named `suspend` must
+  carry the skill; a `graph.suspend` node must be named `suspend`) → reject on mismatch.
+- `suspend=true` on a node whose skill is `graph.math`/`graph.js` → reject.
+- `suspend=true` node with no drawn edge to the `suspend` node → reject (routing is by
+  name, but the diagram must show the suspension path).
+- `graph.suspend` node without `task`/`ttl`, `graph.resume` node without `task` → reject.
+- (Runtime re-checks stay in the skills — CompileGraph is opt-in via
+  `graph.model.automation`, so runtime remains the enforcement floor.)
+
+### 3.7 Reference store module
+
+New optional module **`extensions/minigraph-state-redis`** providing
+`v1.redis.persist.model` + `v1.redis.retrieve.model` (Eric's route names; the v1.* dotted
+convention is documented — code-conventions.md:57):
+- **Imported by the playground/example application, never by the engine (R4)** — the
+  engine stays store-free in every scope (verified: minigraph pom has zero store deps).
+  The engine's own tests use the temp-file mock store (below); the same placement rule
+  applies verbatim to the Rust repo (a separate crate imported by
+  examples/minigraph-playground).
+- **Temp-file mock store (engine test fixture + simplest contract reference):** a
+  @PreLoad test function implementing the same put/get contract with one file per cid
+  under `/tmp/suspend-resume` (MsgPack bytes; mtime+ttl expiry check on read;
+  delete-on-read for consume parity with GETDEL). Doubles as the contract page's
+  "smallest possible store" example for developers writing their own.
+- `@OptionalService("minigraph.state.redis.enabled")` gating + a `RedisConfig`-style
+  record (`redis.host/port/password/ssl/database/timeout.ms`, `${ENV_VAR:default}`) — the
+  sync-over-async pattern (SyncOverAsyncAutoStart.java:44-46, RedisConfig.java:50-66).
+- Lettuce with byte[] value codec; SETEX on put, GETDEL (or GET per D1) on get.
+- Tests: embedded-redis (`com.github.codemonstur:embedded-redis:1.4.3`, arm64-safe, port
+  16379 — RedisTestBase precedent), asserting TTL applied + consume semantics.
+- `helpers/redis-standalone` already exists for live demos.
+
+## 4. Decisions for the maintainer (with recommendations)
+
+- **D1 — Consume-on-retrieve.** Recommend: reference Redis store uses atomic `GETDEL` —
+  a resume consumes the record, so a duplicate resume (double manager click, retried
+  message) cannot double-execute the continuation; a re-suspension later re-persists under
+  the same cid. Trade-off stated in docs: a crash after consume but before completion
+  loses the workflow (mitigation: the next suspension point re-persists; workflows needing
+  stronger guarantees use a custom store with keep-until-ack semantics — the contract
+  permits either).
+- **D2 — Persisted envelope.** Concept says model + node. Recommend **also** persisting
+  the `nodeSeen`/`skillRun` snapshots: without them, any `graph.join` whose predecessors
+  completed *before* suspension can never satisfy its barrier after resume
+  (GraphJoin counts predecessors via exactly those maps). Cheap (two string→boolean maps),
+  engine-internal, invisible to the store. Regardless: `<node>.result` scratch does NOT
+  survive suspension — **"model is the workflow's durable memory"** becomes the loudly
+  documented design rule (map anything needed downstream into `model.*` before a
+  suspension point).
+- **D3 — Resume not-found.** Recommend: default `next` (fresh start falls out naturally);
+  optional `missing=<node-alias>` jump for workflows where an absent record is an error
+  (TTL-expired approval → jump to an "expired" node that stages a 410-style response).
+  Engine can't distinguish "fresh" from "expired" — the designer declares it.
+- **D4 — Suspended-run response.** Recommend: `graph.suspend` stages
+  `{"type":"suspended","cid":…}` into `output.body` when empty (else the caller gets an
+  empty 200 — verified). Designer-staged `output.*` always wins.
+- **D5 — Concurrency constraint.** Recommend: **document** that a suspension point must be
+  the sole active branch (no suspension between a fan-out and its join; suspend after the
+  join instead) + a best-effort runtime WARN when the executor can see other unfinished
+  seen-but-not-run nodes at suspension time. Static analysis of reachability is not worth
+  the complexity for v1; in-flight branches are structurally unpersistable (they live as
+  pending bus events).
+- **D6 — Playground/dry-run.** Recommend: skills execute for real in the traveler (that's
+  the traveler's existing semantics), so suspend/resume is fully testable in the
+  Playground: set `model.cid` via the instantiate command's initial data mapping (already
+  supports constant→model), run to suspension, run again to resume. `graph.suspend`
+  errors clearly when `model.cid` is absent.
+- **D7 — Rust lock-step (RATIFIED with placement refinement).** Graph JSON is
+  engine-portable by commitment (Rust design K3: Java fixtures run verbatim), so a
+  suspend-bearing tutorial graph makes this a cross-engine feature by construction. The
+  Rust side is structurally ready (jump primitive exists, free-form types,
+  executor+traveler pair). **Eric's ruling: the Redis store is its own crate, imported by
+  `examples/minigraph-playground` — never bundled into the knowledge-graph engine crate;
+  the engine's tests use the `/tmp/suspend-resume` temp-file mock store. Identical
+  placement rule in both repos.** Java reference first, Rust arc immediately after
+  (before any release that ships suspend-bearing tutorials); Redis crate choice
+  (`redis-rs`/`fred`) is the Rust session's call. Note: its design record lists "session
+  persistence across restarts" as out-of-scope — that line gets superseded by this arc.
+- **D8 — cid security posture (documentation).** The business cid is a resume capability —
+  whoever presents it continues the workflow. Docs state: resume-bearing endpoints should
+  carry rest.yaml `authentication`; cids must be non-guessable (the engine's generated
+  cids are UUIDs; edge-supplied cids are the caller's responsibility); the store may
+  additionally scope keys. Also documented: business cid does NOT propagate across
+  `graph.extension` today (GraphExtension.java:110 — fresh uuid, no correlation_id
+  header), so resumable workflows are top-level graphs; extension-hop cid propagation is a
+  possible follow-up, not part of this feature.
+
+## 5. Implementation plan (phased; each phase independently green)
+
+**P1 — Engine core** (`system/minigraph-playground-engine`, ~4 files + tests)
+`from` provenance threading; suspend-link classification in walkNext; `suspend=true`
+handling; `resume:<alias>` directive in nextOrJump (+ seen/run marking); RESERVED_PARAMETERS
+additions; `graph.suspend`/`graph.resume` skills (GraphTask-derived; shared base or
+composition — decide in code review); default response staging; loud no-cid error.
+Tests: unit suite with the temp-file mock store (`/tmp/suspend-resume`, R4 — no Redis
+anywhere in the engine) — suspend persists expected envelope (inspectable file per cid);
+resume merges + jumps without re-execution; fresh-start pass-through; `missing=` jump;
+join-after-resume (D2); alias⇔skill mismatch rejection; math/js suspend rejection;
+multi-suspension (suspend→resume→suspend→resume) chain across separate runs.
+Traveler: mirror every executor change (the two walkers stay semantically identical).
+
+**P2 — CompileGraph + Playground surface**
+§3.6 compile checks; Playground grammar already accepts arbitrary types/properties
+(free-form — verified), so the surface work is `describe`/`show` output labeling and the
+UI type-color note; `inspect state machine` unchanged (dev endpoint already dumps model).
+
+**P3 — Reference Redis store** (`extensions/minigraph-state-redis`)
+Module per §3.7; contract page `docs/guides/knowledge-graph/state-store-contract.md`
+(persist/retrieve wire contract, consume semantics, TTL responsibility, serialization
+caveats, security posture); embedded-redis test suite incl. TTL assert + GETDEL consume +
+absent-key behavior.
+
+**P4 — End-to-end + docs + governance**
+Tutorial graph `tutorial-approval-workflow` (suspensible task → suspend → resume → join →
+end) + FlowTest-style e2e: POST /api/graph/{id} → 200 `{type:suspended,cid}` → assert
+Redis record + TTL → POST again with same X-Correlation-Id → assert continuation without
+re-execution → completion body. Docs: knowledge-graph guide chapter (why-before-how:
+workflow suspension story), skills-reference entries, reserved-names additions
+(properties + skill routes), configuration-reference (module keys), concept-doc
+corrections (§2), CHANGELOG. **Propose ADR** in `docs/arch-decisions/ADR.md` (durable
+decision: suspension model — short-runs + external state, skill-encapsulated persistence,
+skill-defines-behavior) — human-gated per protocol.
+
+**P5 — Rust lock-step arc** (separate, delegated to the Rust session)
+Mirror P1/P2 in `crates/knowledge-graph` (executor.rs + traveler.rs dual maintenance,
+model.rs snapshot/rehydrate, compiler.rs checks, commands.rs surface); store-crate
+decision (D7); shared tutorial fixture verbatim; interop check = the same graph JSON
+suspends/resumes identically on both engines (normalized-output diff, the parity method).
+
+Estimated Java-side scope: P1 ≈ the largest single piece (executor + two skills + tests);
+P2-P3 moderate; P4 mostly writing. No changes to platform-core or event-script-engine are
+required (the graph copy of `model` is already detached; reserved-key protection on
+restore is by-construction since the blob excludes them).
+
+## 6. VBDI note
+
+This feature directly serves `vision-mercury-composable` ("workflow operation" for the
+Active Knowledge Graph — business processes with human checkpoints as graph models). It
+warrants a `(blueprint)` Open Thread — **proposed, human-gated**: e.g.
+`- [ ] (blueprint) Workflow suspension for the Active Knowledge Graph — human-in-the-loop
+checkpoints (approval, intervention, inbox) as first-class graph vocabulary → serves:
+vision-mercury-composable`.

--- a/draft-design-specs/http-response-streaming.md
+++ b/draft-design-specs/http-response-streaming.md
@@ -1,0 +1,284 @@
+# HTTP response streaming (event/token streaming to the HTTP edge) — design spec
+
+**Status:** APPROVED AND IMPLEMENTED (Java) — D1 ratified 2026-08-27; **D2–D8 approved
+as recommended by Eric 2026-08-28**; implemented same day with one design addition made
+during implementation (D9, the ordered reply lane — see §2a; **revised same day to
+Eric's checkout-pool design**: dedicated lane per active stream, LIFO stack of 500,
+HTTP-503 back-pressure, no config knob). Rust twin pending (D7:
+Java-first with the vocabulary pinned). **Serves:** `bp-agent-orchestration` (this is Q8 of
+`ai-agent-orchestration.md`, promoted to prerequisite: without it an `llm.chat` node can
+only deliver a buffered completion). **Engine parity:** REST automation is engine
+surface → Java + Rust lock-step with engine-identical vocabulary and framing
+(`conv-telemetry-presentation-parity`; Java is the reference).
+
+---
+
+## 1. Problem and driver
+
+The AI SDLC work needs progressive delivery over plain HTTP for three shapes, all of
+which the industry serves with SSE today: chat token streams (OpenAI/Anthropic/Gemini
+and every OpenAI-compatible server), agent progress events (MCP Streamable HTTP, A2A,
+LangGraph/AI-SDK protocols — typed SSE events), and live watch of a running
+workflow/graph (SSE for the live window; suspension stays on the existing
+suspend/resume + cid model).
+
+**Why the existing Flux/Mono path is not good enough (Eric's ruling).** Today a callee
+can return a `Flux`/hand back `x-stream-id`, and `AsyncHttpResponse.handleStreamContent`
+relays it chunked. But:
+
+- The producer API is **Reactor-typed and JVM-only** — invisible to Event Script,
+  graphs, and the polyglot wrappers (exactly where LLM tokens will come from).
+- **Structured segments do not stream**: a `Map` chunk is buffered into `listOfMap` and
+  rendered as one JSON array at completion — only raw text/bytes flow progressively.
+- **No SSE**: no `text/event-stream` framing, no typed events, no in-band terminal
+  event, and the mid-stream error path rewrites the HTTP status after the head may
+  already be committed.
+- The stream is a **separate object with its own lifecycle** (ObjectStreamIO create /
+  expiry / housekeeping) when the event system already has a simpler primitive.
+
+## 2. The model (RATIFIED)
+
+Streaming is already native to platform-core at the event layer:
+
+```
+caller  ->  callee                      (the request, carrying reply_to + cid)
+callee  ->  caller's reply_to           (continuous events - batches of tokens -
+                                         until a signal declares end of transmission)
+```
+
+The HTTP edge **is** the caller: `HttpRouter` already sets
+`reply_to = async.http.response@origin` with the request id as correlation id, and keeps
+a per-request `AsyncContextHolder` with `touch()` keep-alive. Today that return route is
+**single-shot** — the first event writes the body, closes the context, ends the
+response. This feature makes it **multi-shot**: segment events append to the wire as
+they arrive; an end-of-transmission event closes; the endpoint timeout bounds the whole
+exchange.
+
+Consequences: no new substrate, no Reactor dependency, fully backward compatible
+(unmarked responses behave exactly as today), and language-neutral by construction —
+anything that can send an envelope to a route can stream.
+
+## 2a. Ordered delivery (D9 — added during implementation; REVISED per Eric's design)
+
+`async.http.response` runs with 500 instances: consecutive segment events dispatch to
+concurrent workers, so FIFO order is NOT guaranteed through that lane. The platform's
+own ordering idiom is a route with one instance (cf. ObjectStreamIO's `instances=1`
+consumer). Solution, keeping the D1 contract intact (the callee still just sends to
+reply_to): a streaming endpoint is declared with **`stream: true` in rest.yaml**, and
+the request **checks out a dedicated ordered reply lane for its lifetime** — a
+single-instance route (`async.http.response.stream.{n}`) drawn from a **LIFO stack pool
+of 500** (pinned to the `async.http.response` instance count — no configuration knob).
+The lane rides on the AsyncContextHolder (direct access to the original HTTP
+request/response) and returns to the stack when the request context closes — the "ready"
+signal pattern of the reactive manager/worker design. One request's segments are strict
+FIFO through its own lane; different requests never share a lane. An exhausted pool
+rejects further streaming requests immediately with **HTTP-503 "Streaming response pool
+exhausted"** (deterministic back-pressure). An idle lane costs a little memory and no
+CPU. History: hash-sharded lanes (`event.stream.lanes` default 8, lane =
+hash(requestId)) were the first cut — REPLACED because two concurrent requests hashing
+to one lane share a serialization point (cross-request latency coupling and a routing
+hazard); checkout eliminates collisions by construction. A per-request dynamic route was
+also considered and rejected — register/release lifecycle + leak surface for µs-scale
+rendering work. The checkout removed the `streamResponse` flag from HttpRequestEvent
+(tag "12") — both reply sites resolve the lane from the holder by requestId. The
+housekeeper's in-band timeout targets the holder's lane so it cannot overtake segments.
+The 50-segment unpaced burst test pins per-request ordering; four parallel bursts pin
+cross-request independence; exhaustion (503 + recovery), lane return, and LIFO reuse
+have dedicated tests. A stream-marked response arriving on the ordinary lane still
+renders (single-segment or tolerant producers), but only the declared lane guarantees
+order. `stream: true` and the 503 message are rest.yaml/wire surface → part of the
+cross-engine contract (Rust twin mirrors both).
+
+## 3. Envelope protocol (internal — never on the wire)
+
+One reserved **envelope** header, consumed by the edge exactly as `x-stream-id`/`x-ttl`
+are today (never emitted to the HTTP client):
+
+```
+x-event-stream: data | eof | exception
+```
+
+- The value vocabulary is deliberately the framework's existing ObjectStream vocabulary.
+- **`data`** — the body is one segment (String, byte[], or Map). The FIRST data event
+  commits the HTTP head: its envelope status and headers (content-type etc.) shape the
+  response; later envelopes' status/headers are ignored (debug log). Each arrival
+  touches the context.
+- **`eof`** — end of transmission. Optional body = trailing metadata (rendered as the
+  terminal SSE event's data; ignored in chunked mode). Closes the context, ends the
+  response.
+- **`exception`** — in-band failure after the head is committed: SSE renders an `error`
+  event then closes; chunked mode truncates and closes. Body = {status, message} map or
+  a String message (rendered in the error event, mirroring today's error map shape).
+- **Absence of the header = single-shot response (today's behavior, unchanged).**
+- Mutual exclusivity: `x-event-stream` and `x-stream-id` must not both appear; proposed
+  rule — `x-event-stream` wins, warn log (D5).
+
+Optional companion (SSE only): `x-event-name: <name>` on a data event maps to the SSE
+`event:` field — the typed-events idiom of MCP/A2A-era protocols (D2).
+
+## 4. Wire rendering (public — standards only)
+
+Nothing proprietary reaches the HTTP client. Streaming is expressed the way HTTP
+defines it; the mode is selected by the response `Content-Type` set on the first event:
+
+**SSE mode — `Content-Type: text/event-stream`** (first-class in v1, D2):
+- String segment → `data: <text>` (multi-line text split into successive `data:` lines
+  per the SSE spec); Map segment → `data: <one-line JSON>`.
+- `x-event-name` present → prepend `event: <name>`.
+- eof → terminal `event: done` + `data: <eof body as JSON, or {}>`. (Neutral framing —
+  an application wanting OpenAI-compatible `[DONE]` sends it as its own last data
+  segment before eof.)
+- exception → `event: error` + `data: {"status":n,"message":"...","type":"error"}`,
+  then close.
+- Keep-alive: an SSE comment line (`: ping`) every `event.stream.keep.alive` seconds
+  while idle (proposed default 30s, configurable; defeats idle proxy timeouts —
+  the same trick as Anthropic's `ping` events) (D2).
+- Standard SSE response headers set by the edge: `Cache-Control: no-cache`,
+  `Connection: keep-alive` (HTTP/1.1), no `Content-Length`.
+
+**Chunked mode — any other content type:**
+- String/byte[] segments append raw (`Transfer-Encoding: chunked` on HTTP/1.1; plain
+  DATA frames on HTTP/2).
+- Map segments → **NDJSON** (one JSON object + `\n` per segment) (D4 — replaces the
+  buffered-array behavior *only* in the new marked mode; the legacy `x-stream-id` path
+  keeps its existing semantics untouched).
+- eof ends the response; exception truncates + closes (status is already committed).
+
+Reconnect/`Last-Event-ID` resume and per-event `id:` are explicitly **out of scope for
+v1** (left open by the framing design; token streams industry-wide fail-and-retry
+rather than resume).
+
+## 5. Edge behavior (implementation surface)
+
+`AsyncHttpResponse` (+ context lifecycle in `HttpRouter`):
+- Multi-event dispatch: `data` → render + `holder.touch()` + keep context; `eof` →
+  render terminal + `closeContext` + `end()`; `exception` → error render + close.
+- Streaming state lives on the `AsyncContextHolder` (mode committed, SSE/chunked,
+  content-type, first-event-seen) — no new registry.
+- **Timeouts:** the endpoint timeout (rest.yaml) is the overall budget as today; each
+  segment touches the holder, so the effective contract is an inter-segment idle
+  timeout. Optional `x-ttl` on the FIRST event overrides the idle allowance (same key
+  the stream path uses today). Housekeeping closing an idle streaming context emits the
+  in-band error event first (SSE) rather than silently dropping the connection.
+- **Client disconnect:** the existing connection-close handling closes the context;
+  late segments address a dead correlation id and drop as no-ops — cheap, no cancel
+  channel in v1 (D-noted as future work if producers ever need positive cancellation).
+- **Slow client:** respect the vert.x write queue — on `writeQueueFull`, buffer up to a
+  small cap (proposed 1 MB) and resume on drain; beyond the cap, treat as a failed
+  client: error-close (D6). Token streams are small and paced, so this is a guard rail,
+  not a hot path.
+- HEAD requests never stream (no body) — first event handled as single-shot.
+- Tracing: no per-segment spans (noise); the request span gains summary annotations at
+  close (`stream_events=N`, `stream_bytes=M`, `stream_outcome=eof|error|timeout`).
+
+## 6. Producer contracts
+
+**Java function (v1):** streaming producers are interceptor-style functions
+(`@EventInterceptor` — they receive the raw envelope incl. `reply_to`/`cid` and return
+null), the established house pattern for system functions. A small helper is the
+developer surface:
+
+```java
+var out = new EventStreamWriter(event.getReplyTo(), event.getCorrelationId());
+out.first(200, "text/event-stream");        // optional head control (status, content-type)
+out.write("Hello");                          // x-event-stream: data
+out.write(Map.of("delta", " world"));        // structured segment
+out.write("tokens", Map.of("n", 2));         // named event -> x-event-name: tokens
+out.close(Map.of("usage", usage));           // x-event-stream: eof (+ trailing metadata)
+// or out.fail(e);                           // x-event-stream: exception
+```
+
+Sugar over plain `po.send(...)` — no new runtime concept; its Rust (and later
+python/node) twins keep the contract portable.
+
+**rest.yaml wiring (v1 scope, D3):** streaming endpoints target a `service:` directly
+(still declared in rest.yaml — the no-ad-hoc-controllers rule holds). Streaming
+*through* an Event Script flow needs the http flow adapter to hand `{reply_to, cid}`
+into the transaction (e.g., reserved `model.http.*` keys) so a task can construct the
+writer — proposed as the immediate follow-up (v1.1) unless ruled into v1.
+
+**Graph runs** (`POST /api/graph/{id}`) and **graph.task nodes**: follow-up on the same
+mechanism once the executor forwards reply context — this is the E0+ streaming story
+for `bp-agent-orchestration`, not v1.
+
+**Polyglot wrappers (v1.1, D8):** mechanically possible with zero engine change beyond
+this feature — a wrapper-side function streams by POSTing envelopes over Event-over-HTTP
+addressed to `async.http.response@<engine>` with the relayed `cid` and `x-event-stream`
+headers (one POST per batch; batching amortizes). Formalized wrapper-side
+`EventStreamWriter` twins + relay header-preservation verification are the v1.1 work
+items in the wrapper repos.
+
+## 7. Validation plan
+
+platform-core tests (the release gate for the feature):
+- SSE end-to-end: typed + untyped segments, terminal `done` with eof body, framing
+  byte-exact (multi-line data splitting, keep-alive comment).
+- Chunked text and NDJSON map streaming; eof; HEAD unaffected.
+- Mid-stream `exception` → in-band error event (SSE) / truncate (chunked).
+- Idle timeout → error event + close; each-segment touch extends life.
+- Client-disconnect: late segments are no-ops (no leak, no error).
+- Backward compatibility: unmarked single-shot responses and the legacy `x-stream-id`
+  path byte-identical to today (existing tests as the regression net).
+- Cross-engine: an SSE conformance fixture both engines must render byte-identically
+  after normalizing volatiles (the reference-signature procedure), extending the interop
+  report when the Rust twin lands.
+- Demo: a token-stream service in an example app (`hello.token.stream`, N segments with
+  pacing) — later the E0 `llm.chat` drive plugs into exactly this endpoint shape.
+
+## 8. D-series (rulings)
+
+- **D1 — RATIFIED 2026-08-27:** multi-shot reply_to model; envelope marker
+  `x-event-stream: data|eof|exception`; internal-envelope vs standards-only-wire
+  separation.
+- **D2:** SSE first-class in v1: `text/event-stream` framing, `done`/`error` terminal
+  events, optional `x-event-name` → `event:`, keep-alive comment (default 30s,
+  configurable). *(Recommended: yes.)*
+- **D3:** v1 producer scope = `service:`-target endpoints + `EventStreamWriter`; the
+  Event Script flow handoff (`model.http.*` reserved keys) as v1.1. *(Or pull the flow
+  handoff into v1.)*
+- **D4:** non-SSE structured segments render as NDJSON in the new mode.
+- **D5:** `x-event-stream` + `x-stream-id` together = `x-event-stream` wins, warn log.
+- **D6:** slow-client policy: drain-aware buffering with a 1 MB cap, then error-close.
+- **D7:** Rust lock-step timing — same-day PR pair, or Java-first with the vocabulary
+  pinned and the Rust twin immediately after.
+- **D8:** sanction the wrapper streaming pattern (Event-over-HTTP posts to the reply
+  route) as v1.1 with wrapper-side writer twins.
+
+## 8a. Implementation status (2026-08-28, Java)
+
+- New: `EventStreamWriter` (core.system — producer helper + the wire-contract
+  constants), `EventStreamRenderer` (automation.services — SSE/chunked rendering, head
+  commit, keep-alive, drain-aware cap, in-band error/timeout), `EventStreamState`
+  (automation.models — per-request state + bounded pending queue).
+- Response header transforms (rest.yaml `headers.response` add/keep/drop) apply to
+  the streamed head via the same `filterHeaders` as single-shot responses; the SSE
+  `Cache-Control: no-cache` is a set-if-absent default (explicit header or transform
+  add wins). Closed on Eric's review question, pinned by a dedicated e2e.
+- Modified: `AsyncHttpResponse` (early streaming branch), `AsyncContextHolder`
+  (+eventStream, +streamLane — the checked-out lane rides the request context),
+  `HttpRouter` (lane checkout on `stream: true` + 503 on exhaustion; release in
+  closeContext, the funnel for every termination path; holder-based reply-route
+  resolution), `RoutingEntry`/`RouteInfo` (`stream: true`), `AppStarter` (lane-pool
+  registration + streaming-aware housekeeper timeout), `AsyncHttpClient` (route-prefix
+  constant). `HttpRequestEvent` returned to its pre-feature shape (the interim
+  `streamResponse` tag "12" was removed — the holder carries the lane instead).
+- Config: `event.stream.keep.alive` (default 30s, 0=off). No lane-count knob (D9 revised).
+- Tests: 24 (18 e2e incl. progressive-delivery timing, typed events, NDJSON, in-band
+  error, pre-head error, eof-only, keep-alive pings, in-band housekeeper timeout,
+  touch-extends-life pacing, 8KB×50 FIFO burst forcing the drain path, four parallel
+  bursts (which caught and now pin a real drain-handler race — fixed with a per-request
+  lock), D5 conflict, pool exhaustion → 503 → recovery, lane returns on completion,
+  LIFO reuse, response-header-transform parity; 3 writer-contract; 3 state/cap units).
+  platform-core full suite 450/450; mkdocs strict clean;
+  ai-contract-provider 19/19 with the new guide in files.list.
+- Docs: guides/http-streaming.md (+nav, llms.txt, event-over-http See-also), ADR-0018
+  Proposed, CHANGELOG Unreleased.
+
+## 9. Non-goals (v1)
+
+- WebSockets (exists separately; SSE is the target idiom for these use cases).
+- Reconnect/resume (`Last-Event-ID`), per-event `id:`.
+- Positive cancellation channel to producers on client disconnect.
+- Graph-run streaming endpoint (follow-up on this mechanism).
+- Any change to the legacy `x-stream-id`/Flux relay path — it remains for
+  file-download-style relaying, untouched.

--- a/draft-design-specs/polyglot-script-runner.md
+++ b/draft-design-specs/polyglot-script-runner.md
@@ -1,0 +1,256 @@
+# Polyglot function execution — design investigation & implementation plan
+
+> Status: RATIFIED 2026-08-22 — D0–D8 accepted by Eric (D7 resolved: non-blocking async
+> design and libs). Two in-flight scope refinements ratified the same day:
+> (1) wrappers include the **minimalist utilities** — Configuration Management, Logging,
+> Telemetry — in engine-consistent style, so developers don't invent different ways to do
+> foundational things; (2) configuration follows the engines' **`resources/` location
+> convention** and the **`-Dkey=value` runtime override syntax** (Java JVM / Rust port
+> parity).
+> Executed same day: both wrapper repos (Accenture/mercury-python, Accenture/mercury-nodejs
+> — D2 answered by repurposing them) rebooted on `feature/polyglot-event-over-http`;
+> python 30/30 and node 31/31 tests green incl. the shared golden envelope vectors;
+> cross-wrapper interop proven both directions; composable-example's declarative flow
+> executed the python function unchanged. Remaining: P2 graph.task guard (both engines),
+> P4 docs/demo/interop-report + ADR-0016, P5 publishing.
+> This file is gitignored (draft-design-specs/); the durable record lives in memory/ and
+> the coming ADR.
+
+---
+
+## 1. Intent
+
+Polyglot development lets developers use the best language per use case. Python and
+Node.js excel at rapid development but lack the composable foundation, and porting the
+full foundation to them would destroy exactly the lightness that makes them good for
+prototyping. Goal: python/node functions participate in Event Script flows and MiniGraph
+tasks — input data mapping delivers the request, output data mapping returns the result
+or error.
+
+**Vision trace:** serves `vision-mercury-composable` ("Event Script + custom skills remain
+the escape hatch"; polyglot functions widen who can contribute behavior). Proposed
+Blueprint entry: `(blueprint) polyglot function execution` — human-gated (D0).
+
+## 2. The design pivot (Eric, mid-investigation)
+
+The v1 concept was a composable function that spawns python/node as child processes over
+stdin/stdout. Eric redirected with two insights, both confirmed by the code sweep:
+
+1. **Non-blocking:** the engine's HTTP client path (async.http.request machinery /
+   Event-over-HTTP relay) is interceptor-based on the event loop — an in-flight polyglot
+   call holds **zero threads** in the JVM. The stdio design needed
+   `@KernelThreadRunner` + a kernel thread per in-flight script (pipe I/O and
+   `Process.waitFor` pin virtual-thread carriers on JDK 21 — the BdbElasticStore lesson).
+2. **No subprocess, no stability surface:** if the polyglot code runs as its own
+   long-lived service, the JVM never parents interpreters — no zombie reaping, no
+   process-tree kills, no pipe-deadlock engineering, no Sonar command-injection hotspots.
+   A polyglot peer fails as an HTTP peer, handled by the timeout/retry/exception
+   plumbing flows and graphs already have.
+
+**Direction: wrap the existing "Event over HTTP" protocol for python and node.js.**
+
+## 3. What already exists (evidence, 2026-08-22 sweep)
+
+| # | Capability | Evidence | Consequence |
+|---|-----------|----------|-------------|
+| E1 | Event API endpoint | `event.api.service` built-in; `POST /api/event` auto-merged into rest.yaml as a default system endpoint | Callee side of the protocol is free on every engine app |
+| E2 | **Declarative target maps** | `yaml.event.over.http` → event-over-http.yaml (`route` → `target` URL + optional per-route security headers); resolved inside EventEmitter at all three dispatch paths; `x-event-api` recursion guard; config-substituted URLs (`${peer.host}`) | A flow/graph/function addresses `my.python.function` **as if local**; zero caller code |
+| E3 | Zero-code flow demo SHIPPED | composable-example → lambda-example: flow task `process: 'hello.declarative'` where the route exists only on the peer | Event Script reach is proven, not theoretical |
+| E4 | Language-neutral wire format, documented to implement from | docs/guides/event-envelope-wire-format.md — every field (id, to, cid, trace_id/trace_path/span_id, status, headers, body, exec_time, tags, annotations, stack, obj_type, exception), encoding rules, format detection; MsgPack "standard" format default | A wrapper can be written from this one page — its stated design goal |
+| E5 | Cross-language interop already proven engine-to-engine | docs/test-reports/event-over-http-interop.md (Java↔Rust); Rust platform-core carries post_office.rs / event_api.rs / app_starter.rs support | The protocol the wrappers ride is versioned, tested, and maintained by BOTH first-class engines — unlike the old bespoke language-pack websocket protocol |
+| E6 | Trace continuity | trace_id/trace_path/span_id ride IN the envelope; `/api/event` is a visible traced span (v4.10.1) | Cross-language spans + log correlation for free if the wrapper echoes trace fields |
+| E7 | Security | Per-route `headers:` (e.g. Authorization) caller-side; auth service attachable to `/api/event` callee-side; target functions must be PUBLIC (`isPrivate=false`) else 403 | Enterprise posture exists; wrappers mirror the public/private concept |
+| E8 | Timeout semantics | Caller RPC timeout bounds the wait; callee's `/api/event` rest.yaml timeout (default 60s) bounds execution — same "two deadlines" shape as the async.http.request x-ttl lesson | Document the interplay; long-running python needs the callee entry raised |
+
+**The ONE engine-side gap (G1):** `graph.task` guards route existence
+(`GraphTask.java:74 po.exists(route)`), and `EventEmitter.routeExists()` checks
+origin + local registry + cloud routes — **not** `eventHttpTargets`. So a graph task
+naming a declaratively-mapped foreign route is rejected today ("task 'x' does not
+exist"). The Rust twin has the identical guard (knowledge-graph skills.rs:362).
+Flows are unaffected (no pre-check — that is why E3 works).
+
+Fix options:
+- **Surgical (recommended):** graph.task accepts a route that exists locally, in the
+  cloud, OR in the event-over-http map (`EventEmitter.getEventHttpTarget(route) != null`
+  is already `public`; add a PostOffice passthrough). Java + Rust lock-step, pinned by a
+  foreign-route graph e2e against a stub peer.
+- Global: teach `routeExists()` about the map. Rejected by default — `po.exists()` has
+  many callers (actuators, optional-dependency probes); changing its meaning globally has
+  blast radius the surgical fix avoids. (Note: `graph.suspend`'s store-task guard keeps
+  the local-only check — state stores over HTTP is not this feature.)
+
+## 4. Option space
+
+- **A. stdio subprocess per invocation** (v1 concept — full design preserved in git
+  history of this draft). Unique wins: single-artifact deployment (script rides in the
+  app jar; no second service, port, or supervisor) and no network/auth surface. Costs:
+  the JVM owns process lifecycle (zombies, tree-kills, pipe deadlocks — real field-bug
+  surface), kernel-thread-per-execution on JDK 21, spawn latency per call, Sonar
+  command-injection hotspots, a new framework module on both engines. **Shelved — not
+  built now; revisit only if the field demands embedded single-artifact scripting.**
+- **B. Persistent worker processes over framed stdio** — a mini language server; state
+  leakage; protocol + lifecycle burden. Rejected.
+- **C. Full composable SDK per language** — rejected by the stated rationale (weight).
+- **D. Embedded interpreters in-JVM (GraalPy/GraalJS)** — heavyweight, no Rust analog,
+  and the in-runtime code-execution pattern the graph.js phase-out retires. Rejected.
+- **E. Pre-forked warm pool** — a performance lever for A only; moot while A is shelved.
+- **F. WASM** — real sandbox, but python/node→WASM toolchains defeat "plain python for
+  rapid prototyping". Rejected for now.
+- **G. Event-over-HTTP language wrappers (Eric's direction) — RECOMMENDED.** Thin
+  python/node packages implement the already-documented envelope + `/api/event` host;
+  engines need (almost) nothing.
+- **H. No framework artifact, document a DIY pattern** — the codec/host/registry is
+  exactly what should be written once, correctly. Rejected.
+
+### A vs G, honestly
+
+| Axis | A (stdio subprocess) | G (Event-over-HTTP wrapper) |
+|---|---|---|
+| Engine change | New module both engines | **Zero** except the graph.task guard (G1) |
+| JVM stability surface | Process lifecycle owned by the JVM | **None** — peer fails as an HTTP peer |
+| JVM threading | Kernel thread per in-flight script | **Zero threads** (event-loop interceptor path) |
+| Interpreter startup | Per call (30–100ms+, imports repeated) | Once — heavy libs (pandas, ML) load one time |
+| Envelope semantics / trace | Bolted on via env vars | **Native** — trace/cid/status ride the envelope |
+| Bidirectional (python calls engine functions) | No | Yes — the wrapper client is the same POST |
+| Deployment | Single artifact (script in the jar) | Second service to run (k8s pod / dev terminal) |
+| Dev loop | Drop a .py in resources | `pip install` + one-liner dev runner (see 5.4) |
+| Protocol maintenance | New stdio contract to keep parity on | Rides the Java↔Rust-tested wire format |
+
+G wins on every axis except single-artifact deployment. That niche is real but narrow —
+and it is exactly where the old rationale ("don't own process stability") bites hardest.
+
+## 5. Recommended design (G)
+
+### 5.1 Architecture principle — the scope fence
+
+**Polyglot services contribute FUNCTIONS; orchestration stays in the engines.** The
+wrapper is deliberately NOT a composable foundation: no event bus, no flows, no graphs,
+no local orchestration. It is four small parts per language:
+
+1. **Envelope codec** — the standard MsgPack wire format (E4 is the contract).
+2. **HTTP host** — `POST /api/event`: decode → dispatch → encode reply (or 202 for
+   drop-n-forget). Honors `x-event-format: compact` reply-in-kind like the engines.
+3. **Route registry + handler API** — mirrors the Mercury vocabulary so knowledge
+   transfers across languages (see 5.2).
+4. **Thin client (optional but recommended)** — `request(...)` to call engine functions
+   (or peer polyglot services) over the same protocol: bidirectional polyglot.
+
+Plus a **dev runner CLI** for the prototyping loop. That's the whole package — a few
+hundred lines per language, versioned by protocol compatibility, releasable on its own
+cadence (pip/npm), never coupled to engine releases.
+
+This keeps the architectural invariants intact: functions stay decoupled (route names +
+envelopes — `functions-decoupled-routes` extends across languages verbatim), and the
+same caution as `kafka-mesh-opt-in` applies in docs: use polyglot services where another
+language genuinely earns its place, not to scatter one app across processes.
+
+### 5.2 Handler API sketch (vocabulary mirror)
+
+```python
+# python — mercury wrapper package (final name per D2)
+from mercury import preload, AppException, platform
+
+@preload(route="my.python.function", instances=10)   # instances = concurrency limit
+def handle_event(headers: dict, body):               # TypedLambdaFunction's (headers, body)
+    if "text" not in body:
+        raise AppException(400, "missing 'text'")
+    return {"result": body["text"].upper()}          # return value -> envelope body
+
+platform.run(port=8086)                              # or: mercury serve app.py --port 8086
+```
+
+```javascript
+// node — same shape
+const { preload, AppException, platform } = require('mercury');
+preload('my.node.function', { instances: 10 }, async (headers, body) => {
+  return { result: body.text.toUpperCase() };
+});
+platform.run({ port: 8087 });
+```
+
+Semantics mapping (all existing engine behavior, documented per language):
+- **Addressing:** caller-side event-over-http.yaml maps the route to the service URL
+  (config-substituted per environment). Flows/graphs/functions call the route as local.
+- **Errors:** `AppException(status, message)` → envelope status/error → the engine's
+  normal error path (flow exception handler; graph `error.source/code/message/stack`).
+- **Trace:** wrapper reads trace_id/trace_path from the envelope, exposes them to the
+  handler (context var), stamps its logs, echoes them on replies and onward calls —
+  cross-language spans and one log aggregation (`conv-telemetry-presentation-parity`
+  spirit).
+- **Timeouts:** caller RPC timeout + callee endpoint timeout (E8); document raising the
+  wrapper's per-route execution deadline for long python work.
+- **Public/private:** registry mirrors `isPrivate` (default public — these services
+  exist to be called; private = internal helper routes).
+- **Serialization:** MsgPack standard format; document the numeric gotchas
+  (`conv-serialization-gotchas` analog — int/long/float mapping rules are in the wire
+  format's encoding-rules section).
+
+### 5.3 What changes in the engine repos
+
+1. **graph.task foreign-route acceptance (G1)** — Java + Rust lock-step, the only code
+   change. Pins: graph e2e calling a mapped route against a stub peer; rejection message
+   unchanged for genuinely unknown routes.
+2. **Docs:** new guide "Polyglot functions" (this repo + Rust repo) — when to use,
+   wrapper contract, declarative map recipe, auth, timeouts, trace, deployment patterns
+   (k8s DNS, dev loop); cross-links from event-over-http.md and the AI guides. The wire
+   format page is already the implementable contract — link, don't duplicate.
+3. **Demo:** examples-level — a python service (a few lines) + a flow task + a graph.task
+   node calling it; doubles as the manual regression procedure (kafka-demo README style).
+4. **Interop report:** extend the event-over-http-interop procedure with Java↔python /
+   Java↔node columns (reference-signature procedure exists).
+
+### 5.4 The dev loop (protecting the rapid-prototyping goal)
+
+The honest cost of G vs A is the second process. Mitigations, in order of value:
+`pip install mercury-…` + `mercury serve app.py --port 8086` one-liner; a
+`polyglot-demo` example with docker-compose and bare-terminal variants; config
+substitution so the same flow YAML runs dev/prod. (helpers/-style embedding of a python
+runtime is explicitly NOT planned — that would re-enter the subprocess business.)
+
+## 6. Implementation plan
+
+- **P0 — ratify** D0–D8; freeze wrapper package names.
+- **P1 — python wrapper (reference implementation).** Codec from the wire-format page,
+  host, registry/decorator, AppException, trace plumbing, thin client, dev CLI, unit
+  tests + a live interop gate against a running Java engine app (and Rust — same
+  procedure). Home per D2.
+- **P2 — graph.task guard (G1), Java + Rust lock-step**, with pins both engines.
+- **P3 — node wrapper**, same contract, interop-gated. (Ordering per D3; note this can
+  BE the "fresh node.js re-port" the docs promise — light by design — D3.)
+- **P4 — docs + demo + interop-report extension** on both engine repos; CHANGELOG;
+  propose **ADR-0016** (polyglot functions over Event over HTTP) — human-gated.
+- **P5 — publishing** (PyPI/npm ownership, cadence, protocol-compat versioning) — Eric
+  gates; wrappers declare "implements standard wire format" compatibility, not engine
+  versions.
+
+## 7. Risks
+
+- **The language-pack ghost** (old Mercury python/node packs rotted): mitigated —
+  wrappers ride a protocol two first-class engines already keep honest (E5), scope is
+  fenced tiny, and the interop gate runs per wrapper release. Ownership/cadence is the
+  real question → D6.
+- **Long-running scripts vs 60s endpoint default** — documentation + per-route config.
+- **New ecosystems** (PyPI/npm publishing, supply-chain posture, minimal dependencies —
+  msgpack + one HTTP lib) → D7.
+- **Scope creep toward a full SDK** — the fence in 5.1 is the defense; anything beyond
+  the four parts needs its own ruling.
+
+## 8. Decisions requested (Eric)
+
+- **D0**: Ratify the Blueprint entry `(blueprint) polyglot function execution — Event
+  over HTTP wrappers` → serves vision-mercury-composable.
+- **D1**: Confirm Option G; option A (stdio subprocess) shelved, not built (its niche —
+  single-artifact embedded scripting — revisited only on field demand).
+- **D2**: Wrapper homes + names — new repos (e.g. Accenture/mercury-python,
+  Accenture/mercury-nodejs) vs incubate in-repo first; package names (pip/npm).
+- **D3**: Sequencing — python first (reference), node second? And: is the node wrapper
+  the sanctioned "fresh node.js re-port" answer?
+- **D4**: Ratify the scope fence (5.1): codec + host + registry + thin client + dev CLI,
+  nothing more.
+- **D5**: Approve the surgical graph.task guard change (G1) on both engines (vs leaving
+  graphs without polyglot reach or changing global exists() semantics).
+- **D6**: Publishing ownership + release gate (interop report green per wrapper release).
+- **D7**: Wrapper HTTP stacks (python: aiohttp vs ASGI-neutral; node: stdlib http vs
+  fastify) — can defer to P1 implementation review.
+- **D8**: API vocabulary mirror (preload/route/handle_event/AppException/instances) —
+  recommend yes for cross-language familiarity.

--- a/draft-design-specs/second-level-routing-kafka-flow-adapter.md
+++ b/draft-design-specs/second-level-routing-kafka-flow-adapter.md
@@ -1,0 +1,254 @@
+# Second-Level Routing for the Kafka Flow Adapter
+
+**Status:** design ratified by Eric 2026-07-30 (refined from the ideation draft in a
+review round grounded against the v4.11.0 adapter code); implementation not yet started.
+
+## Concept
+
+The kafka-flow-adapter today routes every record of a binding to ONE flow
+(`flow: <flow-id>`). Second-level routing is an **optional** alternative: inspect a
+key-value in the inbound record's header or payload and pick the target per record —
+the common Kafka pattern of one topic carrying mixed event types (e.g. a `type` header).
+
+Grounding: flow selection is already per-message (the adapter sends `flow_id` as a
+per-request header to `event.script.manager` on every record), so this feature is
+**purely adapter-local** — no engine changes.
+
+## Configuration
+
+`flow` and `flows` are **mutually exclusive** — configure direct or second-level
+routing, never both (startup validation; the `topic` XOR `topic-pattern` precedent).
+
+### Direct routing (unchanged)
+
+```yaml
+consumer:
+  - topic: 'mini-test-topic'
+    flow: 'kafka-sink-flow'
+```
+
+### Second-level routing
+
+```yaml
+consumer:
+  - topic: 'mini-test-topic'
+    flows:
+      - 'input.header.type(order) -> flow://order-flow'
+      - 'input.header.type(order-*) -> flow://order-variant-flow'
+      - 'input.header.type(regex: ^shipment-(eu|us)$) -> flow://shipment-flow'
+      - 'input.body.event.kind(refund) -> task://v1.refund.processor'
+      - 'default -> flow://catch-all-flow'
+```
+
+### Second-level routing on a registry-less JSON topic (`serializer`)
+
+```yaml
+consumer:
+  - topic: 'json-events'
+    serializer: 'json'  # default SimpleMapper tries deserialization; extensible later
+    flows:
+      - 'input.body.event.kind(refund) -> task://v1.refund.processor'
+      - 'default -> flow://catch-all-flow'
+```
+
+## Rule grammar
+
+Each entry: `<selector>(<matcher>) -> <target>` — plus the mandatory `default` entry.
+
+### Selector
+
+- `input.header.<name>` — a Kafka record header. **Header-NAME lookup is
+  case-insensitive** (Kafka preserves wire casing; rules must not depend on it).
+  The matched value is the UTF-8-decoded header value.
+- `input.body` followed by a **dot-bracket composite path** (MultiLevelMap semantics) —
+  a Map body via `input.body.order.type`, a **top-level List body** via
+  `input.body[0].type` (Eric's ruling 2026-07-30: `serializer: 'json'` applies to both
+  Map and List, since the dot-bracket convention retrieves list items naturally), and
+  any nesting of the two (`input.body.items[1].kind`). Usable only when the payload is
+  a Map or List (see Payload prerequisites). Implementation note: body lookups run
+  under a synthetic `body` root — this is what makes a top-level List addressable AND
+  keeps MultiLevelMap's `$`-JsonPath escape hatch (whose parser can throw at record
+  time) structurally unreachable; a `$`-prefixed key is an ordinary literal segment.
+  Rule-lookup is additionally hardened at runtime so any surprise degrades to a
+  non-match — the never-throws contract holds at both layers (review round,
+  2026-07-30).
+
+### Matcher — three modes, explicit over sniffing
+
+| Form | Mode | Notes |
+|------|------|-------|
+| `key(value)` | exact match | case-sensitive value comparison |
+| `key(val*)` | wildcard | the presence of `*` makes it one; `*` matches any run of characters |
+| `key(regex: <expr>)` | regex | always explicit — the exception, not the norm; compiled at startup (the `topic-pattern` precedent) |
+
+Footnote: an *exact* value that legitimately contains `*` cannot be expressed in exact
+mode — use `regex:` with the character escaped. Expected never to matter for routing
+keys.
+
+### Evaluation semantics
+
+- **Order matters: first match wins**, in YAML declaration order. Overlapping rules
+  (natural with wildcards) shadow deliberately — put the most specific first.
+- A missing header/key, a non-Map body for an `input.body` rule, or a non-string value
+  is a **non-match — never an error**. Rule evaluation runs on the binding's single
+  poll thread inside the existing failure envelope; it must not throw.
+- **When none matches, the `default` target is used.** `default` is mandatory
+  (startup-validated; the rest.yaml default-authentication precedent) and may target
+  `flow://` or `task://` alike.
+
+## Targets
+
+### `flow://<flow-id>`
+
+The existing five-site repo convention (Event Script process tag, modules.autostart,
+mini-scheduler, graph.extension, external.state.machine): strip the prefix, dispatch to
+the flow engine exactly as direct routing does today — same dataset
+(`input.header`/`input.body`/`metadata.*`), same model.cid seeding, same trace
+continuity, same ttl (the flow's own).
+
+### `task://<route>` — direct invocation of a composable function
+
+For processing simple enough that a flow is overweight. No input/output data mapping;
+the dispatch contract (which already exists verbatim in TaskExecutor's sub-flow
+dispatch and mini-scheduler's bare-route dispatch):
+
+1. copy all inbound record headers to the EventEnvelope headers;
+2. copy the whole payload (Map or byte[]) as the EventEnvelope body;
+3. stamp traceId / tracePath / spanId and the business-correlation-id tag exactly as
+   the flow path does (platform-core then gives the function trace adoption and the
+   `my_*` metadata view for free — log-context stays business-or-nothing).
+
+**Timeout:** a bare function has no flow ttl — an optional per-binding `ttl` (duration
+syntax: `20s`, `5m`…) applies to task invocations; default 30s. Flows keep their own.
+
+**Naming note (deliberate divergence):** existing dual-target sites use a *bare* route
+name for direct function dispatch. In a field-facing routing table, the explicit
+`task://` prefix is chosen instead — self-documenting and typo-proof; the divergence is
+intentional and documented.
+
+## Payload prerequisites (input.body rules)
+
+Today the body is a Map **only** on the schema-registry path (`schema.enabled: true` +
+registry URL; JSON-schema and Avro-record decodes yield Maps) — and not every
+installation uses a schema registry. Therefore v1 ships an opt-in:
+
+### `serializer: 'json'` — registry-less deserialization (ratified into v1, 2026-07-30)
+
+An optional per-binding parameter for non-schema topics. `json` tells the adapter to
+use the default **SimpleMapper** to TRY deserializing the record value (UTF-8) before
+routing. The parameter is deliberately open-ended so the serializer feature can be
+extended later (other formats, custom implementations).
+
+- A JSON **object** becomes a Map — `input.body.<key>` rules match, and the flow/task
+  receives the same Map-shaped dataset a schema binding produces.
+- A JSON **array** becomes a List — **addressable by bracket rules**
+  (`input.body[0].type(order) -> flow://order-processing`) and delivered as decoded.
+- A top-level **scalar** keeps the raw byte[] like a parse failure does — Kafka's
+  native body is bytes, so "not a JSON structure" means "unchanged" (implementation
+  refinement 2026-07-30, aligned with the parse-failure ruling and the platform-core
+  JSON-sniffing idiom; routing outcome is identical either way).
+- **"Try" semantics — a parse failure needs NO special handling in the adapter's
+  processing loop (ratified):** the record keeps its raw byte[] body, every
+  `input.body` rule is a non-match, routing falls through to header rules / `default`,
+  and the raw byte[] is passed as the input body to whichever flow or task is
+  selected. If that target expects something else, the **target** throws — and the
+  exception rides the existing retry → DLQ path naturally. The schema-registry path
+  stays the strict decode-before-routing contract; `serializer` is best-effort by
+  design.
+- Numeric values follow SimpleMapper's customized-Gson semantics (the documented
+  Integer/Long gotcha — flows should use `util.str2int` / `util.str2long` when a
+  specific width matters).
+- `serializer` combined with `schema.enabled: true` is a startup validation error —
+  the registry already owns the decode.
+- The parameter is independent of `flows`: a plain `flow:` binding benefits too (Map
+  body without a registry).
+
+Bindings with **neither** schema nor `serializer` keep the byte[] body: every
+`input.body` rule is a non-match → `default`. That is the norm there, not an edge
+case — route on headers, or opt in.
+
+On schema-enabled bindings, `input.body.*` rules work as before; a decode failure
+dead-letters before routing (unchanged poison handling).
+
+## Outbound symmetry (ratified by Eric 2026-07-30)
+
+`simple.kafka.notification` and `secondary.kafka.notification` (which inherits — the
+twin-kafka subclass overrides accessors only) accept a **Map or List body** from the
+calling application and automatically serialize it to JSON bytes with the default
+SimpleMapper — the outbound twin of the inbound `serializer: 'json'`. byte[] passes
+through verbatim (the minimalist default); `null` stays `null` (a Kafka tombstone);
+anything else is rejected loudly. **Non-schema-registry topics only** (Eric's
+scoping): with a `subject` header the body contract stays a byte[] JSON document,
+exactly as before — the schema registry owns that encoding.
+
+## Offset commit, retry, DLQ — unchanged envelope, both targets
+
+Unless `auto-commit: true`, the adapter commits only after the target — flow **or
+task** — finishes successfully (synchronous request, reply status < 400; the task path
+reuses the identical await). Failure follows the existing path: retries
+(`kafka.flow.max.retries`, backoff) then the binding's `dlq-topic`. A routing
+*non-match* is not a failure — it selects `default`. A **synchronous dispatch error**
+(e.g. a task route released after startup validation → "Route not found") joins the
+same retry/DLQ envelope instead of escaping to the poll loop, which would kill the
+consumer thread (review round, 2026-07-30).
+
+## Startup validation (fail-fast, before any Kafka connection — the existing contract)
+
+- `flow` XOR `flows`; `flows` non-empty; exactly one `default` entry.
+- Every rule parses; regex matchers compile.
+- Every `flow://` target exists in the compiled flows (the existing `Flows.getFlow`
+  check); every `task://` route exists in the platform registry (checkable — the
+  adapter starts via `@MainApplication`, after function preload).
+- `task://event.script.manager` is rejected — the flow engine is a registered route,
+  but addressing it as a bare task bypasses the flow-launch contract (no `flow_id`);
+  flows are dispatched with `flow://` only (review round, 2026-07-30).
+- Body keys use the dot-bracket composite-path convention (evaluated under a synthetic
+  root, so JsonPath dispatch is unreachable by construction — no key syntax needs
+  rejecting).
+- Per-binding `ttl` (if present) parses as a valid duration.
+- `serializer` (when present) is `json` — the only supported value in v1 — and is not
+  combined with `schema.enabled: true`.
+
+## Observability
+
+Identical presentation for both targets: tracePath `KAFKA /<actual-topic>`, spans
+chained onto the upstream context (traceparent > configured trace header > fresh id),
+business correlation-id from the configured header reaching `model.cid` (flow) / the
+business-cid tag (task). The selected rule may be recorded as a trace annotation
+(e.g. `routing=input.header.type(order)`); the default path likewise.
+
+## Out of scope / future
+
+- `metadata.*` selectors (route by actual topic on pattern bindings) — natural later
+  extension of the same grammar.
+- Additional `serializer` values beyond `json` (plain text, custom implementations) —
+  the parameter is shaped for this.
+- Rust port: minimalist-kafka has no Rust port yet — no lock-step constraint now; this
+  configuration grammar becomes part of the future port's contract (portable YAML).
+
+## Implementation surface (sketch)
+
+- New rule parser + matcher (small, adapter-local — the `key(matcher)` shape is a new
+  grammar; the Event Script mapping DSL does not apply).
+- `KafkaFlowAdapter.buildConsumer`: `flows` + `serializer` parsing + the validation
+  list above; `KafkaConsumerBinding` carries the compiled rule list (immutable) and
+  the serializer choice.
+- `KafkaFlowConsumer.toDataset`: the `serializer: json` SimpleMapper decode branch
+  beside the schema decode (best-effort — raw byte[] body kept on parse failure; no
+  poison logic here, target failure rides the existing retry → DLQ path).
+- `KafkaFlowConsumer.routeToFlow`: rule evaluation before envelope construction; the
+  task-dispatch variant (headers+body copy + trace/cid stamping + per-binding ttl).
+- Tests: matcher unit suite (exact/wildcard/regex/ordering/non-match/casing);
+  embedded-Kafka e2e — header routing, body routing on a schema binding, `serializer:
+  json` body routing without a registry (incl. top-level array → default and malformed
+  JSON keeping byte[] → default), byte[] → default, task:// target incl.
+  commit-after-success and DLQ-on-failure, mutual exclusivity and validation
+  rejections.
+- Docs: minimalist-kafka guide section, configuration reference, CHANGELOG.
+
+## Related pre-existing observation (separate from this feature)
+
+Event Script lowercases `input.header.*` references (matching the HTTP adapter's
+lowercased ingestion), but the Kafka adapter preserves wire casing — a mixed-case
+Kafka header is unreachable in flow data mapping today. Tracked separately; this
+feature's case-insensitive header-name lookup avoids the trap for routing.

--- a/draft-design-specs/suspend-resume-rationalization.md
+++ b/draft-design-specs/suspend-resume-rationalization.md
@@ -1,0 +1,206 @@
+# Suspend/Resume Rationalization — Design Review + Plan
+
+> Review of the proposed re-design (Eric's `suspend-resume-rationalization.md`, 2026-08-07),
+> assessed against the actual engine code in both lanes. Status: **awaiting Eric's rulings**
+> (see §5). No implementation until ratified.
+>
+> Field context (kept generic per compartmentalization): a second field team evaluating
+> suspend/resume reports the same conceptual wall the first team hit — a suspensible node
+> ignores IF-THEN-ELSE routing and suspends unconditionally, which reads as an
+> inconsistency in decision making. Two independent teams hitting the same wall within a
+> week of each other is a design signal, not a documentation gap.
+
+## 1. The proposal in one line
+
+Retire `suspend=true`. Suspension becomes a **destination**, not a property: a node whose
+traversal proceeds into the reserved `suspend` node (by drawn edge on `next`, or by an
+IF-THEN-ELSE jump) is suspended there; `type=Suspensible` stays as UI color only.
+
+## 2. What the code actually does today (verified 2026-08-07)
+
+Both lanes (GraphTraveler dry-run / GraphExecutor deployed) are symmetric; line refs are
+the traveler.
+
+1. **`suspend=true` is only a routing trigger.** On a normal `next` completion,
+   `nextOrJump` redirects a suspensible node to `walkToSuspendNode` (only the suspend
+   node is walked; the drawn continuation edge stays dormant this run)
+   (`GraphTraveler.java:376-381`).
+2. **Persistence is already predecessor-agnostic.** `GraphSuspend` persists
+   `node = FROM header` — whoever routed in — and never consults `suspend=true`
+   (`GraphSuspend.java:71-75, 151`). The record contract `{cid, node, ttl, model, seen,
+   run}` has no notion of the property.
+3. **Resume is already predecessor-agnostic.** `GraphResume` returns
+   `resume:<persisted-node>`; `resumeTraversal` marks that node seen + run and walks its
+   forward links **excluding `suspend`** (`GraphTraveler.java:413-443`).
+4. **Latent divergence A — the plain drawn edge.** The GraphSuspend javadoc, the skill
+   help file, and `GraphModelValidator.validateContinuationEdge`'s comment all state "a
+   plain connection into the suspend node is an unconditional suspension point" — but the
+   walker actually **fans out**: `walkNext` walks ALL forward links, so a non-suspensible
+   node with edges to {suspend, continuation} would checkpoint AND continue in parallel
+   (incoherent — the run completes at the checkpoint while the branch keeps walking). The
+   documented contract and the walker disagree today; the proposal would align them.
+5. **Latent divergence B — the jump.** Nothing blocks a graph.math IF from resolving to
+   `suspend` today. The jump works (persists `node = <decision>`), but resume then calls
+   `walkNext` on the decision — walking **all its outcome edges in parallel**, which is
+   wrong (a decision's edges are alternatives, not branches). So the proposal's item 2
+   half-exists today with a broken resume.
+6. **graph.math can stage the caller's reply.** Its `MAPPING:` statements use the shared
+   data-mapping entry, so `-> output.body.x` targets work — a decision can set the
+   "awaiting decision" reply itself before routing to suspend.
+7. The gate currently enforces: suspend alias⇔skill both directions; suspensible ⇒ drawn
+   checkpoint edge + a continuation edge + not graph.math/graph.js (the teaching error,
+   4 sites); suspend node ⇒ task + ttl + a forward path.
+
+**Conclusion of the code study: the proposal is far less radical than it looks.** The
+persistence and resume layers are already shaped for it; `suspend=true` is a walker-level
+trigger plus validation. The re-design is mostly *removing* a concept and *fixing two
+latent divergences* the concept was papering over.
+
+## 3. Assessment
+
+**What the proposal fixes**
+- The confusion both teams hit disappears structurally: a decision routes one outcome to
+  `suspend` like any other outcome — no "decide before you suspend" rule to learn,
+  because deciding and suspending compose in one node.
+- The walker starts obeying the already-documented plain-edge contract (divergence A).
+- The wait-loop pattern (tutorial-14's `await-decision` + `RESET`) collapses: with
+  re-execute-on-resume for decisions (§4.3), "waiting" is just an edge to `suspend`, and
+  the next request naturally re-runs the decision against the new input. The RESET
+  wait-loop idiom shipped yesterday becomes unnecessary for this case.
+- One less property, one less node type semantic, one less validator rule family.
+
+**What the proposal under-specifies** (resolved in §4, ruled in §5)
+- What "connects to suspend and returns next" means for fan-out (must become a redirect).
+- What resume means when the persisted suspension point is a **decision** (its forward
+  links are alternatives — the current walkNext contract cannot apply).
+- Migration for field models carrying `suspend=true` (field-core surface, both engines).
+
+**Why back-compat is structurally cheap:** every valid v4.11.x model necessarily draws
+the checkpoint edge (the gate required it), so edge-inferred redirect reproduces today's
+behavior exactly on old models — `suspend=true` degrades to a no-op. And the persisted
+record contract is untouched, so records written by v4.11.x resume correctly under the
+new engine (their `node` is a working node → continue-past semantics, same as today).
+Mixed-version fleets are safe in both directions.
+
+## 4. Resolved design (RATIFIED by Eric 2026-08-07 — R1-R6 accepted; R2 refined by Eric)
+
+**The discriminator between the two suspension modes is graph shape — how the
+suspension point relates to the suspend node — not skill class.** Eric's refinement:
+this is cheaper (a forward-link lookup at resume, no skill classification, no statement
+inspection at the gate) and it makes re-execution impossible to apply to a working node
+by construction.
+
+4.1 **Edge mode — the back-compat shape (drawn edge into suspend).** When a node's
+skill returns `next` and `suspend` is among its forward links, the walker redirects to
+the suspend node (today's suspensible behavior); the drawn edge is the declaration.
+On resume: mark seen + run, **skip the suspend path, continue along all other forward
+links** — exactly the current implementation, **no re-execution**. Multiple continuation
+edges fan out on resume (parallel branches, joined later) — that works today and stays.
+Gate (unchanged, structural, cheap): a node with an edge to suspend MUST have at least
+one other edge — a suspend-only node is rejected regardless of skill, even a graph.math
+whose IF-THEN-ELSE might route elsewhere (inspecting statement logic is deliberately out
+of scope; the rule is shape-only). `suspend=true` is accepted and ignored (deprecation
+WARN), `type=Suspensible` stays a color.
+
+4.2 **Jump mode — the forward-looking best practice (no drawn edge; IF-THEN-ELSE jump).**
+A graph.math IF resolving to `suspend` checkpoints with `node = <decision>`. On resume:
+**re-execute the decision** — its persisted seen/run marks are not restored and
+resumeTraversal walks the node itself, so it re-evaluates the NEW request input and
+routes: approval proceeds, explicit rejection terminates, anything else jumps back to
+suspend (re-suspension — the wait loop with no RESET idiom). The decision may stage
+`output.*` first (e.g. the awaiting reply); otherwise the default
+`{type: suspended, cid}` applies. By construction only routing skills can jump (working
+skills always return `next`), so jump mode ⇒ routing skill without any classification.
+
+4.3 **The two modes coexist in one graph.** tutorial-14 shows both naturally: the
+order/approval/delivery working checkpoints keep drawn edges (edge mode, semantics
+unchanged); check-approval jumps to suspend on the waiting outcome (jump mode) —
+`await-decision` and the RESET statements are deleted.
+
+4.4 **Island-anchored suspend (required companion of jump mode).** The export path
+rejects orphan nodes ("a graph with orphan nodes cannot be exported" — help connect.md),
+so a jump-only suspend node needs an incoming edge that plain traversal never crosses:
+`root -> island-node -> suspend` (GraphIsland returns SINK, so the branch stops at the
+island). This is the sanctioned anchor pattern; document it wherever jump mode is taught.
+(P1 must locate the exact orphan-check site and confirm the anchor satisfies it.)
+
+4.5 **Validator rewrite.**
+- Drop: the suspensible property rules (the suspend=true routing-skill ban — the 4-site
+  teaching error retires in its current form).
+- Keep: suspend alias⇔skill both directions, task + ttl, suspend's forward path to end,
+  resume-node task, the continuation-edge rule (now stated as 4.1's shape rule).
+- Add: a routing-skill node (graph.math/graph.js) must NOT draw an edge to suspend —
+  the teaching error's successor ("a decision reaches suspend by jumping from its
+  IF-THEN-ELSE; draw edges to suspend only from working nodes") — because edge-mode
+  resume would fan out a decision's outcome alternatives.
+- Add: `suspend=true` present ⇒ deprecation WARN naming the drawn-edge replacement.
+  `suspend` stays in RESERVED_PARAMETERS through the deprecation window.
+- Add (scope cut, R7): `exception=suspend` rejected — checkpoint-on-failure would give
+  re-execution retry semantics through the back door; revisit deliberately if a field
+  case ever asks for it.
+
+## 5. Rulings
+
+| # | Question | Ruling |
+|---|----------|--------|
+| R1 | Edge into suspend = checkpoint redirect on `next`, never fan-out into suspend | **ACCEPTED** (Eric 2026-08-07) |
+| R2 | Resume semantics | **REFINED + RATIFIED** (Eric): discriminate by shape, not skill — edge mode resumes past the checkpoint with NO re-execution (current behavior; continuation fan-out fine); jump mode re-executes the decision |
+| R3 | Deprecation window for `suspend=true` (no-op + WARN) | **ACCEPTED** |
+| R4 | Remodel tutorial-14 to the new grammar in the same release | **ACCEPTED** |
+| R5 | ADR-0012 proposal partially superseding ADR-0010 vocabulary | **ACCEPTED** |
+| R6 | graph.js: same jump semantics implicitly, zero investment | **ACCEPTED** |
+| R7 | `exception=suspend` rejected at the gate (scope cut) | proposed with the R2 refinement — needs Eric's nod |
+
+## 6. Phased plan (after ratification)
+
+- **P0 — Ratify.** Eric rules on R1–R6; ADR-0012 drafted for the merge that lands P1.
+- **P1 — Java engine.** Both lanes: edge-inferred redirect in `nextOrJump`/`walkTo`
+  (replace `isSuspensible` checks with a forward-link probe), jump path unchanged (it
+  already persists FROM), `resumeTraversal` bifurcation by skill class (incl. NOT
+  restoring a routing node's seen/run marks in GraphResume — restoreMarks gains the same
+  exemption it has for `suspend`), validator rewrite per 4.4, deprecation WARN.
+- **P2 — Tests.** Matrix: v4.11.x compat model (suspend=true, unchanged behavior +
+  WARN); edge-inferred working-node checkpoint; decision-jump checkpoint; wait loop via
+  re-execution (two invalid rounds, then approve — the tutorial-14 e2e reshaped);
+  v4.11.x-written record resumed by the new engine; decision staging output.* before
+  suspend; suspension after a join (sole-active-branch warn unchanged); expired/absent
+  record fresh path.
+- **P3 — Docs + AI grammar (the surface rewrites as ONE story).** Guide (walkthrough +
+  design rules: "route the waiting outcome to suspend" replaces decide-before-you-
+  suspend; wait-loop RESET demoted to a generic-loop technique), tutorial-14 help, skill
+  help, minigraph-commands.json suspend entry (byte-identical cross-engine), CHANGELOG;
+  `npm run release` bundle regen (the Tutorials tab bakes help files — both repos).
+- **P4 — Rust lock-step.** Full mirror (model_validator + traveler/executor lanes +
+  resume skill + fixtures + e2e + docs + INCREMENTS row); byte-identical catalog entries
+  and error strings; graph.js items excluded per phase-out.
+- **P5 — Release.** Lock-step version on both engines; field validation invitation to
+  both teams (their models keep working unmodified — the WARN guides migration);
+  schedule the property's hard retirement for a later release.
+
+## 7. Risk register
+
+- **Field-core, regression-critical surface on both engines** (Eric's standing ruling).
+  The compat matrix in P2 is the gate; the v4.11.x-record replay test is mandatory.
+- **Behavior change for latent shapes:** a model that today draws a plain edge into
+  suspend from a working node currently fans out (divergence A); under R1 it checkpoints.
+  Judged acceptable: the fan-out behavior contradicts the shipped documentation and is
+  incoherent (parallel complete+continue) — call it a bug fix, note it in CHANGELOG.
+- **Docs churn:** this rewrites the grammar surface shipped 2026-08-07 (PR #263/#193).
+  Mitigation: P3 lands as one coherent rewrite, not edits-on-edits.
+- **Re-execution loop safety:** a decision that always routes to suspend re-suspends
+  forever by design (each resume consumes + re-persists the record); the existing
+  high-frequency loop detector still bounds a within-run cycle. No new loop hazard.
+- **Sole-active-branch:** unchanged semantics (FROM-keyed warn).
+
+## 8. Surface inventory (Java; Rust mirrors)
+
+- `services/GraphTraveler.java`, `services/GraphExecutor.java` — redirect + resume
+  bifurcation (drop `isSuspensible` from GraphLambdaFunction when the window closes)
+- `skills/GraphResume.java` — restoreMarks exemption for a routing-skill suspension point
+- `skills/GraphSuspend.java` — javadoc only (mechanics unchanged)
+- `common/GraphModelValidator.java` — rule rewrite + deprecation WARN
+- `resources/graph/tutorial-14.json` + `SuspendResumeTutorialTest` / Rust e2e twin
+- `resources/help/help graph-suspend.md`, `help tutorial 14.md` (+ bundle regen)
+- `docs/guides/knowledge-graph/workflow-suspension.md`, `minigraph-commands.json`
+- `docs/arch-decisions/ADR.md` — ADR-0012 proposal (human-gated)
+- CHANGELOG (Java) / CHANGELOG + INCREMENTS (Rust)

--- a/draft-design-specs/task-ttl-override.md
+++ b/draft-design-specs/task-ttl-override.md
@@ -1,0 +1,94 @@
+# Task-level TTL override — catchable child timeouts
+
+**Status:** ratified by Eric 2026-07-31 (investigation grounded by a 4-reader code study;
+design + both decision points confirmed: name = `ttl`, compile bound + runtime WARN;
+plus Eric's ruling: `model.ttl` becomes a guarded reserved key in the graph engine).
+
+## Problem (field report)
+
+TTL propagation copies the parent's FULL ttl into each child (subflow dataset ttl;
+graph model copy; extension datasets), and each child re-arms a fresh full-length
+timer at a later start — so the parent's deadline always fires first, and a flow's own
+timeout bypasses exception handlers (TIMEOUT → abortFlow → 408 to the original
+caller). A parent can therefore never catch a subflow / subgraph / API-fetcher timeout,
+and cannot retry.
+
+Two verified facts make the fix cheap:
+- The child→parent 408 error channel already works end to end (abortFlow → task.executor
+  → handleFunctionException → task-level `exception` or flow-level handler).
+- EventScriptManager already honors a numeric dataset `ttl` over the flow template.
+
+## Design
+
+**Propagation stays the default** (top-down impedance matching). The per-task `ttl` is
+an opt-in override at the invocation site — fixing catchability (child fails first,
+parent alive to catch and retry within its remaining budget) and readability (the
+deadline story of a composition is visible in one file).
+
+### Event Script — per-task `ttl` on `flow://` tasks
+
+- New optional task key `ttl` (duration string: `8s`, `2m` — flow.ttl grammar).
+- Valid ONLY on sub-flow tasks (`flow://`); compile error elsewhere (a function task
+  has no per-task watchdog — silent no-op is worse than rejection).
+- Compile validation: parses via getDurationInSeconds, floor 1s, and MUST be
+  `< flow.ttl` (the `delay < TTL` precedent).
+- Runtime: TaskExecutor's flow:// dispatch uses task ttl when set, else
+  flowInstance.getTtl(); WARN when task ttl >= the parent instance's EFFECTIVE ttl
+  (rest.yaml may have shrunk it below compile-time flow.ttl).
+- Task model: `private long ttl = -1` beside `delay` (same accessor pattern).
+
+### Graph — per-node `ttl` on graph.extension / graph.api.fetcher / graph.task
+
+- Optional node property `ttl`, SAME grammar as the suspend node's
+  (`<digits>[s|m|h|d]`, parsed by GraphSuspend.getValidTtlSeconds) — semantics are
+  skill-scoped: deadline for the child call on these three skills; store-record expiry
+  on suspend (documented distinction).
+- Overrides getModelTtl at the read sites: GraphExtension (:98, :193),
+  GraphApiFetcher (:114, :167), GraphTask (:80) — both the child dataset ttl and the
+  RPC wait. The extension's existing `exception` error path becomes reachable for
+  timeouts.
+- `ttl` stays NON-reserved in RESERVED_PARAMETERS (skill parameter, per the suspend
+  precedent comment).
+- Validation in GraphModelValidator (one rule covers the CompileGraph gate AND the
+  playground `run` pre-check): grammar valid; allowed on suspend (mandatory, expiry) +
+  the three deadline skills (optional); rejected on other skills.
+
+### Model-metadata immutability guard (Eric's rulings, this round)
+
+The graph engine currently allows a data mapping to rewrite `model.ttl` mid-run
+(undocumented loophole; Event Script compile-blocks the same write). Eric's extended
+ruling: guard the WHOLE model-metadata family, at both layers:
+- **Family:** `model.{cid, instance, flow, ttl, trace, parent, root, none, run}` — one
+  canonical constant on the graph side, kept aligned with GraphStateSkill's
+  NON_PERSISTED_MODEL_KEYS (same nine names) and Event Script's RESERVED_MODEL_KEYS.
+- **Compile/gate:** GraphModelValidator rejects any mapping entry whose RHS targets a
+  reserved model-metadata key (CompileGraph gate + playground `run` pre-check).
+- **Runtime immutability in BOTH walkers:** the shared mapping-application path
+  (GraphLambdaFunction.validateRhs, executed by every skill in both the GraphExecutor
+  and GraphTraveler lanes) rejects reserved-metadata write targets before the model.*
+  short-circuit — dry-run drafts and any future mapping path are covered by
+  construction.
+- The per-node `ttl` is the sanctioned deadline mechanism.
+
+## Also fixed in this round (doc/code divergences found by the investigation)
+
+1. syntax.md claims flow.ttl can exceed the REST timeout — false: rest.yaml `timeout`
+   overrides flow.ttl at the HTTP edge (payload-ttl-wins). Correct the prose.
+2. flow-schema-reference.md (subflow section) claims "the parent's remaining TTL
+   governs the subflow" — false: full value, restarted timer. Correct + document the
+   new override.
+
+## Out of scope (recorded, separate rulings)
+
+- `delay` on flow:// tasks is silently dropped (pre-existing asymmetry).
+- Orphaned children when a parent dies early (child runs to its own timer; late reply
+  dropped) — mitigated by this feature, not eliminated.
+- (superseded in-round: Eric ruled the WHOLE metadata family guarded, not just
+  model.ttl — see the guard section above)
+
+## Delivery
+
+Event Script reference first, then graph side, docs (incl. divergence fixes),
+adversarial review, Rust lock-step handoff (both surfaces are cross-engine contract).
+Tests: compile rejections; catch-the-child-timeout e2e; a budgeted-retry e2e (the
+field's use case); graph validator rules; skill override behavior; model.ttl guard.

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.ByteBufFlux;
@@ -59,14 +60,16 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 @EventInterceptor
 public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void> {
     public static final String ASYNC_HTTP_REQUEST = "async.http.request";
     public static final String ASYNC_HTTP_RESPONSE = "async.http.response";
     // ordered reply-lane family for streaming responses: a pool of single-instance lanes
-    // (async.http.response.stream.{n}) - a request pins to one lane by hash, so its
-    // segment order is guaranteed while different requests stream concurrently
+    // (async.http.response.stream.{n}) - a streaming request checks out one dedicated
+    // lane for its lifetime, so its segment order is guaranteed while different
+    // requests stream concurrently through their own lanes
     public static final String ASYNC_HTTP_RESPONSE_STREAM_PREFIX = "async.http.response.stream.";
     private static final Logger log = LoggerFactory.getLogger(AsyncHttpClient.class);
     private static final AtomicBoolean loaded = new AtomicBoolean(false);
@@ -92,6 +95,8 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
     private static final String HEAD = "HEAD";
     private static final String X_STREAM_ID = "x-stream-id";
     private static final String X_TTL = "x-ttl";
+    private static final String ACCEPT = "accept";
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
     private static final String CONTENT_TYPE = "content-type";
     private static final String CONTENT_LENGTH = "content-length";
     private static final String X_CONTENT_LENGTH = "x-content-length";
@@ -195,8 +200,12 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         // one extra second of grace over the request TTL so a peer that spends
         // its whole TTL and then replies (e.g. an Event-over-HTTP 408 sent AT
         // the deadline) is still readable; the caller's own RPC timeout - not
-        // this wire-level read timeout - governs the user-visible deadline
-        client = client.responseTimeout(Duration.ofSeconds(request.getTimeoutSeconds() + 1L));
+        // this wire-level read timeout - governs the user-visible deadline.
+        // A progressive SSE candidate is exempt: a healthy stream may outlive
+        // any fixed total - the SSE relay enforces a per-read idle allowance
+        if (!isEventStreamCandidate(input, request)) {
+            client = client.responseTimeout(Duration.ofSeconds(request.getTimeoutSeconds() + 1L));
+        }
         if (request.isSecure()) {
             if (request.isTrustAllCert()) {
                 Http11SslContextSpec http11Context = Http11SslContextSpec.forClient()
@@ -394,6 +403,23 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         }
     }
 
+    /**
+     * A request is a progressive-SSE candidate when the caller explicitly accepts
+     * text/event-stream AND supplied a reply_to (a multi-shot-capable consumer).
+     * Everything else keeps the buffered single-shot behavior.
+     *
+     * @param input the request event
+     * @param request the HTTP request dataset
+     * @return true when the response may be consumed progressively
+     */
+    private static boolean isEventStreamCandidate(EventEnvelope input, AsyncHttpRequest request) {
+        if (input.getReplyTo() == null) {
+            return false;
+        }
+        String accept = request.getHeader(ACCEPT);
+        return accept != null && accept.contains(TEXT_EVENT_STREAM);
+    }
+
     private void sendResponse(EventEnvelope input, EventEnvelope response) {
         response.setTo(input.getReplyTo()).setFrom(ASYNC_HTTP_REQUEST)
                 .setCorrelationId(input.getCorrelationId())
@@ -549,6 +575,10 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         }
 
         public void process() {
+            if (isEventStreamCandidate(input, request)) {
+                processEventStreamCapable();
+                return;
+            }
             var noContent = new AtomicBoolean(true);
             http.responseSingle((httpResponse, buffer) -> {
                 response.setStatus(httpResponse.status().code());
@@ -576,6 +606,264 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                     sendResponse(input, response);
                 }
             });
+        }
+
+        /**
+         * The caller opted into SSE (Accept + reply_to). If the upstream answers with
+         * text/event-stream, consume it progressively: one x-event-stream data envelope
+         * per SSE event to the caller's reply_to, then eof - the same producer contract
+         * the HTTP edge consumes. A non-SSE response falls back to the buffered
+         * single-shot rendering, exactly as before.
+         */
+        private void processEventStreamCapable() {
+            var relay = new SseRelay();
+            var fallback = new ByteArrayOutputStream();
+            var streaming = new AtomicBoolean(false);
+            Disposable connection = http.response((httpResponse, content) -> {
+                response.setStatus(httpResponse.status().code());
+                var httpHeaders = httpResponse.responseHeaders();
+                httpHeaders.forEach(kv -> response.setHeader(kv.getKey(), kv.getValue()));
+                String resContentType = resolver.getContentType(response.getHeader(CONTENT_TYPE));
+                if (resContentType != null && resContentType.startsWith(TEXT_EVENT_STREAM)) {
+                    streaming.set(true);
+                    relay.start();
+                }
+                return content.asByteArray();
+            }).subscribeOn(Schedulers.fromExecutor(executor)).subscribe(
+                chunk -> {
+                    if (streaming.get()) {
+                        relay.onChunk(chunk);
+                    } else {
+                        fallback.writeBytes(chunk);
+                    }
+                },
+                e -> {
+                    if (streaming.get()) {
+                        relay.onTransportError(e);
+                    } else {
+                        sendErrorResponse(input, e);
+                    }
+                },
+                () -> {
+                    if (streaming.get()) {
+                        relay.onComplete();
+                    } else {
+                        renderBuffered(fallback.toByteArray());
+                    }
+                });
+            relay.setConnection(connection);
+        }
+
+        /**
+         * Buffered fallback of the SSE-candidate path (the upstream did not stream):
+         * render exactly as the single-shot path would
+         */
+        private void renderBuffered(byte[] b) {
+            String resContentType = resolver.getContentType(response.getHeader(CONTENT_TYPE));
+            String len = response.getHeader(CONTENT_LENGTH);
+            boolean renderAsBytes = "true".equals(request.getHeader(X_NO_STREAM));
+            if (renderAsBytes || len != null || isTextResponse(resContentType)) {
+                if (len == null) {
+                    response.setHeader(X_CONTENT_LENGTH, b.length);
+                }
+                sendFixedLengthResponse(resContentType, response, b);
+            } else if (b.length > 0) {
+                Platform.getInstance().getVirtualThreadExecutor().submit(() ->
+                        sendStreamResponse(response, new ByteArrayInputStream(b)));
+            } else {
+                sendResponse(input, response);
+            }
+        }
+
+        /**
+         * Progressive SSE consumption (raw mode): an incremental frame parser feeding
+         * x-event-stream envelopes to the caller's reply_to. The request TTL is the
+         * per-read idle allowance (any upstream bytes - keep-alive comments included -
+         * reset it); idle expiry and mid-stream transport errors fail the stream
+         * in-band, matching the edge contract.
+         */
+        private class SseRelay {
+            // the reply-lane lesson applies here too: the chunk consumer and the
+            // idle timer run on different threads - one lock serializes them
+            private final ReentrantLock lock = new ReentrantLock();
+            private final ByteArrayOutputStream pending = new ByteArrayOutputStream();
+            private final List<String> dataLines = new ArrayList<>();
+            private final long idleMs = timeoutSeconds * 1000L;
+            private String eventName = null;
+            private boolean headSent = false;
+            private volatile boolean closed = false;
+            private volatile long lastActivity = System.currentTimeMillis();
+            private long timer = -1;
+            private Disposable connection;
+
+            public void start() {
+                lastActivity = System.currentTimeMillis();
+                armIdleTimer(idleMs);
+            }
+
+            public void setConnection(Disposable connection) {
+                this.connection = connection;
+            }
+
+            private void armIdleTimer(long delayMs) {
+                timer = Platform.getInstance().getVertx().setTimer(Math.max(100, delayMs), t -> {
+                    if (closed) {
+                        return;
+                    }
+                    long quiet = System.currentTimeMillis() - lastActivity;
+                    if (quiet >= idleMs) {
+                        onIdleTimeout();
+                    } else {
+                        armIdleTimer(idleMs - quiet);
+                    }
+                });
+            }
+
+            public void onChunk(byte[] chunk) {
+                // any upstream bytes prove liveness - comments included
+                lastActivity = System.currentTimeMillis();
+                lock.lock();
+                try {
+                    if (closed) {
+                        return;
+                    }
+                    pending.writeBytes(chunk);
+                    drainCompleteLines();
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            /**
+             * Extract complete lines from the pending buffer - a newline is a
+             * single byte, so byte-level splitting is UTF-8 safe
+             */
+            private void drainCompleteLines() {
+                byte[] buffer = pending.toByteArray();
+                int start = 0;
+                for (int i = 0; i < buffer.length; i++) {
+                    if (buffer[i] == '\n') {
+                        int end = i > start && buffer[i - 1] == '\r' ? i - 1 : i;
+                        onLine(new String(buffer, start, end - start, StandardCharsets.UTF_8));
+                        start = i + 1;
+                    }
+                }
+                pending.reset();
+                if (start < buffer.length) {
+                    pending.write(buffer, start, buffer.length - start);
+                }
+            }
+
+            /**
+             * One SSE line - the caller holds the lock
+             */
+            private void onLine(String line) {
+                if (line.isEmpty()) {
+                    // blank line dispatches the pending event (SSE specification)
+                    if (!dataLines.isEmpty()) {
+                        emitData(String.join("\n", dataLines), eventName);
+                    }
+                    dataLines.clear();
+                    eventName = null;
+                } else if (line.charAt(0) != ':') {
+                    // a comment line (leading colon) is consumed, never forwarded
+                    int colon = line.indexOf(':');
+                    String field = colon == -1 ? line : line.substring(0, colon);
+                    String value = colon == -1 ? "" : line.substring(colon + 1);
+                    if (!value.isEmpty() && value.charAt(0) == ' ') {
+                        value = value.substring(1);
+                    }
+                    switch (field) {
+                        case "data" -> dataLines.add(value);
+                        case "event" -> eventName = value;
+                        default -> { /* id, retry and unknown fields are ignored */ }
+                    }
+                }
+            }
+
+            private void emitData(String text, String name) {
+                EventEnvelope segment = new EventEnvelope()
+                        .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.DATA)
+                        .setBody(text);
+                if (name != null && !name.isEmpty()) {
+                    segment.setHeader(EventStreamWriter.X_EVENT_NAME, name);
+                }
+                if (!headSent) {
+                    headSent = true;
+                    // head control rides the first envelope: upstream status + SSE type
+                    segment.setStatus(response.getStatus());
+                    segment.setHeader(CONTENT_TYPE, TEXT_EVENT_STREAM);
+                }
+                sendSegment(segment);
+            }
+
+            public void onComplete() {
+                lock.lock();
+                try {
+                    if (closed) {
+                        return;
+                    }
+                    // an incomplete trailing event is discarded (SSE specification)
+                    closed = true;
+                    cancelIdleTimer();
+                    EventEnvelope eof = new EventEnvelope()
+                            .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.EOF);
+                    if (!headSent) {
+                        headSent = true;
+                        eof.setStatus(response.getStatus()).setHeader(CONTENT_TYPE, TEXT_EVENT_STREAM);
+                    }
+                    sendSegment(eof);
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            public void onTransportError(Throwable e) {
+                failInBand(500, e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+            }
+
+            private void onIdleTimeout() {
+                failInBand(408, "Timeout for " + (idleMs / 1000) + " seconds");
+                if (connection != null && !connection.isDisposed()) {
+                    connection.dispose();
+                }
+            }
+
+            private void failInBand(int status, String message) {
+                lock.lock();
+                try {
+                    if (closed) {
+                        return;
+                    }
+                    closed = true;
+                    cancelIdleTimer();
+                    EventEnvelope error = new EventEnvelope()
+                            .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.EXCEPTION)
+                            .setStatus(status)
+                            .setBody(Map.of("status", status, "message", message));
+                    if (!headSent) {
+                        headSent = true;
+                        error.setHeader(CONTENT_TYPE, TEXT_EVENT_STREAM);
+                    }
+                    sendSegment(error);
+                } finally {
+                    lock.unlock();
+                }
+            }
+
+            private void cancelIdleTimer() {
+                if (timer != -1) {
+                    Platform.getInstance().getVertx().cancelTimer(timer);
+                    timer = -1;
+                }
+            }
+
+            private void sendSegment(EventEnvelope segment) {
+                segment.setTo(input.getReplyTo()).setFrom(ASYNC_HTTP_REQUEST)
+                        .setCorrelationId(input.getCorrelationId())
+                        .setTrace(input.getTraceId(), input.getTracePath());
+                EventEmitter.getInstance().send(segment);
+            }
         }
 
         private byte[] resStreamToBytes(EventEnvelope response, InputStream stream, String contentLen) {

--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
@@ -192,7 +192,7 @@ class EventStreamClientTest extends TestBase {
         var events = consume("http://127.0.0.1:" + edgePort, "/api/hello/stream",
                 Map.of("mode", "sse"), 10, 4);
         assertEquals(4, events.size(), "3 data envelopes + eof");
-        EventEnvelope first = events.get(0);
+        EventEnvelope first = events.getFirst();
         assertEquals(EventStreamWriter.DATA, marker(first));
         // head control rides the first envelope: upstream status + SSE content type
         assertEquals(200, first.getStatus());
@@ -211,7 +211,7 @@ class EventStreamClientTest extends TestBase {
     @Test
     void multiFieldFramesMapPerSseSpecification() throws InterruptedException {
         var events = consume("http://127.0.0.1:" + mockPort, "/sse/multifield", null, 5, 2);
-        EventEnvelope data = events.get(0);
+        EventEnvelope data = events.getFirst();
         assertEquals(EventStreamWriter.DATA, marker(data));
         assertEquals("tokens", data.getHeaders().get(EventStreamWriter.X_EVENT_NAME));
         assertEquals("line1\nline2", data.getRawBody(), "multi-line data joins with newline");
@@ -231,7 +231,7 @@ class EventStreamClientTest extends TestBase {
     @Test
     void idleStallFailsInBandWithTimeout408() throws InterruptedException {
         var events = consume("http://127.0.0.1:" + mockPort, "/sse/silent", null, 2, 3);
-        assertEquals("one", events.get(0).getRawBody());
+        assertEquals("one", events.getFirst().getRawBody());
         EventEnvelope error = events.get(1);
         assertEquals(EventStreamWriter.EXCEPTION, marker(error));
         assertEquals(408, error.getStatus());
@@ -245,7 +245,7 @@ class EventStreamClientTest extends TestBase {
         // the comments prove liveness, so the stream must complete
         var events = consume("http://127.0.0.1:" + mockPort, "/sse/comments", null, 2, 3);
         assertEquals(3, events.size());
-        assertEquals("early", events.get(0).getRawBody());
+        assertEquals("early", events.getFirst().getRawBody());
         assertEquals("late", events.get(1).getRawBody());
         assertEquals(EventStreamWriter.EOF, marker(events.get(2)));
     }
@@ -253,7 +253,7 @@ class EventStreamClientTest extends TestBase {
     @Test
     void midStreamDisconnectFailsInBand() throws InterruptedException {
         var events = consume("http://127.0.0.1:" + mockPort, "/sse/abort", null, 10, 3);
-        assertEquals("partial", events.get(0).getRawBody());
+        assertEquals("partial", events.getFirst().getRawBody());
         EventEnvelope error = events.get(1);
         assertEquals(EventStreamWriter.EXCEPTION, marker(error));
         assertEquals(500, error.getStatus());
@@ -288,7 +288,7 @@ class EventStreamClientTest extends TestBase {
     }
 
     @Test
-    void withoutAcceptTheSseResponseBuffersAsBefore() throws IOException, InterruptedException {
+    void withoutAcceptTheSseResponseBuffersAsBefore() {
         // backward-compat pin: an RPC without Accept: text/event-stream receives
         // the whole SSE payload buffered as one text body (today's behavior)
         var po = EventEmitter.getInstance();
@@ -298,17 +298,13 @@ class EventStreamClientTest extends TestBase {
         req.setUrl("/api/hello/stream");
         req.setQueryParameter("mode", "sse");
         req.setTimeoutSeconds(10);
-        try {
-            EventEnvelope response = po.asyncRequest(new EventEnvelope()
-                            .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req.toMap()), 15000)
-                    .toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
-            assertEquals(200, response.getStatus());
-            String text = String.valueOf(response.getRawBody());
-            assertTrue(text.contains("data: Hello"), text);
-            assertTrue(text.contains("event: done"), text);
-        } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
-            fail(e);
-        }
+        EventEnvelope response = assertDoesNotThrow(() -> po.asyncRequest(new EventEnvelope()
+                        .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req.toMap()), 15000)
+                .toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS));
+        assertEquals(200, response.getStatus());
+        String text = String.valueOf(response.getRawBody());
+        assertTrue(text.contains("data: Hello"), text);
+        assertTrue(text.contains("event: done"), text);
     }
 
     @Test

--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
@@ -1,0 +1,347 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation;
+
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.automation.http.AsyncHttpClient;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.EventStreamWriter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Progressive SSE consumption in AsyncHttpClient (raw mode): a request that
+ * declares Accept: text/event-stream and carries a reply_to receives one
+ * x-event-stream data envelope per upstream SSE event, then eof - the same
+ * producer contract the HTTP edge consumes. Everything else keeps the
+ * buffered single-shot behavior.
+ */
+class EventStreamClientTest extends TestBase {
+    private static final HttpClient client = HttpClient.newHttpClient();
+    private static final AtomicInteger seq = new AtomicInteger(0);
+    private static HttpServer mockSse;
+    private static int mockPort;
+    private static String edgePort;
+
+    @EventInterceptor
+    private record CaptureRoute(BlockingQueue<EventEnvelope> received) implements LambdaFunction {
+        @Override
+        public Object handleEvent(Map<String, String> headers, Object input, int instance) {
+            received.add((EventEnvelope) input);
+            return null;
+        }
+    }
+
+    @BeforeAll
+    static void startMockUpstream() throws InterruptedException {
+        var config = AppConfigReader.getInstance();
+        edgePort = config.getProperty("rest.server.port", config.getProperty("server.port", "8100"));
+        var latch = new CountDownLatch(1);
+        mockSse = Platform.getInstance().getVertx().createHttpServer();
+        mockSse.requestHandler(request -> {
+            HttpServerResponse response = request.response();
+            String path = request.path();
+            response.putHeader("content-type", "text/event-stream");
+            response.setChunked(true);
+            var vertx = Platform.getInstance().getVertx();
+            switch (path) {
+                case "/sse/silent" -> // one event, then silence (no pings, never ends)
+                        response.write("data: one\n\n");
+                case "/sse/abort" -> {
+                    // one event, then the connection dies mid-stream
+                    response.write("data: partial\n\n");
+                    vertx.setTimer(200, t -> request.connection().close());
+                }
+                case "/sse/comments" -> {
+                    // quiet for ~2.5s but alive: keep-alive comments every 300ms,
+                    // then a final event and a clean end
+                    response.write("data: early\n\n");
+                    for (int i = 1; i <= 8; i++) {
+                        vertx.setTimer(300L * i, t -> {
+                            if (!response.ended()) {
+                                response.write(": ping\n\n");
+                            }
+                        });
+                    }
+                    vertx.setTimer(2600, t -> {
+                        response.write("data: late\n\n");
+                        response.end();
+                    });
+                }
+                case "/sse/burst" -> {
+                    // 50 unpaced events - FIFO must be preserved through the client
+                    for (int i = 1; i <= 50; i++) {
+                        response.write("data: item-" + i + "\n\n");
+                    }
+                    response.end();
+                }
+                case "/sse/multifield" -> {
+                    // multi-line data, named event, id/retry fields to be ignored
+                    response.write("event: tokens\nid: 7\nretry: 1000\ndata: line1\ndata: line2\n\n");
+                    response.end();
+                }
+                default -> {
+                    response.setStatusCode(404);
+                    response.end();
+                }
+            }
+        }).listen(0).onSuccess(server -> {
+            mockPort = server.actualPort();
+            latch.countDown();
+        });
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "mock SSE upstream must start");
+    }
+
+    @AfterAll
+    static void stopMockUpstream() {
+        if (mockSse != null) {
+            mockSse.close();
+        }
+    }
+
+    /**
+     * Invoke async.http.request with Accept: text/event-stream and a capture
+     * route as reply_to; return the captured envelopes up to and including the
+     * first terminal marker (eof or exception).
+     */
+    private List<EventEnvelope> consume(String targetHost, String url, Map<String, String> query,
+                                        int timeoutSeconds, int expectedEvents) throws InterruptedException {
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String route = "capture.sse.client." + seq.incrementAndGet();
+        platform.registerPrivate(route, new CaptureRoute(captured), 1);
+        try {
+            AsyncHttpRequest req = new AsyncHttpRequest();
+            req.setMethod("GET");
+            req.setTargetHost(targetHost);
+            req.setUrl(url);
+            if (query != null) {
+                query.forEach(req::setQueryParameter);
+            }
+            req.setHeader("accept", "text/event-stream");
+            req.setTimeoutSeconds(timeoutSeconds);
+            EventEmitter.getInstance().send(new EventEnvelope()
+                    .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req.toMap())
+                    .setReplyTo(route).setCorrelationId("cid-" + seq.get()));
+            List<EventEnvelope> events = new ArrayList<>();
+            for (int i = 0; i < expectedEvents; i++) {
+                EventEnvelope event = captured.poll(20, TimeUnit.SECONDS);
+                assertNotNull(event, "expected segment " + (i + 1) + " of " + expectedEvents);
+                events.add(event);
+                String marker = event.getHeaders().get(EventStreamWriter.X_EVENT_STREAM);
+                if (EventStreamWriter.EOF.equals(marker) || EventStreamWriter.EXCEPTION.equals(marker)) {
+                    break;
+                }
+            }
+            return events;
+        } finally {
+            platform.release(route);
+        }
+    }
+
+    private String marker(EventEnvelope event) {
+        return event.getHeaders().get(EventStreamWriter.X_EVENT_STREAM);
+    }
+
+    @Test
+    void rawSseEventsMapToDataEnvelopesWithTerminalEof() throws InterruptedException {
+        // the app's own SSE demo endpoint is the upstream
+        var events = consume("http://127.0.0.1:" + edgePort, "/api/hello/stream",
+                Map.of("mode", "sse"), 10, 4);
+        assertEquals(4, events.size(), "3 data envelopes + eof");
+        EventEnvelope first = events.get(0);
+        assertEquals(EventStreamWriter.DATA, marker(first));
+        // head control rides the first envelope: upstream status + SSE content type
+        assertEquals(200, first.getStatus());
+        assertEquals("text/event-stream", first.getHeaders().get("content-type"));
+        assertEquals("Hello", first.getRawBody());
+        assertEquals("token stream", events.get(1).getRawBody());
+        // the upstream's terminal SSE frame arrives as a NAMED data event - the
+        // client does not interpret payloads (D3); its own eof marks the real end
+        EventEnvelope done = events.get(2);
+        assertEquals(EventStreamWriter.DATA, marker(done));
+        assertEquals("done", done.getHeaders().get(EventStreamWriter.X_EVENT_NAME));
+        assertEquals("{\"segments\":2}", done.getRawBody());
+        assertEquals(EventStreamWriter.EOF, marker(events.get(3)));
+    }
+
+    @Test
+    void multiFieldFramesMapPerSseSpecification() throws InterruptedException {
+        var events = consume("http://127.0.0.1:" + mockPort, "/sse/multifield", null, 5, 2);
+        EventEnvelope data = events.get(0);
+        assertEquals(EventStreamWriter.DATA, marker(data));
+        assertEquals("tokens", data.getHeaders().get(EventStreamWriter.X_EVENT_NAME));
+        assertEquals("line1\nline2", data.getRawBody(), "multi-line data joins with newline");
+        assertEquals(EventStreamWriter.EOF, marker(events.get(1)));
+    }
+
+    @Test
+    void burstEventsArriveInStrictFifoOrder() throws InterruptedException {
+        var events = consume("http://127.0.0.1:" + mockPort, "/sse/burst", null, 10, 51);
+        assertEquals(51, events.size(), "50 data envelopes + eof");
+        for (int i = 1; i <= 50; i++) {
+            assertEquals("item-" + i, events.get(i - 1).getRawBody(), "strict FIFO");
+        }
+        assertEquals(EventStreamWriter.EOF, marker(events.get(50)));
+    }
+
+    @Test
+    void idleStallFailsInBandWithTimeout408() throws InterruptedException {
+        var events = consume("http://127.0.0.1:" + mockPort, "/sse/silent", null, 2, 3);
+        assertEquals("one", events.get(0).getRawBody());
+        EventEnvelope error = events.get(1);
+        assertEquals(EventStreamWriter.EXCEPTION, marker(error));
+        assertEquals(408, error.getStatus());
+        assertInstanceOf(Map.class, error.getRawBody());
+        assertEquals("Timeout for 2 seconds", ((Map<?, ?>) error.getRawBody()).get("message"));
+    }
+
+    @Test
+    void keepAliveCommentsResetTheIdleAllowance() throws InterruptedException {
+        // quiet for 2.5s with 300ms comments under a 2s idle allowance:
+        // the comments prove liveness, so the stream must complete
+        var events = consume("http://127.0.0.1:" + mockPort, "/sse/comments", null, 2, 3);
+        assertEquals(3, events.size());
+        assertEquals("early", events.get(0).getRawBody());
+        assertEquals("late", events.get(1).getRawBody());
+        assertEquals(EventStreamWriter.EOF, marker(events.get(2)));
+    }
+
+    @Test
+    void midStreamDisconnectFailsInBand() throws InterruptedException {
+        var events = consume("http://127.0.0.1:" + mockPort, "/sse/abort", null, 10, 3);
+        assertEquals("partial", events.get(0).getRawBody());
+        EventEnvelope error = events.get(1);
+        assertEquals(EventStreamWriter.EXCEPTION, marker(error));
+        assertEquals(500, error.getStatus());
+    }
+
+    @Test
+    void nonSseUpstreamFallsBackToBufferedSingleShot() throws InterruptedException {
+        // Accept opted in, but the upstream answers JSON - one unmarked reply
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String route = "capture.sse.fallback";
+        platform.registerPrivate(route, new CaptureRoute(captured), 1);
+        try {
+            AsyncHttpRequest req = new AsyncHttpRequest();
+            req.setMethod("GET");
+            req.setTargetHost("http://127.0.0.1:" + edgePort);
+            req.setUrl("/api/hello/world");
+            req.setHeader("accept", "text/event-stream");
+            req.setTimeoutSeconds(10);
+            EventEmitter.getInstance().send(new EventEnvelope()
+                    .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req.toMap())
+                    .setReplyTo(route).setCorrelationId("cid-fallback"));
+            EventEnvelope reply = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(reply);
+            assertNull(reply.getHeaders().get(EventStreamWriter.X_EVENT_STREAM),
+                    "a buffered reply carries no stream marker");
+            assertInstanceOf(Map.class, reply.getRawBody());
+            assertNull(captured.poll(500, TimeUnit.MILLISECONDS), "single-shot means one reply");
+        } finally {
+            platform.release(route);
+        }
+    }
+
+    @Test
+    void withoutAcceptTheSseResponseBuffersAsBefore() throws IOException, InterruptedException {
+        // backward-compat pin: an RPC without Accept: text/event-stream receives
+        // the whole SSE payload buffered as one text body (today's behavior)
+        var po = EventEmitter.getInstance();
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod("GET");
+        req.setTargetHost("http://127.0.0.1:" + edgePort);
+        req.setUrl("/api/hello/stream");
+        req.setQueryParameter("mode", "sse");
+        req.setTimeoutSeconds(10);
+        try {
+            EventEnvelope response = po.asyncRequest(new EventEnvelope()
+                            .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(req.toMap()), 15000)
+                    .toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+            assertEquals(200, response.getStatus());
+            String text = String.valueOf(response.getRawBody());
+            assertTrue(text.contains("data: Hello"), text);
+            assertTrue(text.contains("event: done"), text);
+        } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void selfRelayStreamsProgressivelyOutTheEdge() throws IOException, InterruptedException {
+        // the flagship composition: /api/hello/relay forwards its reply lane into
+        // async.http.request aimed at this app's own SSE endpoint - upstream
+        // frames re-render at the edge, followed by the relay's own terminal
+        HttpRequest request = HttpRequest.newBuilder(
+                        URI.create("http://127.0.0.1:" + edgePort + "/api/hello/relay"))
+                .timeout(Duration.ofSeconds(20)).header("Accept", "text/event-stream").build();
+        long started = System.currentTimeMillis();
+        HttpResponse<java.util.stream.Stream<String>> response =
+                client.send(request, HttpResponse.BodyHandlers.ofLines());
+        assertEquals(200, response.statusCode());
+        assertEquals("text/event-stream", response.headers().firstValue("content-type").orElse(""));
+        List<String> lines = new ArrayList<>();
+        List<Long> arrivals = new ArrayList<>();
+        response.body().forEach(line -> {
+            lines.add(line);
+            arrivals.add(System.currentTimeMillis() - started);
+        });
+        int hello = lines.indexOf("data: Hello");
+        int tokens = lines.indexOf("data: token stream");
+        // the upstream's done event re-renders as a NAMED frame with its metadata
+        int upstreamDone = lines.indexOf("event: done");
+        assertTrue(hello >= 0 && tokens > hello && upstreamDone > tokens, "ordered relay: " + lines);
+        assertTrue(lines.contains("data: {\"segments\":2}"), lines.toString());
+        // the relay's own eof renders one final terminal event
+        long doneCount = lines.stream().filter("event: done"::equals).count();
+        assertEquals(2, doneCount, "upstream done + relay terminal: " + lines);
+        // progressive end to end: the upstream paces segments 250ms apart
+        long elapsed = arrivals.get(lines.indexOf("data: {\"segments\":2}")) - arrivals.get(hello);
+        assertTrue(elapsed >= 300, "progressive relay expected, elapsed " + elapsed + " ms");
+        Utility.getInstance().sleep(100);
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/automation/service/MockSseRelayService.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/service/MockSseRelayService.java
@@ -1,0 +1,59 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation.service;
+
+import org.platformlambda.automation.http.AsyncHttpClient;
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.Map;
+
+/**
+ * The SSE-to-SSE relay demo: a streaming endpoint whose function forwards its own
+ * reply_to and correlation id into an async.http.request aimed at this very
+ * application's SSE demo endpoint. The HTTP client consumes the upstream stream
+ * progressively and its segments ride the caller's reply lane straight out the edge -
+ * an SSE relay with no imperative streaming code.
+ */
+@EventInterceptor
+public class MockSseRelayService implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        var config = AppConfigReader.getInstance();
+        var port = config.getProperty("rest.server.port", config.getProperty("server.port", "8100"));
+        AsyncHttpRequest upstream = new AsyncHttpRequest();
+        upstream.setMethod("GET");
+        upstream.setTargetHost("http://127.0.0.1:" + port);
+        upstream.setUrl("/api/hello/stream");
+        upstream.setQueryParameter("mode", "sse");
+        // explicit Accept opts into progressive SSE consumption (D1)
+        upstream.setHeader("accept", "text/event-stream");
+        upstream.setTimeoutSeconds(10);
+        EventEmitter.getInstance().send(new EventEnvelope()
+                .setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST).setBody(upstream.toMap())
+                .setReplyTo(request.getReplyTo())
+                .setCorrelationId(request.getCorrelationId()));
+        return null;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
+++ b/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.platformlambda.automation.http.AsyncHttpClient;
 import org.platformlambda.automation.service.MockEventStreamService;
+import org.platformlambda.automation.service.MockSseRelayService;
 import org.platformlambda.automation.service.MockHelloWorld;
 import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.EventEnvelope;
@@ -96,6 +97,7 @@ public class TestBase {
             // streaming-response producer (multi-shot reply route) for EventStreamResponseTest -
             // registered before endpoint rendering so the rest.yaml existence check passes
             platform.registerPrivate("hello.event.stream", new MockEventStreamService(), 10);
+            platform.registerPrivate("hello.event.relay", new MockSseRelayService(), 10);
             // test registering the same function with an alias route name
             // hello.list is a special function to test returning result set as a list
             platform.registerPrivate(HELLO_LIST, (headers, input, instance) ->

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -32,6 +32,14 @@ rest:
     timeout: 15s
     stream: true
     headers: header_2
+
+  # SSE-to-SSE relay: the function forwards its reply lane into async.http.request,
+  # which consumes this app's own SSE demo endpoint progressively (raw mode)
+  - service: "hello.event.relay"
+    methods: ['GET']
+    url: "/api/hello/relay"
+    timeout: 15s
+    stream: true
   - service: ["hello.mock"]
     methods: ['GET', 'PUT', 'POST', 'HEAD', 'PATCH', 'DELETE']
     url: "/api/hello/world"


### PR DESCRIPTION
## What

Two changes, one theme - transparency of how the system streams and how it evolves:

**1. Progressive SSE consumption in the HTTP client (ADR-0019, Phase 1 of the ratified
design).** `async.http.request` can now consume a `text/event-stream` response
progressively - an LLM provider's token stream, another engine's streaming endpoint, or
any SSE API - and relay it as the platform's own streaming protocol:

- One `x-event-stream: data` envelope per upstream SSE event to the caller's reply
  route: the event's data is the body (multi-line data joins per the SSE
  specification), an `event:` name maps to `x-event-name`, and comment/`id:`/`retry:`
  fields are consumed by the client, never forwarded. The first envelope carries head
  control (upstream status + the SSE content type); a clean end sends `eof`; idle
  expiry and mid-stream disconnects fail the stream in-band (`exception` with 408/500).
- **Activation is explicit and standard** - all three must hold: the request declares
  `Accept: text/event-stream`, the response actually is SSE, and the request carries a
  `reply_to`. Anything else keeps today's buffered single-shot behavior, byte for byte.
- **The request timeout becomes the per-read idle allowance** for streams (each
  arriving byte resets it - keep-alive comments included, since LLM providers ping
  through long quiet stretches); the wire-level response timeout is exempted for
  streaming candidates so a healthy long stream is never killed by a total cap.
- **Payloads are never interpreted**: provider conventions such as `data: [DONE]`
  forward verbatim - the consumer owns provider semantics, keeping the client
  vendor-neutral.
- **The composition this unlocks**: a `stream: true` endpoint whose function forwards
  its own `reply_to`/correlation id into the client call turns the application into an
  **SSE-to-SSE relay by configuration** - no imperative streaming code. The new
  self-relay test proves it end to end in one process.

**2. `draft-design-specs/` leaves .gitignore.** The design specs are the living
document of how this project evolves - work-in-progress journal records for a human
reader - and committing them is the transparent, open-source-principled choice. All 12
specs were reviewed for proprietary information before publication (no client
identifiers, no secret material; the specs use generic fixtures and placeholder
`${ENV_VAR}` syntax throughout).

A README in the folder states the lifecycle: specs serve during design and
implementation; after a feature ships they are journal records for reference only -
source code is the source of truth, design specs are history.

## Why

HTTP response streaming (#299) delivered the engine→HTTP-edge leg. AI-era workloads
need the two consumption legs: an engine function consuming an LLM provider's token
stream, and (next phases) python/node wrapper functions streaming results back to the
engine over Event-over-HTTP. One mechanism closes both, because the Event-over-HTTP
relay already flows through AsyncHttpClient - so this enhancement is simultaneously the
LLM-client capability and the transport for peer streaming. The option analysis
(recorded in ADR-0019 and the committed spec) chose SSE-on-the-same-call over an
on-demand WebSocket channel (scope-fence growth across four codebases,
gateway-hostility, drift toward the opt-in mesh architecture), per-segment POSTs back
to reply lanes (one round trip per token; a new inbound trust surface), gRPC, and
long-polling. Later phases add envelope-mode streaming between peers using a hybrid
control/data-plane SSE framing (control signals as envelope key-value headers in
base64-MsgPack frames; token segments as raw frames).

## Tests

- 9 new tests (`EventStreamClientTest`): raw event mapping against the app's own SSE
  demo endpoint (including the upstream's terminal frame arriving as a *named data
  envelope* - the no-interpretation rule pinned), multi-field frames per the SSE
  specification, a 50-event FIFO burst, idle-stall in-band 408, keep-alive
  comment-reset under a shorter idle allowance, mid-stream disconnect in-band 500,
  buffered fallback when the upstream answers non-SSE, the no-Accept backward-compat
  pin (an RPC still receives the whole SSE payload buffered as text), and the
  progressive **self-relay e2e** (`/api/hello/relay` consumes `/api/hello/stream`
  through the client and re-renders it out the edge with timing asserted).
- platform-core full suite 459/459; mkdocs strict build clean.

## Compatibility

Fully backward compatible: without the explicit `Accept: text/event-stream` opt-in
(and the Event-over-HTTP relay pins `Accept: */*`, so it never opts in accidentally),
every existing call path behaves exactly as before. No new config keys, no new
dependencies. Rust twin follows (Java-first with the vocabulary pinned), then the
envelope-mode phases.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>