### PR TITLE
Agent orchestration E0 - bounded-agency triage graph, AI-token streaming demo, reply-lane rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    range-checked integrity warnings for individual member updates. The HTTP edge's
    SSE reply-lane pool now registers through it (ADR-0020; lock-step with the Rust
    engine).
+2. `support-triage` demo graph in examples/minigraph-playground - the bounded-agency
+   AI-node pattern (agent-orchestration experiment E0): the LLM node is `llm.chat`, a
+   python wrapper-side function reached through declarative Event-over-HTTP; the graph
+   classifies a user request with a schema-constrained verdict and routes among
+   enumerated branches. Zero engine change - the engine stays LLM-free.
+3. `POST /api/llm/stream` demo endpoint in examples/minigraph-playground - the AI-token
+   streaming composition (E0 follow-up): a relay function forwards its reply lane into
+   the event-over-http mapped `llm.stream` AI node (python demo app pulling the
+   provider's REAL token stream), and the token batches re-render progressively out the
+   engine's HTTP edge as SSE. Live-proven with Gemini: 25+ timestamped token batches
+   over a ~2s generation, one distributed trace across both processes. Zero engine
+   change.
 
 ### Changed
 
@@ -28,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 2. The unused constant `AsyncHttpClient.ASYNC_HTTP_RESPONSE_STREAM_PREFIX` is
    removed; `ASYNC_HTTP_RESPONSE_STREAM_POOL` (the un-dotted pool base) replaces it.
    Lane route names on the wire and in telemetry are unchanged.
+3. Streaming reply-lane checkout now rotates through the pool (FIFO round-robin)
+   instead of re-picking the most recently released lane (LIFO): the first stream
+   takes `async.http.response.stream.0`, the next `.1`, and so on, with a released
+   lane rejoining at the tail - predictable lane selection in telemetry and maximal
+   rest before a lane is reused (lock-step with the Rust engine).
 
 ---
 ## Version 4.12.0, 8/30/2026

--- a/docs/arch-decisions/ADR.md
+++ b/docs/arch-decisions/ADR.md
@@ -118,9 +118,11 @@ Events framing when the content type is `text/event-stream` (typed events, a ter
 chunked transfer with JSON Lines otherwise. A streaming endpoint is declared with
 `stream: true` in rest.yaml, which checks out a dedicated ordered reply lane for the
 request's lifetime — a single-instance route (`async.http.response.stream.{n}`) drawn
-LIFO from a pool of 500 (the `async.http.response` concurrency), returned when the
-request context closes — the "ready" signal pattern of the reactive manager/worker
-design. All segments of one request ride its own lane (strict FIFO) while different
+in FIFO rotation from a pool of 500 (the `async.http.response` concurrency; refined
+2026-08-31 from the original LIFO stack so consecutive requests take successive lanes
+and a released lane, rejoining at the tail, rests longest before reuse), returned when
+the request context closes — a rotating variant of the "ready" signal pattern of the
+reactive manager/worker design. All segments of one request ride its own lane (strict FIFO) while different
 requests stream concurrently through their own lanes; an exhausted pool rejects further
 streaming requests immediately with HTTP-503 (deterministic back-pressure, no
 configuration knob). The first event commits the response head; each

--- a/draft-design-specs/ai-agent-orchestration.md
+++ b/draft-design-specs/ai-agent-orchestration.md
@@ -54,9 +54,11 @@ substituted for "system".
 
 **Evidence discipline (honest-evidence rule):** flows → python function is proven live
 (2026-08-22 flagship drive, my_correlation_id + engine trace_id in the python log).
-graph.task → wrapper function is pinned by engine tests on both engines (v4.11.11,
-unit-test-task-7) but has **no live drive yet** — E0 below produces the first one. No
-LLM or MCP call has run through Mercury yet; that is what the experiments are for.
+graph.task → wrapper function: the first LIVE drive ran 2026-08-30 (E0 below — the
+support-triage graph's classify node reached llm.chat on the python demo app through
+declarative Event-over-HTTP, one unbroken trace across both processes). The first live
+LLM calls through Mercury ran the same day (Gemini; the Anthropic re-drive follows the
+org API key). MCP has not run yet — that is what E2 is for.
 Nothing in this section may be claimed in public docs beyond what has actually run.
 
 ## 3. Architecture concept
@@ -172,6 +174,16 @@ every agent's toolbox — governed in both directions.
   to the REST edge needs design — Q8), token/usage accounting, structured-output
   enforcement, provider neutrality/pluggability, rate-limit retry semantics vs the
   graph's own retry handlers (avoid double-retry).
+  **Enterprise-access requirement (field constraint, 2026-08-30):** enterprise security
+  policies commonly forbid direct vendor API keys — provider access must ride the cloud
+  platforms (AWS Bedrock for Claude models, Google Vertex, Azure AI Foundry) with the
+  platform's own credential chain (AWS credentials / GCP ADC / Entra), never a raw key.
+  The adapter absorbs this at CLIENT CONSTRUCTION only: the Anthropic SDK's platform
+  clients (AnthropicBedrockMantle / AnthropicVertex / AnthropicFoundry) expose the same
+  messages surface (structured outputs GA on Bedrock+Vertex, beta on Foundry; Bedrock
+  model ids take the `anthropic.` prefix), and the Gemini SDK flips to Vertex by
+  environment (GOOGLE_GENAI_USE_VERTEXAI + ADC) with zero adapter change. Direct API
+  keys remain the dev-loop convenience only.
 - **Q3 — MCP registration timing.** Static tool declaration vs boot-time enumeration of
   the server's tool list; allowlist config shape; failure behavior when a listed tool is
   absent at boot (fail-fast per the compiled-or-404 taste?).
@@ -188,6 +200,18 @@ every agent's toolbox — governed in both directions.
 - **Q8 — streaming to the edge.** Token streaming from an LLM node through a graph run
   to the HTTP response — pattern using Flux/ObjectStream, or explicitly out of scope for
   v1 (request-response per node).
+  **PARTIALLY ANSWERED WITH LIVE EVIDENCE (2026-08-31):** for a REST endpoint (no graph
+  run), the composition already exists on the shipped streaming foundation and ran live
+  with REAL Gemini tokens — `llm.stream` in the python demo app pulls the provider's
+  token stream (generate_content_stream / messages.stream) and relays each token batch
+  via EventStreamWriter; the engine's `llm.stream.relay` endpoint (minigraph-playground,
+  POST /api/llm/stream, stream: true) forwards its reply lane + `accept:
+  text/event-stream` into the Event-over-HTTP send; 25+ timestamped token batches
+  rendered progressively out the engine's SSE edge over a ~2s generation, terminal
+  `done` event carrying usage/model/stop_reason/trace ids, one distributed trace across
+  both processes (relay span → async.http.request SSE-consumption span → per-batch
+  reply-lane spans). Zero engine change. STILL OPEN in Q8: token streaming from an LLM
+  node INSIDE a graph run (graph-run streaming — the staged engine follow-up).
 
 ## 7. Experiment plan (E-series — post-workshop; each produces evidence for D-rulings)
 
