### PR TITLE
docs: AI grammar coverage study + the now-phase fixes it recommends

### DIFF
--- a/docs/guides/actuators-and-http-client.md
+++ b/docs/guides/actuators-and-http-client.md
@@ -559,7 +559,8 @@ If you want to enforce Integer or Long, please design a PoJo to fit your use cas
 However, floating point numbers (Float and Double) are rendered without type matching.
 
 For untyped numbers, you may use the convenient type conversion methods in the platform-core's
-Utility class. For examples, util.str2int and util.str2long.
+Utility class (import `org.platformlambda.core.util.Utility`; obtain it with
+`Utility.getInstance()`). For examples, util.str2int and util.str2long.
 <br/>
 
 ## See also

--- a/docs/guides/annotations-reference.md
+++ b/docs/guides/annotations-reference.md
@@ -159,8 +159,10 @@ public class SearchUsers implements TypedLambdaFunction<SearchRequest, List<User
 @PreLoad(route = "greeting.case.1, greeting.case.2", instances = 10)
 public class Greetings implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> { ... }
 
-// Instance count from environment variable
-@PreLoad(route = "v1.heavy.task", envInstances = "${HEAVY_TASK_INSTANCES:10}")
+// Instance count from a configuration KEY: envInstances names a property key looked up in
+// application.properties (e.g. heavy.task.instances=20); a non-numeric or missing value
+// falls back to `instances`. A "${...}" literal here is NOT resolved and silently no-ops.
+@PreLoad(route = "v1.heavy.task", instances = 10, envInstances = "heavy.task.instances")
 public class HeavyTask implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> { ... }
 ```
 
@@ -173,8 +175,11 @@ public class HeavyTask implements TypedLambdaFunction<Map<String, Object>, Map<S
   Constructor injection does NOT work because instances are created before the Spring context.
 - `@PreLoad` can be combined with `@KernelThreadRunner`, `@EventInterceptor`, `@ZeroTracing`,
   and `@OptionalService` on the same class.
-- Runtime instance count override (without recompiling):
-  set `worker.instances.<route>=N` in `application.properties`.
+- Runtime instance count override (without recompiling) — **only for functions whose
+  `@PreLoad` declares `envInstances`**: the annotation names a configuration key (framework
+  built-ins use the `worker.instances.<route>` convention), and setting that key in
+  `application.properties` overrides `instances`. For functions without `envInstances`,
+  use `yaml.preload.override` instead.
 - Preload override YAML: use `yaml.preload.override` to re-map routes or change instance
   counts for library functions you cannot recompile.
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -22,10 +22,12 @@ Mercury Composable applications are configured through `application.properties` 
 equivalent `application.yml`). This page is the exhaustive reference for every configuration
 key supported by the framework and its optional modules.
 
-Properties are set in `src/main/resources/application.properties` and can be overridden via
-environment variables or JVM system properties (`-Dkey=value`) using Spring Boot's standard
-property resolution order. When both `application.properties` and `application.yml` are
-present, `.properties` takes precedence.
+Properties are set in `src/main/resources/application.properties` and can be overridden with
+JVM system properties (`-Dkey=value`), which the config reader checks first. Environment
+variables enter through `${ENV_VAR:default}` substitution inside values (and additionally
+through Spring Boot's own resolution order in `rest-spring-4` apps). When both
+`application.properties` and `application.yml` are present, they are merged and **`.yml`
+values win** for overlapping keys (`application.yml` is merged last).
 
 > **Tip**: In `application.yml`, dots in property names become nested YAML keys.
 > For example, `rest.server.port=8100` becomes:

--- a/docs/guides/event-driven/ai-agent-guide.md
+++ b/docs/guides/event-driven/ai-agent-guide.md
@@ -37,8 +37,10 @@ Functions are **not called directly**. The framework loads them at startup:
 4. Any caller (REST endpoint, Event Script flow, another function) addresses the function **only by
    its route name string**.
 
-A function that violates the contract (duplicate route, invalid `instances`, bad interface) causes the
-application to fail at startup — correctness is checkable before runtime.
+Contract violations are caught at startup, but the application **keeps starting**: a duplicate
+route reloads the earlier registration with a `Reloading` warning, and a bad interface or
+invalid route is skipped with an error log. Check the startup log for these messages —
+correctness is checkable before runtime, but not by relying on a crash.
 
 ---
 

--- a/docs/guides/event-envelope-reference.md
+++ b/docs/guides/event-envelope-reference.md
@@ -451,7 +451,8 @@ When `setException(Throwable ex)` is called, the framework determines the status
 | `IllegalArgumentException` | `400` |
 | Any other `Throwable` | `500` |
 
-Throw `AppException` from user functions to return structured error responses:
+Throw `AppException` (import `org.platformlambda.core.exception.AppException`) from user
+functions to return structured error responses:
 
 ```java
 throw new AppException(404, "Profile not found");
@@ -710,7 +711,7 @@ helps when debugging flows.
 | `output.header.<name>` | Sets a response header |
 | `output.status` | Sets the HTTP response status code |
 | `header.<name>` | Sets a key-value in the next function's `headers` argument |
-| `error.status` | Status code when an exception handler task is invoked |
+| `error.code` | Status code when an exception handler task is invoked |
 | `error.message` | Error message when an exception handler task is invoked |
 | `error.task` | Route of the task that threw the exception |
 | `error.stack` | Stack trace when an exception handler task is invoked |

