### PR TITLE
Export graph: validate the root name only when declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Unreleased
+
+### Fixed
+
+1. The Playground `export graph` overwrite guard no longer rejects a graph whose root
+   node has no `name` property (it compared "null" against the target filename). The
+   root name is validated only when declared - a declared, mismatching name still
+   rejects the overwrite; a missing or blank name is accepted and the export assigns
+   the target id as the root name, exactly like the no-root path. Found by the
+   ai-enabled-repo-demo rehearsal loop: the first export of an unnamed draft worked,
+   re-exporting the same draft failed. Lock-step with the Rust engine.
+
+---
 ## Version 4.12.2, 9/2/2026
 
 ### Added

--- a/docs/guides/knowledge-graph/command-reference.md
+++ b/docs/guides/knowledge-graph/command-reference.md
@@ -272,7 +272,14 @@ import node {node} from {name}
 - `export` is **idempotent**: when the file already holds byte-identical content the physical
   write is skipped, so **the file's mtime is not a write indicator** — verify by content, or by
   the `Described in ...` link in the reply. A genuine I/O failure reports `ERROR: unable to
-  write ...`.
+  write ...`. In a rehearsal loop this means a "successful" export that changed nothing is
+  telling you **the saved file already matches your graph** — you re-exported the version
+  already saved, not a modified working copy.
+- **Overwriting an existing file** validates the root `name` only when one is declared: a
+  declared name that differs from the export target rejects the overwrite
+  (`Expect root node name=...`) — protecting `graph123.json` from another graph's content —
+  while a **missing or blank root name is accepted**, and the export assigns the target id
+  as the root name (the same self-naming a brand-new export performs).
 - `export` writes JSON to `location.graph.temp`; it adds `name={name}` to the root node and
   **fails if any node is an orphan** (every node must connect to ≥1 other).
 - The export reply includes `Described in /api/graph/model/{name}/{token}` — a read-only HTTP

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -1226,45 +1226,51 @@ public class GraphCommandService extends GraphLambdaFunction {
     }
 
     private void handleExportCommand(PostOffice po, String inRoute, String outRoute, String filename) {
-        if (validGraphFileName(filename)) {
-            var graph = graphModels.get(inRoute);
-            if (graph != null) {
-                var file = new File(tempDir, filename+JSON_EXT);
-                // check if the filename is the same as the Root's name property
-                var root = graph.getRootNode();
-                if (root == null) {
-                    root = graph.createRootNode();
-                    root.addType(ROOT);
-                    po.send(new EventEnvelope().setTo(outRoute).setBody("Root node created because it does not exist"));
-                } else {
-                    // the guard fires only on a DECLARED, mismatching identity - a missing or
-                    // blank root name has no identity evidence to contradict the export target
-                    // and adopts the target id below, exactly like the no-root path
-                    var name = root.getProperty(NAME);
-                    var declared = name == null? "" : String.valueOf(name).trim();
-                    if (!declared.isEmpty() && !filename.equals(declared) && file.exists()) {
-                        po.send(new EventEnvelope().setTo(outRoute).setBody("Expect root node name="+
-                                filename+ ", Actual: "+declared+"\nUpdate root node to overwrite existing graph model"));
-                        return;
-                    }
-                }
-                root.addProperty(NAME, filename);
-                var text = SimpleMapper.getInstance().getMapper().writeValueAsString(graph.exportGraph());
-                // str2file skips the physical write when content is identical (mtime is
-                // NOT a write indicator) and returns false only on an I/O failure -
-                // that failure must not be reported as success
-                if (!util.str2file(file, text)) {
-                    po.send(new EventEnvelope().setTo(outRoute).setBody(
-                            "ERROR: unable to write "+file.getPath()+" - check filesystem permissions and space"));
-                    return;
-                }
-                var n = getRandomCounter();
-                po.send(new EventEnvelope().setTo(outRoute).setBody(
-                        "Graph exported to "+file.getPath()+"\n"+"Described in /api/graph/model/"+filename+"/"+n));
-            }
-        } else {
+        if (!validGraphFileName(filename)) {
             po.send(new EventEnvelope().setTo(outRoute).setBody(INVALID_GRAPH_NAME));
+            return;
         }
+        var graph = graphModels.get(inRoute);
+        if (graph == null) {
+            return;
+        }
+        var file = new File(tempDir, filename+JSON_EXT);
+        var root = graph.getRootNode();
+        if (root == null) {
+            root = graph.createRootNode();
+            root.addType(ROOT);
+            po.send(new EventEnvelope().setTo(outRoute).setBody("Root node created because it does not exist"));
+        } else if (exportNameConflicts(root, filename, file)) {
+            po.send(new EventEnvelope().setTo(outRoute).setBody("Expect root node name="+
+                    filename+ ", Actual: "+declaredRootName(root)+"\nUpdate root node to overwrite existing graph model"));
+            return;
+        }
+        root.addProperty(NAME, filename);
+        var text = SimpleMapper.getInstance().getMapper().writeValueAsString(graph.exportGraph());
+        // str2file skips the physical write when content is identical (mtime is
+        // NOT a write indicator) and returns false only on an I/O failure -
+        // that failure must not be reported as success
+        if (!util.str2file(file, text)) {
+            po.send(new EventEnvelope().setTo(outRoute).setBody(
+                    "ERROR: unable to write "+file.getPath()+" - check filesystem permissions and space"));
+            return;
+        }
+        var n = getRandomCounter();
+        po.send(new EventEnvelope().setTo(outRoute).setBody(
+                "Graph exported to "+file.getPath()+"\n"+"Described in /api/graph/model/"+filename+"/"+n));
+    }
+
+    // An export overwrites the wrong file only when the root declares a DIFFERENT
+    // identity than the target: a missing or blank root name has no identity to
+    // contradict the target and adopts it (like a freshly created root).
+    private boolean exportNameConflicts(SimpleNode root, String filename, File file) {
+        var declared = declaredRootName(root);
+        return !declared.isEmpty() && !filename.equals(declared) && file.exists();
+    }
+
+    private String declaredRootName(SimpleNode root) {
+        var name = root.getProperty(NAME);
+        return name == null? "" : String.valueOf(name).trim();
     }
 
     private void handleDeleteCommand(PostOffice po, String inRoute, String outRoute, List<String> words) {

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphCommandService.java
@@ -1237,10 +1237,14 @@ public class GraphCommandService extends GraphLambdaFunction {
                     root.addType(ROOT);
                     po.send(new EventEnvelope().setTo(outRoute).setBody("Root node created because it does not exist"));
                 } else {
+                    // the guard fires only on a DECLARED, mismatching identity - a missing or
+                    // blank root name has no identity evidence to contradict the export target
+                    // and adopts the target id below, exactly like the no-root path
                     var name = root.getProperty(NAME);
-                    if (!filename.equals(name) && file.exists()) {
+                    var declared = name == null? "" : String.valueOf(name).trim();
+                    if (!declared.isEmpty() && !filename.equals(declared) && file.exists()) {
                         po.send(new EventEnvelope().setTo(outRoute).setBody("Expect root node name="+
-                                filename+ ", Actual: "+name+"\nUpdate root node to overwrite existing graph model"));
+                                filename+ ", Actual: "+declared+"\nUpdate root node to overwrite existing graph model"));
                         return;
                     }
                 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -765,7 +765,6 @@ class CompanionSyncTest {
         assertFalse(storedRecord.exists(), "the record is consumed on resume (at-most-once)");
     }
 
-    @SuppressWarnings("unchecked")
     /**
      * The export guard validates the root name only when one is DECLARED: a missing or
      * blank root name has no identity evidence to contradict the export target, so the
@@ -831,6 +830,7 @@ class CompanionSyncTest {
         return sid;
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> syncCommand(EventEmitter po, String sid, String command) throws Exception {
         var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setUrl("/api/companion/{id}/sync").setPathParameter("id", sid)

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -766,6 +766,71 @@ class CompanionSyncTest {
     }
 
     @SuppressWarnings("unchecked")
+    /**
+     * The export guard validates the root name only when one is DECLARED: a missing or
+     * blank root name has no identity evidence to contradict the export target, so the
+     * export adopts the target id as the name (exactly like the no-root path already
+     * does). A declared, mismatching name still rejects the overwrite.
+     */
+    @Test
+    void exportAcceptsMissingRootNameAndStillRejectsMismatch() throws Exception {
+        var po = EventEmitter.getInstance();
+        var file = new File("/tmp/graph/export-guard-test.json");
+        if (file.exists()) {
+            assertTrue(file.delete(), "stale test file must be removable");
+        }
+        try {
+            // an unnamed root exports fine when the file does not exist yet
+            var sid1 = openCompanionSession("990021");
+            syncCommand(po, sid1, "create node root\nwith type Root");
+            var first = syncCommand(po, sid1, "export graph as export-guard-test");
+            assertEquals(Boolean.TRUE, first.get("ok"), "first export: " + first);
+            assertTrue(file.exists(), "first export created the file");
+
+            // the friction case: ANOTHER session's unnamed graph re-exports over the
+            // existing file - missing name must be accepted, not compared as "null"
+            var sid2 = openCompanionSession("990022");
+            syncCommand(po, sid2, "create node root\nwith type Root");
+            var second = syncCommand(po, sid2, "export graph as export-guard-test");
+            var secondOut = ((List<?>) second.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(secondOut.stream().anyMatch(l -> l.startsWith("Graph exported to ")),
+                    "an unnamed root must be accepted over an existing file: " + secondOut);
+            assertTrue(secondOut.stream().noneMatch(l -> l.startsWith("Expect root node name=")),
+                    "no identity rejection without a declared name: " + secondOut);
+
+            // a DECLARED mismatching name still rejects the overwrite
+            var sid3 = openCompanionSession("990023");
+            syncCommand(po, sid3, """
+                    create node root
+                    with type Root
+                    with properties
+                    name=some-other-graph""");
+            var rejected = syncCommand(po, sid3, "export graph as export-guard-test");
+            var rejectedOut = ((List<?>) rejected.get("output")).stream().map(String::valueOf).toList();
+            assertTrue(rejectedOut.stream().anyMatch(
+                    l -> l.startsWith("Expect root node name=export-guard-test, Actual: some-other-graph")),
+                    "a declared mismatch must still reject the overwrite: " + rejectedOut);
+            assertTrue(rejectedOut.stream().noneMatch(l -> l.startsWith("Graph exported to ")),
+                    "the mismatching graph must not be exported: " + rejectedOut);
+        } finally {
+            if (file.exists() && !file.delete()) {
+                file.deleteOnExit();
+            }
+        }
+    }
+
+    private String openCompanionSession(String seq) {
+        var po = EventEmitter.getInstance();
+        var sid = "ws-" + seq + "-2";
+        po.send(new EventEnvelope().setTo(GraphCommandService.ROUTE)
+                .setBody(Map.of("type", "open", "in", "ws." + seq + ".2.in")));
+        for (int i = 0; i < 50 && !GraphCommandService.hasSession(sid); i++) {
+            Utility.getInstance().sleep(20);
+        }
+        assertTrue(GraphCommandService.hasSession(sid), "session must exist before a companion command");
+        return sid;
+    }
+
     private Map<String, Object> syncCommand(EventEmitter po, String sid, String command) throws Exception {
         var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setUrl("/api/companion/{id}/sync").setPathParameter("id", sid)

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/CompanionSyncTest.java
@@ -286,7 +286,7 @@ class CompanionSyncTest {
 
             // 4) the fire-and-forget endpoint is RETIRED (2026-09-02): the bare
             //    companion URL answers 404 via REST automation (no route mapping)
-            var retired = legacyCommand(po, sid, "session");
+            var retired = postToRetiredCompanionUrl(po, sid);
             assertEquals(404, retired.getStatus(),
                     "the retired async endpoint must answer 404: " + retired.getBody());
         } finally {
@@ -602,12 +602,14 @@ class CompanionSyncTest {
         }
     }
 
-    private EventEnvelope legacyCommand(EventEmitter po, String sid, String command) throws Exception {
-        // the RETIRED fire-and-forget URL - kept only to pin its 404
+    private EventEnvelope postToRetiredCompanionUrl(EventEmitter po, String sid) throws Exception {
+        // the RETIRED fire-and-forget URL - kept only to pin its 404. The body is
+        // arbitrary: the bare URL has no route mapping, so REST automation answers 404
+        // before any command is ever read.
         var req = new AsyncHttpRequest().setMethod("POST").setTargetHost(target)
                 .setUrl("/api/companion/{id}").setPathParameter("id", sid)
                 .setHeader("Content-Type", "text/plain").setHeader("Accept", "application/json")
-                .setBody(command);
+                .setBody("any command");
         return po.request(new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(req), 10000).get();
     }
 


### PR DESCRIPTION
## What

The Playground `export graph` overwrite guard no longer rejects a graph whose root node
has no `name` property. The root name is validated **only when declared**: a declared,
mismatching name still rejects the overwrite (`Expect root node name=...`, protecting
`graph123.json` from another graph's content); a missing or blank name is accepted, and
the export assigns the target id as the root name — exactly what the no-root path and a
brand-new export already do. Test: `CompanionSyncTest.exportAcceptsMissingRootNameAndStillRejectsMismatch`
(unnamed-over-existing succeeds; declared mismatch still rejects). Command reference
documents the rule, plus the rehearsal-idempotency note the demo follow-up asked for.

## Why

Found by the ai-enabled-repo-demo rehearsal loop: the guard compared a missing root name
as "null" against the target filename, so the first export of an unnamed draft worked but
re-exporting the same draft failed. The rule is now coherent — no identity evidence
proceeds (and self-names), only contradictory evidence rejects. Lock-step with the Rust
engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>