### PR TITLE
docs(deck): home logo button at bottom-left — the site's atom mark links back to the home page

### DIFF
--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -109,6 +109,11 @@
   }
   .wordmark{font-family:var(--display); font-weight:600; letter-spacing:.02em}
   .wordmark .dot{color:var(--accent)}
+  .home{display:flex; align-items:center; gap:9px; color:inherit; text-decoration:none}
+  .home svg{width:21px; height:21px; fill:var(--accent); flex:none; transition:fill .15s}
+  .home:hover svg{fill:var(--accent-ink)}
+  .home:hover .wordmark{color:var(--accent-ink)}
+  .home:focus-visible{outline:2px solid var(--amber); outline-offset:3px; border-radius:6px}
   .counter{font-variant-numeric:tabular-nums; color:var(--muted); font-size:.85em; margin-left:auto}
   .dots{display:flex; gap:7px}
   .dots button{width:9px; height:9px; border-radius:50%; border:0; background:var(--line); cursor:pointer; padding:0}
@@ -531,7 +536,11 @@
   <button class="zone back" id="zback" aria-label="Previous slide" tabindex="-1"></button>
   <button class="zone fwd" id="zfwd" aria-label="Next slide" tabindex="-1"></button>
   <div class="bar">
-    <span class="wordmark">mercury<span class="dot">·</span>composable</span>
+    <a class="home" href="https://accenture.github.io/mercury-composable/"
+       title="Mercury Composable home" aria-label="Mercury Composable home">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 11a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1M4.22 4.22C5.65 2.79 8.75 3.43 12 5.56c3.25-2.13 6.35-2.77 7.78-1.34s.79 4.53-1.34 7.78c2.13 3.25 2.77 6.35 1.34 7.78s-4.53.79-7.78-1.34c-3.25 2.13-6.35 2.77-7.78 1.34S3.43 15.25 5.56 12C3.43 8.75 2.79 5.65 4.22 4.22m11.32 4.24c.61.62 1.17 1.25 1.69 1.88 1.38-2.13 1.88-3.96 1.13-4.7-.74-.75-2.57-.25-4.7 1.13.63.52 1.26 1.08 1.88 1.69m-7.08 7.08c-.61-.62-1.17-1.25-1.69-1.88-1.38 2.13-1.88 3.96-1.13 4.7.74.75 2.57.25 4.7-1.13-.63-.52-1.26-1.08-1.88-1.69m-2.82-9.9c-.75.74-.25 2.57 1.13 4.7.52-.63 1.08-1.26 1.69-1.88.62-.61 1.25-1.17 1.88-1.69-2.13-1.38-3.96-1.88-4.7-1.13m4.24 8.48c.7.7 1.42 1.34 2.12 1.91.7-.57 1.42-1.21 2.12-1.91s1.34-1.42 1.91-2.12c-.57-.7-1.21-1.42-1.91-2.12S12.7 8.54 12 7.97c-.7.57-1.42 1.21-2.12 1.91S8.54 11.3 7.97 12c.57.7 1.21 1.42 1.91 2.12m8.48 4.24c.75-.74.25-2.57-1.13-4.7-.52.63-1.08 1.26-1.69 1.88-.62.61-1.25 1.17-1.88 1.69 2.13 1.38 3.96 1.88 4.7 1.13"/></svg>
+      <span class="wordmark">mercury<span class="dot">·</span>composable</span>
+    </a>
     <span class="hint">← → to navigate · P to print the handout</span>
     <nav class="dots" id="dots" aria-label="Slides"></nav>
     <button class="navbtn" id="prev" aria-label="Previous">‹ Prev</button>

--- a/memory/sessions/2026-09-05-164801.md
+++ b/memory/sessions/2026-09-05-164801.md
@@ -1,0 +1,17 @@
+# Session (2026-09-05T16:48:01.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** deck UX touch-up on Eric's idea — the site header's atom logo (material/atom,
+inlined SVG) now pairs with the bottom-left wordmark as one link back to the home page, closing
+the deck's dead-end (recognition over recall: the mark the user knows from the site header).
+Commit `fae9db23` on `docs/deck-home-link`; same change ported to the Rust deck in lock-step.
+
+Commit `fae9db23` — docs(deck): home logo button at bottom-left
+
+```
+ docs/presentations/ai-grammar-story.html | 10 +++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+```
+
+## Memory References
+(none)


### PR DESCRIPTION
## What

The deck's bottom-left wordmark now pairs with the site header's own logo (`material/atom`,
inlined as SVG so the deck stays self-contained), and the two together form one link back to the
home page. Hover tint and a keyboard focus ring included; the print handout is unaffected (the
bar is already hidden in print). The link is an absolute site URL so it works wherever the file
travels — the mkdocs site, a local file, or an artifact.

## Why

The deck opened as a dead end: full screen, no way back to the site except the browser's back
button. Reusing the exact mark the user already knows from the site header means recognition
with no learning — the same logo does the same thing everywhere.

## Validation

Rendered and verified: the mark matches the header glyph, the bar layout is unchanged, and the
anchor carries `title`/`aria-label` for accessibility.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>