### PR TITLE
fix(kafka): let the serdes inherit the Schema Registry client config

### DIFF
--- a/.agent/secret-scan-ignore
+++ b/.agent/secret-scan-ignore
@@ -13,3 +13,10 @@
 # Examples:
 #   test/fixtures/postman-collection.json
 #   **/test/resources/dummy-creds.properties
+
+# 2026-09-04 (Eric + Claude Fable 5, field MR reconstruction): synthetic OAuth test fixtures for
+# the Schema Registry — values are dictionary-word placeholders asserted verbatim by unit tests
+# (SchemaRegistryOAuthTest, SchemaCodecCsfleConfigTest); loopback issuer URL; nothing real.
+# .properties cannot carry the same-line lint:allow tag without corrupting the value.
+system/minimalist-kafka/src/test/resources/schema-registry-oauth-test.properties
+system/minimalist-kafka/src/test/resources/schema-registry-serde-inherit-test.properties

--- a/.github/workflows/agent-memory.yml
+++ b/.github/workflows/agent-memory.yml
@@ -71,7 +71,10 @@ jobs:
                 case "$pat" in ''|'#'*) continue ;; esac
                 case "$f" in $pat) keep=0; break ;; esac
               done < .agent/secret-scan-ignore
-              [ "$keep" = "1" ] && printf '%s\n' "$f"
+              # if/fi, not '[ ] &&': under bash -e, a trailing exempted file would otherwise
+              # return 1 from the substitution and abort the step with no output (found the
+              # first time a waiver was exercised, 2026-09-04)
+              if [ "$keep" = "1" ]; then printf '%s\n' "$f"; fi
             done)"
           fi
           [ -z "$cfgs" ] && { echo "no changed config files; skipping."; exit 0; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-1. The Playground `export graph` overwrite guard no longer rejects a graph whose root
+1. [Kafka] Schema Registry credentials now reach the serdes, so client-side field level
+   encryption works against an authenticated registry. `SchemaCodec` passed its serdes a
+   config map built only from `schema.registry.serde.*`, which is empty for almost every
+   application. Confluent's serdes do not only use the `SchemaRegistryClient` they are
+   given: the CSFLE rule executor (`EncryptionExecutor.configure`) builds its **own**
+   `DekRegistryClient` from that map alone, so every DEK lookup went out unauthenticated
+   and any encrypted field failed with `Unauthorized; error code: 401` — even though the
+   codec's own client was fully authenticated against the same registry with the same
+   identity. The serdes now inherit the registry client template and apply their own
+   `schema.registry.serde.*` entries on top, so a serde-only setting (a KMS driver
+   credential, a serde-specific identity) still wins. Duplicating `bearer.auth.*` under
+   `schema.registry.serde.*` was not a usable workaround: those keys live in
+   `application.properties`, whose `${...}` references `AppConfigReader` resolves — and
+   destructively rewrites — at construction, before any `@MainApplication` credential
+   bootstrap has published its system properties. Contributed from the field.
+
+2. The Playground `export graph` overwrite guard no longer rejects a graph whose root
    node has no `name` property (it compared "null" against the target filename). The
    root name is validated only when declared - a declared, mismatching name still
    rejects the overwrite; a missing or blank name is accepted and the export assigns

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/schema/SchemaCodec.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -117,6 +118,17 @@ public class SchemaCodec {
         this.client = client;
         this.registryUrl = registryUrl;
         this.extraSerdeConfig = extraSerdeConfig;
+    }
+
+    /**
+     * The config handed to every serde (and, through them, to Confluent's rule executors).
+     * Package-private (like {@link #extractSerdeConfig(ConfigBase)}) so the composition performed by
+     * {@link #fromConfig(ConfigBase, String, String)} is directly unit-testable.
+     *
+     * @return an unmodifiable view of the serde config
+     */
+    Map<String, Object> serdeConfig() {
+        return Collections.unmodifiableMap(extraSerdeConfig);
     }
 
     /**
@@ -227,8 +239,9 @@ public class SchemaCodec {
          * template, so they always win: the registry URL comes from application.properties (the feature
          * switch) and the negative caches stay pinned off.
          */
-        Map<String, Object> srConfig = new HashMap<>(
-                KafkaClientConfig.schemaRegistryProperties(config, keyPrefix + ".properties", templateDefaults));
+        Map<String, Object> srTemplate =
+                KafkaClientConfig.schemaRegistryProperties(config, keyPrefix + ".properties", templateDefaults);
+        Map<String, Object> srConfig = new HashMap<>(srTemplate);
         Object bearerAuthSource = srConfig.get(SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE);
         srConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, registryUrl);
         /*
@@ -244,9 +257,33 @@ public class SchemaCodec {
                 IDENTITY_MAP_CAPACITY,
                 List.of(new JsonSchemaProvider(), new AvroSchemaProvider()),
                 srConfig, cache, versionCache);
-        Map<String, Object> extraSerdeConfig = extractSerdeConfig(config, keyPrefix + ".serde.");
+        /*
+         * The serdes inherit the SAME registry client template, then apply their own
+         * schema.registry.serde.* overrides on top.
+         *
+         * Confluent's serdes do not only use the SchemaRegistryClient handed to them: the CSFLE
+         * rule executor (EncryptionExecutor.configure) builds its OWN DekRegistryClient from the
+         * serde config map alone. Seeded from an empty map, that client inherits no credentials and
+         * every DEK lookup reaches the registry unauthenticated, so an encrypted field fails with
+         * `Unauthorized; error code: 401` even though this class's own client is fully authenticated
+         * against the same registry with the same identity.
+         *
+         * Duplicating the bearer.auth.* block under schema.registry.serde.* is not a viable
+         * workaround for the caller: those keys live in application.properties, whose ${...}
+         * references AppConfigReader resolves - and destructively rewrites - at construction, before
+         * any @MainApplication credential bootstrap has published its system properties. The
+         * registry client template does not have that problem because it is read later, which is
+         * precisely why the credentials this method already resolved are the right ones to pass on.
+         *
+         * Inheriting the template rather than the post-processed srConfig keeps the library's own
+         * pins (registry URL, negative-cache TTLs) out of the serde config, so the serdes see only
+         * what the application authored.
+         */
+        Map<String, Object> serdeOverrides = extractSerdeConfig(config, keyPrefix + ".serde.");
+        Map<String, Object> extraSerdeConfig = new HashMap<>(srTemplate);
+        extraSerdeConfig.putAll(serdeOverrides);
         log.info("Schema codec ready (registry={}, cache={}, ttlMs={}, types={}, csfle={}, auth={})",
-                registryUrl, keyPrefix, ttlMillis, List.of(SchemaType.values()), !extraSerdeConfig.isEmpty(),
+                registryUrl, keyPrefix, ttlMillis, List.of(SchemaType.values()), !serdeOverrides.isEmpty(),
                 bearerAuthSource == null ? "none" : bearerAuthSource);
         return new SchemaCodec(client, registryUrl, extraSerdeConfig);
     }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecCsfleConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/schema/SchemaCodecCsfleConfigTest.java
