### PR TITLE
Release v4.12.1 - version sweep to the lock-step registry-debut line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.12.1, 9/1/2026
+
+The lock-step companion to the first public-registry releases (the Rust engine's
+crates.io debut and the python/node wrappers' PyPI/npm debuts all carry 4.12.1):
+the route pool platform API, the agent-orchestration E0 demos, and the streaming
+reply-lane rotation.
 
 ### Added
 
@@ -30,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    engine's HTTP edge as SSE. Live-proven with Gemini: 25+ timestamped token batches
    over a ~2s generation, one distributed trace across both processes. Zero engine
    change.
+4. Placeholder manifests for the retired Spring Boot 3 modules (system/rest-spring-3,
+   examples/rest-spring-3-example) - parentless, dependency-free poms outside the
+   reactor so the dependency scanner's per-manifest projects re-test to an empty
+   graph instead of freezing on the retired lane's last dependency tree; relocation
+   metadata points local source builds at the rest-spring-4 equivalents.
 
 ### Changed
 

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.1</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.1</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -96,7 +96,7 @@
   vectors are the conformance gate; interop report per wrapper release (D6). Spec:
   draft-design-specs/polyglot-script-runner.md. Delivered by [[thread-polyglot-initiative]];
   serves [[bp-polyglot-functions]].
-  <!-- id: polyglot-event-over-http-design | created: 2026-08-22 | last_used: 2026-09-01 | uses: 12 | tier: active | origin: 2026-08-22-164936 -->
+  <!-- id: polyglot-event-over-http-design | created: 2026-08-22 | last_used: 2026-09-02 | uses: 13 | tier: active | origin: 2026-08-22-164936 -->
 
 - **Graph workflow suspension: short runs + external state store, encapsulated in skills
   (design ratified by Eric 2026-07-28). (ADR-0010)** A human checkpoint = persist
@@ -243,7 +243,7 @@
   examples/rest-spring-3-example (PR #305) with relocation metadata to the Boot-4 twins;
   **release version sweeps must include these non-reactor poms deliberately.** Relates
   [[stack-integration-spring-boot4]].
-  <!-- id: snyk-retired-manifest-placeholders | created: 2026-09-01 | last_used: 2026-09-01 | uses: 2 | tier: active | origin: 2026-09-01-022524 -->
+  <!-- id: snyk-retired-manifest-placeholders | created: 2026-09-01 | last_used: 2026-09-02 | uses: 3 | tier: active | origin: 2026-09-01-022524 -->
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
   <!-- id: conv-add-capability | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
@@ -273,7 +273,7 @@
   flows and MiniGraph graphs as Event-over-HTTP peers (ratified design D0–D8, 2026-08-22);
   wrappers live in the repurposed Accenture/mercury-python + mercury-nodejs repos.
   → serves: vision-mercury-composable
-  <!-- id: bp-polyglot-functions | created: 2026-08-22 | last_used: 2026-09-01 | uses: 10 | tier: working -->
+  <!-- id: bp-polyglot-functions | created: 2026-08-22 | last_used: 2026-09-02 | uses: 11 | tier: working -->
 - [ ] (blueprint) Integrate a **pluggable AI companion LLM backend**; mature `POST /api/companion/{id}`
   from a dev-only command pipe into a governed collaboration layer. → serves: vision-mercury-composable
   <!-- id: bp-ai-companion-llm-backend | created: 2026-06-20 | last_used: 2026-08-25 | uses: 3 | tier: working -->
@@ -299,7 +299,7 @@
   memory 2026-08-22: the smoke test found six session logs referencing this id while the
   fact lived only in an agent's personal store — a project-relevant working rhythm belongs
   in the shared layer.)
-  <!-- id: eric-release-rhythm | created: 2026-08-22 | last_used: 2026-09-01 | uses: 24 | tier: active | origin: 2026-08-22-180334 -->
+  <!-- id: eric-release-rhythm | created: 2026-08-22 | last_used: 2026-09-02 | uses: 25 | tier: active | origin: 2026-08-22-180334 -->
 
 ## Team / Members
 

--- a/memory/open-threads/thread-ot-agent-orchestration-e0.md
+++ b/memory/open-threads/thread-ot-agent-orchestration-e0.md
@@ -8,4 +8,4 @@
   .0,.1,.2 — ADR-0018 amended). Lesson: PyCharm validates monkeypatch attr-name literals —
   route the name through a helper parameter. Design: [[bp-agent-orchestration]].
   origin: 2026-09-01-022524.
