### PR TITLE
Harden the progressive-relay SSE test against late-reader coalescing

### DIFF
--- a/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/automation/EventStreamClientTest.java
@@ -338,9 +338,18 @@ class EventStreamClientTest extends TestBase {
         // the relay's own eof renders one final terminal event
         long doneCount = lines.stream().filter("event: done"::equals).count();
         assertEquals(2, doneCount, "upstream done + relay terminal: " + lines);
-        // progressive end to end: the upstream paces segments 250ms apart
-        long elapsed = arrivals.get(lines.indexOf("data: {\"segments\":2}")) - arrivals.get(hello);
-        assertTrue(elapsed >= 300, "progressive relay expected, elapsed " + elapsed + " ms");
+        // progressive end to end: the upstream paces segments 250ms apart, so a buffered
+        // relay would deliver every line in one flush (~0ms apart). Assert the largest
+        // consecutive-arrival gap, not the first-to-last span: a reader that starts late
+        // on a loaded runner observes the already-queued frames coalesced, which
+        // compresses the span (CI flake 2026-09-02: 127ms observed against a 300ms
+        // floor) but can only erase every gap by missing the whole production window.
+        long maxGap = 0;
+        for (int i = hello + 1; i < arrivals.size(); i++) {
+            maxGap = Math.max(maxGap, arrivals.get(i) - arrivals.get(i - 1));
+        }
+        assertTrue(maxGap >= 100, "progressive relay expected, max arrival gap " + maxGap
+                + " ms, arrivals " + arrivals);
         Utility.getInstance().sleep(100);
     }
 }


### PR DESCRIPTION
## What

Harden `EventStreamClientTest.selfRelayStreamsProgressivelyOutTheEdge`: assert the
largest consecutive frame-arrival gap (≥ 100ms) instead of the first-to-last arrival
span (≥ 300ms). Test-only change; ran the class three times locally, all green.

## Why

The span assertion is load-sensitive and flaked on main (run 33660347841): the fixture
paces frames at 0/250/500ms, but a reader that starts late on a loaded runner receives
the already-queued frames coalesced, compressing the observed span (127ms observed
against the 300ms floor) even though delivery was genuinely progressive. The largest
consecutive gap survives a late start — it only vanishes if the reader misses the whole
production window — while a buffered relay still fails correctly at ~0ms. The failing
run's own numbers pass under the new assertion; a buffered regression would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>