@@ -29,9 +29,12 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.platformlambda.core.util.Utility;
 import org.platformlambda.core.util.common.ConfigBase;
+import org.platformlambda.mini.kafka.OAuthUrlAllowList;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -64,6 +67,8 @@ class SchemaCodecCsfleConfigTest {
     private static final String TAGGED_FIELD = "ssn";
     private static final String PII_TAG = "PII";
     private static final Utility util = Utility.getInstance();
+
+    private String savedAllowList;
 
     /** Minimal, fully-controlled {@link ConfigBase} backed by a flat key-value map (no dotted-key flattening). */
     private static final class MapConfig implements ConfigBase {
@@ -190,6 +195,66 @@ class SchemaCodecCsfleConfigTest {
         Map<String, Object> decoded = (Map<String, Object>) decoder.decode(TOPIC, framed);
         assertEquals("123-45-6789", decoded.get(TAGGED_FIELD), "SchemaCodec.Decoder decrypts the Avro field back");
         assertEquals("world", decoded.get("hello"));
+    }
+
+    /**
+     * The inherit-template fixture carries an OAuth token endpoint (required by Confluent's
+     * OauthCredentialProvider), and loading it auto-registers that URL on a JVM-wide system property.
+     * Save and restore it so these tests leave no global state behind, as SchemaRegistryOAuthTest does.
+     */
+    @BeforeEach
+    void saveAllowList() {
+        savedAllowList = System.getProperty(OAuthUrlAllowList.ALLOWED_URLS_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreAllowList() {
+        if (savedAllowList == null) {
+            System.clearProperty(OAuthUrlAllowList.ALLOWED_URLS_PROPERTY);
+        } else {
+            System.setProperty(OAuthUrlAllowList.ALLOWED_URLS_PROPERTY, savedAllowList);
+        }
+    }
+
+    @Test
+    void serdeInheritsRegistryClientTemplate() {
+        // A serde's rule executors build their own registry clients from this config map alone -
+        // Confluent's CSFLE EncryptionExecutor.configure() creates a DekRegistryClient from it - so a
+        // map seeded empty leaves those clients unauthenticated and every DEK lookup 401s, even though
+        // the codec's own client authenticates against the same registry. The credentials the template
+        // already resolved must therefore reach the serdes too.
+        Map<String, Object> appConfig = new HashMap<>();
+        appConfig.put("schema.registry.properties", "classpath:/schema-registry-serde-inherit-test.properties");
+        // no calls are made against this URL; only the config composition is under test
+        SchemaCodec codec = SchemaCodec.fromConfig(new MapConfig(appConfig), "http://127.0.0.1:1");
+
+        Map<String, Object> serdeConfig = codec.serdeConfig();
+        assertEquals("OAUTHBEARER", serdeConfig.get("bearer.auth.credentials.source"));
+        assertEquals("inherit-client", serdeConfig.get("bearer.auth.client.id"));
+        assertEquals("inherit-secret", serdeConfig.get("bearer.auth.client.secret"));
+        assertEquals("lsrc-test", serdeConfig.get("bearer.auth.logical.cluster"));
+        // the library's own pins belong to the registry REST client, not to the serdes: inheriting the
+        // template (not the post-processed client config) keeps them out
+        assertFalse(serdeConfig.containsKey("schema.registry.url"),
+                "serde config carries only what the application authored");
+        assertFalse(serdeConfig.containsKey("missing.id.cache.ttl.sec"),
+                "the library's negative-cache pins stay on the registry client");
+    }
+
+    @Test
+    void serdeOverridesWinOverInheritedTemplate() {
+        Map<String, Object> appConfig = new HashMap<>();
+        appConfig.put("schema.registry.properties", "classpath:/schema-registry-serde-inherit-test.properties");
+        // an explicit serde.* entry must still take precedence, so a serde-only identity stays expressible
+        appConfig.put("schema.registry.serde.bearer.auth.client.id", "serde-specific-client");
+        appConfig.put("schema.registry.serde.secret", "local-kms-passphrase");
+        SchemaCodec codec = SchemaCodec.fromConfig(new MapConfig(appConfig), "http://127.0.0.1:1");
+
+        Map<String, Object> serdeConfig = codec.serdeConfig();
+        assertEquals("serde-specific-client", serdeConfig.get("bearer.auth.client.id"), "serde.* overrides the template");
+        assertEquals("local-kms-passphrase", serdeConfig.get("secret"), "serde-only keys still pass through");
+        assertEquals("inherit-secret", serdeConfig.get("bearer.auth.client.secret"),
+                "keys the serde does not override are still inherited");
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/resources/schema-registry-serde-inherit-test.properties
+++ b/system/minimalist-kafka/src/test/resources/schema-registry-serde-inherit-test.properties
@@ -1,0 +1,15 @@
+#
+# Test template: a realistic OAuth 2.0 bearer-auth registry client config, used to prove that the
+# serdes inherit it (see SchemaCodecCsfleConfigTest#serdeInheritsRegistryClientTemplate).
+#
+# bearer.auth.issuer.endpoint.url is required, not optional decoration: with
+# credentials.source=OAUTHBEARER, Confluent's OauthCredentialProvider.configure() validates it while
+# the registry client is being constructed and throws without it. Loading it also auto-registers the
+# URL on the JVM-wide OAuth allow-list, which the test saves and restores. Nothing is called over the
+# network here - only the config composition is asserted.
+#
+bearer.auth.credentials.source=OAUTHBEARER
+bearer.auth.issuer.endpoint.url=http://127.0.0.1:18081/oauth/token
+bearer.auth.client.id=inherit-client
+bearer.auth.client.secret=inherit-secret
+bearer.auth.logical.cluster=lsrc-test


### PR DESCRIPTION
## What

`SchemaCodec` now hands its serdes the registry client template it already resolved,
with `schema.registry.serde.*` entries applied on top as overrides. Previously the
serde config map was built from `schema.registry.serde.*` alone — empty for almost
every application.

## Why

Confluent's serdes do not only use the `SchemaRegistryClient` they are given: the CSFLE
rule executor (`EncryptionExecutor.configure`) builds its **own** `DekRegistryClient`
from the serde config map alone. Seeded from an empty map, that client carries no
credentials — so every DEK lookup reached the registry unauthenticated and any encrypted
field failed with `Unauthorized; error code: 401`, while the codec's own client was
fully authenticated against the same registry with the same identity in the same JVM.
The 401 is the no-credential response (distinct from a rejected token's
`Invalid Token : User Identity not found`), which makes it easy to misread as an ACL
problem.

Duplicating `bearer.auth.*` under `schema.registry.serde.*` was not a usable workaround:
those keys live in `application.properties`, whose `${...}` references `AppConfigReader`
resolves — and destructively rewrites — at construction, before any `@MainApplication`
credential bootstrap has published its system properties. The template does not have
that problem because it is read later.

**Contributed from the field**, reconstructed for upstream.

## Design notes

- The serdes inherit the **template**, not the post-processed `srConfig`, so the
  library's own pins (registry URL, negative-cache TTLs) stay on the REST client and
  the serdes see only what the application authored.
- A serde-scoped setting (a KMS driver credential, a serde-specific identity) still
  wins: `serde.*` overrides apply on top of the inherited template.
- The `csfle=` field of the "Schema codec ready" log keeps its previous meaning by
  reporting the serde-specific overrides, not the now-always-populated merged map.

## Testing

- Two new tests over a new bearer-auth fixture: `serdeInheritsRegistryClientTemplate`
  (credentials inherited; library pins excluded) and
  `serdeOverridesWinOverInheritedTemplate` (precedence). The fixture's values are
  synthetic placeholder strings asserted verbatim by the tests (same idiom as the
  existing OAuth fixture) and both fixtures are waived in `.agent/secret-scan-ignore`
  with a dated rationale — the guard passes through the audited mechanism, not
  `--no-verify`.
- Module suite: **193 tests, 0 failures, BUILD SUCCESS** (JaCoCo gates met); the
  existing CSFLE encrypt/decrypt round-trips and `SchemaRegistryOAuthTest` unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>