### PR TITLE
Release/v4.12.3

### DIFF
--- a/.agent/version.md
+++ b/.agent/version.md
@@ -4,7 +4,7 @@
 > Mode B can detect drift and upgrade in place (see the tool's `UPGRADE.md`).
 > `version` gates the upgrade ladder — don't hand-edit it unless you mean to.
 
-- **version:**       4.39.1
+- **version:**       4.39.2
 - **enabled_with:**  4.14.1
-- **last_upgraded:** 2026-09-01
+- **last_upgraded:** 2026-09-04
 - **mode:**          A

--- a/.github/workflows/agent-memory.yml
+++ b/.github/workflows/agent-memory.yml
@@ -71,9 +71,8 @@ jobs:
                 case "$pat" in ''|'#'*) continue ;; esac
                 case "$f" in $pat) keep=0; break ;; esac
               done < .agent/secret-scan-ignore
-              # if/fi, not '[ ] &&': under bash -e, a trailing exempted file would otherwise
-              # return 1 from the substitution and abort the step with no output (found the
-              # first time a waiver was exercised, 2026-09-04)
+              # if/fi, not `[ ... ] && ...`: a waived LAST file would make the test the loop's
+              # final command, fail the substitution's assignment, and abort under `-e` (v4.39.2)
               if [ "$keep" = "1" ]; then printf '%s\n' "$f"; fi
             done)"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## Unreleased
+## Version 4.12.3, 9/4/2026
 
 ### Added
 
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    WARN. The flag is a veto, not a trigger — the default starts nothing that is not
    otherwise configured, and only the literal `false` disables. Java-only: the Rust port
    carries no Kafka module.
+
+2. **The Mercury Story** — a white paper (`docs/ai-grammar-methodology.md`) and a
+   presentation deck (`docs/presentations/ai-grammar-story.html`, self-contained HTML
+   served by the docs site), featured front and center on the documentation home page.
+   The story of the framework — origin, the three-layer ascent, governed nondeterminism —
+   and the **AI grammar methodology**: documentation engineered as a machine-consumable,
+   CI-verified, token-budgeted contract, including the three-step developer journey where
+   building blocks built on Mercury compile AI grammars of their own. Grounded in 19
+   verified industry and academic references.
+
+3. `llms.txt` is now **complete and CI-enforced**: every guide page and DSL catalog is
+   listed (nine were missing, including the whole REST automation spec kit — grammar,
+   AI agent guide, and `rest-automation.json` — leaving `rest.yaml` authoring
+   undiscoverable to AI agents), and `check-doc-canon.py` gains a coverage check so a
+   new guide cannot ship unlisted.
 
 ### Fixed
 

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -49,13 +49,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-09-04-174753.md
+++ b/memory/sessions/2026-09-04-174753.md
@@ -1,48 +1,63 @@
 # Session (2026-09-04T17:47:53.000Z)
 
-**Agent:** (auto-stub — replace with your agent name and enrich)
-**Lightweight:** auto-captured by the post-commit hook; summary pending.
+**Agent:** Claude Fable 5 (Claude Code)
 
-Commit `803c46a4` — release: version 4.12.3
+## What happened
 
