### PR TITLE
docs: the Mercury story — white paper + presentation deck, front and center

### DIFF
--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -1,0 +1,279 @@
+---
+title: The Mercury Story
+summary: White paper — why Mercury exists, its ascent from code to configuration to knowledge,
+  and the AI grammar methodology for building applications and building blocks with an AI partner.
+audience: [developer, architect, business, ai-agent]
+keywords: [ai grammar, composable, active knowledge graph, human-ai collaboration, methodology, white paper]
+---
+
+# The Mercury Story — Origin, Evolution, and the AI Grammar Methodology
+
+*A white paper · Eric Law with Claude Code · 2026-09-04 · written at the ai-enabled-repo-demo
+milestone, where the AI grammar was proven end-to-end by fresh AI agents and the feedback loop
+from those runs shipped to the field in v4.12.2.*
+
+> Prefer slides? This paper has a **[presentation deck](presentations/ai-grammar-story.html)**.
+
+---
+
+## Abstract
+
+Mercury Composable is an eight-year-old event-driven framework that spent its first years
+solving a people problem — teams coupling software at the joints — and, in doing so, quietly
+built the substrate the AI era turns out to need. Its three-layer ascent moved application
+behavior out of imperative code into **configuration** and then into **knowledge**: declarative
+artifacts that a compiler validates, a human certifies, and a machine can author. This paper
+tells that story, then articulates the discipline the milestone proved out: the **AI grammar
+methodology** — engineering a codebase's documentation as a machine-consumable, CI-verified
+contract, so an AI partner can build correct applications from the grammar alone, and so every
+building block created on Mercury can compile a grammar of its own and stay legible to the next
+project that depends on it.
+
+---
+
+## 1 · Origin — composability before it was needed
+
+Mercury's copyright line starts in 2018, well before AI pair programmers existed. The problem it
+was built against is older still: enterprise backends rot at the joints. Direct calls between
+components, shared data structures, orchestration logic threaded through business code — every
+one of these is a coupling that makes the next change more expensive than the last.
+
+The founding decision came from the actor-model lineage (Scala/Akka) carried onto the Eclipse
+Vert.x event bus: **functions know nothing about each other.** A Mercury function is a
+self-contained unit addressed by a route-name string, exchanging immutable event envelopes. There
+is no other coupling surface — no shared objects, no direct references, nothing to rot. That rule
+is the framework's first architectural invariant, and it has never changed.
+
+For years the honest cost of this style was ergonomics: event-driven code asked developers to
+think in callbacks and reactive chains. Java 21 virtual threads dissolved that tax. A synchronous
+request in Mercury suspends a virtual thread instead of blocking a kernel thread, so plain
+sequential code performs on par with reactive code. The event-driven core became free to use —
+which mattered, because everything above it depends on it.
+
+> You can only compose what you never coupled. The decade of discipline at layer one is the
+> precondition for everything this paper describes.
+
+## 2 · The ascent — code → configuration → knowledge
+
+Each layer of Mercury removes a class of imperative code, and each removal was learned from
+watching where coupling sneaks back in.
+
+**Layer 1 — Event-driven (Platform Core).** Decoupled functions on the event bus. One atom, four
+roles: the same function is called a *service* when `rest.yaml` maps it to an HTTP endpoint, a
+*task* when a flow sequences it, a *skill* when a graph node carries it. Code remains the unit of
+work — never the unit of wiring.
+
+**Layer 2 — Composable (Event Script, introduced in v4).** Orchestration written as code is where
+coupling returns, so orchestration became configuration: YAML flows that name tasks by route,
+map data field-by-field between them, declare execution types, branches, and the exception path.
+A flow file does two jobs code cannot do as well: it **communicates intent** — the sequence,
+branches, and failure path are legible without reading Java — and it **manages dependencies**,
+because the engine enforces the wiring. Roughly half of an application stops being code.
+
+**Layer 3 — Semantic (the Active Knowledge Graph, executed by the MiniGraph engine).** The
+observation behind the third layer: most backend behavior — fetch, decide, transform, respond —
+is *knowledge about the business*, not engineering. So the model became the application: a
+property graph whose nodes carry skills that execute during traversal. Data contracts, decision
+logic, API composition, even long-running workflow suspension and resumption live in the model.
+For the common case, **zero imperative code**.
+
+The third layer is guarded the way production software must be: a graph deploys only through
+**CompileGraph**, the mandatory validation gate — a model is compiled and listed, or its endpoint
+answers 404 as if it never existed. Dry-run in the Playground, validate, then deploy: the same
+compile-before-run discipline that code has always had, applied to knowledge.
+
+This is deliberately **not** a "no code ever" dogma. Zero-code is the default, not a limit;
+Event Script and custom functions remain the escape hatch for the demanding edge, and the three
+layers compose cleanly — graph → flow → function — with no coupling anywhere in the stack.
+
+## 3 · The turn — why this matters to the AI world
+
+Two problems dominate serious AI-assisted engineering, and they meet exactly here.
+
+**The governance problem.** AI writes imperative code fast, and ungoverned. Enterprises cannot
+certify what they cannot read, and reviewing machine-authored code at machine speed does not
+scale. The industry's answer so far is more review. Mercury's answer is different: **change the
+artifact the AI authors.** An AI that authors a flow or a graph model is producing a declarative,
+compiler-validated, human-legible artifact. CompileFlows and CompileGraph reject malformed intent
+at build time; the Playground dry-runs it; a product owner can read and certify it. Mercury calls
+this **governed nondeterminism** — the creativity of a model author, bounded by gates. Never a
+determinism claim; a governance design.
+
+**The context problem.** AI agents consume context expensively. The default way an agent learns
+a dependency is to read its source — and that cost repeats for every dependency, every session,
+every team. A platform meant to be built *on* by AI partners has to make itself legible at a
+price that scales.
+
+The framework's decade of pushing behavior into declarations answers the first problem. The
+**AI grammar** answers the second.
+
+## 4 · The AI grammar — making a platform legible to machines
+
+**Definition.** An AI grammar is the machine-consumable contract of a codebase: the discovery
+map, reference guides, machine-readable catalogs, and validation gates that together let an AI
+agent author correct artifacts **without reading engine source**. It is not documentation with an
+AI sticker on it. It is documentation engineered to be *sufficient* (an agent guide may claim
+"you can generate correct artifacts from this page alone" — and only agent guides may claim it),
+*verified* (CI ties every claim to the code), and *cheap* (measured in tokens, not pages).
+
+**What Mercury ships today:**
+
+| Component | What it does |
+|---|---|
+| `llms.txt` discovery map | Routes an agent to the right page in one hop. On the Java engine it is an exhaustive site map with a CI **coverage gate** (a new guide cannot ship unlisted); on the Rust engine it is a deliberately curated agent map with a CI **link-integrity gate**. |
+| Three DSL spec kits | For each authoring surface — `rest.yaml`, Event Script flows, MiniGraph commands — a grammar reference, a machine-readable JSON catalog, an AI agent guide, and a **CI drift test** binding them to the engine. |
+| `ai-contract-provider` | Serves the documentation set as a **version-matched contract**: discovery endpoint, per-file SHA-256 manifest, exportable as an offline Agent Skill. The agent's docs match the engine it is actually driving. |
+| Registration Metadata Contract | The grammar of *declaring* functions — one metadata model with fixed boot semantics, carried by per-language idioms (Java annotations, Rust macros, future Python/Node decorators), proven by **golden vectors** shared verbatim between engines. |
+| Engine parity | The Java engine is the reference implementation; the Rust engine ships in lock-step; flow YAML ports unchanged; python/node functions join flows as Event-over-HTTP peers speaking the same envelope. The grammar is language-neutral because the contracts are. |
+| The shared memory layer | The *project's* grammar, distinct from the platform's: Vision, Blueprint, continuity, session logs — so every AI session starts oriented on intent and state, not just API shape. |
+
+**The benchmark.** The maintainer's ruling, and the discipline behind every entry: **doc
+discovery and token efficiency**. A grammar is useful only if the agent finds the right page in
+one hop and the map stays cheap to read. Measured on the Rust engine this week: a ~2,500-token
+map routes to ~46,000 tokens of source-verified reference — replacing a hunt through ~515,000
+tokens of source. Completeness that costs discovery is a regression; the map is curated, dense
+with the exact tokens an agent searches for, and gated so it cannot silently rot.
+
+**"Compiled" is meant literally.** What separates an AI grammar from ordinary documentation is
+that CI binds it to the code: drift tests for the three DSLs, the coverage and link-integrity
+gates on the maps, golden vectors for the cross-language contracts, the version-matched manifest.
+When documentation can drift freely, agents rationally learn to distrust it and go read source —
+which defeats the entire economics. The gates are what make guide-first behavior rational.
+
+**The proof.** The ai-enabled-repo-demo exercise put the grammar under load: fresh AI agents —
+no project context, no human hints — built and ran applications from the grammar alone, through
+repeated rehearsals and a live demonstration. Every friction they hit became a fix within days,
+shipped to the field in v4.12.2: a `json` simple plugin closing a data-mapping gap, an
+export-guard correction in the Playground, recipe lines added to the agent guides where two
+independent fresh agents drew the same wrong conclusion, and discovery gaps closed with CI gates
+behind them. That loop — **agent friction → grammar or engine fix → field release** — is the
+methodology working, not a promise that it might.
+
+## 5 · The methodology — how a developer builds with an AI partner
+
+The developer journey has three steps. Each is ordinary on its own; the compounding effect is
+the point.
+
+### Step 1 — AI-enable the project
+
+Greenfield or existing, the first act is not code: install the shared memory layer, and write
+the **Vision** with the AI partner — confirmed by the human, never fabricated by the machine.
+From the Vision, derive the **Blueprint**: the measured gap between the current state and the
+target. Plan implementation as increments that close it. Every subsequent session — any agent,
+any vendor — starts oriented: *Vision → Blueprint → Design → Implementation*, with feedback
+closing the loop.
+
+The proof point is Mercury's own Rust engine: AI-enabled **before its first line of code**, so
+every increment was derived from stated intent rather than reconstructed after the fact. Roughly
+a hundred increments later it ships in lock-step with the Java engine, with the same discipline
+intact.
+
+### Step 2 — add mercury-composable to the session, and choose the path
+
+The engine arrives carrying its own grammar — the `llms.txt` map, the version-matched contract,
+the exportable Agent Skill — so the session needs no source archaeology. Then choose the path:
+
+- **Recommended for user applications: Layer 3, the knowledge graph.** Express the service as a
+  graph model; dry-run it in the Playground with the AI companion; deploy it behind the
+  CompileGraph gate. The application *is* the model.
+- **Layer 2, Event Script**, when a flow is the natural shape — and beneath any graph that
+  composes onto flows.
+- **Layer 1, custom functions**, where code is genuinely the unit of work.
+
+The path is a dial, not a wall. The layers compose downward without coupling, so a project can
+start at the top and reach down exactly as far as the problem demands.
+
+### Step 3 — build the application — or a building block
+
+Two kinds of things get built on Mercury, and the methodology treats them differently on one
+crucial point.
+
+**A user application** goes intent → model (plus flows where needed) → certify → deploy. Its
+behavior changes by refining the model — the Vision's core promise.
+
+**A building block** — a common library or utility that rides on Mercury, the pattern of the
+framework's own Kafka adapter family — is implemented with **layer-2 and layer-3 patterns**:
+composable functions and reusable flows and skills, coupled to nothing, addressable by route
+name like everything else. And then the step that makes the methodology recursive:
+
+> **Compile an AI grammar into the building block's own repository.** Its guide, its map
+> entries, its machine-readable catalog where it has an authoring surface, its drift gates.
+> The block becomes legible to AI partners the same way Mercury is.
+
+A new application session then loads Mercury's grammar **plus each building block's grammar**,
+alongside the application's own memory layer. Grammar composes the way dependencies compose —
+transitively, and at near-constant token cost per block, because each grammar routes the agent
+to exactly what it needs instead of handing it source.
+
+**The recursion is already live inside the framework.** Twin-kafka is a building block built on
+a building block — a second Kafka cluster on top of minimalist-kafka — and this week supplied
+the cautionary tale that makes the premise concrete: while twin-kafka's entry was missing from
+the discovery map, the module was effectively invisible to AI partners, who fell back to source.
+The entry landed, with a CI gate behind it, and one hop of discovery replaced the hunt.
+
+**To an AI partner, undocumented capability is absent capability.** That sentence is the whole
+methodology in eight words.
+
+## 6 · Industry context — standing on recognized practice
+
+The AI grammar is not a private invention; it is a hardening of practices the industry already
+trusts, assembled into one discipline and pointed at AI collaboration:
+
+- **`llms.txt`** — the emerging convention for machine-readable site maps. Mercury adopts it and
+  then does what conventions alone cannot: gates it in CI (coverage on the exhaustive map,
+  link integrity on the curated one) and holds it to a measured token-efficiency benchmark.
+- **Docs-as-code** — documentation versioned, reviewed, and built like software. Mercury extends
+  it to *docs-as-contract*: drift tests fail the build when a guide and its engine disagree.
+- **Architecture Decision Records** (Nygard) — Mercury's ADR ledger holds the durable rationale;
+  the memory layer's facts point at ADRs, so agents inherit the *why*, not just the what.
+- **Consumer-driven contract testing** — the golden-vector suites (envelope wire format,
+  registration metadata) are contract tests shared verbatim between independent engine
+  implementations, the same trust mechanism Pact-style testing brought to service boundaries.
+- **Agent-instruction conventions** (`AGENTS.md` and kin) — Mercury layers a routing shim on
+  top: contributors are directed into the memory protocol, consumers into the version-matched
+  contract, so each audience gets its own grammar.
+- **Event-driven architecture and the actor model** — the substrate itself is orthodox EDA;
+  Mercury's contribution is carrying its decoupling discipline up into configuration and
+  knowledge.
+- **Human-in-the-loop governance** — dry-run before deploy, compile gates, human certification,
+  and staged promotion mirror the review-and-release controls enterprises already run in their
+  delivery pipelines; the graph lifecycle applies them to model artifacts.
+- **Evaluation culture** — the demo's fresh-agent rehearsals are evals for documentation; the
+  memory smoke test is an eval for project memory. Both run on cadence, both produced fixes.
+
+The synthesis is the contribution: each practice is known; **binding them into a single,
+CI-enforced, token-budgeted contract that an AI partner can build from is the AI grammar.**
+
+## 7 · What this unlocks
+
+- **Enterprise-grade AI development.** The AI authors models and configuration; compilers and
+  humans gate; the certified artifact deploys. Nondeterministic authorship, governed outcome.
+- **Sustainable context economics.** An agent's context budget scales with the task, not with
+  the dependency tree — because every dependency worth using carries a grammar.
+- **Human–AI co-authorship as a first-class capability.** Playground sessions an AI can host
+  with humans joining as equal co-authors; a synchronous companion endpoint; suspend/resume as
+  the human-in-the-loop primitive inside a running workflow.
+- **Language independence.** The envelope and registration contracts make the grammar polyglot:
+  Java and Rust engines in lock-step, python and node functions joining the same flows as peers.
+
+## 8 · Where it goes
+
+The public Blueprint continues the same line: **AI agent orchestration on the graph runtime** —
+bounded-agency decision graphs where LLM reasoning and tools join as nodes, with the first
+experiment already run end-to-end (a support-triage graph driving live LLM verdicts through the
+engine under one distributed trace); a **pluggable AI companion backend** maturing the
+collaboration layer; and the **enterprise governance lifecycle** — dry-run → certify → stage →
+approve → production — so models promote to production as standard endpoints.
+
+The north star does not move:
+
+> **The Active Knowledge Graph is the application.** Humans and AI co-author the model, the
+> event-driven runtime executes it, and changing behavior means editing knowledge — not
+> shipping code.
+
+---
+
+*Sources: this repository's `docs/guides/` and `docs/arch-decisions/ADR.md`; the shared memory
+layer (`memory/vision.md`, `memory/continuity.md`); the ai-enabled-repo-demo exercise records;
+measurements taken 2026-09-04 on the Rust engine's documentation map. All figures are
+reproducible from the cited artifacts.*