--- a/docs/guides/event-script/flow-grammar.md
+++ b/docs/guides/event-script/flow-grammar.md
@@ -87,7 +87,7 @@ Every `input`/`output` entry is `'source -> target'` (one `->` per rule; a three
 | `input.*` | the HTTP request dataset (`input.body`, `input.header.*`, `input.query.*`, `input.path_parameter.*`, `input.method`, …) |
 | `model.*` | flow-instance state (dot/bracket/`{model.key}` dynamic keys) |
 | `model.parent.*` / `model.root.*` | parent-flow state (in sub-flows) |
-| `error.*` | exception context in a handler (`error.task/.status/.message/.stack`) |
+| `error.*` | exception context in a handler (`error.task/.code/.message/.stack`) |
 | `$.…` | a JSONPath expression |
 | `result` / `input` / `header` / `status` / `datatype` | (in `output` rules) the function's result, the task input, response headers, status code, or result class name |
 | constants | `text(…)`, `int(…)`, `long(…)`, `float(…)`, `double(…)`, `boolean(…)`, `map(k=v,…)`, `file(text:/json:/binary:path)`, `classpath(…)` |

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -551,7 +551,7 @@ to a task or the generic exception handler that attaches to the flow itself.
 The error dataset includes the following:
 
 1. error.task - this is the task name of the task that throws exception
-2. error.status - the status code of the exception
+2. error.code - the status code of the exception
 3. error.message - the error message
 4. error.stack - stack trace if any
 

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -49,7 +49,7 @@ File names of individual flow configuration YAML files to load.
 |---|---|
 | string | No |
 
-Base directory for resolving file names. Default: resources folder root. Example: `classpath:/flows/`.
+Base directory for resolving file names. Default: `classpath:/flows/`.
 
 Multiple flow list files can be specified as a comma-separated list:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -54,6 +54,25 @@ mvn clean install
 **2. Build and run the example app.**
 
 > **Note**: `x.y.z` denotes the current Mercury version shown in the root `pom.xml`.
+>
+> **Depending on Mercury from your own application** — module artifacts use the
+> `org.platformlambda` groupId (the reactor parent `com.accenture.mercury` is build-only):
+>
+> ```xml
+> <dependency>
+>     <groupId>org.platformlambda</groupId>
+>     <artifactId>platform-core</artifactId>
+>     <version>x.y.z</version>
+> </dependency>
+> <dependency>
+>     <groupId>org.platformlambda</groupId>
+>     <artifactId>event-script-engine</artifactId>
+>     <version>x.y.z</version>
+> </dependency>
+> ```
+>
+> Opt-in modules follow the same pattern: `rest-spring-4`, `minimalist-kafka`, `twin-kafka`,
+> `minigraph-playground-engine`, `minigraph-state-redis`.
 
 ```shell
 cd examples/composable-example

--- a/docs/guides/http-streaming.md
+++ b/docs/guides/http-streaming.md
@@ -89,7 +89,8 @@ public class TokenProducer implements TypedLambdaFunction<EventEnvelope, Void> {
 }
 ```
 
-`EventStreamWriter` is thin sugar over plain event sends:
+`EventStreamWriter` (import `org.platformlambda.core.system.EventStreamWriter`) is thin sugar
+over plain event sends:
 
 | Method | Meaning |
 | ------ | ------- |

--- a/docs/guides/knowledge-graph/build-your-first-graph.md
+++ b/docs/guides/knowledge-graph/build-your-first-graph.md
@@ -127,8 +127,8 @@ export graph as my-first-graph
 
 ```
 > export graph as my-first-graph
-Added name=my-first-graph to Root node
 Graph exported to /tmp/graph/my-first-graph.json
+Described in /api/graph/model/my-first-graph/{token}
 ```
 
 ## Step 4 — deploy it {#deploy}

--- a/docs/guides/knowledge-graph/command-reference.md
+++ b/docs/guides/knowledge-graph/command-reference.md
@@ -211,7 +211,7 @@ cleared run marks — which is the standard idiom for a second dry-run with diff
 ```
 run                        # traverse from root to end
 execute {node}             # run a single node (after instantiate)
-inspect {namespace.key}    # read a value from the state machine (leaf keys resolve; a subtree prints {})
+inspect {namespace.key}    # read a value from the state machine (a leaf value or a whole subtree)
 ```
 
 ```
@@ -222,10 +222,10 @@ inspect error                # the exception context after a failed node routed 
 
 > **Placeholder convention:** `{…}` in the syntax lines above (e.g. `{node}`,
 > `{namespace.key}`) marks a value you substitute — **do not type the braces**.
-> **`inspect` resolves leaves, not subtrees**: `inspect output` prints `{}` even when
-> `output.body.rmdAmount` holds a value — ask for the specific composite key. (An AI driver on
-> the `/sync` companion endpoint rarely needs `inspect` at all: a run's structured outcome comes
-> back in the response's `result` field.)
+> **`inspect` returns subtrees too**: `inspect output` prints the whole populated namespace
+> map; ask for a composite key like `inspect output.body.rmdAmount` when you want one value.
+> (An AI driver on the `/sync` companion endpoint rarely needs `inspect` at all: a run's
+> structured outcome comes back in the response's `result` field.)
 
 > Write `inspect output.body.name`, not `inspect {output.body.name}` (a literal
 > `{output.body}` is treated as the key `{output` → `body}` and resolves to nothing).
@@ -280,8 +280,9 @@ import node {node} from {name}
   (`Expect root node name=...`) — protecting `graph123.json` from another graph's content —
   while a **missing or blank root name is accepted**, and the export assigns the target id
   as the root name (the same self-naming a brand-new export performs).
-- `export` writes JSON to `location.graph.temp`; it adds `name={name}` to the root node and
-  **fails if any node is an orphan** (every node must connect to ≥1 other).
+- `export` writes JSON to `location.graph.temp` and adds `name={name}` to the root node.
+  (Orphan nodes are not rejected at export — the CompileGraph deployment gate re-validates
+  the whole model.)
 - The export reply includes `Described in /api/graph/model/{name}/{token}` — a read-only HTTP
   view of the exported model.
 

--- a/docs/guides/knowledge-graph/composing-the-layers.md
+++ b/docs/guides/knowledge-graph/composing-the-layers.md
@@ -156,11 +156,16 @@ REST endpoint while keeping execution decoupled from the protocol.
 ```
 
 ```yaml
-# graph-executor.yml — wraps the engine as a flow task
+# graph-executor.yml — wraps the engine as a flow task (the complete, loadable flow —
+# it ships pre-wired in the MiniGraph playground engine and example app)
 flow:
   id: 'graph-executor'
+  description: 'MiniGraph Traveler'
+  ttl: 60s
   exception: 'graph.exception.handler'
+
 first.task: 'graph.executor'
+
 tasks:
   - input:
       - 'model.instance -> header.instance'
@@ -170,8 +175,22 @@ tasks:
       - 'status -> output.status'
       - 'header -> output.header'
       - 'result -> output.body'
+    description: 'Perform active graph traversal and execute nodes'
+    execution: end
+
+  - input:
+      - 'error.code -> status'
+      - 'error.message -> message'
+      - 'error.stack -> stack'
+    process: 'graph.exception.handler'
+    output:
+      - 'result.status -> output.status'
+      - 'result -> output.body'
+    description: 'Render graph errors as clean HTTP responses'
     execution: end
 ```
+
+> `graph.exception.handler` is an engine **built-in** — you reference it, you do not write it.
 
 So a request flows: `http.flow.adapter` → `graph-executor` flow → `graph.executor` (loads the model
 by `graph_id`, traverses it) → `async.http.response`. Calling it:

--- a/docs/guides/knowledge-graph/workflow-suspension.md
+++ b/docs/guides/knowledge-graph/workflow-suspension.md
@@ -364,7 +364,8 @@ curl -s -X POST http://127.0.0.1:8085/api/graph/tutorial-14 \
   correlation ID and is fully resumable on its own; the parent orchestrates —
   see [the orchestrator pattern](#orchestrator-pattern).
 - Reserved model keys (`model.cid`, `model.instance`, `model.flow`, `model.ttl`,
-  `model.trace`, `model.run`) are never persisted — the resumed run's own identity is
+  `model.trace`, `model.parent`, `model.root`, `model.none`, `model.run`) are never
+  persisted — the resumed run's own identity is
   authoritative. `model.run` is part of the read-only flow metadata family: `graph.resume`
   is its only writer, and the flow compiler rejects any data mapping that targets it
   (like the other reserved keys).
@@ -466,7 +467,17 @@ suspends. Configuration uses the same
 `redis.*` keys as the sync-over-async extension (`redis.host`, `redis.port`,
 `redis.password`, `redis.ssl`, `redis.database`, `redis.timeout.ms`), and the worker
 counts are ops-tunable via `worker.instances.v1.redis.persist.model` /
-`worker.instances.v1.redis.retrieve.model`. See the module README for details.
+`worker.instances.v1.redis.retrieve.model`. Dependency:
+
+```xml
+<dependency>
+    <groupId>org.platformlambda</groupId>
+    <artifactId>minigraph-state-redis</artifactId>
+    <version>x.y.z</version>  <!-- the current Mercury version in the root pom.xml -->
+</dependency>
+```
+
+See the module README for details.
 
 ## See also
 

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -48,7 +48,15 @@ which is a different concern; this library is an application-level building bloc
 
 ## Enabling the library {#enable}
 
-1. Depend on `system/minimalist-kafka` (it depends on `event-script-engine`).
+1. Depend on `system/minimalist-kafka` (it depends on `event-script-engine`):
+
+    ```xml
+    <dependency>
+        <groupId>org.platformlambda</groupId>
+        <artifactId>minimalist-kafka</artifactId>
+        <version>x.y.z</version>  <!-- the current Mercury version in the root pom.xml -->
+    </dependency>
+    ```
 2. Point `yaml.kafka.flow.adapter` at your adapter config (inbound). Without it, no consumer starts.
 3. Provide the Kafka client templates (see [client config](#client-config)) — the classpath defaults work
    for local dev.
@@ -367,7 +375,7 @@ auto-commit only changes *when* Kafka considers the offset committed, not whethe
 dead-lettered. Choose this per binding for high-volume topics (e.g. clickstream/telemetry) that can tolerate
 occasional loss on crash in exchange for throughput; leave strict topics on the default.
 
-A flow **succeeds** when it replies with status `200`. Any other status — or a thrown exception, including a
+A flow **succeeds** when it replies with a status below `400` (any 2xx/3xx). A `4xx`/`5xx` status — or a thrown exception, including a
 **timeout** when the flow does not reply within its own `ttl` — is a **failure**. (Kafka is asynchronous, so
 unlike an HTTP entry the adapter has no inherent request timeout: the flow's `ttl` *is* the processing
 deadline. There is no separate flow-timeout knob.)

--- a/docs/guides/rest-automation/rest-automation.json
+++ b/docs/guides/rest-automation/rest-automation.json
@@ -15,6 +15,7 @@
     { "field": "url", "required": true, "meaning": "URI path; supports {param} variables and a trailing * wildcard (case-insensitive)" },
     { "field": "flow", "required": false, "meaning": "flow id (used with service: http.flow.adapter)" },
     { "field": "timeout", "required": false, "meaning": "duration like 30s (default 30s; clamped 1s-5m); an inbound x-ttl request header (ms) overrides it - end-to-end deadline propagation from a Mercury caller" },
+    { "field": "stream", "required": false, "meaning": "true/false (default false) - progressive response streaming (SSE or chunked JSON Lines) on a dedicated ordered reply lane; see the HTTP Response Streaming guide (http-streaming.md)" },
     { "field": "cors", "required": false, "meaning": "id of a cors entry (must exist)" },
     { "field": "headers", "required": false, "meaning": "id of a headers entry (must exist)" },
     { "field": "authentication", "required": false, "meaning": "a service route, or routing specs: 'default: svc' / 'header: svc' / 'header: value: svc'" },

--- a/docs/guides/rest-automation/rest-grammar.md
+++ b/docs/guides/rest-automation/rest-grammar.md
@@ -48,13 +48,14 @@ related:
 | `authentication` | no | a service route, or routing specs: `'default: svc'`, `'header: svc'`, `'header: value: svc'` |
 | `upload` | no | `true`/`false` (default false) — enable multipart upload |
 | `tracing` | no | `true`/`false` (default false) — enable distributed tracing |
+| `stream` | no | `true`/`false` (default false) — progressive response streaming (SSE / chunked JSON Lines) on a dedicated ordered reply lane; see the [HTTP Response Streaming](../http-streaming.md) guide |
 | `trace.id.header` | no | per-endpoint override of the global `http.trace.id.header` (default `X-Trace-Id`) — impedance matching for a caller that sends its own trace-id header name; a well-formed W3C `traceparent` still takes precedence |
 | `correlation.id.header` | no | per-endpoint override of the global `http.correlation.id.header` (default `X-Correlation-Id`) — impedance matching for a caller that sends its own business correlation-id header name |
 | `traceparent.header` | no | per-endpoint override of the global `http.traceparent.header` (default `traceparent`) — the header carrying the full W3C trace context, for **backward compatibility with a legacy intermediary only** (departure from the W3C/OTel standard is discouraged); the standard `traceparent` always wins, and the custom name is read only when the standard is absent |
 | `trust_all_cert` | no | `true`/`false` — **HTTPS relay only** |
 | `url_rewrite` | no | a list of **exactly two** strings `[from, to]` — **HTTP(S) relay only** |
 
-Boolean fields (`upload`, `tracing`, `trust_all_cert`) are written **unquoted**, e.g. `tracing: true`.
+Boolean fields (`upload`, `tracing`, `stream`, `trust_all_cert`) are written **unquoted**, e.g. `tracing: true`.
 The header-override values are header names, written quoted like other strings, e.g.
 `trace.id.header: 'X-Legacy-Trace'` (header capture is case-insensitive; precedence is
 per-entry > `application.properties` global > built-in default — see

--- a/draft-design-specs/ai-grammar-coverage-study.md
+++ b/draft-design-specs/ai-grammar-coverage-study.md
@@ -1,0 +1,287 @@
+# AI Grammar Coverage Study — does Mercury live up to its claims?
+
+**Status:** STUDY REPORT — empirical, fresh-agent evaluation of the Java engine's AI grammar
+(discovery, sufficiency, token economics), with a ranked improvement backlog for the feedback
+circuit.
+**Method owner:** Claude Code, 2026-09-06 · commissioned by Eric Law
+**Engine under test:** mercury-composable @ main `63621f1a` (post-v4.12.3)
+**Study cost:** 46 subagents across two orchestrated phases (~4.9M tokens of agent work),
+verdicts backed by file:line evidence throughout.
+
+---
+
+## 1 · What was tested, and how
+
+The white paper ("Intent-Driven Development…", `docs/mercury-story.md`) makes four testable
+claims about the AI grammar: it is **sufficient** (an AI partner can author correct artifacts
+without reading engine source), **verified** (CI binds its claims to the code),
+**discoverable** (the map routes to the right page in one hop), and **economical** (context
+cost scales with the task, not the dependency tree). The study tested all four the way the
+paper says methodology should be tested: with fresh agents under load.
+
+**Phase 1 — inventory + discovery (12 agents).** Five persona seeds (app developer, graph
+author, platform/ops engineer, field-history reconstruction from the CHANGELOG, AI-agent
+authoring) proposed 45 use cases, canonicalized to **24** (10 core / 8 intermediate / 6 edge)
+spanning all three layers, config/ops, building blocks, and polyglot. Each use case then went
+to a **map-only** router: an agent allowed to read exactly one file — `docs/llms.txt` — and
+required to pick its first-hop page(s) and judge the map (obvious / ambiguous / missing).
+
+**Phase 2 — sufficiency trials (34 agents).** 17 of the 24 (8 of 10 core, 4 of 8
+intermediate, 5 of 6 edge — including every case Phase 1 rated ambiguous) went through an
+author → adversarial verifier pipeline:
+
+- **Authors** were fresh agents locked to the documentation tier (`docs/**` only — no source,
+  no examples, no poms), given only the developer's question (never the acceptance rubric),
+  required to log every file read and to declare gaps instead of inventing.
+- **Verifiers** had full repository access and an adversarial mandate: refute each artifact
+  against engine source, tests, and reference examples; classify every defect and every
+  author-declared gap as *doc gap confirmed* vs *author error*, citing file:line evidence.
+
+The three highest-impact findings were independently re-verified by the study author before
+publication.
+
+## 2 · Headline results
+
+| Claim | Result | Evidence |
+|---|---|---|
+| **Sufficient** | **Substantially holds.** 17/17 docs-only artifacts were working or near-working; **0/17 wrong**. 8/17 correct as-is; 9/17 minor-issues — and the majority of those defects were *inherited from incorrect doc sentences*, not authoring failures. Every edge-case gotcha trial (serialization downcast, Mono trace teardown, sub-flow ttl, suspend/resume, CSFLE) came out **correct**. | §5 matrix |
+| **Discoverable** | **Holds with named exceptions.** 19/24 one-hop routes obvious, 5/24 ambiguous, **0 missing**. All five ambiguities are annotation gaps in the map text, not structural holes — and in Phase 2, four of those five still produced correct artifacts. | §4C |
+| **Economical** | **Strongly holds.** Map ≈ 4.0k tokens. Per-task docs cost: **min 13.7k / median 45.8k / max 86.4k tokens**, vs ≈ 542k tokens of engine source — **2.5%–16% of the source-corpus ceiling, 8.4% at the median** (ceiling, not a measured source-hunt control; see §6). The full guide tier is ≈ 230k tokens; no trial needed even half of it. | §3, §6 |
+| **Verified** | **Holds for the gated surfaces; measurable drift in ungated prose.** The three DSL kits (catalogs + drift tests) held up — no trial found a catalog contradicting the engine, with one omission (`stream:`). But the study found **10 places where doc *prose* contradicts engine behavior**, none covered by any gate. | §4A |
+| **Prototyping speed** | Assessed by proxy only (no wall-clock or source-arm control): authors produced each complete deliverable in a single pass over 4–12 doc files, with high self-reported confidence in 17/17, and no trial stalled. The declared-gap mechanism worked as designed: 81 declared gaps, most verifier-confirmed as genuine, about one in eight reclassified as author error or non-gap. | §5, §6 |
+
+**Bottom line:** Mercury lives up to its claims for the objective Eric set — *meaningful
+coverage for most use cases, source as the edge-case fallback*. No trial produced an unusable
+deliverable, even at the edges (one printed *element* — UC-09's guessed Maven groupId — would
+fail resolution as written; its author flagged it as unverified). The study's real yield is
+the backlog below:
+10 drift fixes and a short list of recurrent gaps that would move several "minor-issues"
+verdicts to "correct".
+
+## 3 · Token economics (Java engine, measured)
+
+| Tier | Size | ≈ Tokens |
+|---|---|---|
+| `docs/llms.txt` (exhaustive map) | 16.0 KB | ~4,000 |
+| Full guide tier (46 md + 3 JSON catalogs) | 921 KB | ~230,000 |
+| Engine source (`system/*` main Java) | 2,169 KB | ~542,000 |
+
+Per-trial cost = map + the pages the author actually read (4–12 files):
+13.7k (UC-17, SSE) … 45.8k median … 86.4k max (UC-04, error handling). The paper's benchmark
+(measured on the Rust engine's curated map: ~2.5k → ~46k vs ~515k) is **consistent with the
+Java measurement**: the Java map is larger (exhaustive by design, 4k vs 2.5k) but the routed
+per-task cost lands in the same band, and the median task costs ~8% of the source alternative.
+
+## 4 · Findings
+
+### 4A · Doc drift — prose that contradicts the engine (10, ranked by blast radius)
+
+These are the "verified" claim's blind spot: all live outside the drift-tested surfaces.
+Each was confirmed against source; items 1–3 re-verified independently.
+
+1. **`error.status` should be `error.code`** — the exception-context status key is named
+   `error.status` in `flow-grammar.md:90`, `syntax.md:554`, and
+   `event-envelope-reference.md:713`, but the engine defines only `code`
+   (`TaskExecutor.java:84`); `error.status` maps null silently. The worked examples and
+   `flow-schema-reference.md` are correct — the three prose/table mentions are the drift.
+   *(Hit in 2 independent trials; both authors navigated it by trusting the examples.)*
+2. **Config precedence inverted** — `configuration-reference.md:27-28` says `.properties`
+   beats `.yml`; the engine merges `application.yml` last with putAll semantics, so **.yml
+   wins** (`app-config-reader.yml:24`, `AppConfigReader.java:121` — proven empirically by
+   running platform-core-4.12.3.jar with both files present). Same lines also overstate
+   env-var handling for plain-Java apps (env vars enter via `${VAR}` substitution, not direct
+   key override).
+3. **Kafka success threshold** — `minimalist-kafka.md:370` says a flow succeeds only with
+   status 200; the engine acknowledges any status **< 400** (`KafkaFlowConsumer.java:459`).
+   A 201/204/3xx reply is NOT retried or dead-lettered. *(Hit in 2 trials.)*
+4. **Startup failure semantics overstated** — `event-driven/ai-agent-guide.md:40-41` says
+   duplicate routes / bad interfaces fail the application at startup; the engine reloads or
+   skips with a log and keeps starting (`Platform.java:565-568`, `AppStarter.java:393-424`).
+5. **`envInstances` example invalid** — `annotations-reference.md:163` shows
+   `envInstances="${HEAVY_TASK_INSTANCES:10}"`, but `envInstances` must be a property KEY;
+   the `${...}` literal silently no-ops (`AppStarter.java:495-496`). Lines 176-177 also
+   present `worker.instances.<route>` as a generic override without the opt-in condition that
+   `configuration-reference.md:357-369` states correctly.
+6. **`inspect` semantics wrong** — `command-reference.md:214, 225-226` say inspect resolves
+   only leaf keys / prints `{}` for subtrees; the engine returns populated nested subtrees
+   (`MultiLevelMap.getElement`, pinned by `PlaygroundTest.java:308`).
+7. **Orphan-export rule unbacked** — `command-reference.md:284` claims export fails on orphan
+   nodes; no such check exists in the export path (and a single-unconnected-root export
+   succeeds in `CompanionSyncTest`). CompileGraph re-validates at the gate, so the claim is
+   also unnecessary.
+8. **Non-compilable snippet** — `composing-the-layers.md#exposure`'s `graph-executor.yml`
+   omits mandatory `flow.description`/`flow.ttl`/task `description` (CompileFlows rejects it)
+   and the exception-handler task the real flow carries. *(Partly author-avoidable in the
+   trial — `flow-grammar.md`, which the author read, states the mandatory fields — but the
+   published snippet is genuinely broken and worth fixing.)*
+9. **Flows location default wrong** — `flow-schema-reference.md:52` says the default is the
+   resources folder root; the engine default is `classpath:/flows/` (`CompileFlows.java:135`).
+10. **Stale Playground transcript** — `build-your-first-graph.md:129-130` shows an export
+    acknowledgment line the current engine no longer emits.
+
+*(Minor accuracy nits, same class: `workflow-suspension.md:367` lists 6 of 9 reserved model
+keys; suspend-node validation requires ≥1 outgoing connection, not literally "to end".)*
+
+### 4B · Coverage gaps — genuinely missing from the docs tier (ranked by recurrence)
+
+1. **Maven coordinates — the #1 systemic gap (6 of 17 trials).** No page in `docs/` prints a
+   dependency block for `platform-core`, `event-script-engine`, `minimalist-kafka`, or
+   `minigraph-state-redis`. Framing note: this is partly by design — the docs delegate to
+   `examples/*/pom.xml` and module READMEs, a path the study's docs-only tier deliberately
+   severed. But the trap inside the gap is real regardless of tier: module artifacts use the
+   legacy `org.platformlambda` groupId while the reactor parent is `com.accenture.mercury`,
+   and one author guessed wrong exactly there (the only outright-broken element produced in
+   17 trials). One dependency-coordinates block in `getting-started.md` (plus per-guide
+   snippets for the opt-in modules) kills the entire class — for both repo readers and
+   packaged-skill consumers, who have no `examples/` either.
+2. **Import/package lines (5 trials).** `AppException`, `Utility`, `EventStreamWriter`,
+   `TraceInfo`/`po.getTrace()` appear in docs unqualified; `org.platformlambda.core.exception`
+   and `.core.util` appear nowhere in `docs/`. Authors guessed by convention (correctly), but
+   an import line each, once, ends the guessing.
+3. **`stream: true` missing from the REST catalog.** Documented only in `http-streaming.md`;
+   absent from `rest-grammar.md` and `rest-automation.json`'s `rest_entry_fields` — an agent
+   validating against the authoritative catalog would flag a correct entry as unknown. This is
+   the one place a *gated* surface has a hole.
+4. **`configuration-reference.md` completeness**: no entries for `graph.model.automation`,
+   `location.graph.temp`, or the `schema.registry.serde.*` pass-through prefix.
+5. **Decision-task runtime semantics** (undocumented and surprising): a null decision aborts
+   the flow, but a garbage string silently coerces to branch 1 (`TaskExecutor.java:720-737`,
+   `Math.max(1, str2int(...))`). Belongs in `syntax.md`'s decision section.
+6. **`graph.extension` edge behaviors**: a missing `flow://` target throws *before* the call
+   and is NOT `exception=`-routable; `flow://` ids are not validated by the CompileGraph gate
+   (call-time resolution). Belongs in `skills-reference.md`'s delegation contract.
+7. **Event-over-HTTP operational note** (→ `event-over-http.md`): the map loads once at
+   startup — editing requires a restart (`EventEmitter.java:135-147`); nowhere stated. Also
+   unstated there: nested `event:`/`http:` and flat `event.http:` spellings are equivalent.
+8. **Tracing API reference** (→ `api-overview.md` Distributed-tracing section +
+   `observability.md` ~line 73): `po.getTrace()`/`TraceInfo` in no reference page; the
+   annotate-before-worker-return deadline for Mono functions; late `annotateTrace` is a
+   silent no-op; events sent off-worker get trace id but no span parenting.
+9. **Smaller confirmed absences, each verifier-named to a page**:
+   `graph.exception.handler` is an engine built-in (→ `composing-the-layers.md`); root
+   `purpose` is enforced only at the CompileGraph gate, not by dry-run validation
+   (→ `command-reference.md`); missing/empty `rest.yaml`/`flows.yaml` degrades gracefully,
+   never fails startup (→ `configuration-reference.md`); `simple.kafka.notification`
+   auto-stamps the correlation-id header as fallback and rejects non-byte[]/Map/List/null
+   bodies with IllegalArgumentException (→ `minimalist-kafka.md`); a child flow's own
+   `flow.exception` cannot swallow its TTL abort, the timeout message text, and the
+   resilience-handler missing-attempt→0 default (→ `flow-schema-reference.md` ttl section);
+   no page shows a direct-bound (non-flow) function reading a path parameter end-to-end
+   (→ `rest-automation/index.md`); absent `graph.model.automation` = warn + nothing
+   executable, and the `/api/graph` wiring ships pre-wired in the playground apps
+   (→ `composing-the-layers.md`); Playground browser URL (→ `build-your-first-graph.md`);
+   shipped `auto.offset.reset` default `earliest` and `input.metadata.timestamp` type,
+   epoch millis (→ `minimalist-kafka.md`); default no-handler error body shape
+   (→ `flow-grammar.md`); suspended-reply HTTP status 200 (→ `workflow-suspension.md`);
+   user-PoJo shape requirements (→ `event-driven/ai-agent-guide.md`); the CSFLE serde
+   credential-inheritance guarantee — the v4.12.3 fix, code-proven but unstated
+   (→ `minimalist-kafka.md` CSFLE §3).
+
+### 4C · Map annotation gaps (the 5 ambiguous routes from Phase 1)
+
+No use case was unroutable, but five routed on inference rather than map text. One-line
+annotation touch-ups close them: name **exception handling / `AppException`** somewhere in
+the Event Script cluster; name **`decision`** in a Layer-2 blurb; say which envelope page owns
+**serialization gotchas**; name the **trace-context lifecycle** in the Observability blurb;
+name **`ttl` / sub-flow deadlines** in the flow-grammar blurb. (Also worth a word each:
+`CompileGraph`/manifest in a Layer-3 blurb, env-var/`${VAR:default}` overrides in the
+config-reference blurb, and the graph.js deprecation.)
+
+### 4D · The exoneration file — author errors prove the docs often had it
+
+Verifiers reclassified about one in eight of the 81 author-declared gaps as **author error**
+or non-gap: the information
+existed in docs the author skipped or misread (`int(201) -> output.status` in
+flow-schema-reference; `application.name`, `no.op`'s registration in
+reserved-names-and-headers; the rest.yaml auth contract; `output.status` in the KG agent
+guide; the `:type` suffix's model-only scope). This matters for calibration: the grammar's
+content coverage is *better* than the raw gap count suggests — a real developer with an IDE
+and search closes most of these instantly.
+
+## 5 · Trial matrix
+
+| UC | Use case | Tier | Route | Verdict | Docs tokens | Doc-drift inherited? |
+|---|---|---|---|---|---|---|
+| 01 | REST endpoint → flow | core | obvious | minor-issues | 62k | no (author overstatements) |
+| 02 | Typed PoJo function | core | obvious | minor-issues | 47k | yes (§4A-4, -5) |
+| 04 | AppException + exception handler | core | **ambiguous** | **correct** | 86k | navigated §4A-1 correctly |
+| 05 | Minimum app config | core | obvious | minor-issues | 52k | yes (§4A-2) |
+| 06 | First graph dry-run | core | obvious | minor-issues | 25k | yes (§4A-6, -7) |
+| 07 | CompileGraph deploy gate | core | obvious | minor-issues | 78k | partly (§4A-7, -8, -10; the §4A-8 snippet defect was also author-avoidable) |
+| 08 | Kafka topic → flow | core | obvious | minor-issues | 74k | yes (§4A-3) |
+| 09 | simple.kafka.notification | core | obvious | minor-issues | 37k | yes (§4A-3) + wrong groupId guess (§4B-1) |
+| 11 | Decision branching | int. | **ambiguous** | minor-issues | 31k | partly (§4B-5 unknown to docs) |
+| 15 | graph.extension flow delegation | int. | obvious | minor-issues | 27k | partly (§4B-6) |
+| 17 | SSE progressive streaming | int. | obvious | **correct** | 14k | — |
+| 18 | Declarative Event-over-HTTP | int. | obvious | **correct** | 31k | — |
+| 19 | Long→Integer downcast | edge | **ambiguous** | **correct** | 46k | — |
+| 20 | Mono trace teardown | edge | **ambiguous** | **correct** | 53k | — |
+| 21 | Sub-flow ttl override | edge | **ambiguous** | **correct** | 40k | navigated §4A-1 correctly |
+| 22 | Suspend/resume on Redis | edge | obvious | **correct** | 83k | — |
+| 24 | Schema Registry + CSFLE | edge | obvious | **correct** | 35k | — |
+
+Notable: **the harder the tier, the better the result** — edge 5/5 correct, intermediate 2/4,
+core 1/8 (seven of the eight core trials were minor-issues, most inheriting a §4A drift item);
+the five ambiguous-route trials still went 4/5 correct. The gotcha content — serialization,
+tracing, ttl, suspension, CSFLE — is where the guides are strongest (it was written from field
+pain); the drift lives in the older walkthrough/reference prose that predates the gates.
+
+## 6 · Limitations, honestly
+
+- **The docs-only rule was stricter than the real consumer surface, in two ways.** (1) The
+  packaged Agent Skill (`ai-contract-provider`) ships `references/fixtures/rest-bindings.yaml`,
+  so the "snippet-include outside docs/" gap the UC-01/02/17 authors hit does **not** affect
+  skill consumers — only raw-repo readers. (2) The docs deliberately delegate some content
+  (dependency poms, reference handler code, module READMEs) to `examples/` — a path the study
+  severed; §4B-1's ranking should be read with that in mind, though the fix recommendation
+  stands because packaged-skill consumers have no `examples/` either.
+- **The economics ratio is against a corpus ceiling, not a measured control.** The 542k-token
+  denominator is the whole engine source; no control arm measured what a source-allowed agent
+  actually reads in a grep-guided hunt. The absolute per-task numbers (13.7k/45.8k/86.4k) are
+  the solid claim; the percentage framing is indicative only.
+- **Prototyping speed was assessed by proxy** (files-read counts, single-pass completion,
+  self-reported confidence) — no wall-clock, turn-count, or examples-available comparison arm.
+- Single model family authored and verified (independent contexts, adversarial prompts, but
+  shared blind spots are possible). The paper's fresh-agent exercises used live multi-vendor
+  agents; this study trades that for controlled tiering and source-verified verdicts.
+- 17 of 24 use cases were trialed for sufficiency (all 24 for discovery). Untrialed: UC-03,
+  UC-10 (core), UC-12/13/14/16 (intermediate), UC-23 (edge) — each adjacent in kind to a
+  trialed case.
+- Token counts approximate at 4 bytes/token, same method as the paper's benchmark.
+- Verifier verdicts, while evidence-cited, are themselves agent judgments; the three most
+  load-bearing drift claims were independently re-verified by the study author, and this
+  report itself passed an adversarial claim-check and completeness critique (whose findings
+  were applied).
+
+## 7 · Recommendations (balancing discovery · tokens · prototyping speed)
+
+**Now (cheap, high trust-ROI):**
+1. Fix the 10 drift items in §4A — they are one-line-to-one-paragraph edits, and drift is the
+   direct counterexample to the grammar's "verified" promise.
+2. Add ONE dependency-coordinates block (`getting-started.md`) + module snippets in the
+   Kafka/Redis guides; add the missing import lines where each class is first shown. Kills
+   the two most recurrent gap classes for a few hundred tokens.
+3. Add `stream` to `rest-automation.json` + `rest-grammar.md` — restores the catalog's
+   authority for the one field it misses.
+
+**Next (small PRs, feedback-circuit fed):**
+4. `configuration-reference.md` completeness sweep (§4B-4) and the §4B-5..8 behavioral notes,
+   each on the page the verifier named.
+5. The eight map-annotation touch-ups (§4C) — a few words each; the map stays ~4k tokens.
+
+**Directional (the interesting one):**
+6. The gates cover catalogs and grammar, not prose behavior claims — and that is exactly
+   where all 10 drift items live. Consider a small **claims-fixture test**: a curated list of
+   high-value doc assertions (defaults, precedence, thresholds, failure semantics) each pinned
+   by an existing or tiny new engine test. Ten entries would have caught every §4A item. This
+   extends "compiled documentation" from *shape* to *behavior* — the natural next increment of
+   the methodology, and portable to the Rust engine.
+7. Do **not** inflate the map or split the big pages: 94 KB `syntax.md` still landed inside
+   economical per-task budgets, and Phase 1 shows the exhaustive map's discovery quality is
+   annotation-limited, not size-limited.
+
+---
+
+*Method artifacts: Phase 1 (inventory + discovery) run `wf_d3e82229-9cc`; Phase 2 (authoring
+trials) run `wf_f201705c-02f` — full per-agent transcripts and structured results retained in
+the session's workflow journals. All file:line citations refer to main `63621f1a`.*

--- a/memory/sessions/2026-09-07-013216.md
+++ b/memory/sessions/2026-09-07-013216.md
@@ -1,0 +1,51 @@
+# Session (2026-09-07T01:32:16.000Z)
+
+**Agent:** Claude Code
+
+The AI grammar coverage study (Eric's commission, Ultracode on) and its accepted now-phase
+fixes. Branch `docs/ai-grammar-study`: commit `f07e6452` (the study report,
+`draft-design-specs/ai-grammar-coverage-study.md`) + commit `f08fcee3` (17 guide files:
+10 drift fixes, coordinates/imports gaps, `stream` catalogued).
+
+## What happened
+
+- **The study** (46 subagents, 3 workflow phases, ~4.9M agent tokens): 24-use-case inventory
+  from five persona seeds; map-only one-hop discovery test (19/24 obvious, 5 ambiguous,
+  0 missing); 17 docs-only authoring trials each adversarially verified against engine source
+  (8 correct, 9 minor-issues, **0 wrong**); token economics (map ~4k; per-task median ~46k
+  vs ~542k source corpus). Verdict: the white paper's claims substantially hold; the
+  **"verified" claim's blind spot is prose** — 10 doc statements contradicted the engine,
+  all outside the gated (catalog/drift-test) surfaces. Report itself passed an adversarial
+  claim-check + completeness critique (5+ findings applied, incl. my own arithmetic errors —
+  the guard-tests-the-guard pattern again).
+- **Key result shape**: the edge/gotcha tier went 5/5 correct (serialization, Mono tracing,
+  ttl, suspend/resume, CSFLE — the field-pain content is the strongest); the core walkthrough
+  tier went 1/8, mostly inheriting drift. The #1 recurrent gap: Maven coordinates printed
+  nowhere (the org.platformlambda vs com.accenture.mercury groupId trap produced the study's
+  only outright-broken element).
+- **Now-phase applied** (each fix engine-verified before editing): error.status→error.code
+  (3 pages); .yml-wins config precedence; Kafka success <400; startup violations
+  log-and-continue; envInstances is a config KEY; inspect returns subtrees; no orphan-export
+  rule; loadable graph-executor.yml snippet (+ graph.exception.handler is a built-in);
+  flows location default classpath:/flows/; refreshed export transcript; 9 reserved model
+  keys; dependency blocks (getting-started, minimalist-kafka, workflow-suspension); import
+  lines (AppException, EventStreamWriter, Utility); `stream` added to rest-automation.json +
+  rest-grammar.md.
+- Gates: doc canon OK; catalog JSON valid; ai-contract-provider tests green.
+- **Deferred to the report's next/directional phases** (feedback-circuit backlog, all
+  page-addressed in the report §4B/§4C/§7): config-reference completeness, behavioral notes,
+  8 map-annotation touch-ups, and the **claims-fixture test** idea — extend drift-testing
+  from shape to prose behavior claims (would have caught all 10 drift items; portable to the
+  Rust engine).
+- Rust twin check pending at push time: the Rust docs may carry sibling drift (their guides
+  were authored separately; verify before assuming).
+
+## Memory References
+
+- referenced: conv-telemetry-presentation-parity (Rust-side sibling-drift check queued — the
+  shared doc surfaces move in lock-step when affected), eric-release-rhythm (branch prepared
+  and pushed; PR-open gated), typed-io-map-or-pojo and compilegraph-mandatory-gate (study
+  use-case rubrics drew on both), conv-declare-consulted-references (this list follows it)
+- created: (none — the study report is the repo-visible artifact; its recommendations are the
+  backlog)
+- Superseded: (none)


### PR DESCRIPTION
## What

Two commits:

1. **The coverage study** (`draft-design-specs/ai-grammar-coverage-study.md`) — an empirical,
   fresh-agent evaluation of the AI grammar's four claims on the Java engine: 46 subagents in
   three orchestrated phases (use-case inventory from five personas → map-only one-hop discovery
   test → docs-only authoring trials adversarially verified against engine source), plus token
   economics and a ranked improvement backlog. Headline: **17/17 docs-only artifacts working or
   near-working, 0 wrong; 19/24 one-hop routes obvious, 0 missing; median task ~46k docs-tokens
   vs the ~542k source corpus** — and 10 places where doc *prose* contradicts the engine, all
   outside the gated surfaces.

2. **The study's "now" recommendations, applied** (17 guide files, every fix verified against
   the engine before editing):
   - **Drift fixes**: `error.status` → `error.code` (3 pages; engine: `TaskExecutor` `CODE="code"`);
     config precedence corrected (`.yml` wins; env vars via `${VAR}` substitution); Kafka flow
     success threshold `< 400`, not `== 200`; startup contract violations log-and-continue (no
     crash); `envInstances` names a configuration key (the `${...}` example silently no-oped);
     `inspect` returns subtrees; no orphan-export rule; the `composing-the-layers` graph-executor
     snippet is now the real, loadable flow; flows `location` default `classpath:/flows/`;
     refreshed export transcript; 9 reserved model keys.
   - **Gap fixes**: Maven dependency blocks (getting-started, minimalist-kafka,
     workflow-suspension — the `org.platformlambda` groupId trap called out); import lines for
     `AppException`, `EventStreamWriter`, `Utility`; **`stream` added to `rest-automation.json`
     and `rest-grammar.md`** (engine: `RoutingEntry.java:48/513`) — the one hole found in a
     gated surface.

## Why

The white paper claims the grammar is sufficient, verified, discoverable, and economical. The
study tested those claims the way the paper says methodology should be tested — fresh agents
under load — and they substantially hold. The drift items are the "verified" claim's blind
spot: prose behavior statements no gate covers. Fixing them now, with the study as evidence,
keeps guide-first behavior rational; the report's "next" and "directional" phases (config-
reference completeness, map annotation touch-ups, and a claims-fixture test extending drift
testing from shape to behavior) remain in the backlog.

## Validation

- Every drift fix verified against the cited engine source before editing; the three
  highest-impact items re-verified independently (incl. empirically running the jar for the
  config-precedence inversion).
- Doc canon OK; `rest-automation.json` parses; `ai-contract-provider` tests green (all edited
  guides repackaged and link-validated). Full reactor in PR CI.
- The study report itself passed an adversarial claim-check + completeness critique; their
  findings are incorporated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>