### PR TITLE
Progressive rendering milestone v4.12.0 - demo relay, interop report, telemetry continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.12.0, 8/30/2026
+
+The progressive-rendering milestone: token/event streaming end to end - HTTP edge,
+HTTP client, and Event-over-HTTP peers - with full OpenTelemetry lineage and
+business-correlation continuity across all four runtimes (Java, Rust, Python,
+Node.js language packs at the same version). Useful on its own, and the
+foundation for the AI SDLC (agent, MCP and tool adapters as wrapper-side
+functions with complete observability).
 
 ### Added
 
@@ -60,6 +67,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    streaming endpoint (plain RPC traffic never consumes a lane). The consuming
    client guards the dialect (a missing envelope head or a transport end without a
    terminal fail in-band). See the HTTP Response Streaming guide. (ADR-0019)
+
+4. **Engine-to-wrapper streaming demo and interop test report.** The lambda-example
+   gains `GET /api/hello/remote` (`hello.remote.relay`): a streaming endpoint whose
+   function forwards its caller's reply lane into an event-over-http mapped remote
+   streaming function (the Python/Node.js demo apps' `hello.tokens`), rendering a
+   remote peer's tokens progressively out this application's HTTP edge with zero
+   imperative streaming code. `hello.sse` is now public, so wrapper clients can
+   consume it over `/api/event`. A permanent interop test report
+   (`docs/test-reports/progressive-rendering-interop.md`, packaged with the AI
+   contract provider) records the live ten-combination cross-runtime matrix, the
+   OpenTelemetry span-lineage and business-correlation-id verification, and a
+   captured end-to-end telemetry + application-log-context example.
 
 ### Changed
 

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -289,4 +289,6 @@ response, `x-event-stream` wins and the stray `x-stream-id` is ignored with a wa
 ## See also
 
 - [Event over HTTP](event-over-http.md) - the same envelope protocol between applications
+- [Interop Test Report — Progressive Rendering](../test-reports/progressive-rendering-interop.md) -
+  the live four-runtime validation of this contract
 - [Actuators and HTTP client](actuators-and-http-client.md)

--- a/docs/test-reports/progressive-rendering-interop.md
+++ b/docs/test-reports/progressive-rendering-interop.md
@@ -1,0 +1,371 @@
+---
+title: Interop Test Report — Progressive Rendering, all four runtimes
+summary: Permanent record of the live cross-runtime validation of the progressive
+  streaming contract - the multi-shot reply protocol and the Event-over-HTTP
+  envelope-mode SSE dialect - across the Java and Rust engines and the Python and
+  Node.js function hosts.
+layer: reference
+audience: [developer, architect]
+keywords: [interop, streaming, sse, event over http, envelope mode, test report]
+---
+
+# Interop Test Report — Progressive Rendering, all four runtimes
+
+*Live cross-runtime validation of the progressive streaming contract across the four
+Mercury Composable runtimes — the Java engine
+([mercury-composable](https://github.com/Accenture/mercury-composable)), the Rust engine
+([mercury](https://github.com/Accenture/mercury)), and the Python
+([mercury-python](https://github.com/Accenture/mercury-python)) and Node.js
+([mercury-nodejs](https://github.com/Accenture/mercury-nodejs)) function hosts — conducted
+2026-08-30 (UTC) at the close of the streaming program's wrapper round. This report is a
+permanent record in the tradition of the
+[Event over HTTP interop report](event-over-http-interop.md): what was tested, the
+evidence, and the defects the round surfaced with their fixes.*
+
+## The contract under test
+
+One paradigm on all four runtimes: **the caller provides a reply address; the callee
+streams events to it until a terminal signal.** Each segment is one event to the
+caller's `reply_to`, marked with the reserved envelope header
+`x-event-stream: data | eof | exception`. Across the Event-over-HTTP hop, the peer
+answers the one POST with a Server-Sent Events response in the **hybrid envelope-mode
+dialect**: envelope frames (the reserved SSE event name `envelope`, one base64-encoded
+serialized envelope per frame) wherever envelope semantics matter — the head, the
+terminals, and any segment that cannot round-trip as plain text — and raw SSE frames
+for text tokens. The consuming client decodes the dialect and forwards each event to
+the original reply address with the original correlation id, so a local stream and a
+remote stream are indistinguishable to the consumer.
+
+Delivered by: Java engine PRs
+[#299](https://github.com/Accenture/mercury-composable/pull/299) (edge streaming),
+[#300](https://github.com/Accenture/mercury-composable/pull/300) (SSE consumption),
+[#301](https://github.com/Accenture/mercury-composable/pull/301) (envelope mode) —
+ADR-0018/0019; Rust engine PRs
+[#216](https://github.com/Accenture/mercury/pull/216),
+[#217](https://github.com/Accenture/mercury/pull/217),
+[#218](https://github.com/Accenture/mercury/pull/218) — ADR-0015/0016; and the
+matching wrapper round in mercury-python and mercury-nodejs (interceptor functions,
+`EventStreamWriter`, streaming `/api/event` host, `stream()`/`stream_to()` client).
+
+## The live matrix
+
+Ten producer/consumer combinations were driven live with the SHIPPED demo applications
+— no test shims. Producers pace their segments (300 ms in these drives), so
+progressive delivery is directly observable in the arrival timestamps; buffered
+delivery would show all segments arriving together.
+
+| # | Consumer | Producer | Result |
+|---|----------|----------|--------|
+| 1 | Node.js client | Python `hello.tokens` | segments at ~11/312/612/916 ms, eof metadata `{count, language: python}` |
+| 2 | Python client | Node.js `hello.tokens` | segments at ~5/304/606/908 ms, eof metadata `{count, language: node.js}` |
+| 3 | Python client | **Java engine** `hello.sse` | segments at ~103/407/708/1012 ms, terminal `eof` |
+| 4 | Node.js client | **Java engine** `hello.sse` | segments at ~13/320/620/924 ms, terminal `eof` |
+| 5 | Python client | **Rust engine** `hello.sse` | segments at ~3/306/607 ms, terminal `eof` |
+| 6 | Node.js client | **Rust engine** `hello.sse` | segments at ~10/312/615 ms, terminal `eof` |
+| 7 | **Java engine** edge (`/api/hello/remote`) | Python `hello.tokens` | SSE out the engine edge at ~195/493/793/1094 ms, terminal `event: done` with the Python eof metadata |
+| 8 | **Java engine** edge | Node.js `hello.tokens` | ~217/516/817 ms, terminal metadata `{count, language: node.js}` |
+| 9 | **Rust engine** edge | Python `hello.tokens` | ~20/323/624 ms, same shape |
+| 10 | **Rust engine** edge | Node.js `hello.tokens` | ~19/320/622 ms, same shape |
+
+Common observations across all ten:
+
+- **Progressive on the wire** — arrival gaps match the producer's pacing; nothing
+  buffers end-to-end (rows 7–10 traverse the full chain: HTTP edge → engine relay
+  function → Event-over-HTTP → wrapper host → wrapper function and back).
+- **Correlation** — the caller's correlation id is restored on every delivered
+  envelope (D7), and the engines' demo authentication (`authorization: demo`) rides
+  the per-target security headers unchanged.
+- **Exact types** — eof trailing metadata arrives as a real map, not text, on every
+  path (the envelope-frame escape hatch).
+- **Explicit degradation, observed live** — a missing token produced the engine's
+  401 and a private target its 403, both delivered as clean envelopes through the
+  buffered fallback; a caller without the `accept: text/event-stream` opt-in receives
+  the pinned `406 Streaming function requires a caller that accepts
+  text/event-stream`.
+
+## Engine ⇄ engine and per-runtime coverage
+
+Because the protocol signatures are identical across the four runtimes, each
+repository's unit suite exercises the full protocol against its own application
+instance (client consuming its own `/api/event` host in one process): Java
+`EventOverHttpStreamTest` (14 cases), Rust `event_over_http_stream.rs` (14), Python
+`test_event_stream.py` (17), Node.js `event-stream.test.ts` (17). Each suite also
+carries **misbehaving-peer fixtures** — a raw first frame, a transport end without a
+decoded terminal, trailing frames after the terminal — because a self-loop alone
+cannot catch a deviation implemented identically in both halves of one runtime; the
+live matrix above is the cross-implementation conformance check, and it passed with
+zero shims.
+
+## Trace continuity (OpenTelemetry span / parent-span verification)
+
+The drives were repeated with telemetry capture to verify distributed-trace
+continuity across the streaming hop. Findings, with the observed evidence:
+
+- **One trace id end to end, both directions.** In the engine→wrapper drive, the
+  Java edge minted trace `f22af2e005f2445198563e2dc4f1ba54`; every engine span
+  carried it (the relay function, the HTTP client leg, each reply-lane segment
+  delivery), the Python function received it (trace id and path ride inside the
+  wire envelope), and the demo now echoes it in the eof trailing metadata - so
+  the terminal frame rendered out the engine's own edge carries the same trace
+  id the edge minted: continuity is self-documenting in the demo output. In the
+  wrapper→engine drive, a Python caller supplied W3C trace id
+  `4bf92f3577b34da6a3ce929d0e0e4736` with trace path `PY /stream-drive`; the
+  engine's `event.api.auth`, `event.api.service` and `hello.sse` spans all
+  carried that id, and the function's span carried the caller's trace path.
+- **Span parenting chains on the engines.** The streaming target's span parents
+  onto the Event API service span - observed live:
+  `event.api.service span_id=bfcddb32dd597ddb` →
+  `hello.sse parent_span_id=bfcddb32dd597ddb`. Outbound, the engines' relay leg
+  sends the W3C `traceparent` header carrying the sending function's span id
+  (the trace-aware PostOffice stamps the span onto the outbound event), so a
+  receiving ENGINE parents its spans onto the caller's - the same cross-engine
+  parenting validated in the Event over HTTP interop report.
+- **Wrapper executions are real spans** (closed at this round - the wrappers
+  originally propagated the trace id but minted no spans, which broke the
+  lineage into disconnected segments at every wrapper hop). The function hosts
+  now implement the engines' exact span model: every traced execution mints a
+  16-hex span with the caller's span (from the inbound envelope) as its
+  parent; outbound calls and stream segments carry the current span onward;
+  and non-RPC executions emit the engines' distributed-trace dataset record on
+  the `distributed.tracing` log stream - the same
+  `{"trace": {...}, "annotations": {...}}` shape the Java engine logs - so one
+  log aggregation (or a stdout log-ingest agent forwarding to an observability
+  dashboard) stitches the full span tree across all four runtimes. RPC
+  round-trips emit no dataset, exactly like the engines: their metrics fold
+  into the caller's view.
+- **The connected tree, live-proven in all three directions.** Engine→wrapper:
+  under one Java-edge trace, the relay function's span `8cbc0b4d4be75362`
+  became the Python `hello.tokens` span's parent (`span_id=7b90847f4b8b617a`,
+  `parent_span_id=8cbc0b4d4be75362` in the wrapper's own trace record), and
+  the Java reply-lane delivery spans then parented onto the Python span -
+  edge → engine function → wrapper function → engine deliveries, one unbroken
+  chain. Wrapper→engine: a Python caller carrying external span
+  `00f067aa0ba902b7` (the shape of a user-edge OpenTelemetry span) produced
+  `event.api.auth` and `event.api.service` spans parented on it, with
+  `hello.sse` parented on the service span. Wrapper⇄wrapper: a Node.js
+  execution's record showed the Python caller's span as its parent. This is
+  the lineage the AI SDLC requires - user → agent → MCP → tools in one tree.
+- **One deliberate exception**: plain-text token segments ride raw SSE frames,
+  which carry no envelope metadata (the zero-overhead token path), so their
+  engine-side delivery spans join the trace unparented; a stream's head and
+  terminal segments ride envelope frames and parent correctly. The engines'
+  HTTP client leg (`async.http.request`) remains a sibling span - classic
+  Event-over-HTTP parity.
+- **Correlation id**: the caller's cid rode every delivered envelope in every
+  drive (`cid-trace-drive` on all four segments of the supplied-trace drive).
+
+The check itself surfaced defect #5: the engine demo relay originally built its
+forward event with the raw EventEmitter, which stamps no trace - the hop
+continued cid but DROPPED the trace id. Fixed by using a trace-aware
+PostOffice (its `touch` fill-stamps from/trace/span), and the wrapper demos'
+`hello.tokens` now echo their received trace id in the eof metadata so the
+continuity is visible in every future drive.
+
+## Business correlation-id continuity
+
+The same verification was run for the business correlation-id (`my_cid`) - the
+engine-managed envelope tag captured at an engine's HTTP edge from the
+configured header (default `X-Correlation-Id`) and injected into every
+receiving function's input headers as the read-only `my_correlation_id` view.
+The wrapper demos' `hello.tokens` echo the view in the eof metadata alongside
+the trace id, so every future drive self-documents both continuity dimensions.
+Live results:
+
+- **Java engine edge → Python**: `X-Correlation-Id: biz-e2w-001` on the edge
+  request came back in the terminal metadata rendered out the same edge -
+  edge header → `my_cid` tag → relay function's injected header view →
+  trace-aware PostOffice re-stamp → packed envelope over the hop → wrapper
+  host injection → function echo.
+- **Rust engine edge → Python**: `biz-rust-005` echoed identically. The Rust
+  demo relay needed no change: the Rust engine has one PostOffice and
+  `apply_current_trace` always stamps trace and business correlation-id from
+  the ambient context.
+- **Python → Node.js and Node.js → Python** (wrapper ⇄ wrapper): a caller-side
+  context (`trace_context(..., my_correlation_id=...)` / `runWithTrace({...,
+  myCorrelationId})`) produced `biz-w2w-002` / `biz-w2w-003` echoes from the
+  opposite wrapper - the tag crossed the hop and the receiving host injected
+  the view.
+- **Wrapper → engine**: the wrappers stamp the identical tag bytes (the same
+  codec proven above), and the engines' pinned suites cover the receiving
+  half: an `/api/event` caller carrying the `my_cid` tag reaches the target
+  function as `po.getMyCorrelationId()` (Java
+  `EventHttpTest.eventOverHttpPropagatesTraceAndCorrelationId`; Rust twin).
+
+The check surfaced one parity gap in the (unreleased) wrapper round, fixed and
+test-pinned in both wrappers: the wrapper clients inherited trace id/path and
+the internal correlation id into outbound events but did not re-stamp the
+business correlation-id as the `my_cid` tag, and local bus deliveries skipped
+the header-view injection that the HTTP host performs. Both halves now mirror
+the engines (`PostOffice.touch` / WorkerHandler parity): outbound events carry
+the context's business correlation-id as the tag, local deliveries inject the
+read-only view, and the trace context (`get_trace()` / `getTrace()`) exposes
+it to handlers and relays.
+
+By design (confirmed at this verification round): an engine's `/api/event`
+ingress serves LOCAL routes only - it answers 404 for a route it does not
+host, even when its own `yaml.event.over.http` map points that route at a
+peer. The map is caller-side routing for the app's own outbound calls;
+forwarding inbound calls onward would make every application an
+Event-over-HTTP relay and open routing loops (the `x-event-api` wire marker
+exists precisely to prevent such re-forwarding). Callers address the owning
+peer directly; deliberate hop-through composition is an explicit relay
+function - the demo `hello.remote.relay` is exactly that pattern.
+
+## Defects surfaced by the round (fixed and re-verified)
+
+Honest engineering record — each was caught by the twin-building discipline before
+any release:
+
+1. **Rust engine**: the envelope-mode single-shot reply initially reached the caller
+   unwrapped (rendered as plain JSON instead of the classic packed-envelope wire);
+   fixed by wrapping at the one `SingleShot` outcome site — caught by the twin suite's
+   first run.
+2. **Node.js host**: a `Promise.race` against a queue waiter abandoned the losing
+   waiter, which would steal and drop the next envelope; fixed by reusing one pending
+   promise across keep-alive cycles (`raceMs` documents the rule) — caught in design
+   review before the first test run.
+3. **Error-body contract**: the in-band exception bodies converged on the standard
+   error key-values `type` / `status` / `message` across all four runtimes (three
+   Java sites and their twins were missing the `type` key or used a plain-text body).
+4. **Node.js**: object error bodies would have stringified as `[object Object]`;
+   fixed with JSON rendering (`errorText`).
+5. **Java demo relay**: the forward event was built with the raw (untraced)
+   EventEmitter, silently dropping the distributed trace across the hop; fixed
+   with a trace-aware PostOffice - found by the trace-continuity verification
+   above.
+
+## Reproduce
+
+Every row of the matrix uses shipped demo applications:
+
+- **Engine as producer**: run the Java `lambda-example` (port 8085) or Rust
+  `hello-world` (8085; any port with `-Drest.server.port=…`); their public
+  `hello.sse` streams paced test messages. Consume from a wrapper with
+  `PostOffice.stream("hello.sse", …, endpoint="http://host:port/api/event")` and the
+  demo `authorization: demo` header.
+- **Engine as consumer**: run a wrapper demo app (python `mercury-serve
+  examples/demo_app.py`, port 8086; node demo, 8087), then the engine demo with its
+  routing map (Java: `-Dyaml.event.over.http=classpath:/event-over-http.yaml`; Rust:
+  ships enabled) and `-Dpeer.demo.port` as needed, and watch
+  `curl -N -H 'accept: text/event-stream'
+  'http://127.0.0.1:8085/api/hello/remote?delay=300&count=3'` render the wrapper's
+  tokens progressively out the engine's edge.
+- **Wrapper ⇄ wrapper**: point either wrapper's `stream()` at the other demo's
+  `/api/event`.
+
+Baselines at the time of the drives: Java engine main after PR #301, Rust engine main
+after PR #218, mercury-python and mercury-nodejs at the streaming feature round -
+shipped together as the v4.12.0 milestone release across all four repositories.
+
+## Appendix - telemetry and app context example (live capture)
+
+One live request, captured end to end, showing how the telemetry stream and
+the application log context connect the engine to the wrapper. Setup: the Java
+`lambda-example` (port 8085) with its event-over-http map pointing
+`hello.tokens` at the Python demo app (port 8086, `-Dlog.format=compact`).
+The caller supplies a business correlation-id; the engine's HTTP edge mints
+the trace:
+
+```bash
+curl -N -H 'accept: text/event-stream' -H 'X-Correlation-Id: biz-e2e-777' \
+  'http://127.0.0.1:8085/api/hello/remote?delay=100&count=1'
+```
+
+**1. Java engine - the relay function's telemetry record** (the root span of
+trace `710dcb0b706e4b5b949be138d0992b0b`, minted at the edge):
+
+```json
+{
+  "level": "INFO",
+  "time": "2026-08-29 21:24:17.734",
+  "source": "org.platformlambda.core.services.Telemetry.handleEvent(Telemetry.java:81)",
+  "thread": 762,
+  "message": {
+    "trace": {
+      "path": "GET /api/hello/remote?delay=100&count=1",
+      "span_id": "afa2897918e3871b",
+      "service": "hello.remote.relay",
+      "success": true,
+      "origin": "20260830a0dcb550832b4683b4853c609778cd82",
+      "start": "2026-08-30T04:24:17.733Z",
+      "exec_time": 0.728,
+      "from": "http.request",
+      "id": "710dcb0b706e4b5b949be138d0992b0b",
+      "status": 200
+    }
+  }
+}
+```
+
+**2. The wire** - the relay's trace-aware PostOffice stamps the outbound event
+with the trace id and path, its own span id (`afa2897918e3871b`) and the
+`my_cid` tag (`biz-e2e-777`); the whole envelope crosses `POST /api/event`,
+with `X-Trace-Id` and the W3C `traceparent` on the HTTP headers.
+
+**3. Python wrapper - the function's own application log line.** The handler
+runs `log.info("Streaming %d messages", count)`; the app-log-context feature
+adds the `context` block. Note the join keys: the engine's trace id, the
+business `cid` from the edge header, and this execution's `spanId` with the
+relay's span as `parentSpanId`:
+
+```json
+{"time": "2026-08-29 21:24:17.847", "level": "INFO", "logger": "mercury_user_app:93", "message": "Streaming 1 messages", "context": {"cid": "biz-e2e-777", "traceId": "710dcb0b706e4b5b949be138d0992b0b", "tracePath": "GET /api/hello/remote?delay=100&count=1", "spanId": "55ebd6464ffdf9c2", "parentSpanId": "afa2897918e3871b", "service": "hello.tokens", "timestamp": "2026-08-30T04:24:17.847Z"}}
+```
+
+**4. Python wrapper - the telemetry record for the same execution** (same
+`span_id` as the app log line's `spanId` - the join key between the two
+streams; `from` names the calling engine function):
+
+```json
+{"time": "2026-08-29 21:24:17.949", "level": "INFO", "logger": "distributed.tracing:158", "message": {"trace": {"origin": "202608303cbae673831a4ab08cbb6f108fec0171", "id": "710dcb0b706e4b5b949be138d0992b0b", "path": "GET /api/hello/remote?delay=100&count=1", "service": "hello.tokens", "start": "2026-08-30T04:24:17.847Z", "success": true, "from": "hello.remote.relay", "exec_time": 101.673, "status": 200, "span_id": "55ebd6464ffdf9c2", "parent_span_id": "afa2897918e3871b"}}}
+```
+
+**5. Java engine - a reply-lane delivery record.** The wrapper's stream
+segments carry its span, so the engine-side delivery span parents onto the
+Python function (`parent_span_id = 55ebd6464ffdf9c2`):
+
+```json
+{
+  "level": "INFO",
+  "time": "2026-08-29 21:24:17.853",
+  "source": "org.platformlambda.core.services.Telemetry.handleEvent(Telemetry.java:81)",
+  "thread": 779,
+  "message": {
+    "trace": {
+      "path": "GET /api/hello/remote?delay=100&count=1",
+      "parent_span_id": "55ebd6464ffdf9c2",
+      "span_id": "a50c19b7415406df",
+      "service": "async.http.response.stream.499",
+      "success": true,
+      "origin": "20260830a0dcb550832b4683b4853c609778cd82",
+      "start": "2026-08-30T04:24:17.851Z",
+      "exec_time": 1.202,
+      "from": "hello.tokens",
+      "id": "710dcb0b706e4b5b949be138d0992b0b",
+      "status": 200
+    }
+  }
+}
+```
+
+**6. The caller's view** - the terminal SSE frame rendered back out the Java
+edge echoes both continuity dimensions:
+
+```text
+event: done
+data: {"trace_id":"710dcb0b706e4b5b949be138d0992b0b","count":1,"my_correlation_id":"biz-e2e-777","language":"python"}
+```
+
+**Connectivity, in one paragraph.** Every record above carries the one trace
+id the engine minted at its HTTP edge, and the span ids chain across the
+runtime boundary in both directions: the edge request → the relay function's
+span (`afa289...`) → the Python execution's span (`55ebd6...`, parented on the
+relay) → the engine's reply-lane delivery spans (parented on the Python span).
+The business correlation-id from the `X-Correlation-Id` edge header rides the
+`my_cid` envelope tag through every hop and surfaces as the `cid` in the
+wrapper's app-log context and in the demo's terminal metadata. The wrapper's
+application log line and its telemetry record share the same `span_id`, which
+is what lets a log aggregation (or a stdout log-ingest agent) attach a
+function's own log output to the exact span of the distributed trace - the
+complete telemetry and app-context story from user to engine to wrapper and
+back, assembled entirely from the four runtimes' stdout logs.

--- a/draft-design-specs/async-http-client-sse-streaming.md
+++ b/draft-design-specs/async-http-client-sse-streaming.md
@@ -336,10 +336,156 @@ pin; Map/bytes/`\r`/reserved-name escape-hatch round-trips (exact types); eof tr
 metadata round-trip; mid-stream `fail()` propagation; server idle 408 through the chain;
 pool-dry 503; x-async and RPC pins unchanged; trailing-frame discard tolerance.
 
-## 8. Follow-ups staged (not this spec's scope)
+## 8. Phase 3 design — wrapper twins (RATIFIED by Eric 2026-08-30, incl. the reply_to revision)
 
-- Phase 3 detail round (wrapper host/writer twins; interop report round per
-  `conv-telemetry-presentation-parity`).
+The python/node language packs gain both halves of the dialect: their `/api/event`
+host answers streaming-capable calls with the envelope-mode SSE response (a wrapper
+FUNCTION streams to an engine caller), and their client consumes SSE (a wrapper
+function calls a remote streaming function). Everything stays inside the wrapper
+scope fence — codec + host + thin client; no orchestration.
+
+### W1 — reply_to in the primitive bus; interceptor handlers; engine-identical writer
+
+**Eric's revision (2026-08-30), replacing the contextvar proposal:** the wrappers'
+primitive event bus allows the **reply_to mechanism** — envelope-addressed delivery
+to a LOCAL route — so the producer paradigm is identical across all four runtimes:
+*the caller provides a reply address; the callee streams events to it until a
+terminal signal.* It is not orchestration — simple routing to a local function,
+exactly what the engines' in-memory bus does. reply_to never routes across the wire
+(cross-wire replies ride the SSE response, as on the engines). Consequences:
+
+- `@preload` gains the engines' **interceptor flavor**: an envelope-receiving
+  handler whose return value is not auto-replied — manual sends via reply_to.
+  Streaming producers and relay functions are interceptors, as on the engines.
+- `EventStreamWriter.from_request(event)` — the engines' exact producer API
+  (reads reply_to + cid from the incoming envelope; head control on the first
+  outgoing event; write / write_named / close(metadata) / fail; writes after
+  close dropped; the standard error triple on fail).
+- Per-request **inbox sinks** (generated local route names backed by queues, the
+  engines' AsyncInbox idea) give interceptor dispatch its reply addressing; the
+  single-process host needs no lane pool — a per-request sink IS the lane.
+- This unlocks the **relay composition** in wrappers: a streaming function
+  forwards its own reply_to into a call against a remote streaming peer, and
+  segments flow engine → wrapper → peer → back with zero buffering.
+
+### W2 — host dispatch (the EventApiService half)
+
+For a capable call (`Accept: text/event-stream`, not x-async) to an interceptor
+target, the host dispatches with reply_to = a per-request sink and classifies the
+first envelope exactly like the engines: unmarked → the classic single-shot
+response, byte-identical; marked → the envelope-mode SSE dialect (same frame
+rules; terminals then clean end; x-ttl ms as per-segment idle with the in-band
+408 triple; `event.stream.keep.alive` pings, same config key, default 30s).
+A NON-capable call whose first reply carries `x-event-stream` answers the pinned
+`406 Streaming function requires a caller that accepts text/event-stream` — the
+engines' exact detection mechanism. Non-interceptor targets keep today's
+future-based dispatch untouched. An uncaught handler exception after the head
+becomes an in-band exception frame (the host awaits the handler — a small
+wrapper-side improvement over engine interceptors).
+
+### W3 — client surface (the AsyncHttpClient half)
+
+- `po.stream(route, body, ...)` → an async iterator (`for await` on node) yielding
+  the SAME decoded envelopes an engine reply route receives — data segments then
+  the terminal; a non-streaming target yields its one classic reply (graceful
+  degradation). Local routes are supported through the same sink mechanics (a
+  dividend of W1's reply_to ruling — the earlier "local = error" proposal is
+  superseded).
+- `po.stream_to(route, body, reply_to=..., cid=...)` → the raw relay form for
+  composition: decoded envelopes forward verbatim to the named LOCAL route with
+  the given correlation id; awaits the terminal.
+- Conformance guards identical to the engines: missing envelope head / malformed
+  frame / transport end without a decoded terminal synthesize the pinned in-band
+  exception envelopes; per-read idle = x-ttl with the 408 triple; frames after a
+  decoded terminal are discarded.
+
+### W3a — business correlation-id parity (added at the interop verification, 2026-08-30)
+
+The continuity check surfaced the missing outbound half in the wrappers: they
+injected the `my_cid` tag as the read-only `my_correlation_id` header view at
+HTTP delivery but never re-stamped it on outbound calls, and local bus
+deliveries skipped the injection. Completed to full engine parity
+(`PostOffice.touch` / WorkerHandler): the trace context carries the business
+correlation-id (`get_trace()` / `trace_context(...)`; node `getTrace()` /
+`runWithTrace`, now exported), outbound client envelopes fill-stamp the
+`my_cid` tag from context, and local deliveries inject the header view exactly
+like the HTTP host. Pinned by two tests per wrapper; live-proven in the interop
+report's business-correlation-id section (both engine edges → python echo;
+wrapper ⇄ wrapper both directions).
+
+### W7 — wrapper span lineage (RATIFIED direction 2026-08-30; implemented same day)
+
+Eric's framing: for the AI SDLC, OpenTelemetry lineage is the observability
+substrate - *user → agent → MCP → tools*, "the lineage documents the graphs."
+Wrapper functions are exactly where the agent-orchestration adapters (LLM, MCP,
+tools) will live, so a span-less wrapper boundary would break the trace tree at
+its most important nodes. The wrappers therefore implement the engines' full
+span model rather than trace-id passthrough:
+
+- Every traced execution mints a 16-hex (W3C-shaped) span; the caller's span
+  (from the inbound envelope) is its parent. The trace context exposes
+  `span_id`/`parent_span_id` (python; camelCase on node), and
+  `trace_context()`/`runWithTrace()` accept a caller span so a batch edge can
+  parent onto an external OpenTelemetry span.
+- Outbound client events and EventStreamWriter segments carry the CURRENT
+  span (PostOffice.touch parity), which also lights the W3C `traceparent`
+  header the wrapper clients already stamped conditionally.
+- Non-RPC executions emit the engines' distributed-trace dataset record
+  (`{"trace": {...}, "annotations": {...}}`, Java-reference key set incl.
+  origin/start/exec_time/status/span_id/parent_span_id) on a
+  `distributed.tracing` logger; the wrapper log pipeline renders structured
+  messages as real JSON objects in json/compact mode and compact JSON in text
+  mode. The stdout log stream is the field-grade sink: log-ingest agents
+  (e.g. a Dynatrace stdout ingest agent) forward it to dashboards - per Eric,
+  often a better field solution than an OTLP forwarder; OTLP export from
+  wrappers stays out of the minimalist fence.
+- RPC round-trips emit no dataset (engine WorkerHandler parity): the wrapper
+  clients stamp the engines' `rpc` envelope tag on `request()` calls and the
+  bus suppresses the record for reply-future or rpc-tagged deliveries.
+- Live-proven three ways under single traces: Java relay span → python span
+  (parent = relay) → Java lane spans (parent = python span); python caller's
+  external span → engine event.api.auth/service parents; node execution
+  parented on a python caller's span. Interop report carries the evidence.
+- Known nuance: raw SSE token frames carry no envelope metadata, so their
+  engine-side delivery spans join the trace unparented (head/terminal parent
+  correctly via envelope frames) - see the §9 follow-up.
+- Sender attribution (Eric's review find): the hosts fill `from` with
+  `event.api.service` for an anonymous wire caller (the Java EventApiService's
+  touch fill), the trace context carries the executing route so onward calls
+  and stream segments attribute themselves, and bare local callers fall back
+  to the engines' `unknown`.
+- Application log context (Eric's follow-on gap): the app-log-context twin -
+  `app.log.context` on by default with a packaged `default-log-context.yaml`
+  (the engines' classpath-resource twin, not a code constant) carrying the
+  engines' template
+  (cid/traceId/tracePath/spanId/parentSpanId/service/timestamp), replaceable
+  via `resources/app-log-context.yaml` ($tokens + `${ENV:default}` constants,
+  invalid tokens fail fast), a `context` block on json/compact log lines
+  inside traced requests only, `update_context`/`updateContext` developer API
+  with reserved-key guard - so app logs and trace records correlate end to
+  end. Long-lived bus workers detach from the creating caller's context
+  (a leak the sample drives exposed).
+
+### W4–W6
+
+- **W4** — a sync-bridge `stream_sync` (blocking iterator for plain-`def` python
+  handlers) is DEFERRED to field demand; the async form covers the LLM-relay case.
+- **W5** — config: the same `event.stream.keep.alive` key (30s default, 0 off);
+  x-ttl stays milliseconds on the wire.
+- **W6** — conformance: wrapper suites against conforming and misbehaving mock
+  peers, then a live interop round against BOTH engines at ship (wrapper→engine
+  and engine→wrapper token streams), recorded in the interop report per
+  `conv-telemetry-presentation-parity`.
+
+Rollout: mercury-python first (the reference wrapper), mercury-nodejs as its twin,
+then the live interop round and the wrapper docs chapters.
+
+## 9. Follow-ups staged (not this spec's scope)
+
 - Event Script flow handoff (`model.http.*` reserved keys) — unchanged from the edge
   spec's v1.1 list.
 - graph-run streaming (bp-agent-orchestration).
+- Raw-frame lane parenting (optional polish, Java+Rust lock-step): the engines'
+  SSE-consuming client could remember the stream head's span id and stamp it on
+  the envelopes it rebuilds from RAW token frames, so per-token delivery spans
+  parent onto the producer like the head/terminal already do.

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/README.md
+++ b/examples/lambda-example/README.md
@@ -39,7 +39,7 @@ reply lane for the multi-shot response.
 Start the application:
 
 ```shell
-java -jar target/lambda-example-4.11.12.jar
+java -jar target/lambda-example-4.12.0.jar
 ```
 
 Then consume the endpoint with the companion script (Node.js 18+) that prints each
@@ -61,3 +61,30 @@ appear all at once when the stream ends.
 
 Optional query parameters: `delay` in milliseconds between messages (default 1000)
 and `count` for the number of messages (default 10), e.g. `/api/hello/sse?delay=500&count=5`.
+
+### Streaming from a remote function
+
+The companion endpoint `GET /api/hello/remote` demonstrates the engine-to-wrapper
+composition: its function ([HelloRemoteRelay.java](src/main/java/org/platformlambda/services/HelloRemoteRelay.java))
+forwards its reply lane into a send to the event-over-http mapped `hello.tokens`
+function - the streaming demo of the python or node.js function host - and the
+remote segments re-render progressively out this application's HTTP edge, with no
+imperative streaming code in between.
+
+Start a wrapper demo app (mercury-python's `mercury-serve examples/demo_app.py` on
+port 8086, or mercury-nodejs' demo on 8087 with `-Dpeer.demo.port=8087`), then run
+this application with the declarative routing map enabled:
+
+```shell
+java -Dyaml.event.over.http=classpath:/event-over-http.yaml -jar target/lambda-example-4.12.0.jar
+```
+
+and watch the remote function's tokens render one by one:
+
+```shell
+curl -N -H 'accept: text/event-stream' 'http://127.0.0.1:8085/api/hello/remote?delay=300&count=3'
+```
+
+The same `hello.sse` function is public, so the composition also runs the other way:
+a python or node.js function can consume this application's stream through
+`POST /api/event` - see the wrapper documentation sites' Event Streaming chapters.

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/HelloRemoteRelay.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/HelloRemoteRelay.java
@@ -1,0 +1,80 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.services;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.EventStreamWriter;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+
+/**
+ * The engine-to-wrapper streaming composition: this endpoint's function forwards
+ * its own reply lane and correlation id into a 'send' to the event-over-http mapped
+ * "hello.tokens" function - the python/node demo apps' streaming function - and
+ * opts in with the "accept: text/event-stream" event header. The remote segments
+ * relay through the peer's /api/event in envelope mode and re-render progressively
+ * out this application's HTTP edge, with no imperative streaming code in between.
+ * <p>
+ * Requires yaml.event.over.http=classpath:/event-over-http.yaml (see
+ * application.properties) and a running wrapper demo app - the README's
+ * "Streaming from a remote function" section walks through it.
+ */
+@PreLoad(route = "hello.remote.relay", instances = 10)
+@EventInterceptor
+public class HelloRemoteRelay implements TypedLambdaFunction<EventEnvelope, Void> {
+    private static final String REMOTE_ROUTE = "hello.tokens";
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        if (EventEmitter.getInstance().getEventHttpTarget(REMOTE_ROUTE) == null) {
+            // teaching failure: the demo depends on the declarative routing map
+            new EventStreamWriter(request).fail(new AppException(503,
+                    "Remote streaming demo is not configured - start a wrapper demo app and run " +
+                    "this application with -Dyaml.event.over.http=classpath:/event-over-http.yaml"));
+            return null;
+        }
+        AsyncHttpRequest http = new AsyncHttpRequest(request.getRawBody());
+        EventEnvelope forward = new EventEnvelope().setTo(REMOTE_ROUTE)
+                .setReplyTo(request.getReplyTo())
+                .setCorrelationId(request.getCorrelationId())
+                // the event-level opt-in for progressive streaming over Event-over-HTTP
+                .setHeader("accept", "text/event-stream")
+                // idle allowance between stream events on both hops (ms)
+                .setHeader("x-ttl", "30000");
+        String delay = http.getQueryParameter("delay");
+        if (delay != null) {
+            forward.setHeader("delay", delay);
+        }
+        String count = http.getQueryParameter("count");
+        if (count != null) {
+            forward.setHeader("count", count);
+        }
+        // a trace-aware PostOffice stamps the current trace onto the outbound
+        // event, so the distributed trace continues across the hop
+        new PostOffice(headers, instance).send(forward);
+        return null;
+    }
+}

--- a/examples/lambda-example/src/main/java/org/platformlambda/services/HelloSse.java
+++ b/examples/lambda-example/src/main/java/org/platformlambda/services/HelloSse.java
@@ -45,7 +45,10 @@ import java.util.Map;
  * Try it with the companion script: {@code node scripts/sse-client.mjs} or with
  * {@code curl -N -H 'accept: text/event-stream' http://127.0.0.1:8085/api/hello/sse}
  */
-@PreLoad(route = "hello.sse", instances = 10)
+// public so a peer application (an engine or a python/node function host) can
+// consume this stream through /api/event - the cross-runtime streaming demo,
+// the hello.declarative precedent
+@PreLoad(route = "hello.sse", instances = 10, isPrivate = false)
 @EventInterceptor
 public class HelloSse implements TypedLambdaFunction<EventEnvelope, Void> {
     private static final long DEFAULT_DELAY_MS = 1000;

--- a/examples/lambda-example/src/main/resources/event-over-http.yaml
+++ b/examples/lambda-example/src/main/resources/event-over-http.yaml
@@ -2,3 +2,8 @@ event:
   http:
     - route: 'hello.world'
       target: 'http://127.0.0.1:8086/api/event'
+    # the wrapper demo apps' streaming function (python demo-app defaults to
+    # port 8086, node demo-app to 8087) - point at another peer with
+    # -Dpeer.demo.host / -Dpeer.demo.port
+    - route: 'hello.tokens'
+      target: 'http://${peer.demo.host:127.0.0.1}:${peer.demo.port:8086}/api/event'

--- a/examples/lambda-example/src/main/resources/rest.yaml
+++ b/examples/lambda-example/src/main/resources/rest.yaml
@@ -93,6 +93,22 @@ rest:
     tracing: true
     stream: true
 
+  #
+  # The engine-to-wrapper streaming composition: the endpoint's function forwards
+  # its reply lane into a 'send' to the event-over-http mapped "hello.tokens"
+  # function (the python/node demo apps) - the remote segments re-render
+  # progressively out this application's HTTP edge. See HelloRemoteRelay.java
+  # and the README's "Streaming from a remote function" section.
+  #
+  - service: "hello.remote.relay"
+    methods: ['GET']
+    url: "/api/hello/remote?delay=_&count=_"
+    timeout: 30s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+    stream: true
+
   - service: "hello.upload"
     methods: ['POST']
     url: "/api/hello/upload"

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
     - Event Envelope Wire Format: guides/event-envelope-wire-format.md
     - Registration Metadata Contract: guides/registration-metadata-contract.md
     - Interop Test Report (Java ⇄ Rust): test-reports/event-over-http-interop.md
+    - Interop Test Report — Progressive Rendering: test-reports/progressive-rendering-interop.md
     - Interop Test Report — Suspend/Resume: test-reports/suspend-resume-interop.md
     - Reserved Names & Headers: guides/reserved-names-and-headers.md
     - Actuators & HTTP Client: guides/actuators-and-http-client.md

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -106,6 +106,7 @@
                     <include>arch-decisions/ADR.md</include>
                     <include>guides/**</include>
                     <include>test-reports/event-over-http-interop.md</include>
+                    <include>test-reports/progressive-rendering-interop.md</include>
                 </includes>
             </resource>
             <!-- The canonical rest.yaml fixture is owned by platform-core, where

--- a/system/ai-contract-provider/src/main/resources/skill/files.list
+++ b/system/ai-contract-provider/src/main/resources/skill/files.list
@@ -52,4 +52,5 @@ references/guides/sync-over-async.md
 references/guides/twin-kafka.md
 references/index.md
 references/test-reports/event-over-http-interop.md
+references/test-reports/progressive-rendering-interop.md
 security.json

--- a/system/ai-contract-provider/src/test/java/org/platformlambda/discovery/SkillSnapshotTest.java
+++ b/system/ai-contract-provider/src/test/java/org/platformlambda/discovery/SkillSnapshotTest.java
@@ -52,6 +52,7 @@ class SkillSnapshotTest {
         expected.add("references/index.md");
         expected.add("references/arch-decisions/ADR.md");
         expected.add("references/test-reports/event-over-http-interop.md");
+        expected.add("references/test-reports/progressive-rendering-interop.md");
         expected.add("references/fixtures/rest-bindings.yaml");
         try (var paths = Files.walk(docs.resolve("guides"))) {
             paths.filter(Files::isRegularFile).forEach(path ->

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.0</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.0</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

The v4.12.0 milestone release PR for the Java engine. It carries the release
version sweep (32 poms, CHANGELOG section for 8/30/2026) plus the closing
engine-side round of the progressive-rendering program:

- **Engine-to-wrapper streaming demo**: lambda-example gains
  `GET /api/hello/remote` (`hello.remote.relay`) - a `stream: true` endpoint
  whose interceptor forwards its caller's reply lane into the event-over-http
  mapped `hello.tokens` (the Python/Node.js demo apps' streaming function),
  rendering a remote peer's tokens progressively out this application's HTTP
  edge with zero imperative streaming code. The relay uses a trace-aware
  PostOffice, so the distributed trace and business correlation-id continue
  across the hop. `hello.sse` is now public for wrapper clients over
  `/api/event`.
- **Interop test report** (`docs/test-reports/progressive-rendering-interop.md`,
  packaged with the AI contract provider): the live ten-combination
  cross-runtime matrix (Java/Rust engines ⇄ Python/Node.js language packs),
  the OpenTelemetry span-lineage and business-correlation-id continuity
  verification, the ratified `/api/event` local-routes-only ruling, and an
  appendix with a captured end-to-end telemetry + application-log-context
  example joining the engine and wrapper records on one trace.
- **Spec**: the Phase-3 wrapper design record (W1–W7 - reply_to bus, host
  dispatch, client surface, business-cid parity, span lineage with the
  stdout-ingest telemetry story, app log context) and staged follow-ups.

## Why

Token/event streaming end to end - HTTP edge, HTTP client, and Event-over-HTTP
peers, now demonstrated engine-to-wrapper with full observability - is useful
on its own and is the foundation for the AI SDLC: agent, MCP and tool adapters
join as wrapper-side functions whose spans, business correlation and app-log
context document the run. The four repositories ship this milestone in
lock-step at v4.12.0.

## Verification

- Full reactor `mvn clean install` green at v4.12.0 (all module test suites,
  including the AI contract provider's packaged-documentation closure checks).
- mkdocs strict build clean.
- Live drives recorded in the interop report, executed with the shipped demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>