--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -38,8 +38,9 @@ was built against is older still: enterprise backends rot at the joints. Direct 
 components, shared data structures, orchestration logic threaded through business code — every
 one of these is a coupling that makes the next change more expensive than the last.
 
-The founding decision came from the actor-model lineage (Scala/Akka) carried onto the Eclipse
-Vert.x event bus: **functions know nothing about each other.** A Mercury function is a
+The founding decision came from the actor-model lineage [2] (Scala/Akka) carried onto the Eclipse
+Vert.x event bus: **functions know nothing about each other** — information hiding [1], applied
+without exception. A Mercury function is a
 self-contained unit addressed by a route-name string, exchanging immutable event envelopes. There
 is no other coupling surface — no shared objects, no direct references, nothing to rot. That rule
 is the framework's first architectural invariant, and it has never changed.
@@ -92,7 +93,11 @@ Two problems dominate serious AI-assisted engineering, and they meet exactly her
 
 **The governance problem.** AI writes imperative code fast, and ungoverned. Enterprises cannot
 certify what they cannot read, and reviewing machine-authored code at machine speed does not
-scale. The industry's answer so far is more review. Mercury's answer is different: **change the
+scale. The evidence is measurable: AI-generated code reproduces known vulnerability patterns in a
+large fraction of security-relevant scenarios [3]; developers assisted by AI write less secure
+code while believing it more secure [4]; and industry-wide delivery research ties rising AI
+adoption to reduced delivery stability, even as throughput improves [5]. The industry's answer so
+far is more review. Mercury's answer is different: **change the
 artifact the AI authors.** An AI that authors a flow or a graph model is producing a declarative,
 compiler-validated, human-legible artifact. CompileFlows and CompileGraph reject malformed intent
 at build time; the Playground dry-runs it; a product owner can read and certify it. Mercury calls