@@ -197,6 +221,26 @@ every agent's toolbox — governed in both directions.
   graph.task → wrapper drive** (closes that evidence gap incidentally).
   *Evidence out:* the demo graph JSON, the live trace (engine trace_id in the python
   log), token usage surfaced in `model`.
+  **E0 DONE 2026-08-30 — live drive complete.** Built beyond the spec: `llm.chat` is
+  PROVIDER-NEUTRAL (Anthropic + Gemini backends behind one contract; `llm.provider`
+  config / `params.provider` select; schema → structured output with additionalProperties
+  defaulted closed; usage/stop_reason surfaced; provider errors ride the envelope status;
+  params.timeout_ms → SDK timeout) + the `support-triage` graph in
+  examples/minigraph-playground (input-validation decision, verdict schema expressed in
+  mapping lines, triage decision over three enumerated branches). *Live evidence (Gemini
+  `gemini-3.6-flash`, Eric's personal key; the Anthropic re-drive runs when the org key
+  arrives):* all three branches returned real verdicts and routed correctly
+  (bug-filed / answered / feature-routed) with usage in `model` (bug run:
+  input_tokens 32, output_tokens 21); ONE trace across both processes — engine span
+  chain http.flow.adapter → check-input → classify (graph.task task=llm.chat) → triage
+  → file-bug, with the same trace id (208feaeabce2488eaf90bbb723b7f23f) in the wrapper
+  log (`Handled llm.chat status=200 exec_time=2111ms`); the provider-ERROR path was
+  live-proven first (Google 401/404/504 rode the envelope into the graph error context,
+  `target=llm.chat`). Token-free CI: a mock on the same route pins the full path
+  (route decoupling = the mock-by-config story; engine module 20/20, python 92/92).
+  Engine finding → thread-compilegraph-syntax-validation: a node carrying
+  task/input/output but NO `skill` property compiles and silently passes through —
+  gate-warning candidate.
 - **E1 — human authority.** Insert `graph.suspend` before a side-effectful step; approve
   → resume; reject → re-suspend loop (tutorial-14 shape, LLM verdict as the decision
   input). *Evidence out:* suspension record contents with conversation context (feeds Q5).

