### PR TITLE
docs/deck-benchmark-study (e385eec2, 55ab58e1 + logs), title Deck slide 13 + paper benchmark: the effect measured on both engines

### DIFF
--- a/docs/mercury-story.md
+++ b/docs/mercury-story.md
@@ -644,11 +644,20 @@ An AI partner can navigate from a compact discovery map to authoritative guidanc
 repeatedly reading an entire dependency's source. Context consumption can follow the task instead
 of the full dependency tree.
 
-The effect is measurable. On the Rust engine's documentation map (measured 2026-09-04, v4.12.3),
-a roughly 2,500-token discovery map routes an agent to about 46,000 tokens of source-verified
-reference, replacing a hunt through roughly 515,000 tokens of engine source. Completeness that
-costs discovery is a regression: the map must stay small, dense with the exact terms an agent
-searches for, and gated so it cannot silently rot.
+The effect is measured — on both engines. On the Rust engine's documentation map (2026-09-04,
+v4.12.3), a roughly 2,500-token discovery map routes an agent to about 46,000 tokens of
+source-verified reference, replacing a hunt through roughly 515,000 tokens of engine source. An
+empirical study then ran 46 agents through 24 use cases against the Java engine's grammar
+(2026-09-06): 17 of 17 docs-only builds were viable and none wrong — every edge-case gotcha
+trial came out correct; none of the 24 discovery routes was missing (19 obvious in one hop; the
+five ambiguous ones were map-annotation gaps, since annotated); and the median task consumed
+45,800 documentation tokens against a roughly 542,000-token source-corpus ceiling — 8.4 percent.
+
+The study's sharpest finding shaped the platform: every drifted sentence lived in ungated prose,
+while generated and gated surfaces held. Both engines now drift-test their documentation
+behavior claims in CI — 31 claims pinned to engine tests at this writing (11 Java, 20 Rust).
+Completeness that costs discovery is a regression: the map must stay small, dense with the exact
+terms an agent searches for, and gated so it cannot silently rot.
 
 ### Human-AI Co-Authorship
 

--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -385,17 +385,22 @@
 
   <!-- 9 · the benchmark -->
   <section class="slide" aria-label="The benchmark">
-    <p class="eyebrow">The benchmark</p>
+    <p class="eyebrow">The benchmark — measured, both engines</p>
     <h2>Doc discovery and token efficiency</h2>
-    <p class="lede">A grammar is useful only if the agent finds the right page in one hop and the
-    map stays cheap. Measured on the Rust engine, 2026-09-04:</p>
+    <p class="lede">A grammar is useful only if the agent finds the right page in one hop, the docs
+    suffice without opening source, and the map stays cheap. An empirical study — 46 agents running
+    24 use cases against the Java engine's grammar (2026-09-06) — measured exactly that:</p>
     <div class="stats">
-      <div class="stat"><div class="n">~2,500</div><div class="l">tokens — the whole discovery map</div></div>
-      <div class="stat"><div class="n">~46,000</div><div class="l">tokens of source-verified reference it routes to, one hop away</div></div>
-      <div class="stat dim"><div class="n">~515,000</div><div class="l">tokens of engine source — the hunt the map replaces</div></div>
+      <div class="stat"><div class="n">17/17</div><div class="l">docs-only builds viable, zero wrong — every edge-case gotcha trial came out correct</div></div>
+      <div class="stat"><div class="n">0/24</div><div class="l">discovery routes missing — 19 obvious in one hop; the 5 ambiguous were map-annotation gaps, since annotated</div></div>
+      <div class="stat"><div class="n">8.4%</div><div class="l">median docs cost against the ~542,000-token source-corpus ceiling — 45,800 tokens for a typical task</div></div>
+      <div class="stat"><div class="n">31</div><div class="l">documentation behavior claims now CI-pinned across both engines (11 Java + 20 Rust) — the gate the study produced</div></div>
     </div>
