### PR TITLE
Route pool platform API - registerRoutePool/releaseRoutePool with SSE lane adoption

### DIFF
--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -22,6 +22,45 @@ in that ADR's own *Rationale* section.
 
 ---
 
+## ADR-0020 — Route pools: numbered singleton lanes as a first-class platform registration {#adr-0020}
+**Status:** Proposed · **Date:** 2026-08-30 · **Serves:** vision-mercury-composable · **Formalizes:** route-pool-registration-design
+<!-- id: adr-0020 | status: proposed -->
+
+**Abstract.** `Platform.registerRoutePool(prefix, lambda, count)` registers a set of
+private singleton routes `{prefix}.{n}` for n = 0 to count-1 and returns the member
+names in order; `releaseRoutePool(prefix)` removes the set symmetrically. Each member is
+a strict FIFO lane (instances=1, one shared stateless lambda), so a caller that checks
+out a lane gets per-conversation event ordering while other lanes serve concurrent
+traffic — the pattern the HTTP edge's SSE reply lanes (`async.http.response.stream.{n}`)
+introduced, promoted from an open-coded loop in AppStarter to a platform API with
+registry-level identity (a pool registry mapping prefix to lane count). Pools are always
+private: lane checkout is an in-process rendezvous, so advertising members to the
+service mesh would be meaningless. Registering an existing pool reloads it (the previous
+member set is released first, house reload semantics); individual register/release calls
+that touch a pool member are warned, never refused — range-checked, so a neighbor route
+such as `{prefix}.10` beside a count-3 pool is never misclassified. Pool mutations are
+atomic under a `ReentrantLock` (virtual-thread-friendly on Java 21).
+`getLocalRoutingTable()` is deliberately untouched: it remains the truthful live
+registry consumed by mesh route advertising and Spring autowiring; the compact pool
+rendering stays display-only in the actuator (`compressRouteFamilies`).
+
+**Rationale.** The v4.12.0 streaming milestone shipped the lane-pool pattern without an
+abstraction: 500 `registerPrivate` calls, no release counterpart, and no way for the
+platform to tell a pool from 500 coincidentally numbered routes; upcoming consumers
+(graph-run streaming, wrapper relay pools under the AI SDLC work) would each re-open-code
+it. Alternatives rejected: naming the API `registerStreams` (one character from the
+existing `registerStream(String, StreamFunction)` with entirely different semantics —
+and the abstraction is a pool of ordered lanes, not a stream); collapsing pool members
+inside `getLocalRoutingTable()` (the collapsed display key is not a valid route name,
+and the table has functional consumers — the Kafka mesh advertises from it, rest-spring-4
+autowires from it); an `isPrivate` flag (no remote use case exists, and the platform
+expresses privacy as method pairs, never booleans); renaming the lane family to
+`http.response.stream.{n}` (the lanes are sibling instances of `async.http.response` —
+renaming the child while the parent stays would split the `async.http.*` namespace
+family, and the name already shipped in traces, actuator views and docs).
+
+---
+
 ## ADR-0019 — The HTTP client consumes SSE progressively; Event-over-HTTP streams on the same call {#adr-0019}
 **Status:** Accepted · **Date:** 2026-08-29 · **Serves:** vision-mercury-composable · **Formalizes:** async-http-client-sse-streaming-design
 <!-- id: adr-0019 | status: accepted -->

--- a/docs/guides/api-overview.md
+++ b/docs/guides/api-overview.md
@@ -295,6 +295,29 @@ platform.release("another.function");
 
 The above API will unload the function from memory and release it from the "event loop".
 
+### Register a route pool
+
+When many concurrent conversations each need strict event ordering, register a
+"route pool" - a set of private singleton routes `{prefix}.{n}` sharing one stateless
+function. Each member runs exactly one worker, so it is a strict FIFO lane: an
+application checks out a lane for one conversation's lifetime to keep that
+conversation's events in order, while other conversations flow through their own lanes
+concurrently. This is the pattern behind the HTTP edge's SSE reply lanes
+(`async.http.response.stream.{n}`).
+
+```java
+// registers my.lane.0, my.lane.1, ... my.lane.4 - route pools are always private
+List<String> lanes = platform.registerRoutePool("my.lane", new MyLaneFunction(), 5);
+
+// releases all members and the pool itself
+platform.releaseRoutePool("my.lane");
+```
+
+The returned list contains the generated member routes in order, ready to seed your own
+checkout structure - lane checkout and return are your application's concern; the
+platform covers registration only. Registering an existing pool reloads it: the previous
+member set is released first.
+
 ### Check if a function is available
 
 You can check if a function with the named route has been deployed.

