### PR TITLE
Event-over-HTTP peer streaming - envelope mode on the SSE relay (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    reads (keep-alive comments reset it); idle expiry and mid-stream disconnects fail
    the stream in-band. (ADR-0019)
 
+3. **Event-over-HTTP peer streaming (envelope mode)** - a remote streaming function
+   reached through `/api/event` can stream its segments back to the caller's reply
+   route on the same HTTP call. The caller opts in per event: a send with a
+   `reply_to` and the `accept: text/event-stream` event header; the `x-ttl` event
+   header (ms, default 60s) is the idle allowance between stream events on both
+   hops. On the wire, the peer answers with SSE in a hybrid dialect - control
+   signals (the head, the eof/exception terminals, and any segment that cannot
+   round-trip as plain text) ride base64-encoded serialized envelopes under the
+   reserved SSE event name `envelope`, while text segments ride raw frames - so
+   segment types and terminal metadata survive the hop exactly, and token relays
+   stay near-zero overhead. Compatibility is explicit: a non-streaming target
+   answers byte-identical to the classic callback reply; a streaming function
+   invoked without the opt-in (RPC, or no accept header) receives
+   `406 Streaming function requires a caller that accepts text/event-stream`;
+   server-side lane exhaustion answers the same 503 back-pressure as a local
+   streaming endpoint (plain RPC traffic never consumes a lane). The consuming
+   client guards the dialect (a missing envelope head or a transport end without a
+   terminal fail in-band). See the HTTP Response Streaming guide. (ADR-0019)
+
 ### Changed
 
 1. The `/info/routes` actuator endpoint renders pool-style route families compactly:

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -23,8 +23,8 @@ in that ADR's own *Rationale* section.
 ---
 
 ## ADR-0019 — The HTTP client consumes SSE progressively; Event-over-HTTP streams on the same call {#adr-0019}
-**Status:** Proposed · **Date:** 2026-08-29 · **Serves:** vision-mercury-composable · **Formalizes:** async-http-client-sse-streaming-design
-<!-- id: adr-0019 | status: proposed -->
+**Status:** Accepted · **Date:** 2026-08-29 · **Serves:** vision-mercury-composable · **Formalizes:** async-http-client-sse-streaming-design
+<!-- id: adr-0019 | status: accepted -->
 
 **Abstract.** `async.http.request` consumes a `text/event-stream` response progressively
 and relays it as the platform's own streaming protocol: one `x-event-stream: data`
@@ -64,8 +64,8 @@ gateways already accommodate for LLM traffic.
 ---
 
 ## ADR-0018 — HTTP response streaming rides the multi-shot reply route; the wire stays standards-only {#adr-0018}
-**Status:** Proposed · **Date:** 2026-08-28 · **Serves:** vision-mercury-composable · **Formalizes:** http-response-streaming-design
-<!-- id: adr-0018 | status: proposed -->
+**Status:** Accepted · **Date:** 2026-08-28 · **Serves:** vision-mercury-composable · **Formalizes:** http-response-streaming-design
+<!-- id: adr-0018 | status: accepted -->
 
 **Abstract.** A function streams an HTTP response (LLM token segments, agent progress
 events, live updates) by exercising the platform's native streaming pattern: the callee

--- a/docs/guides/event-over-http.md
+++ b/docs/guides/event-over-http.md
@@ -385,6 +385,21 @@ register the same `hello.declarative` route in their demo apps and default to th
 port 8085, so the identical `curl` executes a Python or Node.js function with zero
 changes — see [Polyglot Functions](polyglot-functions.md).
 
+## Streaming across the hop
+
+A remote streaming function - one that produces a multi-shot reply with
+`EventStreamWriter` - can stream its segments back to your reply route through the
+same `/api/event` call: supply a `reply_to` on the send and opt in with the
+`accept: text/event-stream` event header. The peer answers the one POST with a
+Server-Sent Events response carrying the envelope-mode wire dialect, and the
+consuming client forwards each decoded event to your reply route with your
+correlation id - a local stream and a remote stream look identical to the consumer.
+A non-streaming target called this way answers byte-identical to the classic
+callback reply, and a streaming function invoked without the opt-in receives an
+explicit 406 refusal instead of a truncated reply. The full contract - the wire
+dialect, compatibility matrix and idle-timeout semantics - lives in
+[HTTP Response Streaming](http-streaming.md#stream-across-applications-event-over-http).
+
 ## Advantages
 
 The Event API exposes all public functions of an application instance to the network using a single REST endpoint.

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -226,6 +226,59 @@ public class SseRelay implements TypedLambdaFunction<EventEnvelope, Void> {
 }
 ```
 
+## Stream across applications (Event-over-HTTP)
+
+The same client capability carries the platform's own streaming protocol between
+applications: a function in another application (or a polyglot function host) can
+stream its segments back to your reply route through `/api/event` - engine to engine,
+on the one HTTP call the relay already makes.
+
+The caller side is one send. Address the remote function through your
+`yaml.event.over.http` mapping as usual, supply a `reply_to`, and opt in with the
+`accept` event header:
+
+```java
+// the remote function's segments arrive at my.reply.handler as
+// x-event-stream data envelopes, then eof - exactly like a local stream
+po.send(new EventEnvelope().setTo("remote.token.stream")
+        .setReplyTo("my.reply.handler")
+        .setCorrelationId(myCorrelationId)
+        .setHeader("accept", "text/event-stream")
+        .setHeader("x-ttl", "30000"));
+```
+
+The remote function is a normal streaming producer - it writes with
+`EventStreamWriter` and never knows the caller is remote. On the wire, the peer
+answers the same POST with an SSE response in a hybrid dialect: control signals -
+the first envelope (head), the `eof`/`exception` terminals, and any segment that
+cannot round-trip as plain text (a Map or byte body, text containing a carriage
+return, an event name colliding with the reserved word) - ride base64-encoded
+serialized envelopes under the reserved SSE event name `envelope`, while plain text
+segments ride raw SSE frames with near-zero overhead. The consuming client decodes
+the dialect and forwards each event to your reply route with your correlation id, so
+segment types (a Map stays a Map, bytes stay bytes) and terminal metadata survive the
+hop exactly.
+
+Everything degrades explicitly, never silently:
+
+- a **non-streaming target** called this way answers byte-identical to the classic
+  callback reply - opting in is always safe;
+- a **streaming function invoked without the opt-in** (an RPC call, or a caller
+  without the `accept` header) receives an explicit error -
+  `406 Streaming function requires a caller that accepts text/event-stream` -
+  instead of a truncated first segment;
+- an **older peer** that cannot stream answers single-shot as today;
+- when the server has **no reply lane available** the call is refused with the same
+  `503 Streaming response pool exhausted` back-pressure as a local streaming endpoint.
+
+The `x-ttl` event header (milliseconds, default 60 seconds) is the idle allowance
+between stream events on both hops; the producer can extend it for the whole stream
+with `first(status, contentType, ttlSeconds)`. Idle expiry, disconnects and
+truncated streams fail in-band with an `exception` envelope, exactly like a local
+stream. Combined with a `stream: true` endpoint that forwards its reply lane into the
+send, the composition streams a remote function's tokens progressively out your HTTP
+edge with no imperative streaming code.
+
 ## Relation to `x-stream-id`
 
 The existing `x-stream-id` relay (object streams, file downloads, `Flux` results) is

--- a/draft-design-specs/async-http-client-sse-streaming.md
+++ b/draft-design-specs/async-http-client-sse-streaming.md
@@ -13,7 +13,23 @@ data join), buffered fallback for non-SSE responses on the candidate path, and t
 self-relay demo endpoint (/api/hello/relay in the test app). Gates: 9 new tests
 (mapping, multi-field frames, 50-event FIFO burst, idle 408, comment-reset,
 mid-stream disconnect, buffered fallback, no-Accept backward-compat pin, progressive
-self-relay e2e) — platform-core 459/459. ADR-0019 Proposed.
+self-relay e2e) — platform-core 459/459. ADR-0019 Proposed (Accepted at the Phase-1
+merge; Rust twin same day).
+**Phase 2 P2-1…P2-6 RATIFIED by Eric and IMPLEMENTED (Java) 2026-08-29:** the
+envelope-mode relay per §7 — EventApiService streaming branch with dynamic lane
+binding, envelope-mode rendering in the edge renderer, the caller-side relay in
+EventEmitter (accept event-header opt-in), the envelope submode in AsyncHttpClient
+(dialect decode, strict-head and truncation guards, buffered-fallback decode), and
+the 406/503 refusals. One contract alignment found during implementation (completed
+by Eric's review): every in-band exception body now carries the standard error
+key-values {"type": "error", "status": n, "message": text} — the edge housekeeper's
+408 abort was String-bodied, and EventStreamWriter.fail() and the client's in-band
+failures were missing the "type" key (wire-invisible at the local edge, which
+re-wraps; shape-visible to envelope-mode callers and reply-route consumers). Gates: 14 new tests
+(EventOverHttpStreamTest — dialect round-trips incl. every escape-hatch trigger,
+byte-identical single-shot fallback, both 406 paths, 503 pool exhaustion, REST-error
+unwrap, misbehaving-peer conformance guards, progressive engine⇄engine e2e out the
+edge) — platform-core 473/473. Next: the Rust twin, then Phase 3 (wrapper twins).
 **Serves:** `bp-agent-orchestration` (an `llm.chat` node consuming provider token streams)
 and `bp-polyglot-functions` (wrapper functions streaming back to the engine) — the two
 remaining gaps after [[thread-http-response-streaming]] closed the engine→HTTP-edge leg.
@@ -145,8 +161,9 @@ Two consumption modes, selected by context:
     base64-encoded MsgPack envelope (the one codec; golden vectors still the gate).
   - **First frame** = envelope frame (head control: status, content-type, x-ttl).
   - **Terminal frames** (`eof` / `exception`) = envelope frames — one per stream, so
-    zero meaningful cost, and trailing metadata / {status,message} keep exact Map
-    types end-to-end (matters when the consumer is a function, not the edge).
+    zero meaningful cost, and trailing metadata / the standard error body
+    {"type": "error", "status": n, "message": text} keep exact Map types end-to-end
+    (matters when the consumer is a function, not the edge).
   - **Text segments** = raw frames: `data: <text>`, optional user `event: <name>` →
     `x-event-name` (SSE's native field; the same grammar the edge renders).
   - **Adaptive escape hatch**: the writer emits an envelope frame for any segment that
@@ -206,10 +223,123 @@ Two consumption modes, selected by context:
   buffered (backward-compat pin), burst FIFO through the relay.
 - Mutation-proof the idle timer and the terminal mapping (kill the fix, watch it fail).
 
-## 7. Follow-ups staged (not this spec's scope)
+## 7. Phase 2 design — envelope-mode relay internals (RATIFIED by Eric 2026-08-29; implemented same day)
 
-- Phase 2/3 detail rounds (envelope-mode relay internals; wrapper host/writer twins;
-  interop report round per `conv-telemetry-presentation-parity`).
+The engine⇄engine leg: a streaming function on engine B, invoked over Event-over-HTTP
+from engine A, streams its segments back to the original caller's reply route on A.
+Zero new config keys; zero new endpoints; the wire is the D5 hybrid dialect.
+
+### P2-1 — Trigger: the caller's `accept` EVENT header on the callback path
+
+Today's `send()` over an event-over-http mapping already has a **callback mode**
+(`reply_to` present → RPC + response delivered to the callback route). Streaming extends
+exactly that path: when the outbound event carries `reply_to` AND the event header
+`accept: text/event-stream`, the relay switches to streaming-capable mode — the POST
+advertises `Accept: text/event-stream` (D6) and the caller's `reply_to`/`cid` pass
+through to `async.http.request` (the Phase-1 relay pattern) with an internal
+envelope-mode marker. Without the accept header, the callback path is byte-identical to
+today. The RPC path (`po.request` — a Future completes once, it cannot stream) and the
+drop-n-forget path (`x-async`) never stream and never advertise; a streaming target
+invoked via RPC gets the P2-4 refusal. D1 parity: explicit Accept opt-in, now at the
+event level — a stray user `accept` header is harmless (single-shot targets fall back
+byte-identically).
+
+### P2-2 — Server realization: dynamic reply lane + envelope mode in the edge renderer
+
+`/api/event` stays a normal (non-`stream: true`) endpoint — plain RPC traffic keeps its
+unbounded concurrency. When the POST accepts SSE (and is not `x-async`), EventApiService,
+after the existing route/private validation:
+
+1. binds an envelope-mode stream context: reuse the holder's lane if the endpoint was
+   (unusually) declared `stream: true`, else check out a lane from the SAME 500-lane pool
+   (dry pool → single-shot error, the pinned "Streaming response pool exhausted" 503);
+   the bind records the requester's wire format (COMPACT/STANDARD mirroring, as today)
+   and an atomic release guard closes the checkout race with client disconnect;
+2. rewrites the relayed request's `reply_to` to the lane and its `cid` to the edge
+   requestId (exact parity: today's RPC inbox rewrites the cid the same way), then
+   dispatches with `po.send` — no RPC future; the holder's idle timer (x-ttl from the
+   POST, per P2-6) is the guard.
+
+The lane's handler (AsyncHttpResponse) sees the envelope-mode context and renders the
+**wire dialect** instead of user-facing SSE:
+
+- **first envelope (whatever it is — EventStreamWriter puts head control on the first
+  outgoing event)** → `event: envelope` + `data: <base64(MsgPack(envelope))>` — packed
+  verbatim in the mirrored wire format after clearing `to`/`reply_to` (server-internal
+  route names never leak; the client rewrites addressing anyway per D7). Outer HTTP head:
+  status mirrors the envelope status, content-type `text/event-stream`, Cache-Control
+  no-cache; keep-alive pings, back-pressure queue and slow-client guard inherited.
+- **subsequent data envelopes** → raw frame (`data: <text>`, `event: <x-event-name>`)
+  when losslessly raw-able: String body, no `\r`, no custom headers, name ≠ `envelope`;
+  otherwise the envelope-frame escape hatch (Map/bytes segments keep exact types).
+- **terminals (`eof`/`exception`)** → one envelope frame, then clean HTTP end. The
+  engine⇄engine wire carries NO cosmetic `event: done` / `event: error` frames — those
+  are the edge's human-facing dialect; the decoded terminal envelope is the signal
+  (P2-5). A pre-head exception also rides SSE-uniform (head + exception frame + end) so
+  the caller always receives the exact error envelope.
+- **a single-shot reply (no x-event-stream marker)** → NOT SSE: packed-envelope
+  octet-stream response, byte-identical to today's RPC wire (P2-3) — so a streaming-
+  capable call to a non-streaming function is indistinguishable from today.
+
+### P2-3 — Compatibility matrix (all paths explicit)
+
+| Caller | Target | Result |
+| --- | --- | --- |
+| new, accept declared | streams | progressive envelope-mode relay (NEW) |
+| new, accept declared | single-shot | byte-identical to today (buffered fallback decode) |
+| new, no accept / RPC / async | single-shot | byte-identical to today |
+| any non-accepting caller (incl. old engines) | streams | explicit refusal per P2-4 |
+| new, accept declared | old peer (no SSE production) | non-SSE response → buffered fallback, today's semantics |
+
+### P2-4 — Refusal wording (D6 pinned, engine-identical)
+
+A streaming target invoked by a non-accepting caller: the first segment completes the
+server's RPC inbox carrying `x-event-stream` → EventApiService answers **406**
+`"Streaming function requires a caller that accepts text/event-stream"` instead of
+relaying a truncated first segment. Orphan follow-up segments die on the closed inbox.
+
+### P2-5 — Client realization (AsyncHttpClient envelope submode)
+
+The Phase-1 SSE branch gains the envelope dialect when the request event carries the
+internal relay marker (`x-event-api: stream`, stripped before wire):
+
+- `event: envelope` frame → base64 → MsgPack decode → forward to the original `reply_to`
+  with the original `cid` (D7 rewrite); a decoded terminal stops forwarding, cancels the
+  idle timer, and discards any trailing frames (tolerance for wrapper dialects).
+- raw frame → data envelope (`x-event-stream: data`, body = text, `event:` name →
+  `x-event-name`) — the inverse of the server's raw framing.
+- **strict head rule:** the first frame MUST be an envelope frame; a raw first frame is
+  an in-band exception 500 "Invalid event stream - missing envelope head" (conformance
+  guard for wrapper implementations).
+- clean HTTP end WITHOUT a decoded terminal → in-band exception 500 "Event stream ended
+  without eof" (catches truncating middleware); transport eof after a decoded terminal
+  is suppressed (no double-terminal).
+- buffered (non-SSE) fallback → decode the packed envelope and deliver to the callback
+  with today's rewrite — including today's tolerant wrap of a non-envelope error body.
+- Phase-1 in-band 408/500 idle/transport handling unchanged.
+
+### P2-6 — TTL semantics across the hop (D4 extended)
+
+The outbound event's `x-ttl` header (default: the existing 60s relay allowance) becomes
+the idle allowance on BOTH hops: it rides the POST's `x-ttl` (server holder idle timer —
+housekeeper aborts with the in-band 408 exception frame) and sets the client's per-read
+idle allowance. The target can extend it mid-relationship via `first(status, ct, ttl)` —
+the head frame's x-ttl reaches both the server holder and (decoded) the caller's edge,
+exactly as a local stream would.
+
+### Phase 2 test plan
+
+Full-chain e2e in one process (edge `stream: true` endpoint → function relays via
+event-over-http to the app's OWN `/api/event` → local streaming target), progressive
+timing asserted; single-shot-over-capable-path byte-compare vs classic RPC; 406 refusal
+pin; Map/bytes/`\r`/reserved-name escape-hatch round-trips (exact types); eof trailing
+metadata round-trip; mid-stream `fail()` propagation; server idle 408 through the chain;
+pool-dry 503; x-async and RPC pins unchanged; trailing-frame discard tolerance.
+
+## 8. Follow-ups staged (not this spec's scope)
+
+- Phase 3 detail round (wrapper host/writer twins; interop report round per
+  `conv-telemetry-presentation-parity`).
 - Event Script flow handoff (`model.http.*` reserved keys) — unchanged from the edge
   spec's v1.1 list.
 - graph-run streaming (bp-agent-orchestration).

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -31,6 +31,7 @@ import reactor.netty.ByteBufFlux;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
 import io.netty.handler.codec.http.HttpMethod;
+import org.platformlambda.automation.services.EventStreamRenderer;
 import org.platformlambda.automation.services.HttpRouter;
 import org.platformlambda.automation.util.CustomContentTypeResolver;
 import org.platformlambda.core.annotations.EventInterceptor;
@@ -42,6 +43,7 @@ import org.platformlambda.core.serializers.SimpleMapper;
 import org.platformlambda.core.serializers.SimpleXmlParser;
 import org.platformlambda.core.serializers.SimpleXmlWriter;
 import org.platformlambda.core.system.*;
+import org.msgpack.core.MessagePackException;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 import org.platformlambda.core.util.W3cTrace;
@@ -97,6 +99,14 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
     private static final String X_TTL = "x-ttl";
     private static final String ACCEPT = "accept";
     private static final String TEXT_EVENT_STREAM = "text/event-stream";
+    // the Event-over-HTTP relay marks its request event so the SSE consumption
+    // switches to the envelope-mode wire dialect
+    private static final String X_EVENT_API = "x-event-api";
+    private static final String STREAM_RELAY = "stream";
+    private static final String ENVELOPE = EventStreamWriter.ENVELOPE;
+    private static final String TYPE = "type";
+    private static final String ERROR = "error";
+    private static final String MESSAGE = "message";
     private static final String CONTENT_TYPE = "content-type";
     private static final String CONTENT_LENGTH = "content-length";
     private static final String X_CONTENT_LENGTH = "x-content-length";
@@ -565,6 +575,8 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
         private final AsyncHttpRequest request;
         private final HttpClient.ResponseReceiver<?> http;
         private final int timeoutSeconds;
+        // the Event-over-HTTP relay path consumes the peer's envelope-mode wire dialect
+        private final boolean envelopeRelay;
 
         public HttpResponseHandler(EventEnvelope input, AsyncHttpRequest request, HttpClient.ResponseReceiver<?> http) {
             this.input = input;
@@ -572,6 +584,7 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
             this.http = http;
             int timeout = request.getTimeoutSeconds();
             this.timeoutSeconds = timeout > 0? timeout : DEFAULT_TTL_SECONDS;
+            this.envelopeRelay = STREAM_RELAY.equals(input.getHeader(X_EVENT_API));
         }
 
         public void process() {
@@ -659,6 +672,12 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
          * render exactly as the single-shot path would
          */
         private void renderBuffered(byte[] b) {
+            if (envelopeRelay) {
+                // the peer answered single-shot (a non-streaming target, or an edge
+                // error) - deliver the decoded reply with the classic callback semantics
+                deliverToCallback(decodeRelayReply(b));
+                return;
+            }
             String resContentType = resolver.getContentType(response.getHeader(CONTENT_TYPE));
             String len = response.getHeader(CONTENT_LENGTH);
             boolean renderAsBytes = "true".equals(request.getHeader(X_NO_STREAM));
@@ -673,6 +692,65 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
             } else {
                 sendResponse(input, response);
             }
+        }
+
+        /**
+         * Decode a single-shot Event-over-HTTP reply: a serialized envelope normally,
+         * with the classic tolerant handling of an edge-level REST error body
+         * and of a payload that is not a packed envelope at all
+         *
+         * @param b the buffered response body
+         * @return the reply envelope for the callback
+         */
+        private EventEnvelope decodeRelayReply(byte[] b) {
+            if (b.length == 0) {
+                return new EventEnvelope().setStatus(response.getStatus());
+            }
+            try {
+                return new EventEnvelope(b);
+            } catch (IllegalArgumentException | MessagePackException e) {
+                EventEnvelope restError = restErrorReply(b);
+                return restError != null? restError : new EventEnvelope().setStatus(400)
+                        .setBody("Did you configure rest.yaml correctly? Invalid result set - " + e.getMessage());
+            }
+        }
+
+        /**
+         * An edge-level REST error ({"status": n, "message": ..., "type": "error"})
+         * arrives as JSON, not as a packed envelope - unwrap it exactly as the
+         * classic relay does
+         *
+         * @param b the buffered response body
+         * @return the unwrapped error envelope, or null when it is not a REST error
+         */
+        @SuppressWarnings("unchecked")
+        private EventEnvelope restErrorReply(byte[] b) {
+            if (response.getStatus() >= 400) {
+                try {
+                    Map<String, Object> data = SimpleMapper.getInstance().getMapper().readValue(b, Map.class);
+                    if (ERROR.equals(data.get(TYPE)) && data.get(MESSAGE) instanceof String text) {
+                        return new EventEnvelope().setStatus(response.getStatus()).setBody(text);
+                    }
+                } catch (Exception e) {
+                    // not a REST error body
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Forward one decoded or synthesized event to the original caller's reply
+         * route with the original correlation id (the relay rewrites addressing)
+         *
+         * @param reply the event to forward
+         */
+        private void deliverToCallback(EventEnvelope reply) {
+            reply.setTo(input.getReplyTo())
+                    .setFrom(input.getFrom() == null? ASYNC_HTTP_REQUEST : input.getFrom())
+                    .setReplyTo(null)
+                    .setCorrelationId(input.getCorrelationId())
+                    .setTrace(input.getTraceId(), input.getTracePath());
+            EventEmitter.getInstance().send(reply);
         }
 
         /**
@@ -782,6 +860,10 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
             }
 
             private void emitData(String text, String name) {
+                if (envelopeRelay) {
+                    emitRelayFrame(text, name);
+                    return;
+                }
                 EventEnvelope segment = new EventEnvelope()
                         .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.DATA)
                         .setBody(text);
@@ -797,7 +879,79 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                 sendSegment(segment);
             }
 
+            /**
+             * Envelope-mode dialect (the Event-over-HTTP relay): an "envelope" frame
+             * carries one base64-encoded serialized EventEnvelope - the head, the
+             * terminals and non-text segments; any other frame is a raw text segment.
+             * A decoded terminal (eof or exception) ends the logical stream - trailing
+             * frames are discarded. The caller holds the lock.
+             *
+             * @param text the frame's data text
+             * @param name the frame's event name, if any
+             */
+            private void emitRelayFrame(String text, String name) {
+                if (closed) {
+                    return;
+                }
+                if (ENVELOPE.equals(name)) {
+                    deliverEnvelopeFrame(text);
+                } else if (!headSent) {
+                    // the dialect guarantees an envelope frame first (conformance guard)
+                    failInBand(500, "Invalid event stream - missing envelope head");
+                } else {
+                    deliverRawFrame(text, name);
+                }
+            }
+
+            /**
+             * Decode one envelope frame and forward it; a decoded terminal
+             * (eof or exception) ends the logical stream
+             *
+             * @param text the frame's base64-encoded serialized envelope
+             */
+            private void deliverEnvelopeFrame(String text) {
+                final EventEnvelope decoded;
+                try {
+                    decoded = new EventEnvelope(util.base64ToBytes(text));
+                } catch (IllegalArgumentException | MessagePackException e) {
+                    failInBand(500, "Invalid event stream - malformed envelope frame");
+                    return;
+                }
+                headSent = true;
+                deliverToCallback(decoded);
+                String signal = EventStreamRenderer.getSignal(decoded);
+                if (EventStreamWriter.EOF.equals(signal) || EventStreamWriter.EXCEPTION.equals(signal)) {
+                    closed = true;
+                    cancelIdleTimer();
+                    if (connection != null && !connection.isDisposed()) {
+                        connection.dispose();
+                    }
+                }
+            }
+
+            /**
+             * Synthesize a data envelope from one raw text frame and forward it
+             *
+             * @param text the frame's data text
+             * @param name the frame's event name, if any
+             */
+            private void deliverRawFrame(String text, String name) {
+                EventEnvelope segment = new EventEnvelope()
+                        .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.DATA)
+                        .setBody(text);
+                if (name != null && !name.isEmpty()) {
+                    segment.setHeader(EventStreamWriter.X_EVENT_NAME, name);
+                }
+                deliverToCallback(segment);
+            }
+
             public void onComplete() {
+                if (envelopeRelay) {
+                    // the dialect ends with a decoded terminal - a bare transport end
+                    // is a truncation; after a terminal this is a silent no-op
+                    failInBand(500, "Event stream ended without eof");
+                    return;
+                }
                 lock.lock();
                 try {
                     if (closed) {
@@ -840,12 +994,16 @@ public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void>
                     EventEnvelope error = new EventEnvelope()
                             .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.EXCEPTION)
                             .setStatus(status)
-                            .setBody(Map.of("status", status, "message", message));
+                            .setBody(Map.of(TYPE, ERROR, "status", status, MESSAGE, message));
                     if (!headSent) {
                         headSent = true;
                         error.setHeader(CONTENT_TYPE, TEXT_EVENT_STREAM);
                     }
-                    sendSegment(error);
+                    if (envelopeRelay) {
+                        deliverToCallback(error);
+                    } else {
+                        sendSegment(error);
+                    }
                 } finally {
                     lock.unlock();
                 }

--- a/system/platform-core/src/main/java/org/platformlambda/automation/models/AsyncContextHolder.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/models/AsyncContextHolder.java
@@ -19,6 +19,9 @@
 package org.platformlambda.automation.models;
 
 import io.vertx.core.http.HttpServerRequest;
+import org.platformlambda.core.models.EventEnvelope;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @SuppressWarnings("java:S1104")
 public class AsyncContextHolder {
@@ -37,6 +40,10 @@ public class AsyncContextHolder {
     // the dedicated reply lane checked out for a streaming endpoint; volatile because
     // the housekeeper reads it from another thread; returned to the pool at context close
     public volatile String streamLane;
+    // non-null when this context serves an Event-over-HTTP streaming relay (/api/event):
+    // stream events render as the envelope-mode wire dialect in the requester's format
+    public volatile EventEnvelope.Format envelopeStreamFormat;
+    private final AtomicBoolean laneReleased = new AtomicBoolean(false);
 
     public AsyncContextHolder(HttpServerRequest request) {
         this.request = request;
@@ -76,5 +83,16 @@ public class AsyncContextHolder {
 
     public void touch() {
         this.lastAccess = System.currentTimeMillis();
+    }
+
+    /**
+     * Claim the one-time right to return this context's reply lane to the pool.
+     * The atomic claim lets a dynamic lane binding race safely with a concurrent
+     * context close - whichever side runs second performs the release, exactly once.
+     *
+     * @return the lane to release, or null when there is none, or it was already claimed
+     */
+    public String claimLaneRelease() {
+        return streamLane != null && laneReleased.compareAndSet(false, true) ? streamLane : null;
     }
 }

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/AsyncHttpResponse.java
@@ -57,6 +57,8 @@ public class AsyncHttpResponse implements TypedLambdaFunction<EventEnvelope, Voi
     private static final String INPUT_STREAM_SUFFIX = ".in";
     private static final String SET_COOKIE = "Set-Cookie";
     private static final String CONTENT_TYPE = "Content-Type";
+    private static final String LOWER_CONTENT_TYPE = "content-type";
+    private static final String OCTET_STREAM = "application/octet-stream";
     private static final String CONTENT_LEN = "Content-Length";
     private static final String HTML_START = "<html><body><pre>\n";
     private static final String HTML_END = "\n</pre></body></html>";
@@ -82,6 +84,17 @@ public class AsyncHttpResponse implements TypedLambdaFunction<EventEnvelope, Voi
         holder.touch();
         // multi-shot streaming response? (x-event-stream: data | eof | exception)
         String streamSignal = EventStreamRenderer.getSignal(event);
+        if (holder.envelopeStreamFormat != null && !HEAD.equals(holder.method)) {
+            // Event-over-HTTP streaming relay context (/api/event with an SSE-accepting
+            // caller): stream events render as the envelope-mode wire dialect, while a
+            // single-shot reply renders as the classic packed-envelope response so a
+            // non-streaming target stays byte-identical to the RPC path
+            if (streamSignal != null) {
+                EventStreamRenderer.handleEnvelopeMode(requestId, holder, event, streamSignal);
+                return null;
+            }
+            event = packedSingleShot(event, holder.envelopeStreamFormat);
+        }
         if (streamSignal != null && !HEAD.equals(holder.method)) {
             EventStreamRenderer.handle(requestId, holder, event, streamSignal);
             return null;
@@ -103,6 +116,20 @@ public class AsyncHttpResponse implements TypedLambdaFunction<EventEnvelope, Voi
         HttpRouter.closeContext(requestId);
         response.end();
         return null;
+    }
+
+    /**
+     * Mirror the classic Event-over-HTTP RPC reply wire: the whole result envelope
+     * rides as a serialized byte body with an octet-stream content type
+     *
+     * @param result the target function's single-shot reply
+     * @param format the requester's envelope serialization format
+     * @return the wire-level envelope for the classic rendering path
+     */
+    private EventEnvelope packedSingleShot(EventEnvelope result, EventEnvelope.Format format) {
+        return new EventEnvelope()
+                .setHeader(LOWER_CONTENT_TYPE, OCTET_STREAM)
+                .setBody(result.toBytes(format));
     }
 
     private void setBusinessCorrelationIdHeader(HttpServerResponse response, AsyncContextHolder holder) {

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/EventStreamRenderer.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/EventStreamRenderer.java
@@ -59,6 +59,7 @@ public class EventStreamRenderer {
     private static final String DATA = EventStreamWriter.DATA;
     private static final String EOF = EventStreamWriter.EOF;
     private static final String EXCEPTION = EventStreamWriter.EXCEPTION;
+    private static final String ENVELOPE = EventStreamWriter.ENVELOPE;
     private static final String X_EVENT_STREAM = EventStreamWriter.X_EVENT_STREAM;
     private static final String X_EVENT_NAME = EventStreamWriter.X_EVENT_NAME;
     private static final String X_TTL = "x-ttl";
@@ -126,6 +127,21 @@ public class EventStreamRenderer {
     }
 
     /**
+     * Validate the x-event-stream marker; an unknown value is dropped with a warning
+     *
+     * @param requestId the request correlation id
+     * @param signal the x-event-stream marker value
+     * @return true when the signal is not a valid stream marker
+     */
+    private static boolean invalidSignal(String requestId, String signal) {
+        if (DATA.equals(signal) || EOF.equals(signal) || EXCEPTION.equals(signal)) {
+            return false;
+        }
+        log.warn("Dropping event for {} - invalid {} signal '{}'", requestId, X_EVENT_STREAM, signal);
+        return true;
+    }
+
+    /**
      * Extract the x-event-stream marker from an envelope (case-insensitive), if any
      *
      * @param event the incoming envelope
@@ -149,8 +165,7 @@ public class EventStreamRenderer {
      * @param signal the x-event-stream marker value
      */
     public static void handle(String requestId, AsyncContextHolder holder, EventEnvelope event, String signal) {
-        if (!DATA.equals(signal) && !EOF.equals(signal) && !EXCEPTION.equals(signal)) {
-            log.warn("Dropping event for {} - invalid {} signal '{}'", requestId, X_EVENT_STREAM, signal);
+        if (invalidSignal(requestId, signal)) {
             return;
         }
         if (holder.eventStream == null) {
@@ -166,6 +181,131 @@ public class EventStreamRenderer {
             case EOF -> renderEof(requestId, holder, event);
             default -> renderException(requestId, holder, event);
         }
+    }
+
+    /**
+     * Envelope-mode rendering for the Event-over-HTTP streaming relay ("/api/event"
+     * with a caller that accepts text/event-stream). The wire is the hybrid dialect:
+     * envelope frames (SSE event name "envelope", one base64-encoded serialized
+     * EventEnvelope per frame) wherever envelope semantics matter - the head, the
+     * terminals and non-text segments - and raw SSE frames for plain text segments.
+     * The terminals end the response cleanly; the engine-to-engine wire carries no
+     * cosmetic done/error frames because the decoded terminal envelope is the signal.
+     *
+     * @param requestId the request correlation id
+     * @param holder the request context
+     * @param event the incoming envelope
+     * @param signal the x-event-stream marker value
+     */
+    public static void handleEnvelopeMode(String requestId, AsyncContextHolder holder,
+                                          EventEnvelope event, String signal) {
+        if (invalidSignal(requestId, signal)) {
+            return;
+        }
+        boolean first = holder.eventStream == null;
+        if (first) {
+            // uniform SSE, a pre-head failure included - the caller always receives
+            // the exact envelope, while the transport head mirrors its status
+            openEnvelopeStream(requestId, holder, event);
+        }
+        EventStreamState state = holder.eventStream;
+        if (state.isClosed()) {
+            return;
+        }
+        holder.touch();
+        if (DATA.equals(signal)) {
+            Buffer frame = envelopeModeDataFrame(holder, event, first);
+            if (frame != null) {
+                state.incrementEventCount();
+                state.addByteCount(frame.length());
+                writeOrQueue(requestId, holder, frame);
+            }
+        } else {
+            writeOrQueue(requestId, holder, envelopeFrame(holder, event));
+            finish(requestId, holder, signal);
+        }
+    }
+
+    private static void openEnvelopeStream(String requestId, AsyncContextHolder holder, EventEnvelope event) {
+        HttpServerResponse response = holder.request.response();
+        if (event.getStatus() != 200) {
+            response.setStatusCode(event.getStatus());
+        }
+        if (holder.cidHeaderName != null && holder.businessCorrelationId != null) {
+            response.putHeader(holder.cidHeaderName, holder.businessCorrelationId);
+        }
+        // the target's own headers stay inside the envelope frames; only the endpoint's
+        // response header transform (add rules) reaches the outer response
+        applyTransformOnlyHeaders(response, holder);
+        response.putHeader(CONTENT_TYPE, TEXT_EVENT_STREAM);
+        if (!response.headers().contains(CACHE_CONTROL)) {
+            response.putHeader(CACHE_CONTROL, NO_CACHE);
+        }
+        var state = new EventStreamState(EventStreamState.Mode.SSE);
+        holder.eventStream = state;
+        response.setChunked(true);
+        applyIdleTimeoutOverride(holder, event);
+        response.closeHandler(unused -> cleanup(requestId, holder));
+        if (KEEP_ALIVE_MS > 0) {
+            long timer = Platform.getInstance().getVertx().setPeriodic(KEEP_ALIVE_MS, t -> ping(holder));
+            state.setKeepAliveTimer(timer);
+        }
+    }
+
+    private static void applyTransformOnlyHeaders(HttpServerResponse response, AsyncContextHolder holder) {
+        if (holder.resHeaderId != null) {
+            var httpUtil = SimpleHttpUtility.getInstance();
+            HeaderInfo hi = RoutingEntry.getInstance().getResponseHeaderInfo(holder.resHeaderId);
+            Map<String, String> added = httpUtil.filterHeaders(hi, new HashMap<>());
+            for (Map.Entry<String, String> kv : added.entrySet()) {
+                String prettyHeader = httpUtil.getHeaderCase(kv.getKey());
+                if (prettyHeader != null) {
+                    response.putHeader(prettyHeader, kv.getValue());
+                }
+            }
+        }
+    }
+
+    private static Buffer envelopeModeDataFrame(AsyncContextHolder holder, EventEnvelope event, boolean first) {
+        if (first || hasEnvelopeSemantics(event)) {
+            return envelopeFrame(holder, event);
+        }
+        Object body = event.getRawBody();
+        // a bare no-op segment carries nothing - parity with raw-mode rendering
+        return body == null ? null : sseFrame(getEventName(event), (String) body);
+    }
+
+    /**
+     * A data segment must ride as an envelope frame when a raw SSE frame cannot carry
+     * it losslessly: a non-text body, text containing a carriage return (SSE normalizes
+     * line endings), a custom envelope header, a non-200 status, or a user event name
+     * that collides with the reserved "envelope" word.
+     *
+     * @param event the data segment
+     * @return true when the segment needs the envelope-frame escape hatch
+     */
+    private static boolean hasEnvelopeSemantics(EventEnvelope event) {
+        if (event.getStatus() != 200) {
+            return true;
+        }
+        for (Map.Entry<String, String> kv : event.getHeaders().entrySet()) {
+            String key = kv.getKey().toLowerCase();
+            boolean reserved = X_EVENT_STREAM.equals(key) || X_EVENT_NAME.equals(key) || X_TTL.equals(key);
+            if (!reserved || (X_EVENT_NAME.equals(key) && ENVELOPE.equals(kv.getValue()))) {
+                return true;
+            }
+        }
+        Object body = event.getRawBody();
+        return !(body == null || (body instanceof String text && !text.contains("\r")));
+    }
+
+    private static Buffer envelopeFrame(AsyncContextHolder holder, EventEnvelope event) {
+        // server-internal addressing never leaks to the wire - the consuming relay
+        // rewrites addressing to the original caller anyway
+        EventEnvelope wire = event.copy().setTo(null).setReplyTo(null);
+        EventEnvelope.Format format = holder.envelopeStreamFormat == null ?
+                EventEnvelope.Format.STANDARD : holder.envelopeStreamFormat;
+        return sseFrame(ENVELOPE, util.bytesToBase64(wire.toBytes(format)));
     }
 
     private static void sendErrorBeforeHead(String requestId, AsyncContextHolder holder, EventEnvelope event) {

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/HttpRouter.java
@@ -213,10 +213,58 @@ public class HttpRouter {
 
     public static void closeContext(String requestId) {
         AsyncContextHolder holder = contexts.remove(requestId);
-        if (holder != null && holder.streamLane != null) {
-            // the atomic map removal guarantees the lane is released exactly once
-            EventStreamRenderer.releaseLane(holder.streamLane);
+        if (holder != null) {
+            // the atomic claim in the holder guarantees the lane is released exactly once,
+            // even against a concurrent dynamic lane binding (bindEnvelopeStream)
+            String lane = holder.claimLaneRelease();
+            if (lane != null) {
+                EventStreamRenderer.releaseLane(lane);
+            }
         }
+    }
+
+    /**
+     * Bind an envelope-mode event stream to a live request context - the Event-over-HTTP
+     * streaming relay ("/api/event" with a caller that accepts text/event-stream).
+     * Reuses the reply lane already checked out when the endpoint is stream-enabled,
+     * otherwise checks out a lane dynamically so plain RPC traffic never consumes one.
+     *
+     * @param requestId the edge request correlation id
+     * @param format the requester's envelope serialization format for the wire frames
+     * @param timeoutMs idle allowance between stream events
+     * @return the reply lane's route name, or null when the context is gone or the pool is exhausted
+     */
+    public static String bindEnvelopeStream(String requestId, EventEnvelope.Format format, long timeoutMs) {
+        AsyncContextHolder holder = contexts.get(requestId);
+        if (holder == null) {
+            return null;
+        }
+        if (holder.streamLane == null) {
+            String lane = EventStreamRenderer.checkoutLane();
+            if (lane == null) {
+                return null;
+            }
+            holder.streamLane = lane;
+        }
+        holder.envelopeStreamFormat = format;
+        holder.setTimeout(timeoutMs);
+        if (!contexts.containsKey(requestId)) {
+            // the context closed while binding - undo through the atomic claim
+            String lane = holder.claimLaneRelease();
+            if (lane != null) {
+                EventStreamRenderer.releaseLane(lane);
+            }
+            return null;
+        }
+        return holder.streamLane;
+    }
+
+    /**
+     * @param requestId the edge request correlation id
+     * @return true when the request context is still open
+     */
+    public static boolean hasContext(String requestId) {
+        return requestId != null && contexts.containsKey(requestId);
     }
 
     public void handleEvent(AssignedRoute route, String requestId, int status, String error) {

--- a/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/models/EventEnvelope.java
@@ -117,7 +117,7 @@ public class EventEnvelope {
      * Decoding is automatic: {@link #load(byte[])} detects the format because
      * the two key namespaces are disjoint (compact keys are exactly one
      * character; standard keys are all longer). Encoding is transport policy:
-     * a transport selects the format explicitly via {@link #toBytes(Format)}
+     * transport selects the format explicitly via {@link #toBytes(Format)}
      * or {@link #toMap(Format)}.
      */
     public enum Format { COMPACT, STANDARD }
@@ -869,8 +869,8 @@ public class EventEnvelope {
 
     /**
      * The serialization format detected by the most recent {@link #load(byte[])},
-     * or null if this envelope was not created from a serialized form. A
-     * transport that answers a request can mirror the requester's format.
+     * or null if this envelope was not created from a serialized form.
+     * Transport that answers a request can mirror the requester's format.
      *
      * @return the detected wire format or null
      */
@@ -947,7 +947,7 @@ public class EventEnvelope {
      * <p>
      * This no-argument form is equivalent to {@code toBytes(Format.COMPACT)} and
      * preserves the historical wire behavior for same-language transports
-     * (service mesh, streams). A transport that needs cross-language
+     * (service mesh, streams). Transport that needs cross-language
      * interoperability selects {@link Format#STANDARD} explicitly.
      *
      * @return byte array

--- a/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/services/EventApiService.java
@@ -18,6 +18,8 @@
 
 package org.platformlambda.core.services;
 
+import org.platformlambda.automation.services.EventStreamRenderer;
+import org.platformlambda.automation.services.HttpRouter;
 import org.platformlambda.core.annotations.EventInterceptor;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.models.AsyncHttpRequest;
@@ -48,6 +50,10 @@ import java.util.Map;
 @PreLoad(route=EventApiService.EVENT_API_SERVICE, instances=250)
 public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void> {
     public static final String EVENT_API_SERVICE = "event.api.service";
+
+    /** The calling mode of one Event-over-HTTP request: drop-n-forget, streaming-capable or RPC */
+    private record CallMode(long timeout, boolean async, boolean acceptsSse) {}
+
     private static final Logger log = LoggerFactory.getLogger(EventApiService.class);
     private static final String TYPE = "type";
     private static final String ASYNC = "async";
@@ -57,6 +63,11 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
     private static final String OCTET_STREAM = "application/octet-stream";
     private static final String X_TTL = "x-ttl";
     private static final String X_ASYNC = "X-Async";
+    private static final String ACCEPT = "accept";
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
+    private static final String STREAM_CALLER_REQUIRED =
+            "Streaming function requires a caller that accepts text/event-stream";
+    private static final String POOL_EXHAUSTED = "Streaming response pool exhausted";
     private static final String MISSING_ROUTING_PATH = "Missing routing path";
     private static final String PRIVATE_FUNCTION = " is private";
     private static final String ROUTE = "Route ";
@@ -70,6 +81,9 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
             Map<String, String> sessionInfo = request.getSessionInfo();
             long timeout = Math.max(1000, util.str2long(request.getHeader(X_TTL)));
             boolean async = "true".equals(request.getHeader(X_ASYNC));
+            String accept = request.getHeader(ACCEPT);
+            boolean acceptsSse = accept != null && accept.contains(TEXT_EVENT_STREAM);
+            var mode = new CallMode(timeout, async, acceptsSse);
             PostOffice po = new PostOffice(headers, instance);
             // capture this service's span on the worker thread - the trace context is
             // thread-keyed and torn down when the worker returns, so the async RPC
@@ -78,7 +92,7 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
             String spanId = trace == null? null : trace.spanId;
             if (request.getBody() instanceof byte[] b) {
                 try {
-                    handleRequest(sessionInfo, po, spanId, b, input, timeout, async);
+                    handleRequest(sessionInfo, po, spanId, b, input, mode);
                 } catch (Exception e) {
                     // the envelope could not be decoded, so its format is unknown -
                     // fall back to the classic compact format for the error reply
@@ -92,8 +106,7 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
     }
 
     private void handleRequest(Map<String, String> sessionInfo, PostOffice po, String spanId,
-                               byte[] requestBody, EventEnvelope input,
-                               long timeout, boolean async) {
+                               byte[] requestBody, EventEnvelope input, CallMode mode) {
         EventEnvelope request = new EventEnvelope(requestBody);
         // Mirror the requester's serialization format in the response so a
         // caller on either wire format (compact or standard) needs no
@@ -102,34 +115,79 @@ public class EventApiService implements TypedLambdaFunction<EventEnvelope, Void>
                 EventEnvelope.Format.COMPACT : request.getWireFormat();
         // propagate session info if any
         sessionInfo.forEach(request::setHeader);
-        if (request.getTo() != null) {
-            if (po.exists(request.getTo())) {
-                if (Platform.getInstance().isPrivate(request.getTo())) {
-                    sendError(input, spanId, format, 403, request.getTo() + PRIVATE_FUNCTION);
-                } else {
-                    if (async) {
-                        // Drop-n-forget
-                        po.send(request);
-                        Map<String, Object> ackBody = new HashMap<>();
-                        ackBody.put(TYPE, ASYNC);
-                        ackBody.put(DELIVERED, true);
-                        ackBody.put(TIME, new Date());
-                        EventEnvelope pending = new EventEnvelope().setStatus(202).setBody(ackBody);
-                        sendResponse(input, spanId, format, pending);
-                    } else {
-                        // RPC - po.asyncRequest stamps this service's span on the relayed
-                        // event (worker thread), so the target function parents onto it
-                        po.asyncRequest(request, timeout)
-                                .onSuccess(result -> sendResponse(input, spanId, format, result))
-                                .onFailure(e -> sendError(input, spanId, format, 408, e.getMessage()));
-                    }
-                }
-            } else {
-                sendError(input, spanId, format, 404, ROUTE + request.getTo() + NOT_FOUND);
-            }
-        } else {
+        if (request.getTo() == null) {
             sendError(input, spanId, format, 400, MISSING_ROUTING_PATH);
+        } else if (!po.exists(request.getTo())) {
+            sendError(input, spanId, format, 404, ROUTE + request.getTo() + NOT_FOUND);
+        } else if (Platform.getInstance().isPrivate(request.getTo())) {
+            sendError(input, spanId, format, 403, request.getTo() + PRIVATE_FUNCTION);
+        } else if (mode.async()) {
+            acknowledgeAsyncDelivery(po, spanId, request, input, format);
+        } else if (mode.acceptsSse()) {
+            relayEventStream(po, spanId, request, input, format, mode.timeout());
+        } else {
+            relayRpc(po, spanId, request, input, format, mode.timeout());
         }
+    }
+
+    private void acknowledgeAsyncDelivery(PostOffice po, String spanId, EventEnvelope request,
+                                          EventEnvelope input, EventEnvelope.Format format) {
+        // Drop-n-forget
+        po.send(request);
+        Map<String, Object> ackBody = new HashMap<>();
+        ackBody.put(TYPE, ASYNC);
+        ackBody.put(DELIVERED, true);
+        ackBody.put(TIME, new Date());
+        EventEnvelope pending = new EventEnvelope().setStatus(202).setBody(ackBody);
+        sendResponse(input, spanId, format, pending);
+    }
+
+    private void relayRpc(PostOffice po, String spanId, EventEnvelope request,
+                          EventEnvelope input, EventEnvelope.Format format, long timeout) {
+        // RPC - po.asyncRequest stamps this service's span on the relayed
+        // event (worker thread), so the target function parents onto it
+        po.asyncRequest(request, timeout)
+                .onSuccess(result -> {
+                    if (EventStreamRenderer.getSignal(result) != null) {
+                        // a streaming reply cannot ride a single-shot response
+                        sendError(input, spanId, format, 406, STREAM_CALLER_REQUIRED);
+                    } else {
+                        sendResponse(input, spanId, format, result);
+                    }
+                })
+                .onFailure(e -> sendError(input, spanId, format, 408, e.getMessage()));
+    }
+
+    /**
+     * Streaming-capable relay: the caller accepts text/event-stream, so the target
+     * streams to a dedicated reply lane bound to this request context and the edge
+     * renders the envelope-mode wire dialect. A non-streaming target's single reply
+     * takes the same lane and renders byte-identical to the classic RPC response.
+     *
+     * @param po this service's post office instance
+     * @param spanId this service's span, captured on the worker thread
+     * @param request the relayed request for the target function
+     * @param input the incoming edge event
+     * @param format the requester's envelope serialization format
+     * @param timeout idle allowance between stream events (from the request's x-ttl)
+     */
+    private void relayEventStream(PostOffice po, String spanId, EventEnvelope request,
+                                  EventEnvelope input, EventEnvelope.Format format, long timeout) {
+        String requestId = input.getCorrelationId();
+        String lane = requestId == null? null : HttpRouter.bindEnvelopeStream(requestId, format, timeout);
+        if (lane == null) {
+            if (HttpRouter.hasContext(requestId)) {
+                sendError(input, spanId, format, 503, POOL_EXHAUSTED);
+            }
+            // otherwise the request context is already gone - nothing to serve
+            return;
+        }
+        // the target streams to the lane; the edge requestId becomes the correlation
+        // id, exactly as the RPC inbox would rewrite it - po.send stamps this
+        // service's span so the target function parents onto it
+        request.setReplyTo(lane + "@" + Platform.getInstance().getOrigin());
+        request.setCorrelationId(requestId);
+        po.send(request);
     }
 
     private void sendResponse(EventEnvelope input, String spanId, EventEnvelope.Format format, EventEnvelope result) {

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/AppStarter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/AppStarter.java
@@ -841,13 +841,14 @@ public class AppStarter {
             String message = "Timeout for " + (holder.timeout / 1000) + " seconds";
             if (holder.eventStream != null && holder.streamLane != null) {
                 // a streaming response times out in-band through the SAME ordered
-                // lane as its segments, so the timeout cannot overtake them
+                // lane as its segments, so the timeout cannot overtake them -
+                // the body is the exception contract's {status, message} shape
                 try {
                     EventEmitter.getInstance().send(new EventEnvelope()
                             .setTo(holder.streamLane)
                             .setCorrelationId(id).setStatus(408)
                             .setHeader(EventStreamWriter.X_EVENT_STREAM, EventStreamWriter.EXCEPTION)
-                            .setBody(message));
+                            .setBody(Map.of("type", "error", "status", 408, "message", message)));
                 } catch (IllegalArgumentException e) {
                     log.error("Unable to time out event stream {} - {}", id, e.getMessage());
                 }

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventEmitter.java
@@ -65,6 +65,9 @@ public class EventEmitter {
     private static final String ERROR = "error";
     private static final String MESSAGE = "message";
     private static final String X_EVENT_API = "x-event-api";
+    // x-event-api marker of the streaming-capable relay (progressive SSE consumption)
+    private static final String STREAM_RELAY = "stream";
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
     private static final String X_NO_STREAM = "x-small-payload-as-bytes";
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
@@ -779,6 +782,10 @@ public class EventEmitter {
 
     private void sendWithEventHttp(EventEnvelope event, String to, String targetHttp) {
         String callback = event.getReplyTo();
+        if (callback != null && acceptsEventStream(event)) {
+            relayEventStream(event, to, targetHttp, callback);
+            return;
+        }
         String eventApiType = callback == null? "async" : "callback";
         event.setReplyTo(null);
         EventEnvelope forwardEvent = EventEnvelope.of(event.toMap()).setHeader(X_EVENT_API, eventApiType);
@@ -803,6 +810,89 @@ public class EventEmitter {
                 }
             }
         });
+    }
+
+    /**
+     * The event-level opt-in for progressive streaming over Event-over-HTTP:
+     * the outbound event declares the header "accept: text/event-stream"
+     *
+     * @param event the outbound event
+     * @return true when the caller accepts a progressive event stream
+     */
+    private boolean acceptsEventStream(EventEnvelope event) {
+        for (Map.Entry<String, String> kv : event.getHeaders().entrySet()) {
+            if (ACCEPT.equalsIgnoreCase(kv.getKey())) {
+                String value = kv.getValue();
+                return value != null && value.contains(TEXT_EVENT_STREAM);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Streaming-capable Event-over-HTTP relay (callback mode with the accept opt-in):
+     * the POST advertises Accept: text/event-stream and the caller's reply route and
+     * correlation id pass through to the HTTP client, which consumes the peer's SSE
+     * response progressively and forwards each decoded event to the callback. A peer
+     * that answers single-shot (the target does not stream, or an older engine) falls
+     * back to the classic callback delivery. The event's x-ttl header (milliseconds,
+     * default 60 seconds) is the idle allowance between stream events on both hops.
+     *
+     * @param event the outbound event (a copy - safe to mutate)
+     * @param to the target route
+     * @param targetHttp the peer's event endpoint
+     * @param callback the caller's reply route
+     */
+    private void relayEventStream(EventEnvelope event, String to, String targetHttp, String callback) {
+        final URI url;
+        try {
+            url = new URI(targetHttp);
+        } catch (URISyntaxException e) {
+            log.error("Unable to relay event stream {} to {} - {}", to, targetHttp, e.getMessage());
+            return;
+        }
+        String ttlHeader = null;
+        for (Map.Entry<String, String> kv : event.getHeaders().entrySet()) {
+            if (X_TTL.equalsIgnoreCase(kv.getKey())) {
+                ttlHeader = kv.getValue();
+            }
+        }
+        long ttlMs = ttlHeader == null?
+                ASYNC_EVENT_HTTP_TIMEOUT : Math.max(1000L, Utility.getInstance().str2long(ttlHeader));
+        event.setReplyTo(null);
+        EventEnvelope forwardEvent = EventEnvelope.of(event.toMap()).setHeader(X_EVENT_API, STREAM_RELAY);
+        AsyncHttpRequest req = new AsyncHttpRequest();
+        req.setMethod(POST);
+        req.setHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
+        req.setHeader(X_NO_STREAM, "true");
+        req.setHeader(ACCEPT, TEXT_EVENT_STREAM);
+        req.setHeader(X_TTL, String.valueOf(ttlMs));
+        Map<String, String> securityHeaders = getEventHttpHeaders(to);
+        if (securityHeaders != null) {
+            for (Map.Entry<String, String> kv : securityHeaders.entrySet()) {
+                if (!X_EVENT_FORMAT.equalsIgnoreCase(kv.getKey())) {
+                    req.setHeader(kv.getKey(), kv.getValue());
+                }
+            }
+        }
+        setTraceHeaders(req, forwardEvent);
+        req.setUrl(url.getPath());
+        req.setTargetHost(getTargetFromUrl(url));
+        byte[] b = forwardEvent.toBytes(httpEventFormat(securityHeaders));
+        req.setBody(b);
+        req.setContentLength(b.length);
+        // the client's per-read idle allowance - one extra second so the peer's
+        // in-band 408, sent AT the deadline, wins the race
+        req.setTimeoutSeconds((int) (ttlMs / 1000) + 1);
+        EventEnvelope request = new EventEnvelope().setTo(AsyncHttpClient.ASYNC_HTTP_REQUEST)
+                .setBody(req).setHeader(X_EVENT_API, STREAM_RELAY)
+                .setReplyTo(callback).setCorrelationId(event.getCorrelationId())
+                .setFrom(to);
+        if (event.getTraceId() != null) {
+            request.setTraceId(event.getTraceId());
+            request.setTracePath(event.getTracePath());
+        }
+        send(request);
     }
 
     @SuppressWarnings("unchecked")

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/EventStreamWriter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/EventStreamWriter.java
@@ -60,9 +60,14 @@ public class EventStreamWriter {
     public static final String DATA = "data";
     public static final String EOF = "eof";
     public static final String EXCEPTION = "exception";
+    // reserved SSE event name of the Event-over-HTTP envelope-mode wire dialect:
+    // a frame with this name carries one base64-encoded serialized EventEnvelope
+    public static final String ENVELOPE = "envelope";
 
     private static final String X_TTL = "x-ttl";
     private static final String CONTENT_TYPE = "content-type";
+    private static final String TYPE = "type";
+    private static final String ERROR = "error";
     private static final String STATUS = "status";
     private static final String MESSAGE = "message";
 
@@ -171,7 +176,9 @@ public class EventStreamWriter {
     public void fail(Throwable e) {
         if (closed.compareAndSet(false, true)) {
             int status = e instanceof AppException appEx ? appEx.getStatus() : 500;
+            // the standard error key-values: '{"type": "error", "status": n, "message": text}'
             Map<String, Object> error = new HashMap<>();
+            error.put(TYPE, ERROR);
             error.put(STATUS, status);
             error.put(MESSAGE, e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
             var event = envelope(EXCEPTION, error, null).setStatus(status);

--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventOverHttpStreamTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventOverHttpStreamTest.java
@@ -1,0 +1,454 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation;
+
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.automation.services.EventStreamRenderer;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.EventStreamWriter;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Event-over-HTTP peer streaming (envelope mode): a send with reply_to that
+ * declares the "accept: text/event-stream" event header relays a remote
+ * streaming function's segments progressively to the caller's reply route.
+ * The wire is the hybrid dialect - envelope frames (base64 MsgPack) for the
+ * head, the terminals and non-text segments; raw SSE frames for text tokens.
+ * A non-streaming target and every existing calling mode stay byte-identical.
+ */
+class EventOverHttpStreamTest extends TestBase {
+    private static final String X_EVENT_STREAM = EventStreamWriter.X_EVENT_STREAM;
+    private static final String X_EVENT_NAME = EventStreamWriter.X_EVENT_NAME;
+    private static final String DATA = EventStreamWriter.DATA;
+    private static final String EOF = EventStreamWriter.EOF;
+    private static final String EXCEPTION = EventStreamWriter.EXCEPTION;
+    private static final String ACCEPT = "accept";
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
+    private static final String STREAMING_TARGET = "hello.stream.remote";
+    private static final String SINGLE_SHOT_TARGET = "hello.single.remote";
+    private static final HttpClient client = HttpClient.newHttpClient();
+    private static final AtomicInteger seq = new AtomicInteger(0);
+    private static HttpServer mockPeer;
+
+    @EventInterceptor
+    private record CaptureRoute(BlockingQueue<EventEnvelope> received) implements LambdaFunction {
+        @Override
+        public Object handleEvent(Map<String, String> headers, Object input, int instance) {
+            received.add((EventEnvelope) input);
+            return null;
+        }
+    }
+
+    @BeforeAll
+    static void startMisbehavingPeer() throws InterruptedException {
+        // a fixed-port mock so the static event-over-http.yaml can address it -
+        // it violates the envelope dialect in the exact ways the client must catch
+        var util = Utility.getInstance();
+        var config = AppConfigReader.getInstance();
+        int mockPort = util.str2int(config.getProperty("sse.mock.port", "58586"));
+        var latch = new CountDownLatch(1);
+        mockPeer = Platform.getInstance().getVertx().createHttpServer();
+        mockPeer.requestHandler(request -> {
+            HttpServerResponse response = request.response();
+            response.putHeader("content-type", TEXT_EVENT_STREAM);
+            response.setChunked(true);
+            switch (request.path()) {
+                case "/mock/raw-first" -> {
+                    // the dialect guarantees an envelope frame first
+                    response.write("data: hello\n\n");
+                    response.end();
+                }
+                case "/mock/no-terminal" -> {
+                    // a clean transport end without a decoded terminal is a truncation
+                    response.write(envelopeFrame(new EventEnvelope()
+                            .setHeader(X_EVENT_STREAM, DATA)
+                            .setHeader("content-type", TEXT_EVENT_STREAM)
+                            .setStatus(200).setBody("mock-head")));
+                    response.end();
+                }
+                case "/mock/foreign-dialect" -> {
+                    // a conforming foreign peer: envelope head, raw token, envelope eof -
+                    // plus a trailing frame that must be discarded after the terminal
+                    response.write(envelopeFrame(new EventEnvelope()
+                                    .setHeader(X_EVENT_STREAM, DATA)
+                                    .setHeader("content-type", TEXT_EVENT_STREAM)
+                                    .setStatus(200).setBody("mock-head"))
+                            + "data: mock-token\n\n"
+                            + envelopeFrame(new EventEnvelope()
+                                    .setHeader(X_EVENT_STREAM, EOF).setBody(Map.of("done", true)))
+                            + "data: trailing-noise\n\n");
+                    response.end();
+                }
+                default -> {
+                    response.setStatusCode(404);
+                    response.end();
+                }
+            }
+        }).listen(mockPort).onSuccess(server -> latch.countDown());
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "misbehaving-peer mock must start");
+    }
+
+    @AfterAll
+    static void stopMisbehavingPeer() {
+        if (mockPeer != null) {
+            mockPeer.close();
+        }
+    }
+
+    private static String envelopeFrame(EventEnvelope event) {
+        return "event: envelope\ndata: " + Utility.getInstance().bytesToBase64(event.toBytes()) + "\n\n";
+    }
+
+    /**
+     * Send to an event-over-http mapped route with the streaming opt-in and a capture
+     * route as reply_to; return the captured envelopes up to and including the first
+     * terminal marker (eof or exception) - or the first envelope for single-shot pins.
+     */
+    private List<EventEnvelope> sendStreaming(String route, String mode, String ttlMs,
+                                              int expectedEvents) throws InterruptedException {
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String capture = "capture.eoh.stream." + seq.incrementAndGet();
+        platform.registerPrivate(capture, new CaptureRoute(captured), 1);
+        try {
+            EventEnvelope event = new EventEnvelope().setTo(route)
+                    .setReplyTo(capture).setCorrelationId("cid-eoh-" + seq.get())
+                    .setHeader(ACCEPT, TEXT_EVENT_STREAM);
+            if (mode != null) {
+                event.setHeader("mode", mode);
+            }
+            if (ttlMs != null) {
+                event.setHeader("x-ttl", ttlMs);
+            }
+            EventEmitter.getInstance().send(event);
+            List<EventEnvelope> events = new ArrayList<>();
+            for (int i = 0; i < expectedEvents; i++) {
+                EventEnvelope received = captured.poll(20, TimeUnit.SECONDS);
+                assertNotNull(received, "expected event " + (i + 1) + " of " + expectedEvents);
+                events.add(received);
+                String marker = marker(received);
+                if (EOF.equals(marker) || EXCEPTION.equals(marker)) {
+                    break;
+                }
+            }
+            return events;
+        } finally {
+            platform.release(capture);
+        }
+    }
+
+    private String marker(EventEnvelope event) {
+        return event.getHeaders().get(X_EVENT_STREAM);
+    }
+
+    @Test
+    void streamingTargetRelaysProgressivelyToCallback() throws InterruptedException {
+        var events = sendStreaming(STREAMING_TARGET, "tokens", null, 3);
+        assertEquals(3, events.size(), "2 data envelopes + eof");
+        // the decoded head is the target's first envelope, verbatim
+        EventEnvelope head = events.getFirst();
+        assertEquals(DATA, marker(head));
+        assertEquals(200, head.getStatus());
+        assertEquals(TEXT_EVENT_STREAM, head.getHeaders().get("content-type"));
+        assertEquals("alpha", head.getRawBody());
+        assertEquals("cid-eoh-" + seq.get(), head.getCorrelationId(), "original correlation id restored");
+        // the second token rode a raw frame and was synthesized back
+        EventEnvelope token = events.get(1);
+        assertEquals(DATA, marker(token));
+        assertEquals("beta", token.getRawBody());
+        // eof carries the trailing metadata with its exact Map type
+        EventEnvelope eof = events.get(2);
+        assertEquals(EOF, marker(eof));
+        assertInstanceOf(Map.class, eof.getRawBody());
+        assertEquals("2", String.valueOf(((Map<?, ?>) eof.getRawBody()).get("segments")));
+    }
+
+    @Test
+    void typedSegmentsRoundTripExactly() throws InterruptedException {
+        // every escape-hatch trigger rides an envelope frame and keeps its exact form
+        var events = sendStreaming(STREAMING_TARGET, "typed", null, 6);
+        assertEquals(6, events.size(), "5 data envelopes + eof");
+        EventEnvelope mapSegment = events.getFirst();
+        assertInstanceOf(Map.class, mapSegment.getRawBody());
+        assertEquals("1", String.valueOf(((Map<?, ?>) mapSegment.getRawBody()).get("n")));
+        EventEnvelope crlf = events.get(1);
+        assertEquals("crlf", crlf.getHeaders().get(X_EVENT_NAME));
+        assertEquals("line1\r\nline2", crlf.getRawBody(), "carriage return preserved");
+        EventEnvelope reservedName = events.get(2);
+        assertEquals("envelope", reservedName.getHeaders().get(X_EVENT_NAME),
+                "a user event name colliding with the reserved word survives");
+        assertEquals("reserved-name", reservedName.getRawBody());
+        EventEnvelope bytes = events.get(3);
+        assertInstanceOf(byte[].class, bytes.getRawBody());
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, (byte[]) bytes.getRawBody());
+        assertEquals("plain token", events.get(4).getRawBody(), "text segment rides a raw frame");
+        EventEnvelope eof = events.get(5);
+        assertEquals(EOF, marker(eof));
+        assertEquals("true", String.valueOf(((Map<?, ?>) eof.getRawBody()).get("done")));
+    }
+
+    @Test
+    void singleShotTargetOverCapablePathIsClassic() throws InterruptedException {
+        // the capable path against a non-streaming function delivers exactly the
+        // classic callback reply - the buffered fallback decode
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String capture = "capture.eoh.single." + seq.incrementAndGet();
+        platform.registerPrivate(capture, new CaptureRoute(captured), 1);
+        try {
+            // classic callback (no accept header) as the baseline
+            EventEmitter.getInstance().send(new EventEnvelope().setTo(SINGLE_SHOT_TARGET)
+                    .setReplyTo(capture).setCorrelationId("cid-classic").setBody("ping-1"));
+            EventEnvelope classic = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(classic);
+            // streaming-capable call to the same target
+            EventEmitter.getInstance().send(new EventEnvelope().setTo(SINGLE_SHOT_TARGET)
+                    .setReplyTo(capture).setCorrelationId("cid-capable").setBody("ping-1")
+                    .setHeader(ACCEPT, TEXT_EVENT_STREAM));
+            EventEnvelope capable = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(capable);
+            assertNull(marker(capable), "a single-shot reply carries no stream marker");
+            assertEquals(classic.getStatus(), capable.getStatus());
+            assertEquals(classic.getRawBody(), capable.getRawBody());
+            assertEquals("cid-capable", capable.getCorrelationId());
+            assertNull(captured.poll(500, TimeUnit.MILLISECONDS), "single-shot means one reply");
+        } finally {
+            platform.release(capture);
+        }
+    }
+
+    @Test
+    void streamingTargetWithoutAcceptIsRefused406() throws InterruptedException {
+        // classic callback mode (no accept opt-in) against a streaming function:
+        // the peer answers with an explicit refusal instead of a truncated reply
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String capture = "capture.eoh.refuse." + seq.incrementAndGet();
+        platform.registerPrivate(capture, new CaptureRoute(captured), 1);
+        try {
+            EventEmitter.getInstance().send(new EventEnvelope().setTo(STREAMING_TARGET)
+                    .setReplyTo(capture).setCorrelationId("cid-refuse")
+                    .setHeader("mode", "tokens"));
+            EventEnvelope reply = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(reply);
+            assertEquals(406, reply.getStatus());
+            assertEquals("Streaming function requires a caller that accepts text/event-stream",
+                    reply.getError());
+        } finally {
+            platform.release(capture);
+        }
+    }
+
+    @Test
+    void streamingTargetViaRpcIsRefused406() {
+        // the RPC path never streams (a Future completes once)
+        var po = EventEmitter.getInstance();
+        EventEnvelope response = assertDoesNotThrow(() -> po.asyncRequest(
+                        new EventEnvelope().setTo(STREAMING_TARGET).setHeader("mode", "tokens"), 15000)
+                .toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS));
+        assertEquals(406, response.getStatus());
+        assertEquals("Streaming function requires a caller that accepts text/event-stream",
+                response.getError());
+    }
+
+    @Test
+    void midStreamFailurePropagatesExactStatus() throws InterruptedException {
+        var events = sendStreaming(STREAMING_TARGET, "error-mid", null, 3);
+        assertEquals("partial", events.getFirst().getRawBody());
+        EventEnvelope error = events.get(1);
+        assertEquals(EXCEPTION, marker(error));
+        assertEquals(503, error.getStatus());
+        assertInstanceOf(Map.class, error.getRawBody());
+        // the standard error key-values: '{"type": "error", "status": n, "message": text}'
+        Map<?, ?> body = (Map<?, ?>) error.getRawBody();
+        assertEquals("error", body.get("type"));
+        assertEquals("503", String.valueOf(body.get("status")));
+        assertEquals("backend on fire", body.get("message"));
+    }
+
+    @Test
+    void failureBeforeFirstSegmentArrivesAsException() throws InterruptedException {
+        // a pre-head failure still rides the stream (SSE-uniform) - the caller
+        // receives the exact error envelope
+        var events = sendStreaming(STREAMING_TARGET, "error-first", null, 1);
+        EventEnvelope error = events.getFirst();
+        assertEquals(EXCEPTION, marker(error));
+        assertEquals(503, error.getStatus());
+        assertEquals("no backend", ((Map<?, ?>) error.getRawBody()).get("message"));
+    }
+
+    @Test
+    void idleStallFailsInBand408() throws InterruptedException {
+        // the target declares a one-second idle allowance and goes silent - the server
+        // housekeeper (10s sweep) or the client's own idle timer must fail it in-band;
+        // both produce the pinned 408 wording
+        long started = System.currentTimeMillis();
+        var events = sendStreaming(STREAMING_TARGET, "stall", "5000", 2);
+        long elapsed = System.currentTimeMillis() - started;
+        assertEquals("one", events.getFirst().getRawBody());
+        EventEnvelope error = events.get(1);
+        assertEquals(EXCEPTION, marker(error));
+        assertEquals(408, error.getStatus());
+        Map<?, ?> body = (Map<?, ?>) error.getRawBody();
+        assertEquals("error", body.get("type"));
+        String message = String.valueOf(body.get("message"));
+        assertTrue(message.startsWith("Timeout for "), message);
+        assertTrue(elapsed < 15000, "in-band timeout expected within one sweep, took " + elapsed + " ms");
+    }
+
+    @Test
+    void serverPoolExhaustionAnswers503() throws InterruptedException {
+        // with no reply lane available, a streaming-capable call is refused
+        // single-shot with the pinned message - and recovers after release
+        List<String> drained = new ArrayList<>();
+        String lane;
+        while ((lane = EventStreamRenderer.checkoutLane()) != null) {
+            drained.add(lane);
+        }
+        assertFalse(drained.isEmpty(), "the pool should have lanes to drain");
+        try {
+            var events = sendStreaming(STREAMING_TARGET, "tokens", null, 1);
+            EventEnvelope reply = events.getFirst();
+            assertEquals(503, reply.getStatus());
+            assertEquals("Streaming response pool exhausted", reply.getError());
+        } finally {
+            drained.forEach(EventStreamRenderer::releaseLane);
+        }
+        // capacity restored - the same call streams normally again
+        var events = sendStreaming(STREAMING_TARGET, "tokens", null, 3);
+        assertEquals(EOF, marker(events.get(2)));
+    }
+
+    @Test
+    void restLevelErrorUnwrapsToCallback() throws InterruptedException {
+        // the relay POSTs to a GET-only endpoint: the edge answers a REST error
+        // (JSON, not a packed envelope) - the client unwraps it classically
+        var events = sendStreaming("mock.rest.error", null, null, 1);
+        EventEnvelope reply = events.getFirst();
+        assertNull(marker(reply), "an edge error is a single-shot reply");
+        assertEquals(405, reply.getStatus());
+        assertEquals("Method not allowed", reply.getError());
+    }
+
+    @Test
+    void rawFirstFrameFromForeignServerIsRejected() throws InterruptedException {
+        var events = sendStreaming("mock.sse.raw.first", null, null, 1);
+        EventEnvelope error = events.getFirst();
+        assertEquals(EXCEPTION, marker(error));
+        assertEquals(500, error.getStatus());
+        assertEquals("Invalid event stream - missing envelope head",
+                ((Map<?, ?>) error.getRawBody()).get("message"));
+    }
+
+    @Test
+    void transportEndWithoutTerminalIsTruncation() throws InterruptedException {
+        var events = sendStreaming("mock.sse.no.terminal", null, null, 2);
+        assertEquals("mock-head", events.getFirst().getRawBody());
+        EventEnvelope error = events.get(1);
+        assertEquals(EXCEPTION, marker(error));
+        assertEquals(500, error.getStatus());
+        assertEquals("Event stream ended without eof",
+                ((Map<?, ?>) error.getRawBody()).get("message"));
+    }
+
+    @Test
+    void foreignDialectPeerWorksAndTrailingFramesDrop() throws InterruptedException {
+        var platform = Platform.getInstance();
+        var captured = new LinkedBlockingQueue<EventEnvelope>();
+        String capture = "capture.eoh.foreign." + seq.incrementAndGet();
+        platform.registerPrivate(capture, new CaptureRoute(captured), 1);
+        try {
+            EventEmitter.getInstance().send(new EventEnvelope().setTo("mock.sse.foreign")
+                    .setReplyTo(capture).setCorrelationId("cid-foreign")
+                    .setHeader(ACCEPT, TEXT_EVENT_STREAM));
+            EventEnvelope head = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(head);
+            assertEquals("mock-head", head.getRawBody());
+            EventEnvelope token = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(token);
+            assertEquals(DATA, marker(token));
+            assertEquals("mock-token", token.getRawBody());
+            EventEnvelope eof = captured.poll(20, TimeUnit.SECONDS);
+            assertNotNull(eof);
+            assertEquals(EOF, marker(eof));
+            assertNull(captured.poll(500, TimeUnit.MILLISECONDS),
+                    "frames after the decoded terminal are discarded");
+        } finally {
+            platform.release(capture);
+        }
+    }
+
+    @Test
+    void remoteStreamRendersProgressivelyOutTheEdge() throws IOException, InterruptedException {
+        // the engine-to-engine composition: a streaming edge endpoint forwards its
+        // reply lane into a 'send' to the event-over-http mapped streaming function -
+        // segments relay through /api/event and re-render progressively here
+        HttpRequest request = HttpRequest.newBuilder(
+                        URI.create(localHost + "/api/hello/remote"))
+                .timeout(Duration.ofSeconds(20)).header("Accept", TEXT_EVENT_STREAM).build();
+        long started = System.currentTimeMillis();
+        HttpResponse<java.util.stream.Stream<String>> response =
+                client.send(request, HttpResponse.BodyHandlers.ofLines());
+        assertEquals(200, response.statusCode());
+        assertEquals(TEXT_EVENT_STREAM, response.headers().firstValue("content-type").orElse(""));
+        List<String> lines = new ArrayList<>();
+        List<Long> arrivals = new ArrayList<>();
+        response.body().forEach(line -> {
+            lines.add(line);
+            arrivals.add(System.currentTimeMillis() - started);
+        });
+        int alpha = lines.indexOf("data: alpha");
+        int beta = lines.indexOf("data: beta");
+        int done = lines.indexOf("event: done");
+        assertTrue(alpha >= 0 && beta > alpha && done > beta, "ordered relay: " + lines);
+        // the remote eof's trailing metadata is the terminal frame's data
+        assertTrue(lines.contains("data: {\"segments\":2}"), lines.toString());
+        // progressive end to end: the remote target paces segments 250ms apart
+        long elapsed = arrivals.get(beta) - arrivals.get(alpha);
+        assertTrue(elapsed >= 150, "progressive relay expected, elapsed " + elapsed + " ms");
+        Utility.getInstance().sleep(100);
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
@@ -236,7 +236,10 @@ class EventStreamClientTest extends TestBase {
         assertEquals(EventStreamWriter.EXCEPTION, marker(error));
         assertEquals(408, error.getStatus());
         assertInstanceOf(Map.class, error.getRawBody());
-        assertEquals("Timeout for 2 seconds", ((Map<?, ?>) error.getRawBody()).get("message"));
+        // the standard error key-values: '{"type": "error", "status": n, "message": text}'
+        Map<?, ?> body = (Map<?, ?>) error.getRawBody();
+        assertEquals("error", body.get("type"));
+        assertEquals("Timeout for 2 seconds", body.get("message"));
     }
 
     @Test

--- a/system/platform-core/src/test/java/org/platformlambda/automation/service/MockRemoteRelayService.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/service/MockRemoteRelayService.java
@@ -1,0 +1,52 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation.service;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+
+import java.util.Map;
+
+/**
+ * The Event-over-HTTP streaming composition: a streaming edge endpoint whose
+ * function forwards its own reply lane and correlation id into a 'send' to a
+ * REMOTE (event-over-http mapped) streaming function, opting in with the
+ * "accept: text/event-stream" event header. The remote function's segments
+ * relay through "/api/event" and re-render progressively out this app's edge -
+ * engine-to-engine streaming with no imperative streaming code.
+ */
+@EventInterceptor
+public class MockRemoteRelayService implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        AsyncHttpRequest http = new AsyncHttpRequest(request.getRawBody());
+        String mode = http.getQueryParameter("mode");
+        EventEmitter.getInstance().send(new EventEnvelope().setTo("hello.stream.remote")
+                .setReplyTo(request.getReplyTo())
+                .setCorrelationId(request.getCorrelationId())
+                .setHeader("accept", "text/event-stream")
+                .setHeader("x-ttl", "10000")
+                .setHeader("mode", mode == null? "tokens" : mode));
+        return null;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/automation/service/MockRemoteStreamService.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/service/MockRemoteStreamService.java
@@ -1,0 +1,82 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.automation.service;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventStreamWriter;
+import org.platformlambda.core.util.Utility;
+
+import java.util.Map;
+
+/**
+ * Test producer for Event-over-HTTP peer streaming: a PUBLIC streaming target
+ * invoked through "/api/event". Unlike the edge mock, it is addressed as a plain
+ * function - modes are selected by the "mode" event header, not a query parameter.
+ */
+@EventInterceptor
+public class MockRemoteStreamService implements TypedLambdaFunction<EventEnvelope, Void> {
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
+    private static final long PACE = 250;
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        var util = Utility.getInstance();
+        String mode = headers.get("mode");
+        var out = new EventStreamWriter(request);
+        switch (mode == null? "tokens" : mode) {
+            case "tokens" -> {
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write("alpha");
+                util.sleep(PACE);
+                out.write("beta");
+                util.sleep(PACE);
+                out.close(Map.of("segments", 2));
+            }
+            case "typed" -> {
+                // every escape-hatch trigger: a Map body, text with a carriage return,
+                // a user event name colliding with the reserved "envelope" word, a
+                // byte body - plus one plain text segment that rides a raw frame
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write(Map.of("n", 1));
+                out.write("crlf", "line1\r\nline2");
+                out.write("envelope", "reserved-name");
+                out.write(new byte[]{1, 2, 3, 4});
+                out.write("plain token");
+                out.close(Map.of("done", true));
+            }
+            case "error-mid" -> {
+                out.first(200, TEXT_EVENT_STREAM);
+                out.write("partial");
+                out.fail(new AppException(503, "backend on fire"));
+            }
+            case "error-first" -> out.fail(new AppException(503, "no backend"));
+            case "stall" -> {
+                // one-second declared idle allowance, then silence - the server
+                // housekeeper or the consuming client must fail the stream in-band
+                out.first(200, TEXT_EVENT_STREAM, 1);
+                out.write("one");
+            }
+            default -> out.fail(new AppException(400, "unknown mode " + mode));
+        }
+        return null;
+    }
+}

--- a/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
+++ b/system/platform-core/src/test/java/org/platformlambda/common/TestBase.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.platformlambda.automation.http.AsyncHttpClient;
 import org.platformlambda.automation.service.MockEventStreamService;
+import org.platformlambda.automation.service.MockRemoteRelayService;
+import org.platformlambda.automation.service.MockRemoteStreamService;
 import org.platformlambda.automation.service.MockSseRelayService;
 import org.platformlambda.automation.service.MockHelloWorld;
 import org.platformlambda.core.models.AsyncHttpRequest;
@@ -98,6 +100,15 @@ public class TestBase {
             // registered before endpoint rendering so the rest.yaml existence check passes
             platform.registerPrivate("hello.event.stream", new MockEventStreamService(), 10);
             platform.registerPrivate("hello.event.relay", new MockSseRelayService(), 10);
+            // Event-over-HTTP peer streaming (EventOverHttpStreamTest): a PUBLIC streaming
+            // target reachable through /api/event, a PUBLIC single-shot echo for the
+            // fallback pins, and the edge relay of the engine-to-engine composition
+            platform.registerPrivate("hello.stream.remote", new MockRemoteStreamService(), 10);
+            platform.makePublic("hello.stream.remote");
+            platform.registerPrivate("hello.single.remote", (headers, input, instance) ->
+                    Map.of("echo", input == null? "none" : input), 5);
+            platform.makePublic("hello.single.remote");
+            platform.registerPrivate("hello.remote.relay", new MockRemoteRelayService(), 10);
             // test registering the same function with an alias route name
             // hello.list is a special function to test returning result set as a list
             platform.registerPrivate(HELLO_LIST, (headers, input, instance) ->

--- a/system/platform-core/src/test/resources/application.properties
+++ b/system/platform-core/src/test/resources/application.properties
@@ -4,6 +4,9 @@
 application.name=platform-core
 server.port=8585
 rest.automation=true
+# fixed port of the misbehaving-peer mock SSE server (EventOverHttpStreamTest) -
+# referenced by the mock.sse.* entries in event-over-http.yaml
+sse.mock.port=58586
 #
 # log.format = text | compact | json
 # text and json are for human readers

--- a/system/platform-core/src/test/resources/event-over-http.yaml
+++ b/system/platform-core/src/test/resources/event-over-http.yaml
@@ -8,3 +8,23 @@ event.http:
     target: 'http://127.0.0.1:${server.port}/api/event'
     headers:
       authorization: 'demo'
+  # Event-over-HTTP peer streaming (EventOverHttpStreamTest): the streaming target
+  # and the single-shot echo loop back to this app's own /api/event
+  - route: 'hello.stream.remote'
+    target: 'http://127.0.0.1:${server.port}/api/event'
+    headers:
+      authorization: 'demo'
+  - route: 'hello.single.remote'
+    target: 'http://127.0.0.1:${server.port}/api/event'
+    headers:
+      authorization: 'demo'
+  # an edge-level REST error on the relay path (POST to a GET-only endpoint)
+  - route: 'mock.rest.error'
+    target: 'http://127.0.0.1:${server.port}/api/hello/stream'
+  # conformance guards against a misbehaving peer (fixed-port mock SSE server)
+  - route: 'mock.sse.raw.first'
+    target: 'http://127.0.0.1:${sse.mock.port}/mock/raw-first'
+  - route: 'mock.sse.no.terminal'
+    target: 'http://127.0.0.1:${sse.mock.port}/mock/no-terminal'
+  - route: 'mock.sse.foreign'
+    target: 'http://127.0.0.1:${sse.mock.port}/mock/foreign-dialect'

--- a/system/platform-core/src/test/resources/rest.yaml
+++ b/system/platform-core/src/test/resources/rest.yaml
@@ -40,6 +40,15 @@ rest:
     url: "/api/hello/relay"
     timeout: 15s
     stream: true
+
+  # Event-over-HTTP streaming composition: the function forwards its reply lane
+  # into a send to a remote (event-over-http mapped) streaming function - the
+  # segments relay through /api/event (envelope mode) and re-render here
+  - service: "hello.remote.relay"
+    methods: ['GET']
+    url: "/api/hello/remote"
+    timeout: 15s
+    stream: true
   - service: ["hello.mock"]
     methods: ['GET', 'PUT', 'POST', 'HEAD', 'PATCH', 'DELETE']
     url: "/api/hello/world"


### PR DESCRIPTION
## What

**Event-over-HTTP peer streaming (envelope mode) — Phase 2 of the SSE consumption design.**
A remote streaming function reached through `/api/event` now streams its segments back to
the caller's reply route on the same HTTP call, engine to engine. This completes the
progressive-rendering chain: a function on engine B can token-stream through engine A's
HTTP edge with no imperative streaming code on either side.

- **Caller contract** — one send: address the remote function through the
  `yaml.event.over.http` mapping with a `reply_to` and opt in with the
  `accept: text/event-stream` event header. The `x-ttl` event header (ms, default 60s) is
  the idle allowance between stream events on both hops. The RPC and drop-n-forget paths
  never stream and are unchanged.
- **Wire dialect (ratified hybrid)** — control signals ride envelope frames (reserved SSE
  event name `envelope`, one base64-encoded serialized EventEnvelope per frame, requester's
  wire format mirrored): the head, the `eof`/`exception` terminals, and any segment that
  cannot round-trip as plain text (Map/byte bodies, text with a carriage return, an event
  name colliding with the reserved word). Plain text segments ride raw SSE frames with
  near-zero overhead. Segment types and terminal metadata survive the hop exactly.
- **Server side** — `EventApiService` binds a reply lane dynamically only for
  streaming-capable calls (plain RPC traffic never consumes one; a dry pool answers the
  pinned `503 Streaming response pool exhausted`), rewrites the relayed request's
  correlation id exactly as the RPC inbox would, and the edge renderer produces the
  dialect. An atomic release claim closes the lane checkout race with client disconnects.
- **Client side** — the Phase-1 SSE branch gains the envelope submode: dialect decode,
  addressing restored to the original caller, and conformance guards (a raw first frame or
  a transport end without a decoded terminal fail in-band with pinned 500 messages).
- **Explicit degradation, never silent** — a non-streaming target called over the capable
  path answers byte-identical to the classic callback reply; a streaming function invoked
  by a non-accepting caller receives
  `406 Streaming function requires a caller that accepts text/event-stream`; older peers
  answer single-shot as today.
- **Error-body contract alignment** — every in-band exception body now carries the
  standard error key-values `{"type": "error", "status": n, "message": text}`: the edge
  housekeeper's 408 abort was String-bodied, and `EventStreamWriter.fail()` plus the HTTP
  client's in-band failures were missing the `type` key. Wire-invisible at the local edge
  (the renderer re-wraps); shape-visible to reply-route consumers.
- **Docs** — new "Stream across applications (Event-over-HTTP)" section in the HTTP
  Response Streaming guide, a cross-reference section in the Event-over-HTTP guide,
  CHANGELOG entry, and ADR-0018/ADR-0019 flip to **Accepted** (their features merged in
  #299/#300). The design spec records the ratified Phase-2 internals (P2-1…P2-6).

**Tests (14 new, `EventOverHttpStreamTest`):** progressive relay to a callback with exact
head/segment/eof mapping; every escape-hatch trigger round-trips with exact types
(Map, bytes, `\r` text, reserved-name collision, eof trailing metadata); byte-identical
single-shot fallback vs the classic callback baseline; both 406 refusal paths; mid-stream
and pre-head failure propagation with exact status; in-band 408 on idle stall; 503 pool
exhaustion with recovery; REST-level error unwrap; misbehaving-peer conformance guards
(raw-first rejection, truncation detection, foreign-dialect peer with trailing-frame
discard); and the flagship engine⇄engine e2e — a `stream: true` edge endpoint relaying a
remote streaming function progressively out the HTTP edge, pacing asserted.

**Gates:** platform-core 473/473 · full reactor build green · mkdocs strict clean ·
IDE Sonar clean (cognitive-complexity and duplicate-literal findings refactored).

## Why

Phase 1 (#300) taught the engine to consume SSE; this phase closes the remaining gap the
design ratified: a **peer's function** streaming back through Event-over-HTTP — the
transport that polyglot wrapper functions and remote engines already use. It is the
engine⇄engine proof of the hybrid control/data-plane framing (control signals as
key-value headers in the first envelope frame; subsequent blocks are tokens) before the
wrapper twins adopt the same dialect in Phase 3, and it is the streaming backbone the AI
SDLC work needs: an `llm.chat`-style function on any peer can now token-stream to any
engine's edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>