-```
- CHANGELOG.md                                      | 17 ++++++++++++++++-
- benchmark/benchmark-reporter/pom.xml              |  4 ++--
- connectors/adapters/kafka/kafka-connector/pom.xml |  6 +++---
- connectors/adapters/kafka/kafka-presence/pom.xml  |  6 +++---
- connectors/core/cloud-connector/pom.xml           |  4 ++--
- connectors/core/service-monitor/pom.xml           |  6 +++---
- examples/composable-example/pom.xml               |  4 ++--
- examples/kafka-demo/pom.xml                       |  4 ++--
- examples/kotlin-example/pom.xml                   |  4 ++--
- examples/lambda-example/pom.xml                   |  6 +++---
- examples/minigraph-playground/pom.xml             |  6 +++---
- examples/pg-example/pom.xml                       |  6 +++---
- examples/rest-spring-3-example/pom.xml            |  4 ++--
- examples/rest-spring-4-example/pom.xml            |  6 +++---
- examples/scheduler-example/pom.xml                |  4 ++--
- examples/sync-over-async-demo/pom.xml             |  4 ++--
- examples/twin-kafka-demo/pom.xml                  |  4 ++--
- extensions/api-playground/pom.xml                 |  4 ++--
- extensions/minigraph-state-redis/pom.xml          |  4 ++--
- extensions/opentelemetry-forwarder/pom.xml        |  6 +++---
- extensions/reactive-postgres/pom.xml              |  4 ++--
- extensions/sync-over-async/pom.xml                |  4 ++--
- helpers/kafka-standalone/pom.xml                  |  4 ++--
- helpers/redis-standalone/pom.xml                  |  4 ++--
- helpers/schema-registry-standalone/pom.xml        |  4 ++--
- pom.xml                                           |  2 +-
- system/ai-contract-provider/pom.xml               |  8 ++++----
- system/event-script-engine/pom.xml                |  4 ++--
- system/mini-scheduler/pom.xml                     |  4 ++--
- system/minigraph-playground-engine/pom.xml        |  4 ++--
- system/minimalist-kafka/pom.xml                   |  4 ++--
- system/platform-core/pom.xml                      |  2 +-
- system/rest-spring-3/pom.xml                      |  4 ++--
- system/rest-spring-4/pom.xml                      |  4 ++--
- system/twin-kafka/pom.xml                         |  4 ++--
- 35 files changed, 92 insertions(+), 77 deletions(-)
-```
+The v4.12.3 release preparation — and, mid-preparation, a field contribution reconstructed,
+merged, and folded in, which itself flushed out a latent bug in the CI floor.
+
+### Release prep (commit `803c46a4`)
+
+Version sweep 4.12.2 → 4.12.3 across all 34 poms (76 occurrences; the two non-reactor Snyk
+placeholder manifests included deliberately per `snyk-retired-manifest-placeholders`; the white
+paper and deck keep their *historical* v4.12.2 mentions). CHANGELOG rolled to
+"Version 4.12.3, 9/4/2026" with new Added entries for the Mercury story and the llms.txt coverage
+gate. Verified with the full reactor build: BUILD SUCCESS, 29/29 modules, 07:39.
+
+### The field contribution (PR #318, merged `75603294`, folded in `0ff7d485`)
+
+A field MR fixing CSFLE against an authenticated Schema Registry: `SchemaCodec` handed its serdes
+a config map built only from `schema.registry.serde.*` (empty for almost every application), and
+Confluent's CSFLE rule executor builds its **own** DEK registry client from that map alone — so
+every DEK lookup went out unauthenticated and encrypted fields failed with the no-credential 401,
+easy to misread as an ACL problem. The serdes now inherit the registry client template with
+`serde.*` overrides winning. The deepest part of the field author's analysis: duplicating
+`bearer.auth.*` under `serde.*` in application.properties cannot work, because `AppConfigReader`
+resolves `${...}` destructively at construction, before any `@MainApplication` credential
+bootstrap — while the registry template is read later, which is exactly why the already-resolved
+credentials are the right ones to pass on.
+
+Reconstruction notes: code/tests/fixture applied cleanly from the diff (`--3way`); the CHANGELOG
+hunk targeted an older main and was rebuilt by hand; nothing client-identifying entered the repo
+(commit says "contributed from the field"); the three fixture values were verified synthetic
+(test-asserted dictionary words matching the in-tree OAuth-fixture idiom) before Eric's redaction
+question was answered. Both OAuth test fixtures were added to `.agent/secret-scan-ignore` — the
+first active waiver entries in this repo.
+
+### The waiver's first exercise broke the CI floor (fixed in `f8eb051a`, superseded by v4.39.2)
+
+PR #318's `memory` check died in seconds with no output. Root cause: the changed-config secret
+scan's exemption filter ended its loop with `[ "$keep" = "1" ] && printf` — status 1 for a
+trailing waived file, propagated through the command substitution into the assignment, aborted by
+`bash -e`. Latent since v4.34.0; unreachable until the first waiver existed; triggered by the
+first PR ever to exercise one. Reproduced in isolation (after a detour through macOS bash 3.2,
+which cannot parse `case` in `$()` at all), fixed with `if/fi`, verified in real CI (same branch:
+pre-fix failed twice, post-fix passed twice), and reported upstream with a self-contained
+instruction doc. **Upstream shipped v4.39.2 the same day**; Eric's upgrade (`d130f828`) replaced
+the in-repo patch with the canonical fix — verified identical shape in both engines' floors.
+
+## Durable lessons
+
+1. **A guard's first legitimate exercise is a test of the guard.** Both of this repo's newest
+   gates fired on their own subject matter within a day: the contract-provider link gate caught
+   the white-paper PR, and the secret-scan waiver path detonated on its first real waiver. Budget
+   for the gate being wrong the first time a feature meets it.
+2. **`[ cond ] && action` as the last command of a substituted loop under `-e` is a footgun
+   class**, not an instance — swept the local hook fragments (clean) and flagged the GitLab/Azure
+   floor twins upstream.
 
 ## Memory References