-    <p class="muted">Completeness that costs discovery is a regression. The map is dense with the
-    exact tokens an agent searches for — and gated in CI so it cannot silently rot.</p>
+    <p class="muted">The sharpest finding: every drifted sentence lived in ungated prose — generated
+    and gated surfaces held. The Rust engine shows the same economics (a ~2,500-token curated map
+    routing to ~46,000 tokens of reference instead of ~515,000 of source, 2026-09-04), and its
+    sibling sweep reproduced the drift classes before fixing them — both engines now drift-test
+    behavior claims in CI (ADR-0023 ⇄ ADR-0018). Completeness that costs discovery is a regression.</p>
   </section>
 
   <!-- 10 · the proof -->

--- a/memory/sessions/2026-09-07-144247.md
+++ b/memory/sessions/2026-09-07-144247.md
@@ -13,6 +13,11 @@ edition keeps the local map economics in the muted line, port-attribution idiom)
 Verified rendering in the browser (slide 13/19, 2×2 stat grid). Branch
 `docs/deck-benchmark-study`, PR pending Eric's gate.
 
+**Same PR, Eric's follow-up:** the paper's §11 "Sustainable Context Economics" benchmark
+paragraph extended with the same study evidence (both editions) — the Rust map measurement
+now leads into the 46-agent/24-use-case results and the 31-claim cross-engine gate, split
+into a measurements paragraph and a finding paragraph. Doc-canon gate green.
+
 Commit `e385eec2` — docs: deck slide 13 - the benchmark measured on both engines
 
 ```

--- a/memory/sessions/2026-09-07-144247.md
+++ b/memory/sessions/2026-09-07-144247.md
@@ -1,0 +1,24 @@
+# Session (2026-09-07T14:42:47.000Z)
+
+**Agent:** Claude Code
+**Lightweight:** Deck slide 13 ("Doc discovery and token efficiency") updated per Eric's
+direction with the empirical evidence from BOTH engines, replacing the single Rust map
+measurement: the coverage study's headline numbers (17/17 docs-only builds viable / 0
+wrong; 0/24 discovery routes missing; 8.4% median docs cost vs the ~542k-token
+source-corpus ceiling) plus the 31-claim cross-engine gate (11 Java + 20 Rust,
+ADR-0023 ⇄ ADR-0018) and the ungated-prose finding in the muted line. Every number drawn
+from the committed study report (`draft-design-specs/ai-grammar-coverage-study.md`) and
+the live registries — not session memory. Rust deck twin updated in lock-step (its
+edition keeps the local map economics in the muted line, port-attribution idiom).
+Verified rendering in the browser (slide 13/19, 2×2 stat grid). Branch
+`docs/deck-benchmark-study`, PR pending Eric's gate.
+
+Commit `e385eec2` — docs: deck slide 13 - the benchmark measured on both engines
+
+```
+ docs/presentations/mercury-story.html | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+```
+
+## Memory References
+(none)


### PR DESCRIPTION
## What
- Deck slide 13 ("Doc discovery and token efficiency") presents the empirical evidence instead of
  the single Rust map measurement: 17/17 docs-only builds viable (zero wrong), 0/24 discovery
  routes missing, 8.4% median docs cost against the ~542k-token source-corpus ceiling, and 31
  CI-pinned behavior claims across both engines (11 Java + 20 Rust).
- The paper's §11 "Sustainable Context Economics" benchmark paragraph carries the same evidence:
  the Rust map measurement leads into the 46-agent/24-use-case study results and the
  ungated-prose finding that produced the claims-fixture gate.

## Why
The AI-grammar coverage study (draft-design-specs/ai-grammar-coverage-study.md, PR #326) and the
Rust sibling sweep (Accenture/mercury#238) turned the benchmark claim into measured evidence on
both engines. Every figure is drawn from the committed study report and the live claims
registries. Doc-canon gate green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>