### PR TITLE
docs: agent-memory attribution in the white paper — the now-phase of the maintainer review

### DIFF
--- a/docs/ai-grammar-methodology.md
+++ b/docs/ai-grammar-methodology.md
@@ -461,9 +461,12 @@ The grammar remains language-neutral because the contracts remain language-neutr
 
 ### Project Memory
 
-The project's memory is distinct from the platform's grammar. Vision, Blueprint, continuity,
-session records, and architecture decisions orient each AI session on purpose and state rather
-than only API shape.
+The project's memory is distinct from the platform's grammar — and unlike the mechanisms above,
+Mercury does not implement it. The repository is AI-enabled with **agent-memory**, a
+vendor-neutral shared-memory and cognitive-loop tool that installs and versions the memory layer
+whose content Mercury's contributors maintain. Vision, Blueprint, continuity, session records,
+and architecture decisions orient each AI session on purpose and state rather than only API
+shape.
 
 Together, these mechanisms make guide-first behavior rational. If documentation can drift freely,
 an AI partner learns to distrust it and returns to source. Verification gates preserve trust in
@@ -496,6 +499,11 @@ Current state → Vision → Blueprint → Design → Implementation → Feedbac
 Memory preserves continuity, but judgment remains a shared human responsibility.
 
 > Mechanize the arithmetic. Do not mechanize the judgment.
+
+This step has a concrete, reusable implementation: Mercury's repositories are AI-enabled with
+**agent-memory**, which installs the shared memory layer, gates a human-confirmed Vision
+(bootstrapped as a draft, never fabricated), and orients every subsequent session — the same
+tool that maintains this repository's own `memory/`.
 
 The proof point is Mercury's own Rust engine: AI-enabled **before its first line of code**, so
 every increment was derived from stated intent rather than reconstructed after the fact. Roughly
@@ -777,4 +785,5 @@ reproducible from the cited artifacts.*
 
 *Mercury Composable is an official Accenture open-source project (github.com/Accenture/mercury-composable),
 with an official Rust port. agent-memory is a lightweight, vendor-neutral shared-memory and
-cognitive-loop framework for human-AI collaboration, published under Apache-2.0.*
+cognitive-loop tool for human-AI collaboration; it installs and maintains this repository's
+shared `memory/` layer.*

--- a/docs/presentations/ai-grammar-story.html
+++ b/docs/presentations/ai-grammar-story.html
@@ -379,7 +379,7 @@
       <dt>Contract provider</dt><dd>the doc set served as a <b>version-matched contract</b>: discovery endpoint, per-file SHA-256 manifest, exportable Agent Skill</dd>
       <dt>Registration contract</dt><dd>the grammar of <i>declaring</i> functions — one metadata model, per-language carriers, proven by <b>golden vectors</b> shared between engines</dd>
       <dt>Engine parity</dt><dd>Java is the reference; Rust ships in lock-step; flow YAML ports unchanged; python/node functions join as Event-over-HTTP peers</dd>
-      <dt>Memory layer</dt><dd>the <i>project’s</i> grammar — Vision, Blueprint, continuity — so sessions start oriented on intent, not just API shape</dd>
+      <dt>Memory layer</dt><dd>the <i>project’s</i> grammar, via <b>agent-memory</b> — Vision, Blueprint, continuity — so sessions start oriented on intent, not just API shape</dd>
     </dl>
   </section>
 

--- a/draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md
+++ b/draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md
@@ -109,3 +109,16 @@ framework→tool + dangling-license fix are still worth taking, with option B.
 
 *Feedback only — no files in `docs/` were changed. Drafted wording is free to use, adapt,
 or discard.*
+
+---
+
+## Resolution (2026-09-05, Eric's ruling)
+
+**Accepted and applied now, both engines:** F1 (§6 Project Memory provenance), F2 (Step 1 names
+agent-memory), F3 **option B** (framework → tool; license clause dropped in favor of the
+installs-and-maintains sentence), F5 (deck row: "the project's grammar, via agent-memory").
+
+**Deferred by design:** F3 option A's locator and F4's reference entry — direct URLs to
+agent-memory stay out of this official Accenture publication until agent-memory is promoted to
+an official Accenture open-source asset; they land then, at the official URL. Tracked in
+`memory/open-threads/thread-ot-agent-memory-attribution-locators.md`.