--- a/draft-design-specs/http-response-streaming.md
+++ b/draft-design-specs/http-response-streaming.md
@@ -3,7 +3,8 @@
 **Status:** APPROVED AND IMPLEMENTED (Java) — D1 ratified 2026-08-27; **D2–D8 approved
 as recommended by Eric 2026-08-28**; implemented same day with one design addition made
 during implementation (D9, the ordered reply lane — see §2a; **revised same day to
-Eric's checkout-pool design**: dedicated lane per active stream, LIFO stack of 500,
+Eric's checkout-pool design**: dedicated lane per active stream, rotating checkout pool
+of 500 (FIFO round-robin since the 2026-08-31 refinement; originally a LIFO stack),
 HTTP-503 back-pressure, no config knob). Rust twin pending (D7:
 Java-first with the vocabulary pinned). **Serves:** `bp-agent-orchestration` (this is Q8 of
 `ai-agent-orchestration.md`, promoted to prerequisite: without it an `llm.chat` node can
@@ -66,11 +67,15 @@ own ordering idiom is a route with one instance (cf. ObjectStreamIO's `instances
 consumer). Solution, keeping the D1 contract intact (the callee still just sends to
 reply_to): a streaming endpoint is declared with **`stream: true` in rest.yaml**, and
 the request **checks out a dedicated ordered reply lane for its lifetime** — a
-single-instance route (`async.http.response.stream.{n}`) drawn from a **LIFO stack pool
-of 500** (pinned to the `async.http.response` instance count — no configuration knob).
-The lane rides on the AsyncContextHolder (direct access to the original HTTP
-request/response) and returns to the stack when the request context closes — the "ready"
-signal pattern of the reactive manager/worker design. One request's segments are strict
+single-instance route (`async.http.response.stream.{n}`) drawn from a **rotating FIFO
+pool of 500** (pinned to the `async.http.response` instance count — no configuration
+knob). The lane rides on the AsyncContextHolder (direct access to the original HTTP
+request/response) and rejoins the tail of the queue when the request context closes — a
+rotating variant of the "ready" signal pattern of the reactive manager/worker design.
+Selection therefore round-robins (`.0`, `.1`, `.2` ...) — predictable in telemetry —
+and a just-released lane rests the full pool length before reuse, maximizing separation
+from any straggler cleanup on it (refined 2026-08-31 from the original LIFO stack,
+which re-picked the same top-of-stack lane for every sequential request). One request's segments are strict
 FIFO through its own lane; different requests never share a lane. An exhausted pool
 rejects further streaming requests immediately with **HTTP-503 "Streaming response pool
 exhausted"** (deterministic back-pressure). An idle lane costs a little memory and no
@@ -83,8 +88,8 @@ rendering work. The checkout removed the `streamResponse` flag from HttpRequestE
 (tag "12") — both reply sites resolve the lane from the holder by requestId. The
 housekeeper's in-band timeout targets the holder's lane so it cannot overtake segments.
 The 50-segment unpaced burst test pins per-request ordering; four parallel bursts pin
-cross-request independence; exhaustion (503 + recovery), lane return, and LIFO reuse
-have dedicated tests. A stream-marked response arriving on the ordinary lane still
+cross-request independence; exhaustion (503 + recovery), lane return, and rotation
+reuse have dedicated tests. A stream-marked response arriving on the ordinary lane still
 renders (single-segment or tolerant producers), but only the declared lane guarantees
 order. `stream: true` and the 503 message are rest.yaml/wire surface → part of the
 cross-engine contract (Rust twin mirrors both).
@@ -268,7 +273,7 @@ platform-core tests (the release gate for the feature):
   touch-extends-life pacing, 8KB×50 FIFO burst forcing the drain path, four parallel
   bursts (which caught and now pin a real drain-handler race — fixed with a per-request
   lock), D5 conflict, pool exhaustion → 503 → recovery, lane returns on completion,
-  LIFO reuse, response-header-transform parity; 3 writer-contract; 3 state/cap units).
+  rotation reuse, response-header-transform parity; 3 writer-contract; 3 state/cap units).
   platform-core full suite 450/450; mkdocs strict clean;
   ai-contract-provider 19/19 with the new guide in files.list.
 - Docs: guides/http-streaming.md (+nav, llms.txt, event-over-http See-also), ADR-0018

--- a/draft-design-specs/register-route-pool.md
+++ b/draft-design-specs/register-route-pool.md
@@ -55,8 +55,9 @@ instance. Each member has `instances=1`, so each lane is a strict FIFO mailbox; 
 checkout of a lane gives a stream per-conversation ordering while unrelated streams run
 concurrently through their own lanes. Registration and checkout are separate concerns:
 this API owns registration only; checkout stays with the consumer
-(`EventStreamRenderer.LANE_POOL`, a LIFO `ConcurrentLinkedDeque` with
-`checkoutLane()`/`releaseLane()`).
+(`EventStreamRenderer.LANE_POOL`, a rotating FIFO `ConcurrentLinkedDeque` with
+`checkoutLane()`/`releaseLane()` — head checkout, tail return, so selection
+round-robins through the pool; refined 2026-08-31 from the original LIFO stack).
 
 ## 3. Decisions
 