--- a/draft-design-specs/register-route-pool.md
+++ b/draft-design-specs/register-route-pool.md
@@ -1,0 +1,239 @@
+# registerRoutePool / releaseRoutePool — platform API for numbered singleton route pools — design spec
+
+**Status:** APPROVED — direction ratified by Eric 2026-08-30 (concept:
+`~/Desktop/register-streams.md`, same-day review round corrected the loose ends; **D1
+naming and D2 private-only explicitly ratified**; D3–D9 spec'd per the accepted
+review; **D10 ruled same day: KEEP `async.http.response.stream.{n}`**; D7 refined per
+Eric: `ReentrantLock`, not `synchronized`, for virtual-thread friendliness on Java 21
+and codebase consistency). **Same-day follow-up by Eric after implementation:**
+`registerPrivateStream` removed — `registerStream` is now private-only (a stream
+function's use case is always a private route; `ObjectStreamIO` updated), extending the
+pools' private-only philosophy to stream functions; the unused
+`ASYNC_HTTP_RESPONSE_STREAM_PREFIX` constant removed after the adoption. **Serves:** platform
+hygiene for the streaming lane pattern; the staged pool consumers (graph-run streaming,
+wrapper relay pools) live under `bp-agent-orchestration`. **Engine parity:** platform API
+surface → Java + Rust lock-step (Java is the reference,
+`conv-telemetry-presentation-parity`). Wrappers OUT of scope — they host no edge lane
+pool, and the wrapper scope fence keeps platform-registry surface off them.
+
+---
+
+## 1. Problem and driver
+
+The v4.12.0 progressive-rendering milestone introduced the SSE reply-lane pool: 500
+single-instance private routes `async.http.response.stream.{0..499}`, each a dedicated
+FIFO lane that a streaming request checks out for its lifetime. Registration is
+open-coded in `AppStarter.startServer` (AppStarter.java:587):
+
+```java
+var streamResponder = new AsyncHttpResponse(contexts);
+for (int lane = 0; lane < RESPONSE_HANDLER_INSTANCES; lane++) {
+    String laneRoute = AsyncHttpClient.ASYNC_HTTP_RESPONSE_STREAM_PREFIX + lane;
+    platform.registerPrivate(laneRoute, streamResponder, 1);
+    EventStreamRenderer.releaseLane(laneRoute);
+}
+```
+
+This works but is suboptimal:
+
+- The family has **no registry-level identity** — the platform cannot tell a pool from
+  500 coincidentally-named routes.
+- There is **no release counterpart** — acceptable for a process-lifetime edge pool,
+  wrong for a general facility (symmetric lifecycle).
+- The **next consumers would re-open-code it**: graph-run streaming and wrapper relay
+  pools (AI SDLC staged follow-ups) need the same order-preserving lane pattern.
+
+**What is NOT a problem** — already shipped in the streaming release and untouched by
+this spec: the `/info/routes` family compression (`ActuatorServices.compressRouteFamilies`,
+display-only by design) and the 10-minute `ManagedCache` view (`localRoutingCache`,
+ActuatorServices.java:42).
+
+## 2. The pattern being formalized
+
+A **route pool** is a set of numbered singleton routes `{prefix}.{n}` sharing one lambda
+instance. Each member has `instances=1`, so each lane is a strict FIFO mailbox; exclusive
+checkout of a lane gives a stream per-conversation ordering while unrelated streams run
+concurrently through their own lanes. Registration and checkout are separate concerns:
+this API owns registration only; checkout stays with the consumer
+(`EventStreamRenderer.LANE_POOL`, a LIFO `ConcurrentLinkedDeque` with
+`checkoutLane()`/`releaseLane()`).
+
+## 3. Decisions
+
+- **D1 (RATIFIED): names are `registerRoutePool` / `releaseRoutePool`.** The concept
+  name `registerStreams` is disqualified: `Platform.registerStream(String, StreamFunction)`
+  already exists for the `StreamFunction` API (with `registerPrivateStream`, until the
+  same-day follow-up collapsed the pair to a private-only `registerStream`) —
+  one character apart with entirely different semantics. The abstraction is a pool
+  of order-preserving lanes, not a stream; the codebase already says "pool-style route
+  families" (actuator javadoc) and "pool of dedicated single-instance reply lanes"
+  (AppStarter comment).
+
+- **D2 (RATIFIED): pools are private-only.** No `isPrivate` parameter. A checkout pool
+  is an in-process rendezvous — a remote peer cannot participate in local lane checkout,
+  so advertising members to the service mesh is meaningless. Private-only also removes
+  the mesh-advertising hazard (see D3) at the root, and sidesteps the style mismatch (the
+  platform API expresses privacy as method pairs, never a boolean). If a public use case
+  ever materializes, add it then.
+
+- **D3: `getLocalRoutingTable()` is UNTOUCHED** — a correctness constraint, not a
+  preference. It returns the live registry (Platform.java:371) and has functional
+  consumers: `ServiceRegistry.registerMyRoutes()` advertises every non-private entry to
+  the Kafka mesh (ServiceRegistry.java:444), and rest-spring-4's `AppLoader` autowires
+  every registered function from `.values()` (AppLoader.java:60). A collapsed display key
+  such as `"x.0 - 499"` is not even a valid route name (`validServiceName` rejects
+  spaces) and must never appear in the routing table. The collapse stays
+  presentation-only in `ActuatorServices` where it shipped.
+
+- **D4: numbering is 0-based** — `{prefix}.0 … {prefix}.{count-1}`, matching the shipped
+  lanes. Adopting the API for the existing pool is then observationally invisible: same
+  trace `service` names, same `/info/routes` display (`async.http.response.stream.0 - 499`),
+  no test churn.
+
+- **D5: re-registration follows the house RELOAD convention.** `register()` on an
+  existing route releases-then-replaces with a warning; `registerRoutePool` on an
+  existing prefix does the same for the whole member set — release all old members,
+  register the new set — which cleanly handles a count change. WARN log, never a refusal.
+
+- **D6: integrity guards live at mutation time, not read time.** The concept's
+  first/last-member sampling misses holes (a single `release("{prefix}.2")` in a count=3
+  pool passes unseen). Instead: `register()` and `release()` log a WARN when their target
+  route is a member of a registered pool (never refuse — the house never refuses
+  reloads). Membership is range-checked: a route is a member iff its prefix is in the
+  pool registry AND its last segment is canonical digits (no leading zeros) AND
+  `0 <= n < count` — so a user route `{prefix}.10` beside a count=3 pool is NOT a member.
+
+- **D7: pool mutations are atomic** under a private `ReentrantLock` (Eric's refinement:
+  on Java 21 a `synchronized` block still pins a virtual-thread carrier, and the codebase
+  already standardizes on `ReentrantLock`; startup-time operations, contention is nil).
+  `releaseRoutePool` removes the pool-registry entry FIRST, then
+  releases members — so its own internal `release()` calls never trigger the D6 warning,
+  and a concurrent actuator read sees at worst a transient plain-route view (benign:
+  the display heuristic renders irregular families individually, no ERROR spam).
+
+- **D8: display and cache are unchanged in v1.** `compressRouteFamilies` already renders
+  pools correctly (contiguous + uniform-concurrency guards) and is display-only; wiring
+  the pool registry into the display for exactness is a possible later refinement, only
+  if a false-positive collapse of a user family ever bites in practice. The
+  `localRoutingCache` 10-minute TTL already accepts staleness across ALL register/release
+  mutations — pool operations add nothing new, so no invalidation hook.
+
+- **D9: `registerRoutePool` returns the ordered member route list** (`List<String>`).
+  Callers (checkout pools) need the generated names to seed their structures; returning
+  them avoids duplicated name derivation and makes the naming contract explicit.
+  `releaseRoutePool` returns `boolean` like `release()` (true when the pool existed).
+
+- **D10 (RATIFIED 2026-08-30): KEEP `async.http.response.stream.{n}`** — the rename to
+  `http.response.stream.{n}` is rejected. The `async` prefix is the namespace family of
+  the HTTP edge (`async.http.request`, `async.http.response`), and the lanes are
+  literally sibling instances of `async.http.response` (same `AsyncHttpResponse` class,
+  pool sized to its instances) — renaming the child while the parent stays would split a
+  family that sorts, greps, and reads together. The name also shipped in v4.12.0 across
+  trace datasets (lane spans' `service`/`from`), `/info/routes`, both engines' docs, and
+  the interop report in all four repos.
+
+## 4. API specification
+
+```java
+/**
+ * Register a pool of private singleton routes "{prefix}.{n}" for n = 0 to count-1.
+ * Each member has instances=1 (a strict FIFO lane). One lambda instance is shared
+ * across all members - the function must be stateless, the same contract as any
+ * multi-instance function. Registering an existing pool RELOADS it: the previous
+ * member set is released first (house reload semantics, with a warning).
+ *
+ * Registration only - lane checkout/return is the caller's concern.
+ *
+ * @param prefix route-name base, e.g. "async.http.response.stream" (no trailing dot)
+ * @param lambda the shared TypedLambdaFunction
+ * @param count  number of lanes, must be >= 1
+ * @return the generated member routes in order ({prefix}.0 ... {prefix}.{count-1})
+ * @throws IllegalArgumentException for null lambda, count < 1, or an invalid name
+ */
+public List<String> registerRoutePool(String prefix, TypedLambdaFunction<?, ?> lambda, int count);
+
+/**
+ * Release a route pool: removes all members and the pool's registry entry.
+ *
+ * @param prefix the pool's route-name base
+ * @return true if the pool existed and was released
+ */
+public boolean releaseRoutePool(String prefix);
+```
+
+Validation: each member name goes through the existing `getValidatedRoute` (so the
+prefix must be composed of `0-9 a-z . - _` and contain a dot); member registration is
+identical to `registerPrivate(member, lambda, 1)`. Idle-lane cost is a `ServiceQueue`
+plus an empty mailbox — small, per the 500-lane precedent; no hard cap on `count`.
+
+## 5. Registry model
+
+```java
+// prefix -> count; lifecycle metadata only - never consulted for routing
+private static final ConcurrentMap<String, Integer> poolRegistry = new ConcurrentHashMap<>();
+private static final ReentrantLock poolLock = new ReentrantLock();
+```
+
+- `registerRoutePool`: under `poolLock` — if `poolRegistry` has the prefix, release the
+  old member set (WARN "Reloading route pool ..."); register `count` members via the
+  private register path; put the prefix/count entry; return the member list.
+- `releaseRoutePool`: under `poolLock` — remove the entry first (D7), then `release()`
+  each former member; return whether the entry existed.
+- Membership helper (for the D6 guards in `register()`/`release()`): prefix =
+  `route.substring(0, route.lastIndexOf('.'))`, suffix must be canonical digits and
+  within `[0, count)` for a registered prefix.
+
+## 6. Adoption — refactor the shipped SSE lane pool
+
+`AppStarter.startServer` (AppStarter.java:587) becomes:
+
+```java
+var streamResponder = new AsyncHttpResponse(contexts);
+platform.registerRoutePool("async.http.response.stream", streamResponder,
+                           RESPONSE_HANDLER_INSTANCES)
+        .forEach(EventStreamRenderer::releaseLane);
+```
+
+`AsyncHttpClient` keeps `ASYNC_HTTP_RESPONSE_STREAM_POOL` (the un-dotted pool name); the
+old dotted `ASYNC_HTTP_RESPONSE_STREAM_PREFIX` constant had no remaining consumer after
+the adoption and was removed. Behavior-identical by construction: same names, same
+0-based numbering, same display, same trace datasets.
+
+## 7. Out of scope / non-goals
+
+- **Checkout mechanics** — stay in `EventStreamRenderer`. If a second consumer wants the
+  checkout half, consider promoting the LIFO deque into a pool handle then; do not block
+  this round on it.
+- **Public pools** (D2) — add only when a concrete case appears.
+- **`getLocalRoutingTable()` changes** (D3) — permanent non-goal.
+- **Actuator display / cache changes** (D8).
+- **Wrapper repos** — no lane pools; scope fence.
+
+## 8. Test plan
+
+New platform-core unit tests:
+
+- register creates exactly `{prefix}.0..{count-1}`, all private, `hasRoute` true; the
+  returned list is ordered and matches.
+- release removes all members and the registry entry; returns false when absent.
+- reload with a different count leaves exactly the new set (no orphans either way).
+- `count < 1`, null lambda, invalid prefix → `IllegalArgumentException`.
+- single `release()` of a member logs the D6 warning; a later `releaseRoutePool` still
+  cleans the remainder.
+- `register()` over a member logs the D6 warning (and reloads, house semantics).
+- a user route `{prefix}.10` beside a count=3 pool is untouched by pool release and
+  triggers no member warning.
+
+Regression: `RegistrationVectorsTest` and `AdminEndpointTest` unchanged — the
+`/info/routes` display entry stays byte-identical (`async.http.response.stream.0 - 499`);
+full platform-core suite green.
+
+## 9. Rollout
+
+1. Java first (reference implementation): `Platform` API + guards + AppStarter adoption
+   + tests.
+2. Rust twin in the same round: `register_route_pool` / `release_route_pool` on the
+   Platform twin, adoption at the lane registration in `server.rs`, twin tests.
+3. Docs: developer-guide platform API section gains the two methods (both engines).
+   Interop report untouched.
+4. Propose an ADR at implementation time (durable platform API addition; human-gated).

--- a/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/http/AsyncHttpClient.java
@@ -68,11 +68,11 @@ import java.util.concurrent.locks.ReentrantLock;
 public class AsyncHttpClient implements TypedLambdaFunction<EventEnvelope, Void> {
     public static final String ASYNC_HTTP_REQUEST = "async.http.request";
     public static final String ASYNC_HTTP_RESPONSE = "async.http.response";
-    // ordered reply-lane family for streaming responses: a pool of single-instance lanes
-    // (async.http.response.stream.{n}) - a streaming request checks out one dedicated
+    // ordered reply-lane family for streaming responses: a route pool of single-instance
+    // lanes (async.http.response.stream.{n}) - a streaming request checks out one dedicated
     // lane for its lifetime, so its segment order is guaranteed while different
     // requests stream concurrently through their own lanes
-    public static final String ASYNC_HTTP_RESPONSE_STREAM_PREFIX = "async.http.response.stream.";
+    public static final String ASYNC_HTTP_RESPONSE_STREAM_POOL = "async.http.response.stream";
     private static final Logger log = LoggerFactory.getLogger(AsyncHttpClient.class);
     private static final AtomicBoolean loaded = new AtomicBoolean(false);
     private static final long HOUSEKEEPING_INTERVAL = 30 * 1000L;    // 30 seconds

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/AppStarter.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/AppStarter.java
@@ -580,16 +580,13 @@ public class AppStarter {
             EventEmitter.getInstance().send(startupMonitor, "ready");
             platform.registerPrivate(AsyncHttpClient.ASYNC_HTTP_RESPONSE, new AsyncHttpResponse(contexts),
                                      RESPONSE_HANDLER_INSTANCES);
-            // streaming responses use a pool of dedicated single-instance reply lanes:
+            // streaming responses use a route pool of dedicated single-instance reply lanes:
             // a streaming request checks out one lane for its lifetime (strict FIFO for its
             // segments) and returns it when its context closes; the pool size matches the
             // async.http.response instances, and an idle lane costs only a little memory
-            var streamResponder = new AsyncHttpResponse(contexts);
-            for (int lane = 0; lane < RESPONSE_HANDLER_INSTANCES; lane++) {
-                String laneRoute = AsyncHttpClient.ASYNC_HTTP_RESPONSE_STREAM_PREFIX + lane;
-                platform.registerPrivate(laneRoute, streamResponder, 1);
-                EventStreamRenderer.releaseLane(laneRoute);
-            }
+            platform.registerRoutePool(AsyncHttpClient.ASYNC_HTTP_RESPONSE_STREAM_POOL,
+                            new AsyncHttpResponse(contexts), RESPONSE_HANDLER_INSTANCES)
+                    .forEach(EventStreamRenderer::releaseLane);
             // start timeout handler
             Housekeeper housekeeper = new Housekeeper(contexts);
             platform.getVertx().setPeriodic(HOUSEKEEPING_INTERVAL,

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/ObjectStreamIO.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/ObjectStreamIO.java
@@ -102,7 +102,7 @@ public class ObjectStreamIO {
         StreamConsumer consumer = new StreamConsumer(publisher, in, out);
         platform.registerPrivate(in, consumer, 1);
         streams.put(in, new StreamInfo(expirySeconds));
-        platform.registerPrivateStream(out, publisher);
+        platform.registerStream(out, publisher);
         String timer = util.elapsedTime(expirySeconds * 1000L);
         log.debug("Stream {} created, idle expiry {}", id, timer);
     }
@@ -270,13 +270,5 @@ public class ObjectStreamIO {
         }
     }
 
-    private static class CallBackReference {
-        final String cb;
-        final String cid;
-
-        public CallBackReference(String cb, String cid) {
-            this.cb = cb;
-            this.cid = cid;
-        }
-    }
+    private record CallBackReference(String cb, String cid) { }
 }

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -60,6 +60,9 @@ public class Platform {
     private static final AtomicBoolean LOADED = new AtomicBoolean(false);
     private static final ReentrantLock SAFETY1 = new ReentrantLock();
     private static final ReentrantLock SAFETY2 = new ReentrantLock();
+    // route pools (prefix -> lane count): lifecycle metadata only, never consulted for routing
+    private static final ConcurrentMap<String, Integer> poolRegistry = new ConcurrentHashMap<>();
+    private static final ReentrantLock POOL_LOCK = new ReentrantLock();
     private static String originId;
     private static String appId;
     private static Vertx vertx;
@@ -558,6 +561,7 @@ public class Platform {
             throw new IllegalArgumentException("Missing LambdaFunction instance");
         }
         String path = getValidatedRoute(route);
+        warnIfPoolMember("Registering", path);
         if (registry.containsKey(path)) {
             log.warn("{} LambdaFunction {}", RELOADING, path);
             release(path);
@@ -573,43 +577,131 @@ public class Platform {
     }
 
     /**
-     * Register a public stream function
-     *
-     * @param route name of the service
-     * @param lambda function
-     * @throws IllegalArgumentException if the route name is invalid
-     */
-    public void registerStream(String route, StreamFunction lambda) {
-        registerStream(route, lambda, false);
-    }
-
-    /**
      * Register a private stream function
      *
      * @param route name of the service
      * @param lambda function
      * @throws IllegalArgumentException if the route name is invalid
      */
-    public void registerPrivateStream(String route, StreamFunction lambda) {
-        registerStream(route, lambda, true);
-    }
-
-    private void registerStream(String route, StreamFunction lambda, boolean isPrivate) {
+    public void registerStream(String route, StreamFunction lambda) {
         if (lambda == null) {
             throw new IllegalArgumentException("Missing StreamFunction instance");
         }
         String path = getValidatedRoute(route);
+        warnIfPoolMember("Registering", path);
         if (registry.containsKey(path)) {
             log.warn("{} StreamFunction {}", RELOADING, path);
             release(path);
         }
-        ServiceDef service = new ServiceDef(path, lambda).setConcurrency(1).setPrivate(isPrivate);
+        ServiceDef service = new ServiceDef(path, lambda).setConcurrency(1).setPrivate(true);
         ServiceQueue manager = new ServiceQueue(service);
         service.setManager(manager);
         registry.put(path, service);
-        if (!isPrivate) {
-            advertiseRoute(route);
+    }
+
+    /**
+     * Register a route pool - a set of private singleton routes "{prefix}.{n}" for n = 0 to count-1.
+     * Each member runs with instances=1 so it is a strict FIFO lane; a caller may check out a lane
+     * for exclusive use to preserve event order while other lanes serve concurrent traffic.
+     * One lambda instance is shared across all members - the function must be stateless,
+     * the same contract as a multi-instance function.
+     * <p>
+     * Registering an existing pool RELOADS it: the previous member set is released first,
+     * with a warning in the application log. This API covers registration only -
+     * lane checkout and return are the caller's concern. Route pools are always private.
+     *
+     * @param prefix route name base in canonical form, e.g. "async.http.response.stream"
+     * @param lambda function shared by all members of the pool
+     * @param count number of lanes, at least 1
+     * @return the generated member routes in order
+     * @throws IllegalArgumentException for missing lambda, count less than 1 or an invalid prefix
+     */
+    public List<String> registerRoutePool(String prefix, TypedLambdaFunction<?, ?> lambda, int count) {
+        if (lambda == null) {
+            throw new IllegalArgumentException("Missing LambdaFunction instance");
         }
+        if (count < 1) {
+            throw new IllegalArgumentException("Route pool count must be at least 1");
+        }
+        // the prefix must be canonical so the generated names are exactly "{prefix}.{n}" -
+        // silent name filtering would break the returned member-list contract
+        String probe = prefix + ".0";
+        if (!probe.equals(getValidatedRoute(probe))) {
+            throw new IllegalArgumentException(INVALID_ROUTE + prefix + " - route pool prefix must be canonical");
+        }
+        POOL_LOCK.lock();
+        try {
+            Integer previous = poolRegistry.remove(prefix);
+            if (previous != null) {
+                log.warn("{} route pool {} ({} -> {} lanes)", RELOADING, prefix, previous, count);
+                releasePoolMembers(prefix, previous);
+            }
+            List<String> members = new ArrayList<>(count);
+            for (int n = 0; n < count; n++) {
+                String member = prefix + "." + n;
+                register(member, lambda, true, 1);
+                members.add(member);
+            }
+            poolRegistry.put(prefix, count);
+            return members;
+        } finally {
+            POOL_LOCK.unlock();
+        }
+    }
+
+    /**
+     * Release a route pool - removes all its members and the pool itself
+     *
+     * @param prefix route name base of the pool
+     * @return true if the pool existed and was released
+     */
+    public boolean releaseRoutePool(String prefix) {
+        POOL_LOCK.lock();
+        try {
+            // remove the pool entry first so the member release calls below are not
+            // reported as individual updates to an active pool
+            Integer count = poolRegistry.remove(prefix);
+            if (count == null) {
+                return false;
+            }
+            releasePoolMembers(prefix, count);
+            return true;
+        } finally {
+            POOL_LOCK.unlock();
+        }
+    }
+
+    private void releasePoolMembers(String prefix, int count) {
+        for (int n = 0; n < count; n++) {
+            release(prefix + "." + n);
+        }
+    }
+
+    private void warnIfPoolMember(String action, String route) {
+        String pool = getPoolOf(route);
+        if (pool != null) {
+            log.warn("{} {} which belongs to route pool {}", action, route, pool);
+        }
+    }
+
+    private String getPoolOf(String route) {
+        int dot = route.lastIndexOf('.');
+        if (dot > 0) {
+            String prefix = route.substring(0, dot);
+            Integer count = poolRegistry.get(prefix);
+            if (count != null) {
+                String suffix = route.substring(dot + 1);
+                // a member's suffix is canonical digits (no leading zeros) within the pool's range
+                if (!suffix.isEmpty() && suffix.length() < 10 &&
+                        suffix.chars().allMatch(Character::isDigit)) {
+                    int n = Utility.getInstance().str2int(suffix);
+                    if (suffix.equals(String.valueOf(n)) && n < count) {
+                        return prefix;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private String getValidatedRoute(String route) {
@@ -658,6 +750,7 @@ public class Platform {
      */
     public boolean release(String route) {
         if (route != null && registry.containsKey(route)) {
+            warnIfPoolMember("Releasing", route);
             ServiceDef def = registry.get(route);
             if (!def.isPrivate()) {
                 TargetRoute cloud = EventEmitter.getInstance().getCloudRoute();

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -577,7 +577,11 @@ public class Platform {
     }
 
     /**
-     * Register a private stream function
+     * Register a private stream function - this is used exclusively by the ObjectStreamIO module
+     * to publish a stream of objects (String, bytes or Map). Each object is stored in a queue
+     * that a consumer will reactively pull the next available object.<p>
+     *
+     * See StreamPublisher and StreamConsumer in ObjectStreamIO for the reactive mechanism.
      *
      * @param route name of the service
      * @param lambda function

--- a/system/platform-core/src/test/java/org/platformlambda/core/RoutePoolTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/RoutePoolTest.java
@@ -1,0 +1,140 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.core;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.common.TestBase;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.Platform;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.system.ServiceDef;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavior of the route pool registration API (registerRoutePool / releaseRoutePool):
+ * ordered private singleton members, symmetric release, house reload semantics on
+ * re-registration, and tolerance of individual updates to pool members.
+ * See draft-design-specs/register-route-pool.md.
+ */
+class RoutePoolTest extends TestBase {
+
+    private static final LambdaFunction ECHO = (headers, input, instance) -> input;
+
+    @Test
+    void registersOrderedPrivateSingletonMembers() throws InterruptedException, ExecutionException {
+        Platform platform = Platform.getInstance();
+        List<String> members = platform.registerRoutePool("unit.test.pool.a", ECHO, 3);
+        try {
+            assertEquals(List.of("unit.test.pool.a.0", "unit.test.pool.a.1", "unit.test.pool.a.2"), members);
+            for (String member : members) {
+                assertTrue(platform.hasRoute(member), member + " must be registered");
+                ServiceDef def = platform.getLocalRoutingTable().get(member);
+                assertNotNull(def, member + " must be in the routing table");
+                assertTrue(def.isPrivate(), member + " must be private");
+                assertEquals(1, def.getConcurrency(), member + " must be a singleton lane");
+            }
+            // a lane is a normal function - prove liveness with one RPC
+            PostOffice po = new PostOffice("unit.test", "100", "TEST /route/pool");
+            EventEnvelope response = po.request(new EventEnvelope()
+                    .setTo(members.getFirst()).setBody("hello"), 5000).get();
+            assertEquals("hello", response.getBody());
+        } finally {
+            assertTrue(platform.releaseRoutePool("unit.test.pool.a"));
+        }
+        for (String member : members) {
+            assertFalse(platform.hasRoute(member), member + " must be gone after pool release");
+        }
+    }
+
+    @Test
+    void releaseIsSymmetricAndAbsentPoolReturnsFalse() {
+        Platform platform = Platform.getInstance();
+        assertFalse(platform.releaseRoutePool("unit.test.no.such.pool"));
+        platform.registerRoutePool("unit.test.pool.b", ECHO, 2);
+        assertTrue(platform.releaseRoutePool("unit.test.pool.b"));
+        assertFalse(platform.releaseRoutePool("unit.test.pool.b"));
+        assertFalse(platform.hasRoute("unit.test.pool.b.0"));
+        assertFalse(platform.hasRoute("unit.test.pool.b.1"));
+    }
+
+    @Test
+    void reRegistrationReloadsToExactlyTheNewSet() {
+        Platform platform = Platform.getInstance();
+        platform.registerRoutePool("unit.test.pool.c", ECHO, 5);
+        try {
+            List<String> members = platform.registerRoutePool("unit.test.pool.c", ECHO, 3);
+            assertEquals(3, members.size());
+            assertTrue(platform.hasRoute("unit.test.pool.c.2"));
+            // the reload must not leave orphans beyond the new count
+            assertFalse(platform.hasRoute("unit.test.pool.c.3"));
+            assertFalse(platform.hasRoute("unit.test.pool.c.4"));
+        } finally {
+            assertTrue(platform.releaseRoutePool("unit.test.pool.c"));
+        }
+    }
+
+    @Test
+    void invalidArgumentsAreRejected() {
+        Platform platform = Platform.getInstance();
+        assertThrows(IllegalArgumentException.class, () ->
+                platform.registerRoutePool("unit.test.pool.d", null, 1));
+        assertThrows(IllegalArgumentException.class, () ->
+                platform.registerRoutePool("unit.test.pool.d", ECHO, 0));
+        // non-canonical prefixes are rejected so member names are exactly "{prefix}.{n}"
+        assertThrows(IllegalArgumentException.class, () ->
+                platform.registerRoutePool("Unit.Test.Pool", ECHO, 1));
+        assertFalse(platform.hasRoute("unit.test.pool.d.0"));
+    }
+
+    @Test
+    void individualUpdatesToMembersAreToleratedAndCleanedUp() {
+        Platform platform = Platform.getInstance();
+        platform.registerRoutePool("unit.test.pool.e", ECHO, 3);
+        // an individual release of a member is warned, never refused (house semantics)
+        assertTrue(platform.release("unit.test.pool.e.1"));
+        assertFalse(platform.hasRoute("unit.test.pool.e.1"));
+        // an individual re-registration over a member reloads it, also warned
+        platform.registerPrivate("unit.test.pool.e.2", ECHO, 1);
+        assertTrue(platform.hasRoute("unit.test.pool.e.2"));
+        // pool release still cleans the remainder, holes included
+        assertTrue(platform.releaseRoutePool("unit.test.pool.e"));
+        assertFalse(platform.hasRoute("unit.test.pool.e.0"));
+        assertFalse(platform.hasRoute("unit.test.pool.e.2"));
+    }
+
+    @Test
+    void neighborRoutesOutsideThePoolRangeAreUntouched() {
+        Platform platform = Platform.getInstance();
+        platform.registerPrivate("unit.test.pool.f.10", ECHO, 1);
+        platform.registerRoutePool("unit.test.pool.f", ECHO, 3);
+        assertTrue(platform.releaseRoutePool("unit.test.pool.f"));
+        // "{prefix}.10" is outside the pool's range [0, 3) and is not a member
+        assertTrue(platform.hasRoute("unit.test.pool.f.10"));
+        assertTrue(platform.release("unit.test.pool.f.10"));
+    }
+}


### PR DESCRIPTION
## What

- New `Platform` API: `registerRoutePool(prefix, lambda, count)` registers private singleton routes `{prefix}.0..{count-1}` (strict FIFO lanes sharing one stateless function) and returns the ordered member list; `releaseRoutePool(prefix)` removes the set symmetrically. Pool mutations are atomic under a `ReentrantLock`; re-registering a pool follows the house reload semantics (previous member set released first).
- Integrity guards: individual `register` / `registerStream` / `release` calls that touch a pool member log a warning, never refuse - range-checked, so a neighbor route such as `{prefix}.10` beside a count-3 pool is never misclassified.
- Adoption: the HTTP edge's 500-lane SSE reply pool (`async.http.response.stream.{n}`) now registers through the new API - behavior-identical (same names, 0-based numbering, `/info/routes` display byte-identical).
- Follow-up simplifications: `registerStream` is now private-only and `registerPrivateStream` is removed (a stream function's use case is always a private route; its javadoc now documents it as the ObjectStreamIO publishing mechanism - StreamPublisher/StreamConsumer with reactive pull); `ObjectStreamIO` updated and its `CallBackReference` converted to a record; the unused `ASYNC_HTTP_RESPONSE_STREAM_PREFIX` constant removed.
- Docs: "Register a route pool" section in the Platform API guide; ADR-0020 (Proposed); design spec `draft-design-specs/register-route-pool.md` (D1-D10 approved 2026-08-30).

## Why

The v4.12.0 streaming milestone shipped the lane-pool pattern open-coded in AppStarter: 500 `registerPrivate` calls, no release counterpart, and no way for the platform to tell a pool from 500 coincidentally numbered routes. Upcoming consumers (graph-run streaming, wrapper relay pools under the AI SDLC work) would each re-open-code it. This promotes the pattern to a first-class, symmetric platform registration - while `getLocalRoutingTable()` stays deliberately untouched (it is the truthful live registry consumed by the Kafka mesh's route advertising and rest-spring-4's Spring autowiring) and the compact pool rendering stays display-only in the actuator.

Release-notes note: `registerStream` semantics changed from public to private-only (minor breaking; `ObjectStreamIO` was the only in-tree caller and always used the private variant).

## Validation

- New `RoutePoolTest` 6/6: ordered private singleton members + a live RPC through a lane, symmetric release, reload leaves no orphans, invalid arguments, tolerated individual member updates, out-of-range neighbor untouched
- Regression pins: `RegistrationVectorsTest`, `AdminEndpointTest` (display entry `async.http.response.stream.0 - 499` unchanged)
- platform-core suite 479/479; full reactor `BUILD SUCCESS`; `mkdocs build --strict` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>