### PR TITLE
Docs/deck crossref swap

### DIFF
--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -397,10 +397,11 @@
       <div class="stat"><div class="n">31</div><div class="l">documentation behavior claims now CI-pinned across both engines (11 Java + 20 Rust) — the gate the study produced</div></div>
     </div>
     <p class="muted">The sharpest finding: every drifted sentence lived in ungated prose — generated
-    and gated surfaces held. The Rust engine shows the same economics (a ~2,500-token curated map
-    routing to ~46,000 tokens of reference instead of ~515,000 of source, 2026-09-04), and its
-    sibling sweep reproduced the drift classes before fixing them — both engines now drift-test
-    behavior claims in CI (ADR-0023 ⇄ ADR-0018). Completeness that costs discovery is a regression.</p>
+    and gated surfaces held. The Rust engine's pre-study benchmark shows the same economics
+    (2026-09-04: its ~2,500-token curated map routes to ~46,000 tokens of source-verified reference
+    instead of ~515,000 of engine source), and its sibling sweep reproduced the drift classes before
+    fixing them — both engines now drift-test behavior claims in CI (ADR-0023 ⇄ ADR-0018).
+    Completeness that costs discovery is a regression.</p>
   </section>
 
   <!-- 10 · the proof -->

--- a/memory/sessions/2026-09-07-144247.md
+++ b/memory/sessions/2026-09-07-144247.md
@@ -31,5 +31,12 @@ CI-proved the checker's Python-3.9 fix). The #328 squash title leaked the agent'
 PR-handoff preamble — the second [[conv-squash-title-prefill-check]] instance; the fact
 now carries the agent-side guard (title on its own line in handoff text).
 
+**Cross-reference touch-up (Eric, post-merge):** both live slide-13 pages cited the SAME
+Rust pre-study statistic in the muted line — swapped so each deck cross-references the
+OTHER engine: the Java deck's muted line keeps the Rust pre-study benchmark (now labeled
+as such); the Rust deck moves its own trio into the first-person lede and its muted line
+now cites the Java engine's economics (~4,000-token exhaustive map, 45,800-token median
+task, ~542,000 source corpus — the study's inventory). Branch `docs/deck-crossref-swap`.
+
 ## Memory References
 - conv-squash-title-prefill-check — second instance recorded (PR #328); agent-side guard added


### PR DESCRIPTION
## What
Slide 13's muted line now names its cross-reference explicitly: "The Rust engine's pre-study
benchmark" (2026-09-04) with the ~2,500 → ~46,000 vs ~515,000 token economics.

## Why
Both engines' slide 13 cited the same Rust pre-study statistic; each deck should
cross-reference the other engine's numbers. This is the Java half of the swap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>