-(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)
+
+- Referenced: eric-release-rhythm, snyk-retired-manifest-placeholders,
+  conv-declare-consulted-references, conv-telemetry-presentation-parity

--- a/memory/sessions/2026-09-04-174753.md
+++ b/memory/sessions/2026-09-04-174753.md
@@ -1,0 +1,48 @@
+# Session (2026-09-04T17:47:53.000Z)
+
+**Agent:** (auto-stub — replace with your agent name and enrich)
+**Lightweight:** auto-captured by the post-commit hook; summary pending.
+
+Commit `803c46a4` — release: version 4.12.3
+
+```
+ CHANGELOG.md                                      | 17 ++++++++++++++++-
+ benchmark/benchmark-reporter/pom.xml              |  4 ++--
+ connectors/adapters/kafka/kafka-connector/pom.xml |  6 +++---
+ connectors/adapters/kafka/kafka-presence/pom.xml  |  6 +++---
+ connectors/core/cloud-connector/pom.xml           |  4 ++--
+ connectors/core/service-monitor/pom.xml           |  6 +++---
+ examples/composable-example/pom.xml               |  4 ++--
+ examples/kafka-demo/pom.xml                       |  4 ++--
+ examples/kotlin-example/pom.xml                   |  4 ++--
+ examples/lambda-example/pom.xml                   |  6 +++---
+ examples/minigraph-playground/pom.xml             |  6 +++---
+ examples/pg-example/pom.xml                       |  6 +++---
+ examples/rest-spring-3-example/pom.xml            |  4 ++--
+ examples/rest-spring-4-example/pom.xml            |  6 +++---
+ examples/scheduler-example/pom.xml                |  4 ++--
+ examples/sync-over-async-demo/pom.xml             |  4 ++--
+ examples/twin-kafka-demo/pom.xml                  |  4 ++--
+ extensions/api-playground/pom.xml                 |  4 ++--
+ extensions/minigraph-state-redis/pom.xml          |  4 ++--
+ extensions/opentelemetry-forwarder/pom.xml        |  6 +++---
+ extensions/reactive-postgres/pom.xml              |  4 ++--
+ extensions/sync-over-async/pom.xml                |  4 ++--
+ helpers/kafka-standalone/pom.xml                  |  4 ++--
+ helpers/redis-standalone/pom.xml                  |  4 ++--
+ helpers/schema-registry-standalone/pom.xml        |  4 ++--
+ pom.xml                                           |  2 +-
+ system/ai-contract-provider/pom.xml               |  8 ++++----
+ system/event-script-engine/pom.xml                |  4 ++--
+ system/mini-scheduler/pom.xml                     |  4 ++--
+ system/minigraph-playground-engine/pom.xml        |  4 ++--
+ system/minimalist-kafka/pom.xml                   |  4 ++--
+ system/platform-core/pom.xml                      |  2 +-
+ system/rest-spring-3/pom.xml                      |  4 ++--
+ system/rest-spring-4/pom.xml                      |  4 ++--
+ system/twin-kafka/pom.xml                         |  4 ++--
+ 35 files changed, 92 insertions(+), 77 deletions(-)
+```
+
+## Memory References
+(none — auto-stub; enrich per memory/PROTOCOL.md "Close every session", or leave as a lite log)