@@ -202,7 +203,7 @@ the adoption and was removed. Behavior-identical by construction: same names, sa
 ## 7. Out of scope / non-goals
 
 - **Checkout mechanics** — stay in `EventStreamRenderer`. If a second consumer wants the
-  checkout half, consider promoting the LIFO deque into a pool handle then; do not block
+  checkout half, consider promoting the rotating deque into a pool handle then; do not block
   this round on it.
 - **Public pools** (D2) — add only when a concrete case appears.
 - **`getLocalRoutingTable()` changes** (D3) — permanent non-goal.

--- a/examples/minigraph-playground/src/main/java/com/accenture/minigraph/demo/LlmStreamRelay.java
+++ b/examples/minigraph-playground/src/main/java/com/accenture/minigraph/demo/LlmStreamRelay.java
@@ -1,0 +1,78 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.demo;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventEmitter;
+import org.platformlambda.core.system.EventStreamWriter;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+
+/**
+ * The AI-token streaming composition (agent-orchestration follow-up to experiment E0):
+ * this endpoint's function forwards its own reply lane and correlation id into a 'send'
+ * to the event-over-http mapped "llm.stream" function - the python demo app's streaming
+ * AI node, which pulls the provider's REAL token stream (Gemini or Claude models) - and
+ * opts in with the "accept: text/event-stream" event header. The provider's token
+ * batches relay through the peer's /api/event in envelope mode and re-render
+ * progressively out this application's HTTP edge as SSE, with no imperative streaming
+ * code and no LLM dependency in the engine.
+ * <p>
+ * Requires yaml.event.over.http (see application.properties) and a running wrapper
+ * demo app with the provider credential in its environment.
+ */
+@PreLoad(route = "llm.stream.relay", instances = 50)
+@EventInterceptor
+public class LlmStreamRelay implements TypedLambdaFunction<EventEnvelope, Void> {
+    private static final String REMOTE_ROUTE = "llm.stream";
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        var po = new PostOffice(headers, instance);
+        // reachable when registered locally (a test mock) or mapped declaratively
+        if (!po.exists(REMOTE_ROUTE) && EventEmitter.getInstance().getEventHttpTarget(REMOTE_ROUTE) == null) {
+            new EventStreamWriter(request).fail(new AppException(503,
+                    "AI streaming demo is not configured - start a wrapper demo app with an LLM " +
+                    "provider credential and map llm.stream in event-over-http.yaml"));
+            return null;
+        }
+        AsyncHttpRequest http = new AsyncHttpRequest(request.getRawBody());
+        EventEnvelope forward = new EventEnvelope().setTo(REMOTE_ROUTE)
+                .setReplyTo(request.getReplyTo())
+                .setCorrelationId(request.getCorrelationId())
+                // the POST body carries the AI node's request surface
+                // (prompt | messages, system, params)
+                .setBody(http.getBody())
+                // the event-level opt-in for progressive streaming over Event-over-HTTP
+                .setHeader("accept", "text/event-stream")
+                // idle allowance between stream events on both hops (ms) - an LLM can
+                // pause between token batches while it reasons
+                .setHeader("x-ttl", "60000");
+        // the trace-aware PostOffice stamps the current trace onto the outbound event,
+        // so the distributed trace continues across the hop into the AI node
+        po.send(forward);
+        return null;
+    }
+}

--- a/examples/minigraph-playground/src/main/resources/application.properties
+++ b/examples/minigraph-playground/src/main/resources/application.properties
@@ -76,6 +76,11 @@ location.graph.temp=file:/tmp/graph
 #
 graph.model.automation=classpath:/graphs.yaml
 #
+# Declarative Event-over-HTTP: routes served by polyglot peers (the support-triage
+# demo graph's llm.chat AI node runs on the mercury-python demo app)
+#
+yaml.event.over.http=classpath:/event-over-http.yaml
+#
 # set this value to an environment variable in the deployed environment to disable websocket endpoints
 # when the app.env is not 'dev'. e.g. app.env={$ENV_NAME}
 #

--- a/examples/minigraph-playground/src/main/resources/event-over-http.yaml
+++ b/examples/minigraph-playground/src/main/resources/event-over-http.yaml
@@ -1,0 +1,19 @@
+#
+# Declarative Event-over-HTTP targets: routes that live on polyglot peers.
+#
+# The support-triage demo graph's AI node (llm.chat) is a function in the
+# mercury-python demo app (default port 8086) - run it with:
+#
+#     mercury-serve examples/demo_app.py
+#
+# with the provider credential in that app's environment: ANTHROPIC_API_KEY
+# (default provider), or GEMINI_API_KEY with -Dllm.provider=gemini - the
+# graph is provider-neutral and does not change. Point at another peer with
+# -Dllm.peer.host / -Dllm.peer.port overrides.
+#
+event:
+  http:
+    - route: 'llm.chat'
+      target: 'http://${llm.peer.host:127.0.0.1}:${llm.peer.port:8086}/api/event'
+    - route: 'llm.stream'
+      target: 'http://${llm.peer.host:127.0.0.1}:${llm.peer.port:8086}/api/event'