--- a/memory/open-threads/thread-ot-agent-memory-attribution-locators.md
+++ b/memory/open-threads/thread-ot-agent-memory-attribution-locators.md
@@ -1,0 +1,10 @@
+- [ ] (docs) **Add the agent-memory locators to the white paper once agent-memory is promoted
+  to official Accenture open source** — the deferred half of the agent-memory-maintainer
+  review (`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`):
+  F3 option A (append the official repository URL to the closing note's agent-memory
+  sentence) and F4 (References entry #20 for the agent-memory whitepaper, at the official
+  URL). Apply to BOTH engines' `docs/ai-grammar-methodology.md` in lock-step. The now-phase
+  (F1/F2/F3-B/F5 — naming and describing the tool, no links) shipped 2026-09-05 on Eric's
+  ruling: no direct URLs to personal-GitHub research inside an official Accenture
+  publication until the promotion lands. Trigger: Eric announces the promotion.
+  <!-- id: ot-agent-memory-attribution-locators | created: 2026-09-05 | last_used: 2026-09-05 | uses: 1 | tier: working | origin: 2026-09-05-174738 -->

--- a/memory/sessions/2026-09-05-174738.md
+++ b/memory/sessions/2026-09-05-174738.md
@@ -1,0 +1,41 @@
+# Session (2026-09-05T17:47:38.000Z)
+
+**Agent:** Claude Code
+
+Applied the agent-memory-maintainer review of the white paper's agent-memory attribution
+(`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`, left by the
+maintainer session whose log is `2026-09-05-173701.md`). Eric's ruling split the five findings
+into a now-phase and a deferred phase.
+
+Commit `dfdd804a` on `docs/agent-memory-attribution` (paper + deck + the spec's new Resolution
+section); Rust engine synced in lock-step on its own branch.
+
+## What happened
+
+- **Review verdict accepted:** the paper was factually accurate about agent-memory but
+  systematically understated it — every memory mechanism it leans on is agent-memory's,
+  described accurately yet presented as anonymous methodology practice while Mercury's own
+  mechanisms are named and cited.
+- **Now-phase applied (both engines):** F1 — §6 Project Memory states provenance (Mercury does
+  not implement the memory system; the repo is AI-enabled with agent-memory, which installs and
+  versions the layer whose content contributors maintain); F2 — §7 Step 1 names agent-memory as
+  the concrete implementation of "Establish Intent and Memory"; F3 option B — closing note says
+  *tool* (agent-memory's own self-description; "framework" clashed with its stated non-goals)
+  and the dangling license clause became the installs-and-maintains sentence; F5 — the deck's
+  Memory-layer row reads "the project's grammar, via agent-memory".
+- **Deferred (Eric's ruling):** F3 option A's locator and F4's reference entry — no direct URLs
+  to personal-GitHub research inside an official Accenture publication until agent-memory is
+  promoted to an official Accenture open-source asset ("promotion planned soon", Eric); they
+  land then at the official URL. Recorded in the spec's Resolution section; tracked as new open
+  thread [[ot-agent-memory-attribution-locators]].
+- Gates: Java doc canon OK; Rust llms.txt link integrity OK (30 references). The hook suggested
+  enriching the reviewer session's log (within 30 min); declined — never append to another
+  contributor's log, and this ruling is distinct memory-relevant work.
+
+## Memory References
+
+- referenced: conv-telemetry-presentation-parity (both engines' papers edited in lock-step —
+  the shared product story follows the cross-engine contract), eric-release-rhythm (branches
+  prepared and pushed; PR-open gated), conv-declare-consulted-references (this list follows it)
+- created: ot-agent-memory-attribution-locators (open thread, tier: working)
+- Superseded: (none)


### PR DESCRIPTION
## What

Applies the accepted findings of the agent-memory-maintainer review
(`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`) to the white
paper and deck:

- **F1** — §6 "Project Memory" states its provenance: Mercury does not implement the memory
  system; the repository is AI-enabled with **agent-memory**, which installs and versions the
  layer whose content Mercury's contributors maintain.
- **F2** — §7 Step 1 names agent-memory as the concrete, reusable implementation of "Establish
  Intent and Memory" — the same tool that maintains this repository's own `memory/`.
- **F3 (option B)** — the closing note says *tool* (agent-memory's own self-description) and the
  dangling license clause becomes the installs-and-maintains sentence.
- **F5** — the deck's Memory-layer row reads "the project's grammar, via agent-memory".

**Deferred by maintainer ruling:** F3 option A's locator and F4's reference entry — direct URLs
to agent-memory stay out of this official Accenture publication until agent-memory is promoted to
an official Accenture open-source asset; they land then, at the official URL. Recorded in the
review spec's Resolution section and tracked as an open thread.

## Why

The review's core observation was fair: every memory mechanism the paper leans on is
agent-memory's — described accurately, but presented as anonymous methodology practice while
Mercury's own mechanisms are named and cited. Naming the tool is an accuracy fix; the linking
depth is a positioning decision, phased deliberately.

## Validation

- Doc canon / llms.txt link integrity: OK.
- Both engines edited in lock-step (this PR and its twin).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>