### PR TITLE
fix(deps): vertx-core 5.1.6 + Jackson 2 BOM 2.22.2 for the field Snyk gate; proactive Jackson 3 / Tomcat pins

### DIFF
--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -17,9 +17,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -17,9 +17,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -20,9 +20,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -20,6 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -15,9 +15,10 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
     </properties>
 

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -26,6 +26,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
     </properties>
 

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <otel.version>1.63.0</otel.version>
     </properties>

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -24,6 +24,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <otel.version>1.63.0</otel.version>
     </properties>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -17,9 +17,10 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -26,6 +26,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
@@ -96,13 +96,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.22.1</version>
+            <version>${jackson-2-bom.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.1</version>
+            <version>${jackson-2-bom.version}</version>
         </dependency>
 
         <dependency>

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -21,9 +21,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -21,9 +21,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -62,6 +62,21 @@
   (+ demos); MsgPack wire serialization; customized Gson. (Wording refreshed 2026-08-21 at
   invariant re-verify — substance unchanged.)
   <!-- id: stack-messaging-kafka | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
+- **Jackson runs as two coexisting lanes (established at the 2026-09-04 field Snyk
+  remediation, vertx 5.1.6 + Jackson-2 BOM 2.22.2).** Lane 2 = `com.fasterxml.jackson.*`
+  (Kafka 4.3.x broker modules, Confluent 8.3.x serdes, Boot legacy management) — the single
+  fix lever is the per-pom `jackson-2-bom.version` Spring Boot property (management beats
+  nearest-wins; kafka-standalone's two direct pins reference the property, never literals —
+  a direct version would beat dependencyManagement and silently stay vulnerable). Lane 3 =
+  `tools.jackson.*` (Jackson 3; new Maven coordinates AND Java packages, so the lanes cannot
+  conflict) — rides in via vertx-core 5.1.x's deliberately dual-stack JSON codec and is pinned
+  by the per-pom `jackson-bom.version` Boot property (Boot 4 imports `tools.jackson:jackson-bom`
+  at that property; currently 3.2.2, proactively ahead of the Jackson-LTS 3.1.x that both Boot
+  4.1.1 and vertx-dependencies default to). `jackson-annotations` stays on 2.x
+  coordinates by Jackson-3 design (one copy serves both lanes). platform-core excludes only
+  vertx's lane-2 `jackson-core`; Mercury itself is Gson/MsgPack and never touches vertx
+  JSON. The field Snyk gate watches both lanes independently.
+  <!-- id: jackson-dual-lane-coexistence | created: 2026-09-04 | last_used: 2026-09-04 | uses: 1 | tier: working | origin: 2026-09-04-225035 -->
 - CI: GitHub Actions (`.github/workflows/`)
   <!-- id: stack-ci-gha | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
 ## Architectural Invariants

--- a/memory/sessions/2026-09-04-225035.md
+++ b/memory/sessions/2026-09-04-225035.md
@@ -1,0 +1,65 @@
+# Session (2026-09-04T22:50:35.000Z)
+
+**Agent:** Claude Code
+
+Post-release field remediation for v4.12.3: the field's Snyk gate rejected their imported
+build on two OSS libraries; swept the reactor to vertx-core 5.1.6 + Jackson 2 BOM 2.22.2
+on branch `fix/vertx-5.1.6-jackson-2.22.2`.
+
+Commit `8fb8801a` — fix(deps): vertx-core 5.1.6 + Jackson 2 BOM 2.22.2 for the field Snyk gate
+(30 poms, 33 lines), followed by the proactive-pins commit (`jackson-bom.version` 3.2.2
+added to the same 30 poms; `tomcat.version` 11.0.24 → 11.0.25 in the 24 poms carrying it).
+Branch pushed together with this memory commit; PR-open gated on Eric.
+
+## What happened
+
+- Field Snyk scan of their `feature/4.12.3` import: every module row "1 H" = vertx-core
+  5.1.4 (CVE-2026-15075, CWE-346, CVSS 8.7, SNYK-JAVA-IOVERTX-19433234; fixed upstream
+  5.1.5+); Confluent-chain rows add "2 M" = jackson-databind 2.22.1 (CWE-502, PoC; fixed
+  2.22.2) via kafka-avro-serializer / kafka-schema-registry-client-encryption 8.3.0.
+- Eric supplied the field recipe: vertx-core 5.1.6 keeping the `jackson-core` exclusion
+  (already our shipped shape) + `jackson-2-bom.version` 2.22.2.
+- The sweep: property bump in all 30 module poms — `jackson-2-bom.version` is Spring
+  Boot 4's managed property for the Jackson **2.x** BOM, so dependencyManagement lifts
+  Confluent's 2.22.1 and the embedded broker's native 2.21.2 everywhere (management beats
+  nearest-wins; same override idiom as the documented `httpcore5.version` pin). vertx-core
+  5.1.4 → 5.1.6 at its single declaration (platform-core; exclusion unchanged).
+  kafka-standalone's two direct jackson pins moved from literal `2.22.1` to
+  `${jackson-2-bom.version}` — **direct versions beat dependencyManagement**, so the
+  literals would have silently stayed vulnerable and could drift again on any future bump.
+- Snyk placeholder poms (`system/rest-spring-3`, `examples/rest-spring-3-example`)
+  checked deliberately: dependency-free, nothing to change. Rust engine unaffected (no
+  vertx/jackson) — no lock-step item.
+- Validation: full reactor `mvn clean install` 29/29 SUCCESS (6:12, tests on);
+  `dependency:tree` on platform-core / minimalist-kafka / twin-kafka-demo /
+  kafka-standalone resolves 5.1.6 + 2.22.2 on the flagged paths; zero stray
+  5.1.4/2.22.1 anywhere; target artifacts pre-verified present on Maven Central.
+- Dependency insight (Eric walked the full tree himself): vertx-core 5.1.x is
+  deliberately **dual-stack** — Jackson 2 core (required; we exclude it) + Jackson 3
+  `tools.jackson.core` pair (required) — structurally identical in 5.1.4/5.1.5/5.1.6, so
+  Jackson 3 was already present in v4.12.3 as released and carries no Snyk findings.
+  Kafka 4.3.1 (broker, metadata, raft) natively requests lane-2 at 2.21.2 and has no
+  `tools.jackson` anywhere (verified in the poms); Confluent 8.3.0 likewise stays on
+  lane 2. Jackson 3 changed both Maven coordinates and Java packages, so the lanes cannot
+  conflict; `jackson-annotations` stays on 2.x coordinates by Jackson-3 design (one copy
+  serves both). → new fact [[jackson-dual-lane-coexistence]].
+- Proactive lane-3 pin (Eric's directive: "be proactive to get the current jackson-3
+  version"): Boot 4 manages `tools.jackson:jackson-bom` via the `jackson-bom.version`
+  property (its 4.1.1 default 3.1.5 — the Jackson LTS line, the same choice
+  vertx-dependencies makes, which is why the tree showed 3.1.5). Added
+  `<jackson-bom.version>3.2.2</jackson-bom.version>` (current Jackson 3 line) beside the
+  lane-2 property in the same 30 poms; full-reactor rebuild + tree proof validated it.
+  Both lanes are now one-property levers.
+- Same round, also on Eric's word: `tomcat.version` 11.0.24 → 11.0.25 in the 24 poms
+  carrying the property (Boot-managed Tomcat override, same idiom).
+
+## Memory References
+
+- referenced: eric-release-rhythm (commit/push done on Eric's word; PR-open and merge
+  stay individually gated), snyk-retired-manifest-placeholders (deliberate placeholder-pom
+  check during the sweep), conv-telemetry-presentation-parity (lock-step check → Rust
+  unaffected, no cross-engine item), stack-integration-spring-boot4 (Boot 4 parent is what
+  supplies the `jackson-2-bom.version` management lever), conv-declare-consulted-references
+  (this list follows it)
+- created: jackson-dual-lane-coexistence (tier: working)
+- Superseded: (none)

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -23,9 +23,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <gson.version>2.14.0</gson.version>
         <java.version>21</java.version>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -25,7 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override: the Confluent registry client pulls httpclient5, whose paired
              httpcore5/httpcore5-h2 carries a Snyk HIGH (CWE-770, resource allocation without

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -26,6 +26,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override: the Confluent registry client pulls httpclient5, whose paired
              httpcore5/httpcore5-h2 carries a Snyk HIGH (CWE-770, resource allocation without

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>5.1.4</version>
+            <version>5.1.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -18,9 +18,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -20,9 +20,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>11.0.24</tomcat.version>
+        <tomcat.version>11.0.25</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <kafka.version>4.3.1</kafka.version>
         <gson.version>2.14.0</gson.version>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -29,6 +29,7 @@
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
         <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <netty.version>4.2.17.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
              in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement


### PR DESCRIPTION
## What

Dependency security upgrades after a field Snyk gate rejected the v4.12.3 build, plus two proactive pins in the same sweep:

- **vertx-core 5.1.4 → 5.1.6** — single declaration in `system/platform-core/pom.xml`; every module inherits it transitively. The existing `com.fasterxml.jackson.core:jackson-core` exclusion is unchanged.
- **`jackson-2-bom.version` 2.22.1 → 2.22.2** in all 30 module poms — Spring Boot 4's managed property for the Jackson **2.x** BOM, so Boot's `dependencyManagement` lifts every transitive `com.fasterxml.jackson.*` artifact: Confluent's requested 2.22.1 and the embedded broker's native 2.21.2 (management beats nearest-wins; same override idiom as the documented `httpcore5.version` pin).
- **kafka-standalone**: its two direct `jackson-core`/`jackson-databind` declarations move from literal `2.22.1` to `${jackson-2-bom.version}` — a direct version beats dependencyManagement, so the literals would have silently stayed vulnerable and could drift again on future bumps.
- **Proactive: `jackson-bom.version` → 3.2.2** in the same 30 poms — Boot 4's managed property for the Jackson **3** BOM (`tools.jackson:jackson-bom`), which governs the `tools.jackson.core` 3.x lane that vertx-core's dual-stack JSON codec pulls in. Boot 4.1.1 and vertx both default to the 3.1.x LTS line (3.1.5); this pins the current line explicitly, making both Jackson lanes one-property levers.
- **Proactive: `tomcat.version` 11.0.24 → 11.0.25** in the 24 poms carrying the override.

30 poms touched. The dependency-free Snyk placeholder poms (`system/rest-spring-3`, `examples/rest-spring-3-example`) were checked deliberately — nothing to change. The Rust engine is unaffected (no vertx/jackson/tomcat). Includes the session log + continuity fact per the memory protocol.

## Why

The field's Snyk gate rejected the v4.12.3 build on two OSS findings:

| Finding | Library | Fixed in |
|---|---|---|
| Origin Validation Error — CVE-2026-15075, CWE-346, CVSS 8.7 (High), SNYK-JAVA-IOVERTX-19433234 | `io.vertx:vertx-core@5.1.4` | 5.1.5+ (this PR takes 5.1.6, current) |
| Deserialization of Untrusted Data — CWE-502, CVSS 6.3 (Medium) | `com.fasterxml.jackson.core:jackson-databind@2.22.1`, pulled by the Confluent serdes (`kafka-avro-serializer` / `kafka-schema-registry-client-encryption` 8.3.0) | 2.22.2 |

The vertx issue reached every module transitively through platform-core (the "1 H" on every Snyk project row); the jackson-databind issues appeared only in modules resolving the Confluent chain (the "+2 M" rows: minimalist-kafka, twin-kafka, sync-over-async, kafka-standalone, and their demos).

## Notes — the two Jackson lanes

Jackson 2 and Jackson 3 coexist as independent libraries, not two versions of one: Jackson 3 changed both Maven coordinates (`tools.jackson.*`) and Java packages, so the lanes can never conflict on resolution or classpath. In this tree, lane 2 serves the Kafka 4.3.x broker modules, the Confluent 8.3.0 serdes, and Boot's legacy management (all verified Jackson-2-only); lane 3 serves vertx-core's JSON codec and Spring Boot 4's own stack. `jackson-annotations` stays on 2.x coordinates by Jackson 3 design — one copy serves both. Each lane now has a single fix lever: `jackson-2-bom.version` and `jackson-bom.version`.

## Validation

- Full reactor `mvn clean install` on the final state: **29/29 modules BUILD SUCCESS, all tests green** (the remediation commit was also independently built green before the proactive pins were added).
- `mvn dependency:tree` proof — platform-core / minimalist-kafka / twin-kafka-demo / kafka-standalone / rest-spring-4-example resolve: vertx-core **5.1.6**, lane-2 jackson-core/databind **2.22.2**, `tools.jackson.core` **3.2.2**, tomcat-embed-core **11.0.25**. Zero remaining references to 5.1.4 / 2.22.1 / 11.0.24 anywhere in the reactor.
- vertx-core 5.1.6, jackson-bom 2.22.2, tools.jackson jackson-bom 3.2.2, and tomcat-embed-core 11.0.25 all pre-verified present on Maven Central.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>