--- a/examples/minigraph-playground/src/main/resources/graph/support-triage.json
+++ b/examples/minigraph-playground/src/main/resources/graph/support-triage.json
@@ -1,0 +1,261 @@
+{
+  "nodes": [
+    {
+      "alias": "root",
+      "types": [
+        "Root"
+      ],
+      "properties": {
+        "purpose": "Bounded-agency support triage (AI agent orchestration experiment E0): the LLM node classifies a user request into an enumerated category and the graph - not the model - decides the route. The AI capability is a plain wrapper-side function (llm.chat on the python demo app) reached through declarative Event-over-HTTP, so the engine stays LLM-free and the certified graph names exactly what the agent can do",
+        "name": "support-triage"
+      }
+    },
+    {
+      "alias": "check-input",
+      "types": [
+        "Decision"
+      ],
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(={input.body.text}) -> model.text_probe",
+          "IF: {model.text_probe} == '=null'\nTHEN: reject\nELSE: classify"
+        ],
+        "purpose": "Input validation without spending tokens: a request must carry the user's text"
+      }
+    },
+    {
+      "alias": "reject",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "int(400) -> output.status",
+          "text(rejected) -> output.body.type",
+          "text(Missing text. Provide the user request in the 'text' field) -> output.body.message"
+        ],
+        "purpose": "Reject a request without user text before any model call"
+      }
+    },
+    {
+      "alias": "classify",
+      "types": [
+        "Task"
+      ],
+      "properties": {
+        "skill": "graph.task",
+        "task": "llm.chat",
+        "ttl": "30s",
+        "input": [
+          "input.body.text -> model.request_text",
+          "input.body.text -> prompt",
+          "text(You are a support triage assistant. Classify the user request into exactly one category and give one short reason.) -> system",
+          "text(object) -> schema.type",
+          "text(string) -> schema.properties.label.type",
+          "text(question) -> schema.properties.label.enum[0]",
+          "text(bug) -> schema.properties.label.enum[1]",
+          "text(feature) -> schema.properties.label.enum[2]",
+          "text(string) -> schema.properties.reason.type",
+          "text(one short sentence explaining the classification) -> schema.properties.reason.description",
+          "text(label) -> schema.required[0]",
+          "text(reason) -> schema.required[1]",
+          "int(512) -> params.max_tokens",
+          "int(25000) -> params.timeout_ms"
+        ],
+        "output": [
+          "result.data -> model.verdict",
+          "result.usage -> model.usage",
+          "result.model -> model.llm_model"
+        ],
+        "purpose": "Ask the LLM node (llm.chat, a python wrapper function reached via Event-over-HTTP) for a schema-constrained verdict - the model advises within the graph's enumerated choices"
+      }
+    },
+    {
+      "alias": "triage",
+      "types": [
+        "Decision"
+      ],
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(={model.verdict.label}) -> model.label_probe",
+          "IF: {model.label_probe} == '=bug'\nTHEN: file-bug\nELSE: next",
+          "IF: {model.label_probe} == '=feature'\nTHEN: route-feature\nELSE: answer-question"
+        ],
+        "purpose": "The graph decides: route among the enumerated branches on the model's verdict - governed nondeterminism, no open dispatch"
+      }
+    },
+    {
+      "alias": "answer-question",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "text(answered) -> output.body.action",
+          "model.request_text -> output.body.request",
+          "model.verdict -> output.body.verdict",
+          "model.usage -> output.body.usage",
+          "model.llm_model -> output.body.model"
+        ],
+        "purpose": "Question branch: hand the request to the knowledge-base responder"
+      }
+    },
+    {
+      "alias": "file-bug",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "text(bug-filed) -> output.body.action",
+          "model.request_text -> output.body.request",
+          "model.verdict -> output.body.verdict",
+          "model.usage -> output.body.usage",
+          "model.llm_model -> output.body.model"
+        ],
+        "purpose": "Bug branch: file a defect with the model's reasoning attached"
+      }
+    },
+    {
+      "alias": "route-feature",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "text(feature-routed) -> output.body.action",
+          "model.request_text -> output.body.request",
+          "model.verdict -> output.body.verdict",
+          "model.usage -> output.body.usage",
+          "model.llm_model -> output.body.model"
+        ],
+        "purpose": "Feature branch: route the request to product management"
+      }
+    },
+    {
+      "alias": "end",
+      "types": [
+        "End"
+      ],
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "target": "check-input",
+      "relations": [
+        {
+          "type": "run",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "check-input",
+      "target": "classify",
+      "relations": [
+        {
+          "type": "valid",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "check-input",
+      "target": "reject",
+      "relations": [
+        {
+          "type": "invalid",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "classify",
+      "target": "triage",
+      "relations": [
+        {
+          "type": "verdict",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "triage",
+      "target": "file-bug",
+      "relations": [
+        {
+          "type": "bug",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "triage",
+      "target": "route-feature",
+      "relations": [
+        {
+          "type": "feature",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "triage",
+      "target": "answer-question",
+      "relations": [
+        {
+          "type": "question",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "answer-question",
+      "target": "end",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "file-bug",
+      "target": "end",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "route-feature",
+      "target": "end",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ]
+    },
+    {
+      "source": "reject",
+      "target": "end",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ]
+    }
+  ]
+}

--- a/examples/minigraph-playground/src/main/resources/graphs.yaml
+++ b/examples/minigraph-playground/src/main/resources/graphs.yaml
@@ -12,5 +12,6 @@ graphs:
   - 'tutorial-11'
   - 'tutorial-12'
   - 'tutorial-14'
+  - 'support-triage'
 
 location: 'classpath:/graph'

--- a/examples/minigraph-playground/src/main/resources/rest.yaml
+++ b/examples/minigraph-playground/src/main/resources/rest.yaml
@@ -28,6 +28,21 @@ rest:
     headers: header_1
     tracing: true
 
+  #
+  # The AI-token streaming composition: the relay forwards its reply lane into the
+  # event-over-http mapped "llm.stream" AI node (python demo app) and the provider's
+  # real token batches re-render progressively out this application's HTTP edge.
+  # See LlmStreamRelay.java.
+  #
+  - service: 'llm.stream.relay'
+    methods: ['POST']
+    url: '/api/llm/stream'
+    timeout: 60s
+    cors: cors_1
+    headers: header_1
+    tracing: true
+    stream: true
+
   - service: 'show.graph.model'
     methods: ['GET']
     url: '/api/graph/model/{graph_id}/{sequence}'

--- a/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/GraphTests.java
+++ b/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/GraphTests.java
@@ -263,6 +263,83 @@ class GraphTests {
         log.info("Tutorial 12 works");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void supportTriageRejectsMissingTextWithoutModelCall() throws TimeoutException {
+        // proves the deployment gate compiled the AI-node demo graph (a rejected model
+        // answers 404 as if nonexistent) and that its input-validation branch bounds
+        // the run before any LLM call - token-free and wrapper-free by design
+        var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
+                .setBody(Map.of("hello", "world")).setHeader("Content-Type", "application/json");
+        request.setHeader("Accept", "application/json");
+        request.setUrl("/api/graph/support-triage");
+        var event = new EventEnvelope().setTo("async.http.request").setBody(request);
+        var po = PostOffice.trackable("unit.test", "triage-1", "TEST /graph/support-triage");
+        var response = po.asyncRequest(event, TIMEOUT).await(TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(400, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        var mm = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("rejected", mm.getElement("type"));
+        assertEquals("Missing text. Provide the user request in the 'text' field",
+                mm.getElement("message"));
+        log.info("support-triage rejects without spending tokens");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void supportTriageRoutesOnTheVerdict() throws TimeoutException {
+        // the full bounded-agency path, token-free: the route-decoupled AI node resolves
+        // to MockLlmChat in this test scope, so schema staging, the graph.task call,
+        // decision routing on the verdict and the usage surfacing all run for free
+        var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
+                .setBody(Map.of("text", "the app crashes when I save my profile"))
+                .setHeader("Content-Type", "application/json");
+        request.setHeader("Accept", "application/json");
+        request.setUrl("/api/graph/support-triage");
+        var event = new EventEnvelope().setTo("async.http.request").setBody(request);
+        var po = PostOffice.trackable("unit.test", "triage-2", "TEST /graph/support-triage");
+        var response = po.asyncRequest(event, TIMEOUT).await(TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(Map.class, response.getBody());
+        log.info("support-triage response: {}", response.getBody());
+        var mm = new MultiLevelMap((Map<String, Object>) response.getBody());
+        assertEquals("bug-filed", mm.getElement("action"));
+        assertEquals("bug", mm.getElement("verdict.label"));
+        assertEquals("the app crashes when I save my profile", mm.getElement("request"));
+        // token usage rides model.* into the response - the E0 evidence shape
+        assertEquals(42, mm.getElement("usage.input_tokens"));
+        assertEquals(7, mm.getElement("usage.output_tokens"));
+        assertEquals("mock-llm", mm.getElement("model"));
+        log.info("support-triage routes on the verdict - token-free");
+    }
+
+    @Test
+    void llmStreamEndpointRendersTokenBatchesAsSse() throws Exception {
+        // the AI-token streaming composition, token-free: the route-decoupled streaming
+        // AI node resolves to MockLlmStream in this test scope, so the relay endpoint,
+        // the reply-lane checkout and the SSE rendering are pinned without credentials.
+        // A raw JDK HTTP client reads the real SSE document off the wire.
+        java.net.http.HttpResponse<String> httpResponse;
+        try (var client = java.net.http.HttpClient.newHttpClient()) {
+            var httpRequest = java.net.http.HttpRequest.newBuilder()
+                    .uri(java.net.URI.create(target + "/api/llm/stream"))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "text/event-stream")
+                    .POST(java.net.http.HttpRequest.BodyPublishers.ofString("{\"prompt\": \"stream a demo\"}"))
+                    .build();
+            httpResponse = client.send(httpRequest, java.net.http.HttpResponse.BodyHandlers.ofString());
+        }
+        assertEquals(200, httpResponse.statusCode());
+        assertTrue(httpResponse.headers().firstValue("content-type").orElse("")
+                .contains("text/event-stream"));
+        String sse = httpResponse.body();
+        assertTrue(sse.contains("data: Mercury"), sse);
+        assertTrue(sse.contains("data: streams"), sse);
+        assertTrue(sse.contains("data: tokens"), sse);
+        assertTrue(sse.contains("mock-llm"), sse);
+        log.info("llm.stream endpoint renders token batches - token-free");
+    }
+
     private Object runTutorial(int chapter, Map<String, Object> input) throws TimeoutException {
         var request = new AsyncHttpRequest().setMethod(input.isEmpty()? "GET" : "POST").setTargetHost(target);
         if (!input.isEmpty()) {

--- a/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/MockLlmChat.java
+++ b/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/MockLlmChat.java
@@ -1,0 +1,50 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.tests;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * Token-free stand-in for the AI node (agent-orchestration experiment E0).
+ * <p>
+ * In production the support-triage graph reaches 'llm.chat' on a polyglot wrapper
+ * through declarative Event-over-HTTP; in this test scope the same route name
+ * resolves to this mock - the route-decoupling contract is what makes the LLM
+ * node mockable by configuration, so the graph is testable without tokens or
+ * credentials. The reply mirrors the 'llm.chat' contract (data / usage / model /
+ * stop_reason) with a deterministic verdict derived from the prompt.
+ */
+@PreLoad(route = "llm.chat", instances = 10)
+public class MockLlmChat implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        String prompt = String.valueOf(input.get("prompt"));
+        String label = prompt.contains("crash")? "bug" :
+                        prompt.contains("wish") || prompt.contains("feature")? "feature" : "question";
+        return Map.of(
+                "data", Map.of("label", label, "reason", "mock verdict for the token-free test"),
+                "usage", Map.of("input_tokens", 42, "output_tokens", 7),
+                "model", "mock-llm",
+                "stop_reason", "end_turn");
+    }
+}

--- a/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/MockLlmStream.java
+++ b/examples/minigraph-playground/src/test/java/com/accenture/minigraph/tests/MockLlmStream.java
@@ -1,0 +1,52 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.tests;
+
+import org.platformlambda.core.annotations.EventInterceptor;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.models.TypedLambdaFunction;
+import org.platformlambda.core.system.EventStreamWriter;
+
+import java.util.Map;
+
+/**
+ * Token-free stand-in for the streaming AI node (the E0 follow-up). In production the
+ * llm.stream.relay endpoint reaches 'llm.stream' on a polyglot wrapper pulling a REAL
+ * provider token stream; in this test scope the same route name resolves to this mock,
+ * which streams three fixed token batches over the same multi-shot reply contract -
+ * so the endpoint wiring, the lane checkout and the SSE rendering are all pinned
+ * without tokens or credentials.
+ */
+@PreLoad(route = "llm.stream", instances = 10)
+@EventInterceptor
+public class MockLlmStream implements TypedLambdaFunction<EventEnvelope, Void> {
+
+    @Override
+    public Void handleEvent(Map<String, String> headers, EventEnvelope request, int instance) {
+        var out = new EventStreamWriter(request);
+        out.first(200, "text/event-stream");
+        out.write("Mercury ");
+        out.write("streams ");
+        out.write("tokens");
+        out.close(Map.of("model", "mock-llm", "stop_reason", "end_turn",
+                "usage", Map.of("input_tokens", 5, "output_tokens", 3)));
+        return null;
+    }
+}

--- a/system/platform-core/src/main/java/org/platformlambda/automation/services/EventStreamRenderer.java
+++ b/system/platform-core/src/main/java/org/platformlambda/automation/services/EventStreamRenderer.java
@@ -86,9 +86,11 @@ public class EventStreamRenderer {
     // slow-client guard: writes queue here when the socket back-pressures, bounded by this cap
     private static final long PENDING_CAP_BYTES = 1024 * 1024L;
     private static final long KEEP_ALIVE_MS = resolveKeepAlive();
-    // available reply lanes (LIFO stack): a streaming request checks out a dedicated
-    // single-instance route for its lifetime and returns it when the request context
-    // closes - the "ready" signal pattern of the reactive manager/worker design
+    // available reply lanes (rotating FIFO queue): a streaming request checks out a
+    // dedicated single-instance route from the head for its lifetime and the lane
+    // rejoins at the tail when the request context closes - lane selection therefore
+    // round-robins through the pool (.0, .1, .2 ...) and a just-released lane gets
+    // the longest possible rest before reuse
     private static final ConcurrentLinkedDeque<String> LANE_POOL = new ConcurrentLinkedDeque<>();
 
     private EventStreamRenderer() {}
@@ -116,7 +118,7 @@ public class EventStreamRenderer {
      * @param route the lane's route name
      */
     public static void releaseLane(String route) {
-        LANE_POOL.push(route);
+        LANE_POOL.addLast(route);
     }
 
     /**

--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamResponseTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamResponseTest.java
@@ -264,14 +264,17 @@ class EventStreamResponseTest extends TestBase {
     }
 
     @Test
-    void laneCheckoutIsLifo() {
-        // the pool is a stack ("ready" signal pattern): the most recently
-        // released lane is the first to be reused
+    void laneCheckoutRotatesThroughThePool() {
+        // the pool is a rotating FIFO queue: a released lane rejoins at the tail,
+        // so consecutive requests take successive lanes (round-robin) and a
+        // just-released lane gets the longest possible rest before reuse
         String first = EventStreamRenderer.checkoutLane();
         assertNotNull(first);
         EventStreamRenderer.releaseLane(first);
-        assertEquals(first, EventStreamRenderer.checkoutLane(), "most recently released lane is reused first");
-        EventStreamRenderer.releaseLane(first);
+        String second = EventStreamRenderer.checkoutLane();
+        assertNotNull(second);
+        assertNotEquals(first, second, "a released lane must go to the tail, not be reused immediately");
+        EventStreamRenderer.releaseLane(second);
     }
 
     @Test


### PR DESCRIPTION
## What

The first live iteration of AI agent orchestration (experiment E0), plus a streaming
reply-lane refinement it surfaced:

- **`support-triage` demo graph** (examples/minigraph-playground): a decision node routes on a
  schema-constrained verdict from `llm.chat` - a python wrapper-side AI node reached through
  declarative Event-over-HTTP via `graph.task`. Input validation bounds the run before any
  model call (missing text -> HTTP 400, zero tokens spent). Three enumerated branches echo
  verdict, token usage and model.
- **`POST /api/llm/stream` demo endpoint**: a relay function (`LlmStreamRelay`) forwards its
  reply lane, correlation id and the `accept: text/event-stream` opt-in into the
  event-over-http mapped `llm.stream` AI node - the provider's real token batches render
  progressively out this application's HTTP edge as SSE. Zero engine change; the engine
  stays LLM-free.
- **Streaming reply lanes now rotate (platform-core)**: FIFO round-robin checkout replaces
  the LIFO stack - sequential streams walk `async.http.response.stream.0`, `.1`, `.2` ...
  and a released lane rejoins at the tail, resting the full pool length before reuse.
  Predictable lane selection in telemetry; maximal separation from any straggler cleanup.
  The Rust twin ships the same change lock-step (mercury `feature/stream-lane-rotation`).
- Route-decoupled mocks (`MockLlmChat`, `MockLlmStream`) pin both demos token-free in the
  module tests; ADR-0018 gains a dated refinement line; CHANGELOG Unreleased updated;
  the concept doc records E0 as done with the live evidence.

## Why

`bp-agent-orchestration`: the Active Knowledge Graph as the governed run-time for AI
agents. E0 proves the bounded-agency pattern live - the graph decides, the model advises
within a schema, and the certified graph stays the control plane ("governed
nondeterminism"). The streaming demo completes the REST-edge half of progressive token
rendering through the engine. Live evidence: real Gemini verdicts routed all three
branches with usage surfaced in the model; 25+ token batches over a ~2s generation; one
distributed trace across engine and python processes; provider errors (401/404/504) rode
the envelope into the graph's error context.

## Tests

- platform-core: full suite green (incl. the flipped rotation pin
  `laneCheckoutRotatesThroughThePool`); live rotation verified - three sequential streams
  took lanes `.0`, `.1`, `.2`.
- minigraph-playground: 21/21 (graph reject-before-model-call, verdict routing with usage
  assertions, SSE endpoint reading the real wire document).

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)