@@ -101,8 +106,9 @@ determinism claim; a governance design.
 
 **The context problem.** AI agents consume context expensively. The default way an agent learns
 a dependency is to read its source — and that cost repeats for every dependency, every session,
-every team. A platform meant to be built *on* by AI partners has to make itself legible at a
-price that scales.
+every team. Nor is a huge context window a substitute for curation: models measurably degrade at using
+information buried in the middle of long inputs [6]. A platform meant to be built *on* by AI
+partners has to make itself legible at a price that scales.
 
 The framework's decade of pushing behavior into declarations answers the first problem. The
 **AI grammar** answers the second.
@@ -121,7 +127,7 @@ AI sticker on it. It is documentation engineered to be *sufficient* (an agent gu
 | Component | What it does |
 |---|---|
 | `llms.txt` discovery map | Routes an agent to the right page in one hop. On the Java engine it is an exhaustive site map with a CI **coverage gate** (a new guide cannot ship unlisted); on the Rust engine it is a deliberately curated agent map with a CI **link-integrity gate**. |
-| Three DSL spec kits | For each authoring surface — `rest.yaml`, Event Script flows, MiniGraph commands — a grammar reference, a machine-readable JSON catalog, an AI agent guide, and a **CI drift test** binding them to the engine. |
+| Three DSL spec kits | For each authoring surface — `rest.yaml`, Event Script flows, MiniGraph commands — a grammar reference, a machine-readable JSON catalog, an AI agent guide, and a **CI drift test** binding them to the engine — the machine-readable-contract idea OpenAPI proved for HTTP APIs [7], applied to authoring surfaces. |
 | `ai-contract-provider` | Serves the documentation set as a **version-matched contract**: discovery endpoint, per-file SHA-256 manifest, exportable as an offline Agent Skill. The agent's docs match the engine it is actually driving. |
 | Registration Metadata Contract | The grammar of *declaring* functions — one metadata model with fixed boot semantics, carried by per-language idioms (Java annotations, Rust macros, future Python/Node decorators), proven by **golden vectors** shared verbatim between engines. |
 | Engine parity | The Java engine is the reference implementation; the Rust engine ships in lock-step; flow YAML ports unchanged; python/node functions join flows as Event-over-HTTP peers speaking the same envelope. The grammar is language-neutral because the contracts are. |
@@ -219,27 +225,37 @@ methodology in eight words.
 The AI grammar is not a private invention; it is a hardening of practices the industry already
 trusts, assembled into one discipline and pointed at AI collaboration:
 
-- **`llms.txt`** — the emerging convention for machine-readable site maps. Mercury adopts it and
+- **`llms.txt`** [8] — the emerging convention for machine-readable site maps, proposed on the
+  same premise as our benchmark: context is finite, so hand agents a curated, token-efficient
+  map. Mercury adopts it and
   then does what conventions alone cannot: gates it in CI (coverage on the exhaustive map,
   link integrity on the curated one) and holds it to a measured token-efficiency benchmark.
-- **Docs-as-code** — documentation versioned, reviewed, and built like software. Mercury extends
+- **Docs-as-code** [9] — documentation versioned, reviewed, and built like software. Mercury extends
   it to *docs-as-contract*: drift tests fail the build when a guide and its engine disagree.
-- **Architecture Decision Records** (Nygard) — Mercury's ADR ledger holds the durable rationale;
+- **Architecture Decision Records** (Nygard, 2011) [10] — Mercury's ADR ledger holds the durable rationale;
   the memory layer's facts point at ADRs, so agents inherit the *why*, not just the what.
-- **Consumer-driven contract testing** — the golden-vector suites (envelope wire format,
+- **Consumer-driven contract testing** [11] — the golden-vector suites (envelope wire format,
   registration metadata) are contract tests shared verbatim between independent engine
-  implementations, the same trust mechanism Pact-style testing brought to service boundaries.
-- **Agent-instruction conventions** (`AGENTS.md` and kin) — Mercury layers a routing shim on
+  implementations, the same trust mechanism Pact-style testing [12] brought to service boundaries.
+- **Agent-instruction conventions** (`AGENTS.md` and kin) [13] — Mercury layers a routing shim on
   top: contributors are directed into the memory protocol, consumers into the version-matched
   contract, so each audience gets its own grammar.
-- **Event-driven architecture and the actor model** — the substrate itself is orthodox EDA;
+- **Spec-driven development** [14] — the industry's 2025 turn toward the specification as the
+  primary artifact AI builds from, with generation validated against it. The AI grammar applies
+  the same principle one level down: the *platform's* contract, versioned and gated, is what the
+  AI builds *with*.
+- **Event-driven architecture and the actor model** [2] — the substrate itself is orthodox EDA;
   Mercury's contribution is carrying its decoupling discipline up into configuration and
   knowledge.
 - **Human-in-the-loop governance** — dry-run before deploy, compile gates, human certification,
   and staged promotion mirror the review-and-release controls enterprises already run in their
-  delivery pipelines; the graph lifecycle applies them to model artifacts.
-- **Evaluation culture** — the demo's fresh-agent rehearsals are evals for documentation; the
-  memory smoke test is an eval for project memory. Both run on cadence, both produced fixes.
+  delivery pipelines — and the oversight posture that AI risk frameworks and regulation now
+  require of consequential AI systems [15][16][17]; the graph lifecycle applies them to model
+  artifacts.
+- **Evaluation culture** [18][19] — the demo's fresh-agent rehearsals are evals for
+  documentation; the memory smoke test is an eval for project memory. Both run on cadence, both
+  produced fixes — the same systematic-measurement stance the LLM evaluation literature brought
+  to models themselves.
 
 The synthesis is the contribution: each practice is known; **binding them into a single,
 CI-enforced, token-budgeted contract that an AI partner can build from is the AI grammar.**
@@ -270,6 +286,45 @@ The north star does not move:
 > **The Active Knowledge Graph is the application.** Humans and AI co-author the model, the
 > event-driven runtime executes it, and changing behavior means editing knowledge — not
 > shipping code.
+
+
+## References
+
+1. D. L. Parnas, *On the Criteria To Be Used in Decomposing Systems into Modules*, Communications
+   of the ACM 15(12), 1972. <https://dl.acm.org/doi/10.1145/361598.361623>
+2. C. Hewitt, P. Bishop, R. Steiger, *A Universal Modular ACTOR Formalism for Artificial
+   Intelligence*, IJCAI 1973. <https://www.ijcai.org/Proceedings/73/Papers/027B.pdf>
+3. H. Pearce et al., *Asleep at the Keyboard? Assessing the Security of GitHub Copilot's Code
+   Contributions*, IEEE Symposium on Security and Privacy, 2022. <https://arxiv.org/abs/2108.09293>
+4. N. Perry, M. Srivastava, D. Kumar, D. Boneh, *Do Users Write More Insecure Code with AI
+   Assistants?*, ACM CCS 2023. <https://arxiv.org/abs/2211.03622>
+5. DORA / Google Cloud, *Accelerate State of DevOps Report 2024* and *State of AI-assisted
+   Software Development 2025* — AI adoption correlated with reduced delivery stability (−7.2%,
+   2024); throughput positive but stability still negative (2025). <https://dora.dev>
+6. N. F. Liu et al., *Lost in the Middle: How Language Models Use Long Contexts*, Transactions of
+   the ACL 12, 2024. <https://aclanthology.org/2024.tacl-1.9/>
+7. OpenAPI Initiative, *OpenAPI Specification*. <https://spec.openapis.org/oas/latest.html>
+8. J. Howard, *The /llms.txt file* — proposal, Answer.AI, September 2024. <https://llmstxt.org>
+9. Write the Docs community, *Docs as Code*. <https://www.writethedocs.org/guide/docs-as-code/>
+10. M. Nygard, *Documenting Architecture Decisions*, 2011.
+    <https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>
+11. I. Robinson, *Consumer-Driven Contracts: A Service Evolution Pattern*, martinfowler.com, 2006.
+    <https://www.martinfowler.com/articles/consumerDrivenContracts.html>
+12. Pact — consumer-driven contract testing. <https://docs.pact.io>
+13. *AGENTS.md — an open format for guiding coding agents* (donated to the Agentic AI Foundation,
+    Linux Foundation, 2025). <https://agents.md>
+14. GitHub, *Spec-driven development with AI: get started with a new open source toolkit*, 2025.
+    <https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/>
+15. NIST, *Artificial Intelligence Risk Management Framework (AI RMF 1.0)*, NIST AI 100-1,
+    January 2023. <https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf>
+16. Regulation (EU) 2024/1689 (EU AI Act), Article 14 — Human oversight.
+    <https://artificialintelligenceact.eu/article/14/>
+17. ISO/IEC 42001:2023, *Artificial intelligence — Management system*.
+    <https://www.iso.org/standard/42001>
+18. P. Liang et al., *Holistic Evaluation of Language Models*, 2022 (arXiv:2211.09110).
+    <https://arxiv.org/abs/2211.09110>
+19. C. E. Jimenez et al., *SWE-bench: Can Language Models Resolve Real-World GitHub Issues?*,
+    ICLR 2024. <https://arxiv.org/abs/2310.06770>
 
 ---
 

--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -140,7 +140,7 @@ gates on the maps, golden vectors for the cross-language contracts, the version-
 When documentation can drift freely, agents rationally learn to distrust it and go read source —
 which defeats the entire economics. The gates are what make guide-first behavior rational.
 
-**The proof.** The ai-enabled-repo-demo exercise put the grammar under load: fresh AI agents —
+**The proof.** The ai-enabled-repo-demo exercises put the grammar under load: fresh AI agents —
 no project context, no human hints — built and ran applications from the grammar alone, through
 repeated rehearsals and a live demonstration. Every friction they hit became a fix within days,
 shipped to the field in v4.12.2: a `json` simple plugin closing a data-mapping gap, an
@@ -274,6 +274,6 @@ The north star does not move:
 ---
 
 *Sources: this repository's `docs/guides/` and `docs/arch-decisions/ADR.md`; the shared memory
-layer (`memory/vision.md`, `memory/continuity.md`); the ai-enabled-repo-demo exercise records;
+layer (`memory/vision.md`, `memory/continuity.md`); records of the ai-enabled-repo-demo exercises;
 measurements taken 2026-09-04 on the Rust engine's documentation map. All figures are
 reproducible from the cited artifacts.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ event-driven core descends from the **Scala/Akka actor model**, realized on the 
 event bus.
 
 [Get started](guides/getting-started.md){ .md-button .md-button--primary }
-[Read the white paper](ai-grammar-methodology.md){ .md-button }
-[View the deck](presentations/ai-grammar-story.html){ .md-button }
+[Read the white paper](https://accenture.github.io/mercury-composable/ai-grammar-methodology/){ .md-button }
+[View the deck](https://accenture.github.io/mercury-composable/presentations/ai-grammar-story.html){ .md-button }
 
 *The white paper — **The Mercury Story: Origin, Evolution, and the AI Grammar Methodology** — tells
 why Mercury exists and how to build applications and building blocks with an AI partner; the deck is

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,17 @@ event bus.
 
 > **New here?** Start with **[Getting Started](guides/getting-started.md)** — it opens with a 5-minute quickstart.
 
+## The story and the method
+
+Two flagship reads set the frame for everything below:
+
+- **[The Mercury Story — Origin, Evolution, and the AI Grammar Methodology](ai-grammar-methodology.md)** —
+  the white paper: why Mercury exists, the ascent from code to configuration to knowledge, and the
+  methodology for building applications *and building blocks* with an AI partner — where every
+  building block compiles an AI grammar of its own and stays legible to the next project.
+- **[The presentation deck](presentations/ai-grammar-story.html)** — the same story in slides, for
+  a talk or a first briefing.
+
 ## A layered ascent
 
 Mercury grew in three layers. Each builds on the one beneath it, and you can mix them in a single

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,18 +16,13 @@ virtual threads, so straightforward synchronous code performs on par with reacti
 event-driven core descends from the **Scala/Akka actor model**, realized on the **Eclipse Vert.x**
 event bus.
 
-> **New here?** Start with **[Getting Started](guides/getting-started.md)** — it opens with a 5-minute quickstart.
+[Get started](guides/getting-started.md){ .md-button .md-button--primary }
+[Read the white paper](ai-grammar-methodology.md){ .md-button }
+[View the deck](presentations/ai-grammar-story.html){ .md-button }
 
-## The story and the method
-
-Two flagship reads set the frame for everything below:
-
-- **[The Mercury Story — Origin, Evolution, and the AI Grammar Methodology](ai-grammar-methodology.md)** —
-  the white paper: why Mercury exists, the ascent from code to configuration to knowledge, and the
-  methodology for building applications *and building blocks* with an AI partner — where every
-  building block compiles an AI grammar of its own and stays legible to the next project.
-- **[The presentation deck](presentations/ai-grammar-story.html)** — the same story in slides, for
-  a talk or a first briefing.
+*The white paper — **The Mercury Story: Origin, Evolution, and the AI Grammar Methodology** — tells
+why Mercury exists and how to build applications and building blocks with an AI partner; the deck is
+the same story in slides.*
 
 ## A layered ascent
 

--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -316,7 +316,7 @@
   <section class="slide" aria-label="Proven at the milestone">
     <p class="eyebrow">Proven, not promised</p>
     <h2>The milestone: fresh agents, grammar only</h2>
-    <p class="lede">The ai-enabled-repo-demo exercise put the grammar under load: fresh AI agents —
+    <p class="lede">The ai-enabled-repo-demo exercises put the grammar under load: fresh AI agents —
     no project context, no human hints — built and ran applications from the grammar alone, through
     repeated rehearsals and a live demonstration.</p>
     <ul class="list">

--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Mercury Story</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap">
+<style>
+  /* ── The Mercury Story · presentation deck ──────────────────────────────
+     A deliberately single-theme, dark deck (violet-biased ground, amber for
+     measured numbers). Self-contained: works on the mkdocs site, in an
+     artifact, or from a local file. Print flips to a light handout. */
+  :root{
+    --ground:#171221; --surface:#201936; --surface-2:#291f44;
+    --ink:#F1ECFA; --muted:#A79DC2; --line:#382E52;
+    --accent:#A78BFA; --accent-ink:#CDBBFF; --amber:#FFC24B;
+    --display:"Fraunces", Georgia, "Times New Roman", serif;
+    --body:"Instrument Sans", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono:ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  }
+  *{box-sizing:border-box; margin:0; padding:0}
+  html,body{height:100%}
+  body{
+    background:var(--ground); color:var(--ink);
+    font-family:var(--body); font-size:clamp(15px,1.35vw,19px); line-height:1.55;
+    overflow:hidden;
+  }
+  .deck{position:fixed; inset:0; display:flex; flex-direction:column}
+
+  /* ── slides ── */
+  .slide{
+    position:absolute; inset:0 0 56px 0; display:none;
+    padding:clamp(28px,5.5vh,64px) clamp(24px,7vw,110px);
+    overflow-y:auto;
+  }
+  .slide.active{display:flex; flex-direction:column; justify-content:center}
+  @media (prefers-reduced-motion: no-preference){
+    .slide.active{animation:rise .45s ease-out}
+    @keyframes rise{from{opacity:.01; transform:translateY(10px)} to{opacity:1; transform:none}}
+  }
+  .eyebrow{
+    font-size:.72em; font-weight:600; letter-spacing:.14em; text-transform:uppercase;
+    color:var(--accent); margin-bottom:1.1em;
+  }
+  h1,h2{font-family:var(--display); font-weight:600; line-height:1.12; text-wrap:balance; letter-spacing:-.01em}
+  h1{font-size:clamp(34px,5.4vw,72px)}
+  h2{font-size:clamp(26px,3.6vw,48px); margin-bottom:.7em}
+  h3{font-family:var(--body); font-weight:600; font-size:1.05em; margin-bottom:.35em}
+  p{max-width:62ch}
+  .lede{font-size:1.12em; color:var(--muted); max-width:58ch}
+  .lede strong,.cols strong,li strong{color:var(--ink)}
+  em{font-family:var(--display); font-style:italic}
+  code{font-family:var(--mono); font-size:.85em; background:var(--surface); border:1px solid var(--line);
+       padding:.1em .4em; border-radius:5px; white-space:nowrap}
+  .muted{color:var(--muted)}
+  .amber{color:var(--amber)}
+  .accent{color:var(--accent-ink)}
+
+  /* layout helpers */
+  .cols{display:grid; gap:clamp(16px,2.5vw,40px); margin-top:1.4em}
+  .cols.two{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+  .cols.three{grid-template-columns:repeat(auto-fit,minmax(230px,1fr))}
+  .panel{background:var(--surface); border:1px solid var(--line); border-radius:12px;
+         padding:clamp(14px,1.8vw,26px)}
+  .panel .tag{font-size:.7em; font-weight:600; letter-spacing:.12em; text-transform:uppercase;
+              color:var(--muted); margin-bottom:.6em}
+  ul.list{list-style:none; margin-top:1em; max-width:70ch}
+  ul.list li{padding:.42em 0 .42em 1.4em; position:relative}
+  ul.list li::before{content:""; position:absolute; left:0; top:.98em; width:.55em; height:.55em;
+                     border-radius:50%; background:var(--accent); opacity:.85}
+  .quote{font-family:var(--display); font-style:italic; font-weight:500;
+         font-size:clamp(22px,2.9vw,40px); line-height:1.3; max-width:26em; text-wrap:balance}
+  .quote .q{color:var(--accent-ink)}
+  .byline{margin-top:1.6em; color:var(--muted)}
+  .kv{display:grid; grid-template-columns:max-content 1fr; gap:.45em 1.2em; margin-top:1.2em; max-width:78ch}
+  .kv dt{font-weight:600; color:var(--accent-ink); white-space:nowrap}
+  .kv dd{color:var(--muted)}
+  .kv dd b{color:var(--ink); font-weight:600}
+
+  /* stat band */
+  .stats{display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:clamp(14px,2vw,28px); margin:1.6em 0 1.2em}
+  .stat{background:var(--surface); border:1px solid var(--line); border-radius:12px; padding:1.1em 1.2em}
+  .stat .n{font-family:var(--display); font-weight:600; font-size:clamp(30px,3.4vw,52px);
+           font-variant-numeric:tabular-nums; color:var(--amber); line-height:1.1}
+  .stat .l{color:var(--muted); margin-top:.35em; font-size:.92em}
+  .stat.dim .n{color:var(--muted); text-decoration:line-through; text-decoration-thickness:2px;
+               text-decoration-color:var(--accent)}
+
+  /* steps (methodology) */
+  .steps{display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:clamp(14px,2vw,28px); margin-top:1.4em; counter-reset:step}
+  .step{background:var(--surface); border:1px solid var(--line); border-radius:12px; padding:1.2em 1.3em; counter-increment:step}
+  .step::before{content:"Step " counter(step); display:block; font-size:.72em; font-weight:600;
+                letter-spacing:.13em; text-transform:uppercase; color:var(--amber); margin-bottom:.6em}
+  .step h3{font-family:var(--display); font-weight:600; font-size:1.25em; margin-bottom:.4em}
+  .step p{font-size:.95em; color:var(--muted)}
+  .step p b{color:var(--ink)}
+
+  figure{margin:1.4em 0 0}
+  figure svg{max-width:100%; height:auto; display:block}
+  figcaption{color:var(--muted); font-size:.88em; margin-top:.7em; max-width:70ch}
+
+  /* ── chrome ── */
+  .bar{
+    position:absolute; left:0; right:0; bottom:0; height:56px;
+    display:flex; align-items:center; gap:18px; padding:0 clamp(18px,4vw,48px);
+    border-top:1px solid var(--line); background:var(--ground); z-index:5;
+  }
+  .wordmark{font-family:var(--display); font-weight:600; letter-spacing:.02em}
+  .wordmark .dot{color:var(--accent)}
+  .counter{font-variant-numeric:tabular-nums; color:var(--muted); font-size:.85em; margin-left:auto}
+  .dots{display:flex; gap:7px}
+  .dots button{width:9px; height:9px; border-radius:50%; border:0; background:var(--line); cursor:pointer; padding:0}
+  .dots button.on{background:var(--accent)}
+  .dots button:focus-visible{outline:2px solid var(--amber); outline-offset:2px}
+  .navbtn{border:1px solid var(--line); background:var(--surface); color:var(--ink);
+          border-radius:8px; padding:.35em .8em; font:inherit; font-size:.85em; cursor:pointer}
+  .navbtn:hover{background:var(--surface-2)}
+  .navbtn:focus-visible{outline:2px solid var(--amber); outline-offset:2px}
+  .hint{color:var(--muted); font-size:.8em}
+  @media (max-width:720px){ .hint,.dots{display:none} }
+
+  /* invisible page-turn click zones (left third back, right two-thirds forward) */
+  .zone{position:absolute; top:0; bottom:56px; z-index:2; background:transparent; border:0; cursor:pointer}
+  .zone:focus-visible{outline:2px solid var(--amber); outline-offset:-4px}
+  .zone.back{left:0; width:22%} .zone.fwd{right:0; width:26%}
+
+  /* ── print: a light handout, one slide per page ── */
+  @media print{
+    body{background:#fff; color:#231b33; overflow:visible}
+    .deck{position:static}
+    .slide{position:static; display:block !important; inset:auto; padding:24px 8mm; page-break-after:always; overflow:visible}
+    .slide.active{animation:none}
+    :root{--ground:#fff; --surface:#f4f1fa; --surface-2:#ece7f6; --ink:#231b33; --muted:#5d5476;
+          --line:#d8d0e8; --accent:#6d4fc4; --accent-ink:#5636b8; --amber:#a06a00}
+    .bar,.zone{display:none}
+  }
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+
+  <!-- 1 · title -->
+  <section class="slide active" aria-label="Title">
+    <p class="eyebrow">Mercury Composable · white paper briefing</p>
+    <h1>The Mercury Story</h1>
+    <p class="lede" style="margin-top:.9em">Origin, evolution — and the <strong>AI grammar
+    methodology</strong>: how a platform makes itself legible to AI partners, and how everything
+    built on it stays legible too.</p>
+    <p class="byline">Eric Law · with Claude Code &nbsp;·&nbsp; 2026-09-04 &nbsp;·&nbsp;
+    on the occasion of the ai-enabled-repo-demo milestone</p>
+  </section>
+
+  <!-- 2 · two problems -->
+  <section class="slide" aria-label="Two problems">
+    <p class="eyebrow">Why now</p>
+    <h2>Two problems dominate serious AI-assisted engineering</h2>
+    <div class="cols two">
+      <div class="panel">
+        <p class="tag">The governance problem</p>
+        <p>AI writes imperative code fast — and ungoverned. Enterprises cannot certify what they
+        cannot read, and reviewing machine-authored code at machine speed does not scale.</p>
+      </div>
+      <div class="panel">
+        <p class="tag">The context problem</p>
+        <p>AI agents consume context expensively. The default way an agent learns a dependency is
+        to <em>read its source</em> — a cost that repeats for every dependency, every session,
+        every team.</p>
+      </div>
+    </div>
+    <p class="lede" style="margin-top:1.6em">Mercury answers both — and it started answering them
+    <strong>years before the questions were asked</strong>.</p>
+  </section>
+
+  <!-- 3 · origin -->
+  <section class="slide" aria-label="Origin">
+    <p class="eyebrow">Origin · 2018</p>
+    <h2>One rule, never broken: functions know nothing about each other</h2>
+    <p class="lede">From the actor-model lineage (Scala/Akka) onto the Eclipse Vert.x event bus:
+    every function is self-contained, addressed by a <strong>route-name string</strong>, exchanging
+    immutable <strong>event envelopes</strong>. No shared objects. No direct references. Nothing
+    to rot at the joints.</p>
+    <ul class="list">
+      <li><strong>The first architectural invariant</strong> — and it has never changed.</li>
+      <li>For years the honest cost was ergonomics: callbacks and reactive chains.</li>
+      <li><strong>Java 21 virtual threads dissolved that tax</strong> — plain sequential code now
+      performs on par with reactive, so the event-driven core became free to use.</li>
+    </ul>
+    <p class="quote" style="margin-top:1.3em"><span class="q">You can only compose what you never
+    coupled.</span></p>
+  </section>
+
+  <!-- 4 · the ascent -->
+  <section class="slide" aria-label="The ascent">
+    <p class="eyebrow">Evolution</p>
+    <h2>The ascent: code → configuration → knowledge</h2>
+    <figure>
+      <svg viewBox="0 0 960 330" role="img"
+           aria-label="Three layers: an Active Knowledge Graph model composes onto Event Script YAML flows, which sequence decoupled functions on the event bus. Each layer removes a class of imperative code.">
+        <defs>
+          <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#A79DC2"/>
+          </marker>
+        </defs>
+        <!-- layer 3 -->
+        <rect x="40" y="20" width="560" height="80" rx="10" fill="#291f44" stroke="#A78BFA" stroke-width="1.5"/>
+        <text x="64" y="52" fill="#CDBBFF" font-size="13" font-weight="600" letter-spacing="2">LAYER 3 · SEMANTIC</text>
+        <text x="64" y="78" fill="#F1ECFA" font-size="16">Active Knowledge Graph — the model <tspan fill="#A79DC2">is</tspan> the application</text>
+        <!-- layer 2 -->
+        <rect x="40" y="125" width="560" height="80" rx="10" fill="#201936" stroke="#382E52" stroke-width="1.5"/>
+        <text x="64" y="157" fill="#CDBBFF" font-size="13" font-weight="600" letter-spacing="2">LAYER 2 · COMPOSABLE</text>
+        <text x="64" y="183" fill="#F1ECFA" font-size="16">Event Script — YAML flows choreograph functions</text>
+        <!-- layer 1 -->
+        <rect x="40" y="230" width="560" height="80" rx="10" fill="#201936" stroke="#382E52" stroke-width="1.5"/>
+        <text x="64" y="262" fill="#CDBBFF" font-size="13" font-weight="600" letter-spacing="2">LAYER 1 · EVENT-DRIVEN</text>
+        <text x="64" y="288" fill="#F1ECFA" font-size="16">Decoupled functions — route name + envelope only</text>
+        <!-- compose arrows -->
+        <line x1="620" y1="60" x2="620" y2="165" stroke="#A79DC2" stroke-width="1.5" marker-end="url(#arr)"/>
+        <line x1="620" y1="165" x2="620" y2="270" stroke="#A79DC2" stroke-width="1.5" marker-end="url(#arr)"/>
+        <text x="634" y="118" fill="#A79DC2" font-size="12.5">graph.task / graph.extension</text>
+        <text x="634" y="223" fill="#A79DC2" font-size="12.5">tasks call functions by route</text>
+        <!-- what each removes -->
+        <text x="880" y="52" fill="#FFC24B" font-size="13" font-weight="600" text-anchor="end">removes: application code</text>
+        <text x="880" y="78" fill="#A79DC2" font-size="12.5" text-anchor="end">zero-code default; certify &amp; deploy the model</text>
+        <text x="880" y="157" fill="#FFC24B" font-size="13" font-weight="600" text-anchor="end">removes: orchestration code</text>
+        <text x="880" y="183" fill="#A79DC2" font-size="12.5" text-anchor="end">~50% config / 50% code</text>
+        <text x="880" y="262" fill="#FFC24B" font-size="13" font-weight="600" text-anchor="end">removes: coupling</text>
+        <text x="880" y="288" fill="#A79DC2" font-size="12.5" text-anchor="end">code stays the unit of work, never the wiring</text>
+      </svg>
+      <figcaption>Each layer removes a class of imperative code. One atom, four roles: the same
+      function is a <em>service</em> under <code>rest.yaml</code>, a <em>task</em> in a flow, a
+      <em>skill</em> on a graph node. The layers compose downward with no coupling.</figcaption>
+    </figure>
+  </section>
+
+  <!-- 5 · governed layer 3 -->
+  <section class="slide" aria-label="Compiled or 404">
+    <p class="eyebrow">Layer 3, governed</p>
+    <h2>Compiled — or 404</h2>
+    <p class="lede">The semantic layer is guarded the way production software must be. A graph
+    model deploys only through <strong>CompileGraph</strong>, the mandatory validation gate: a
+    model is compiled and listed, or its endpoint answers 404 as if it never existed.</p>
+    <ul class="list">
+      <li><strong>Dry-run</strong> the model in the Playground — with a human and an AI companion
+      in the same live session.</li>
+      <li><strong>Validate</strong> the whole graph at compile time — malformed intent is rejected
+      before it can run.</li>
+      <li><strong>Deploy</strong> as a standard endpoint; suspend/resume gives long-running
+      workflows a built-in human-in-the-loop primitive.</li>
+    </ul>
+    <p class="muted" style="margin-top:1.2em">The same compile-before-run discipline code has
+    always had — applied to knowledge.</p>
+  </section>
+
+  <!-- 6 · the turn -->
+  <section class="slide" aria-label="The turn">
+    <p class="eyebrow">The turn</p>
+    <h2>Don't review AI code harder.<br>Change the artifact the AI authors.</h2>
+    <p class="lede">An AI that authors a <strong>flow</strong> or a <strong>graph model</strong> is
+    producing a declarative, compiler-validated, human-legible artifact. CompileFlows and
+    CompileGraph reject malformed intent at build time; the Playground dry-runs it; a product
+    owner can read it and certify it.</p>
+    <p class="quote" style="margin-top:1.2em"><span class="q">Governed nondeterminism</span> — the
+    creativity of a model author, bounded by gates.</p>
+    <p class="muted" style="margin-top:1em">Never a determinism claim. A governance design.</p>
+  </section>
+
+  <!-- 7 · AI grammar defined -->
+  <section class="slide" aria-label="AI grammar defined">
+    <p class="eyebrow">The AI grammar</p>
+    <h2>Documentation engineered as a machine-consumable contract</h2>
+    <p class="lede">An <strong>AI grammar</strong> is the discovery map, reference guides,
+    machine-readable catalogs, and validation gates that let an AI agent author correct artifacts
+    <strong>without reading engine source</strong>.</p>
+    <div class="cols three">
+      <div class="panel"><p class="tag">Sufficient</p><p>An agent guide may claim “you can generate
+      correct artifacts from this page alone” — and only agent guides may claim it.</p></div>
+      <div class="panel"><p class="tag">Verified</p><p>CI binds every claim to the code: drift
+      tests, coverage and link-integrity gates, golden vectors, a version-matched manifest.</p></div>
+      <div class="panel"><p class="tag">Cheap</p><p>Measured in tokens, not pages. Discovery in
+      one hop; a map that stays lean enough to read every session.</p></div>
+    </div>
+  </section>
+
+  <!-- 8 · what mercury ships -->
+  <section class="slide" aria-label="What Mercury ships">
+    <p class="eyebrow">Shipped today</p>
+    <h2>The grammar Mercury carries</h2>
+    <dl class="kv">
+      <dt>llms.txt map</dt><dd>one-hop discovery — <b>CI coverage gate</b> on the Java engine’s exhaustive map; <b>link-integrity gate</b> on the Rust engine’s curated map</dd>
+      <dt>3 DSL spec kits</dt><dd><code>rest.yaml</code> · Event Script flows · MiniGraph commands — each a grammar reference + <b>machine-readable JSON catalog</b> + AI agent guide + <b>CI drift test</b></dd>
+      <dt>Contract provider</dt><dd>the doc set served as a <b>version-matched contract</b>: discovery endpoint, per-file SHA-256 manifest, exportable Agent Skill</dd>
+      <dt>Registration contract</dt><dd>the grammar of <i>declaring</i> functions — one metadata model, per-language carriers, proven by <b>golden vectors</b> shared between engines</dd>
+      <dt>Engine parity</dt><dd>Java is the reference; Rust ships in lock-step; flow YAML ports unchanged; python/node functions join as Event-over-HTTP peers</dd>
+      <dt>Memory layer</dt><dd>the <i>project’s</i> grammar — Vision, Blueprint, continuity — so sessions start oriented on intent, not just API shape</dd>
+    </dl>
+  </section>
+
+  <!-- 9 · the benchmark -->
+  <section class="slide" aria-label="The benchmark">
+    <p class="eyebrow">The benchmark</p>
+    <h2>Doc discovery and token efficiency</h2>
+    <p class="lede">A grammar is useful only if the agent finds the right page in one hop and the
+    map stays cheap. Measured on the Rust engine, 2026-09-04:</p>
+    <div class="stats">
+      <div class="stat"><div class="n">~2,500</div><div class="l">tokens — the whole discovery map</div></div>
+      <div class="stat"><div class="n">~46,000</div><div class="l">tokens of source-verified reference it routes to, one hop away</div></div>
+      <div class="stat dim"><div class="n">~515,000</div><div class="l">tokens of engine source — the hunt the map replaces</div></div>
+    </div>
+    <p class="muted">Completeness that costs discovery is a regression. The map is dense with the
+    exact tokens an agent searches for — and gated in CI so it cannot silently rot.</p>
+  </section>
+
+  <!-- 10 · the proof -->
+  <section class="slide" aria-label="Proven at the milestone">
+    <p class="eyebrow">Proven, not promised</p>
+    <h2>The milestone: fresh agents, grammar only</h2>
+    <p class="lede">The ai-enabled-repo-demo exercise put the grammar under load: fresh AI agents —
+    no project context, no human hints — built and ran applications from the grammar alone, through
+    repeated rehearsals and a live demonstration.</p>
+    <ul class="list">
+      <li>Every friction became a fix, shipped to the field in days (v4.12.2): a <code>json</code>
+      simple plugin closing a data-mapping gap, an export-guard correction, recipe lines where two
+      independent agents drew the same wrong conclusion.</li>
+      <li>Discovery gaps were closed <strong>with CI gates behind them</strong>, so they stay closed.</li>
+      <li>The loop — <strong class="accent">agent friction → grammar or engine fix → field
+      release</strong> — is the methodology working.</li>
+    </ul>
+  </section>
+
+  <!-- 11 · the methodology -->
+  <section class="slide" aria-label="The methodology">
+    <p class="eyebrow">The methodology</p>
+    <h2>How a developer builds with an AI partner</h2>
+    <div class="steps">
+      <div class="step"><h3>AI-enable the project</h3>
+        <p>Greenfield or existing: install the shared memory layer, write the <b>Vision</b> with
+        the AI partner (human-confirmed, never fabricated), derive the <b>Blueprint</b>, plan
+        increments. Every session thereafter starts oriented.</p></div>
+      <div class="step"><h3>Add mercury-composable, choose the path</h3>
+        <p>The engine arrives carrying its own grammar. <b>Recommended for applications: Layer 3</b>
+        — model the service as a knowledge graph, dry-run in the Playground, deploy behind the
+        CompileGraph gate. The path is a dial, not a wall.</p></div>
+      <div class="step"><h3>Build the app — or a building block</h3>
+        <p>Applications: intent → model → certify → deploy. Building blocks: layer-2 + layer-3
+        patterns — then <b>compile an AI grammar into the block’s own repo</b>, so it becomes as
+        legible as Mercury itself.</p></div>
+    </div>
+    <p class="muted" style="margin-top:1.3em">Proof point for step 1: Mercury’s own Rust engine was
+    AI-enabled <em>before its first line of code</em> — about a hundred increments later it ships
+    in lock-step with the Java engine.</p>
+  </section>
+
+  <!-- 12 · recursion -->
+  <section class="slide" aria-label="Grammar composes like dependencies">
+    <p class="eyebrow">The recursion</p>
+    <h2>Grammar composes the way dependencies compose</h2>
+    <figure>
+      <svg viewBox="0 0 960 300" role="img"
+           aria-label="An application session loads Mercury's grammar plus each building block's grammar plus the app's own memory. Building blocks are built on Mercury and compile grammars of their own.">
+        <defs>
+          <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#A79DC2"/>
+          </marker>
+        </defs>
+        <!-- mercury -->
+        <rect x="30" y="190" width="270" height="80" rx="10" fill="#201936" stroke="#382E52" stroke-width="1.5"/>
+        <text x="165" y="223" fill="#F1ECFA" font-size="16" text-anchor="middle" font-weight="600">mercury-composable</text>
+        <text x="165" y="247" fill="#CDBBFF" font-size="12.5" text-anchor="middle">ships its AI grammar</text>
+        <!-- building block -->
+        <rect x="345" y="105" width="270" height="80" rx="10" fill="#201936" stroke="#382E52" stroke-width="1.5"/>
+        <text x="480" y="138" fill="#F1ECFA" font-size="16" text-anchor="middle" font-weight="600">building block</text>
+        <text x="480" y="162" fill="#CDBBFF" font-size="12.5" text-anchor="middle">compiles its own grammar</text>
+        <!-- app -->
+        <rect x="660" y="20" width="270" height="80" rx="10" fill="#291f44" stroke="#A78BFA" stroke-width="1.5"/>
+        <text x="795" y="53" fill="#F1ECFA" font-size="16" text-anchor="middle" font-weight="600">user application</text>
+        <text x="795" y="77" fill="#CDBBFF" font-size="12.5" text-anchor="middle">its own Vision + memory</text>
+        <!-- build-on arrows -->
+        <line x1="300" y1="215" x2="345" y2="160" stroke="#A79DC2" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <text x="318" y="176" fill="#A79DC2" font-size="12" text-anchor="middle">built on</text>
+        <line x1="615" y1="130" x2="660" y2="75" stroke="#A79DC2" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <text x="633" y="91" fill="#A79DC2" font-size="12" text-anchor="middle">depends on</text>
+        <!-- grammar-loads (dashed, amber) -->
+        <path d="M 165 190 C 240 60, 480 20, 655 44" fill="none" stroke="#FFC24B" stroke-width="1.6" stroke-dasharray="6 5" marker-end="url(#arr2)"/>
+        <path d="M 480 105 C 545 60, 600 48, 655 52" fill="none" stroke="#FFC24B" stroke-width="1.6" stroke-dasharray="6 5"/>
+        <text x="60" y="34" fill="#FFC24B" font-size="12.5">grammars load into the app’s AI session</text>
+        <text x="60" y="52" fill="#FFC24B" font-size="12.5" opacity="0.75">— near-constant token cost per block</text>
+      </svg>
+      <figcaption>The session that builds the application loads Mercury’s grammar <em>plus</em> each
+      building block’s grammar. Already live inside the framework: twin-kafka is a building block on
+      a building block — and while its map entry was missing, AI partners fell back to source.</figcaption>
+    </figure>
+    <p class="quote" style="margin-top:1em; font-size:clamp(19px,2.3vw,30px)"><span class="q">To an
+    AI partner, undocumented capability is absent capability.</span></p>
+  </section>
+
+  <!-- 13 · industry practice -->
+  <section class="slide" aria-label="Industry context">
+    <p class="eyebrow">Industry context</p>
+    <h2>Standing on recognized practice — then gating it</h2>
+    <dl class="kv">
+      <dt>llms.txt convention</dt><dd>adopted — then <b>held to a CI gate and a token budget</b>, which conventions alone cannot do</dd>
+      <dt>Docs-as-code</dt><dd>extended to <b>docs-as-contract</b>: the build fails when a guide and its engine disagree</dd>
+      <dt>Architecture Decision Records</dt><dd>the ADR ledger carries durable rationale; memory facts point at it, so agents inherit the <i>why</i></dd>
+      <dt>Contract testing</dt><dd>golden vectors shared verbatim between independent engines — the Pact-style trust mechanism, applied to a port</dd>
+      <dt>Agent-instruction files</dt><dd><code>AGENTS.md</code> and kin, with a routing shim: contributors → the memory protocol; consumers → the version-matched contract</dd>
+      <dt>Human-in-the-loop governance</dt><dd>dry-run, compile gates, certification, staged promotion — delivery-pipeline controls applied to model artifacts</dd>
+      <dt>Evaluation culture</dt><dd>fresh-agent rehearsals are evals for documentation; the memory smoke test is an eval for project memory — both run on cadence, both produced fixes</dd>
+    </dl>
+    <p class="muted" style="margin-top:1.2em">Each practice is known. <strong class="accent">Binding
+    them into one CI-enforced, token-budgeted contract an AI partner can build from — that is the
+    AI grammar.</strong></p>
+  </section>
+
+  <!-- 14 · close -->
+  <section class="slide" aria-label="Where it goes">
+    <p class="eyebrow">Where it goes</p>
+    <h2>The north star does not move</h2>
+    <ul class="list">
+      <li><strong>AI agent orchestration on the graph runtime</strong> — bounded-agency decision
+      graphs; first experiment already run end-to-end, live LLM verdicts under one distributed trace.</li>
+      <li><strong>A pluggable AI companion backend</strong> — the collaboration layer matures.</li>
+      <li><strong>The governance lifecycle</strong> — dry-run → certify → stage → approve →
+      production, so models promote as standard endpoints.</li>
+    </ul>
+    <p class="quote" style="margin-top:1.4em"><span class="q">The Active Knowledge Graph is the
+    application.</span> Humans and AI co-author the model, the event-driven runtime executes it,
+    and changing behavior means editing knowledge — not shipping code.</p>
+    <p class="byline">White paper: <em>The Mercury Story — Origin, Evolution, and the AI Grammar
+    Methodology</em> · <span class="muted">accenture.github.io/mercury-composable</span></p>
+  </section>
+
+  <!-- chrome -->
+  <button class="zone back" id="zback" aria-label="Previous slide" tabindex="-1"></button>
+  <button class="zone fwd" id="zfwd" aria-label="Next slide" tabindex="-1"></button>
+  <div class="bar">
+    <span class="wordmark">mercury<span class="dot">·</span>composable</span>
+    <span class="hint">← → to navigate · P to print the handout</span>
+    <nav class="dots" id="dots" aria-label="Slides"></nav>
+    <button class="navbtn" id="prev" aria-label="Previous">‹ Prev</button>
+    <button class="navbtn" id="next" aria-label="Next">Next ›</button>
+    <span class="counter" id="counter">1 / 1</span>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+  var slides = Array.prototype.slice.call(document.querySelectorAll(".slide"));
+  var dots = document.getElementById("dots");
+  var counter = document.getElementById("counter");
+  var i = 0;
+
+  slides.forEach(function (s, k) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.setAttribute("aria-label", "Slide " + (k + 1) + ": " + (s.getAttribute("aria-label") || ""));
+    b.addEventListener("click", function () { go(k); });
+    dots.appendChild(b);
+  });
+
+  function go(k) {
+    if (k < 0 || k >= slides.length) return;
+    slides[i].classList.remove("active");
+    i = k;
+    slides[i].classList.add("active");
+    slides[i].scrollTop = 0;
+    counter.textContent = (i + 1) + " / " + slides.length;
+    Array.prototype.forEach.call(dots.children, function (d, k2) {
+      d.classList.toggle("on", k2 === i);
+    });
+    if (("#" + (i + 1)) !== location.hash) {
+      try { history.replaceState(null, "", "#" + (i + 1)); } catch (e) { /* file:// */ }
+    }
+  }
+  function fromHash() {
+    var n = parseInt(location.hash.slice(1), 10);
+    go(isNaN(n) ? 0 : n - 1);
+  }
+
+  document.getElementById("next").addEventListener("click", function () { go(i + 1); });
+  document.getElementById("prev").addEventListener("click", function () { go(i - 1); });
+  document.getElementById("zfwd").addEventListener("click", function () { go(i + 1); });
+  document.getElementById("zback").addEventListener("click", function () { go(i - 1); });
+  window.addEventListener("hashchange", fromHash);
+  document.addEventListener("keydown", function (e) {
+    if (e.altKey || e.ctrlKey || e.metaKey) return;
+    switch (e.key) {
+      case "ArrowRight": case "PageDown": case " ": go(i + 1); e.preventDefault(); break;
+      case "ArrowLeft": case "PageUp": go(i - 1); e.preventDefault(); break;
+      case "Home": go(0); e.preventDefault(); break;
+      case "End": go(slides.length - 1); e.preventDefault(); break;
+      case "p": case "P": window.print(); break;
+    }
+  });
+  fromHash();
+})();
+</script>
+</body>
+</html>

--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -411,6 +411,10 @@
     <p class="muted" style="margin-top:1.2em">Each practice is known. <strong class="accent">Binding
     them into one CI-enforced, token-budgeted contract an AI partner can build from — that is the
     AI grammar.</strong></p>
+    <p class="muted" style="margin-top:.8em; font-size:.82em">Parnas 1972 · Hewitt 1973 · Nygard 2011 ·
+    Robinson 2006 · llms.txt (Howard 2024) · AGENTS.md · GitHub Spec Kit 2025 · NIST AI RMF · EU AI Act
+    art. 14 · ISO/IEC 42001 · DORA 2024–25 · HELM · SWE-bench — full citations in the white paper’s
+    References section.</p>
   </section>
 
   <!-- 14 · close -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
 
   - Orientation:
     - Getting Started: guides/getting-started.md
+    - The Mercury Story (white paper): ai-grammar-methodology.md
 
   - Foundations:
     - Architecture Overview: guides/architecture.md


### PR DESCRIPTION
## What

Two flagship deliverables, written at the ai-enabled-repo-demo milestone, published
front and center on the docs site:

- **The white paper** — `docs/ai-grammar-methodology.md`: *The Mercury Story — Origin,
  Evolution, and the AI Grammar Methodology*. In the nav under Orientation.
- **The presentation deck** — `docs/presentations/ai-grammar-story.html`: the same story
  in 14 slides, as a self-contained single-file HTML that mkdocs copies verbatim, so it
  ships with the site. Keyboard/click/hash navigation, per-slide deep links, and printing
  flips it to a light handout.
- **Home page hero** — `docs/index.md` now opens with three buttons in the agent-memory
  site's presentation: `Get started` (primary), `Read the white paper`, `View the deck`.

## Why

The demo exercises proved the AI grammar end to end — fresh AI agents built and ran
applications from the grammar alone, and every friction they hit shipped as a fix in
v4.12.2. That earns the story a telling, and the methodology an articulation, in one
citable place:

1. **The story**: origin (2018 — *never couple functions*; the actor-model lineage;
   virtual threads dissolving the ergonomics tax) → the ascent (code → configuration →
   knowledge) → the turn (*don't review AI code harder — change the artifact the AI
   authors*: governed nondeterminism).
2. **The AI grammar, defined and inventoried**: documentation engineered as a
   machine-consumable contract — *sufficient* (agent guides may claim "from this page
   alone"), *verified* (CI drift tests, coverage/link gates, golden vectors,
   version-matched manifest), and *cheap* (the measured benchmark: a ~2,500-token map
   routing to ~46,000 tokens of verified reference, replacing a hunt through ~515,000
   tokens of source).
3. **The methodology** — the three-step developer journey: AI-enable the project
   (Vision → Blueprint, human-confirmed); add mercury-composable and choose the path
   (Layer 3 recommended for applications); build the application — or a **building
   block** that then *compiles an AI grammar of its own*. Grammar composes the way
   dependencies compose; the distilled thesis: **to an AI partner, undocumented
   capability is absent capability.**

## Industry & academic grounding

Nineteen references, **each verified by search before citing** (venue, year, identifier).
The load-bearing ones:

- Governance problem: Pearce et al. (IEEE S&P 2022), Perry et al. (ACM CCS 2023),
  DORA 2024–25 (AI adoption ↔ reduced delivery stability even as throughput improves).
- Context problem: *Lost in the Middle* (Liu et al., TACL 2024) — a large window is not
  a substitute for curation.
- Lineage: Parnas 1972 (information hiding), Hewitt et al. 1973 (actor model).
- Per-practice sources in §6: llms.txt (Howard 2024), docs-as-code, Nygard 2011 ADRs,
  Robinson 2006 + Pact, AGENTS.md (Linux Foundation), spec-driven development (GitHub
  Spec Kit 2025), NIST AI RMF / EU AI Act art. 14 / ISO-IEC 42001, HELM + SWE-bench.

## Verification

- `mkdocs build --strict` green; `check-doc-canon.py` green (incl. the llms.txt
  coverage gate — the white paper is a top-level page, deliberately not a guide).
- Rendered and reviewed on a local mkdocs serve: home hero, the white paper page, and
  the deck all verified **through the site** (including the `site_url` path prefix,
  faithful to gh-pages).
- Content discipline: canon vocabulary throughout (the three paradigm layers; AKG /
  MiniGraph naming; one atom, four roles); no client-identifiable material; every claim
  traces to the repo's ADRs, the memory layer, or this week's measurements.

## Notes for review

- The deck commits to a single dark look (violet ground, amber reserved for the measured
  numbers) rather than following the site theme — it is a presentation, opened
  standalone; print emits a light handout.
- `Get started` keeps the primary button style; the paper and deck sit beside it
  outlined. One-word swap if the white paper should carry primary.
- llms.txt is untouched by design: the paper is human-facing storytelling, and the
  coverage gate scopes to `guides/**`. Easy to add an entry later if wanted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>