-  <!-- id: ot-agent-orchestration-e0 | created: 2026-09-01 | last_used: 2026-09-01 | uses: 2 | tier: active | origin: 2026-09-01-022524 -->
+  <!-- id: ot-agent-orchestration-e0 | created: 2026-09-01 | last_used: 2026-09-02 | uses: 3 | tier: active | origin: 2026-09-01-022524 -->

--- a/memory/open-threads/thread-thread-doc-improvement-feedback-loop.md
+++ b/memory/open-threads/thread-thread-doc-improvement-feedback-loop.md
@@ -17,4 +17,4 @@
   [PR #222](https://github.com/Accenture/mercury/pull/222) squash `c730e17e`; python
   [PR #23](https://github.com/Accenture/mercury-python/pull/23) squash `a12c56b6`; node
   [PR #91](https://github.com/Accenture/mercury-nodejs/pull/91) squash `0899ad59`).
-  <!-- id: thread-doc-improvement-feedback-loop | created: 2026-09-01 | last_used: 2026-09-01 | uses: 2 | tier: working | origin: 2026-09-01-032130 -->
+  <!-- id: thread-doc-improvement-feedback-loop | created: 2026-09-01 | last_used: 2026-09-01 | uses: 1 | tier: working | origin: 2026-09-01-032130 -->

--- a/memory/open-threads/thread-thread-polyglot-initiative.md
+++ b/memory/open-threads/thread-thread-polyglot-initiative.md
@@ -1,22 +1,14 @@
-- [ ] (feature — design RATIFIED D0–D8 2026-08-22; **P1–P4 COMPLETE across the four
-  repos**; completed-phase narrative condensed 2026-09-01 — full detail: origin log,
-  2026-08-24-170545, and the wrapper repos' memory) **Polyglot initiative — python/node.js
-  Event-over-HTTP wrappers.** Shipped: wrapper reboots + envelope codecs vs the golden
-  vectors + live python⇄node/engine interop (python PR #15, node PR #86, 2026-08-22);
-  the graph.task event-over-http guard, both engines (Java
-  [PR #292](https://github.com/Accenture/mercury-composable/pull/292), Rust PR #212 —
-  the sole content of field release v4.11.11); the wrapper feature round — primitive
-  event bus, actuator endpoints, log.format (python PR #17, node PR #87); P4 docs —
-  wrapper sites live + engine chapters/ADR-0016 + nav parity (python PR #20, node
-  PR #89, Java PR #294, Rust PR #214/#215). Lesson: new guide pages linked from packaged
-  references must join the ai-contract-provider files.list inventory on BOTH engines.
-  **Remaining — P5 publication, GREEN-LIT by Eric 2026-09-01** ("tomorrow prepare to
-  publish Rust, Python and Node to their public artifactory" — the AI-SDLC-iteration
-  sequencing gate is satisfied by E0). Scope: python → PyPI (name availability to
-  verify), node → npm (legacy mercury-composable v4.3.28 history on the name), **plus
-  the Rust engine → crates.io (NEW surface, widened beyond the wrapper pair)**. Agent
-  prepares everything (dry-runs, metadata, checklists); the publish acts stay Eric's
-  per [[eric-release-rhythm]]. Optional extras still offered: a live
-  Rust-engine→wrapper drive; Rust layer-tab label parity. Design:
+- [x] (feature — **INITIATIVE COMPLETE 2026-09-01: P1–P5 all done.** P5 publication:
+  crates.io (seven mercury-prefixed crates), PyPI and npm all live and verified at
+  v4.12.1 — `pip install mercury-composable`, `npm install mercury-composable`,
+  `cargo add mercury-platform-core` — releases tagged lock-step; detail in each repo's
+  2026-09-01 logs) **Polyglot initiative — python/node.js Event-over-HTTP wrappers**
+  (+ the Rust engine's registry debut, widened into P5 by Eric). Earlier phases:
+  wrapper reboots + codecs + live interop (P1, 2026-08-22); the graph.task
+  event-over-http guard both engines (P2 → field release v4.11.11); wrapper feature
+  round (P3); docs sites + engine chapters (P4). Lessons: packaged-reference guide pages
+  join files.list on BOTH engines; registries throttle new-name bursts — plan first
+  publications in waves; constrain sdists in agent-memory repos. Design:
   [[polyglot-event-over-http-design]]; serves [[bp-polyglot-functions]].
-  <!-- id: thread-polyglot-initiative | created: 2026-08-22 | last_used: 2026-09-01 | uses: 10 | tier: working | origin: 2026-08-22-164936 -->
+  origin: 2026-08-22-164936.
+  <!-- id: thread-polyglot-initiative | created: 2026-08-22 | last_used: 2026-09-02 | uses: 11 | tier: active | origin: 2026-08-22-164936 -->

--- a/memory/sessions/2026-09-02-000827.md
+++ b/memory/sessions/2026-09-02-000827.md
@@ -1,0 +1,37 @@
+# Session (2026-09-02T00:08:28.000Z)
+
+**Agent:** Claude Code
+**Round:** Public-registry publication program — **ALL THREE REGISTRIES LIVE AND
+VERIFIED 2026-09-01** (the walkthrough Eric requested: Rust first, then Python, then
+Node). No Java-repo code changed; this log records the cross-repo milestone and closes
+[[thread-polyglot-initiative]] (P5 was its last open item).
+
+## What happened (detail lives in each repo's own log)
+
+- **crates.io** — seven mercury-prefixed crates at 4.12.1 (lib names unchanged; a clean
+  project resolved `platform_core::envelope::EventEnvelope` from the live registry;
+  docs.rs green). Rust log: mercury 2026-09-01-224359.
+- **PyPI** — `pip install mercury-composable` live at 4.12.1 (PEP 639 metadata; live
+  install + CLI smoke; the constrained-sdist lesson: hatchling's default would have
+  shipped memory/ and agent-skills/). Python log: mercury-python 2026-09-01-224953.
+- **npm** — `npm install mercury-composable` live at 4.12.1 (the name was a
+  fully-unpublished third-party tombstone, reclaimed per npm policy; registry API is the
+  authoritative check — website search lags). Node log: mercury-nodejs 2026-09-01-225325.
+- All three repos released and tagged **v4.12.1** (lock-step line); merges tree-verified
+  (mercury PR #223, mercury-python PR #26, mercury-nodejs PR #94); branches cleaned.
+- Decisions ratified by Eric this round: mercury-* crate naming; fresh v4.12.1 releases
+  so registry artifacts correspond to tags.
+- **OPEN QUESTION handed to Eric:** the Java repo still sits at 4.12.0 with Unreleased
+  content (route pools, E0 demos, rotation) while the other three repos are at 4.12.1 —
+  prep the Java v4.12.1 release round (34-pom sweep incl. the Snyk placeholders), or
+  accept the skew until the next Java release? Also his gate: whether
+  [[bp-polyglot-functions]] (the Blueprint item) is now fully realized and closable.
+
+## Memory References
+
+- Referenced: thread-polyglot-initiative (CLOSED this session), bp-polyglot-functions,
+  polyglot-event-over-http-design, eric-release-rhythm,
+  snyk-retired-manifest-placeholders, ot-agent-orchestration-e0
+- Created: (none in this repo — ot-cratesio-followups lives in the mercury repo)
+- Reactivated: (none)
+- Superseded: (none)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.11.12</version>
+    <version>4.12.1</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.11.12</version>
+            <version>4.12.1</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.0</version>
+            <version>4.12.1</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

The v4.12.1 release: a 34-pom version sweep - the 32 reactor poms plus the two Snyk
placeholder manifests outside the reactor (their own versions AND their relocation
targets, per the release-checklist rule established when they were introduced in
PR #305). CHANGELOG flipped: the 4.12.1 section carries everything riding since
v4.12.0 - the route pool platform API (registerRoutePool/releaseRoutePool, ADR-0020),
the agent-orchestration E0 demos (support-triage graph + /api/llm/stream), the
streaming reply-lane FIFO rotation (ADR-0018 refinement), and the placeholder
manifests themselves.

## Why

The version line is lock-step and the Java engine leads it - but the Rust engine and
the python/node wrappers released and PUBLISHED v4.12.1 today (crates.io / PyPI / npm
debuts), leaving Java main at 4.12.0 with Unreleased content. This release restores
the line and gives the registry artifacts their matching Java reference release.

## Verification

Full reactor `mvn clean install` green (all modules, all tests); both placeholder poms
`mvn validate` clean; zero `4.12.0` occurrences remain in any pom.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)