--- a/memory/sessions/2026-09-04-190356.md
+++ b/memory/sessions/2026-09-04-190356.md
@@ -1,0 +1,13 @@
+# Session (2026-09-04T19:03:56.571Z)
+
+**Agent:** Claude Code
+
+Lightweight: Mode B upgrade 4.39.1 → 4.39.2 (PATCH — .github/workflows/agent-memory.yml
+re-copied: the changed-config secret scan's exemption filter no longer aborts silently
+under `set -e` when the LAST changed config file is waived via .agent/secret-scan-ignore;
+the fix originated from this repo family's own field report, mercury-composable PR #318).
+No script, protocol, or shape change; reconcile converged, memory-lint 0 errors.
+
+## Memory References
+
+(none)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.2</version>
+    <version>4.12.3</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.2</version>
+            <version>4.12.3</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

The v4.12.3 field release, lock-step with the Rust engine at the same version.

- **Version sweep 4.12.2 → 4.12.3** across all 34 poms — the 29 reactor modules plus the
  non-reactor Snyk placeholder manifests (`system/rest-spring-3`,
  `examples/rest-spring-3-example`), included deliberately per the placeholder
  convention. The white paper and deck keep their *historical* v4.12.2 mentions.
- **CHANGELOG** rolls `Unreleased` → **Version 4.12.3, 9/4/2026**.
- **agent-memory floor upgraded to v4.39.2** (the CI secret-scan waiver fix, upstreamed
  from this repo's own finding and re-vendored canonically).
- Session logs enriched on-branch (the upgrade had committed two auto-stubs).

## Why — what ships in 4.12.3

Three field-driven fixes and the milestone story:

1. **Kafka producer/consumer opt-out** (#315) — a one-way bridge leg no longer builds
   the client it has no credentials for: `kafka.producer.enabled` /
   `kafka.consumer.enabled` + the `secondary.*` twins, default `true`, veto-not-trigger.
   DLQ-without-producer fails startup; `kafka.health` probes via the producer template
   on a produce-only leg.
2. **Schema Registry credentials reach the serdes** (#318, contributed from the field) —
   Confluent's CSFLE rule executor builds its own DEK registry client from the serde
   config map, previously empty; encrypted fields failed with the no-credential 401.
   Serdes now inherit the registry client template; `schema.registry.serde.*` still wins.
3. **Playground export guard** (#314) — root `name` validated only when declared; an
   unnamed draft can be re-exported. Lock-step with the Rust engine.
4. **The Mercury Story** (#317) — white paper + deck, front and center on the docs site,
   plus `llms.txt` completeness with a CI coverage gate (#316).

## Verification

- Full reactor `mvn clean install` at 4.12.3: **BUILD SUCCESS, 29/29 modules** (07:39);
  minimalist-kafka re-verified after folding #318 (**193 tests**).
- `agent-memory` checks green on this branch post-upgrade — and this PR itself exercises
  the exact v4.39.2 fix scenario (its diff contains the waived fixture as the last
  changed config file).
- Zero `4.12.2` remaining in any pom; 76 → 76 occurrence parity on the sweep.

## After merge (each step individually gated, as usual)

Tag `v4.12.3` on the squash commit → GitHub release (notes drafted) → the Rust twin.
Python/node packs stay at 4.12.1 — no wrapper changes this round.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>