### PR TITLE
docs: drop the white paper's frontmatter block — it rendered as visible text

### DIFF
--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -1,13 +1,3 @@
----
-title: Intent-Driven Development and the Architecture of Human-AI Collaboration
-summary: White paper — Intent-Driven Development as the collaboration model for the AI era, with
-  Mercury as the working reference implementation: shared memory, AI grammar, and governed
-  execution, from event-driven origins to AI co-authorship.
-audience: [executive, architect, developer, business, ai-agent]
-keywords: [intent-driven development, human-ai collaboration, ai grammar, governed nondeterminism,
-  active knowledge graph, composable, shared memory, enterprise ai governance, white paper]
----
-
 # Intent-Driven Development and the Architecture of Human-AI Collaboration
 
 *The Mercury Story: from event-driven systems to AI co-authorship*

--- a/memory/sessions/2026-09-05-062600.md
+++ b/memory/sessions/2026-09-05-062600.md
@@ -1,0 +1,18 @@
+# Session (2026-09-05T06:26:00.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** the IDD white paper's frontmatter block rendered as visible text on the live
+site (Eric's screenshot) — the summary value's colon-space broke YAML parsing, so mkdocs fell
+back to rendering the block as content. Removed the block entirely (the doc-canon frontmatter
+gate scopes docs/guides/** only; matches the Rust edition). Commit `ae401bf3` on
+`fix/paper-frontmatter`; doc canon OK.
+
+Commit `ae401bf3` — docs: drop the white paper's frontmatter block - it rendered as visible text
+
+```
+ docs/ai-grammar-methodology.md | 10 ----------
+ 1 file changed, 10 deletions(-)
+```
+
+## Memory References
+(none)


### PR DESCRIPTION
## What

Remove the YAML frontmatter block from `docs/ai-grammar-methodology.md` (10 lines). The page now
starts at the H1, matching the Rust edition.

## Why

On the live site the block rendered as visible text above the title. The `summary` value
introduced in #321 contains a colon-space ("…reference implementation: shared memory…"), which
makes the YAML unparseable — mkdocs then falls back to rendering the whole block as content. The
paper needs no frontmatter: the doc-canon frontmatter gate scopes `docs/guides/**` only, the nav
label lives in `mkdocs.yml`, and the H1 supplies the page title.

## Validation

- `scripts/check-doc-canon.py`: OK.
- File verified to start at the H1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>