### PR TITLE
Docs: present the simple-plugin catalog as a table

### DIFF
--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1520,167 +1520,55 @@ For example:
 > double; all-integral inputs keep exact 64-bit arithmetic, including integer division. Once a
 > double enters, precision follows IEEE-754 (integers exact to 2^53).
 
-#### Arithmetic
-
-`add`
-:   At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)
-
-`subtract`
-:   At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)
-
-`multiply`
-:   At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)
-
-`div`
-:   At least two numbers (all whole ⇒ integer division; any decimal ⇒ double division)
-
-`mod`
-:   Two individual numbers (all whole ⇒ long; any decimal ⇒ double)
-
-`increment`
-:   A single number (whole ⇒ long; decimal ⇒ double)
-
-`decrement`
-:   A single number (whole ⇒ long; decimal ⇒ double)
-
-`round`
-:   A number and optional decimal places (whole ≥ 0, default 0) — half-up rounding on the decimal representation (1.005 → 1.01 at 2 places)
-
-#### Generator
-
-`uuid`
-:   None
-
-`dateTime`
-:   None.
-
-`now`
-:   text(iso), text(local) or text(ms)
-
-#### Logical
-
-`eq`
-:   Two Objects, plus up to two optional modifiers. `text(ignoreCase)` compares two
-    strings case-insensitively; `text(ignoreType)` compares the text forms of the two
-    values, allowing relaxed comparison of numbers and booleans so that `"123" == 123`,
-    `"123.456" == 123.456` and `"true" == true`. Use both modifiers together for a
-    case-insensitive text-form comparison.
-    e.g. `f:eq(model.a, model.b, text(ignoreCase))`, `f:eq(model.str, model.n, text(ignoreType))`
-
-`ne`
-:   Two Objects, plus the same optional `text(ignoreCase)` / `text(ignoreType)`
-    modifiers as `eq` — returns the exact complement of `eq`.
-
-`isNull`
-:   A single Object
-
-`notNull`
-:   A single Object
-
-`ternary`
-:   Three variables, the first variable must evaluate to a Boolean
-
-`and`
-:   At least two boolean
-
-`or`
-:   At least two boolean
-
-`not`
-:   A single boolean
-
-`gt`
-:   Two individual whole numbers
-
-`lt`
-:   Two individual whole numbers
-
-`startsWith`
-:   Two strings, case insensitive.
-
-`endsWith`
-:   Two strings, case insensitive.
-
-`includes`
-:   Two strings, case insensitive OR one list and one string
-
-#### Collection
-
-`isEmpty`
-:   A single Collection, Map, String or array — true when it has no elements. Use `isNull` /
-    `notNull` for null checks; a null or unsupported input is an error.
-
-`getFirst`
-:   A single non-empty List — returns its first element.
-
-`getLast`
-:   A single non-empty List — returns its last element.
-
-#### Type Conversion
-
-`b64`
-:   Either a base64 encoded String, OR a byte array.
-
-`binary`
-:   Either a byte[], Map or String
-
-`length`
-:   Either a byte[], List or String
-
-`substring`
-:   Two to three variables. The first must be a String; the second must be an integer; the third is optional.
-
-`concat`
-:   At least two Strings to be concatenated
-
-`boolean`
-:   A list of variables that can evaluate to a boolean
-
-`double`
-:   A list of variables that can evaluate to a double
-
-`float`
-:   A list of variables that can evaluate to a float
-
-`int`
-:   A list of variables that can evaluate to an integer
-
-`long`
-:   A list of variables that can evaluate to a long integer
-
-`text`
-:   A list of variables that can evaluate to a String
-
-`json`
-:   A single JSON text (String or byte[]) — an object `{...}` becomes a map, an array `[...]` becomes a list. See details below.
-
-`listOfMap`
-:   Convert "a map of lists" to "a list of maps" — **order-preserving**: list order follows array index order (guaranteed)
-
-`updateListOfMap`
-:   Update "a list of maps" with "maps of lists"
-
-`removeKey`
-:   Remove one or more keys from a map or "list of maps". Syntax: `f:removeKey(source, text(key1), text(key2), …)` — see the worked example below.
-
-`defaultValue`
-:   If the first argument is null, return the 2nd argument
-
-`parseDate`
-:   Parse a date string to ISO, Local or Milliseconds.
-
-`parseDateTime`
-:   Parse a date-time string to ISO, Local or Milliseconds.
-
-`validate`
-:   Perform simple field validation. See details below.
-
-#### Configuration
-
-`setConfig`
-:   A parameter name (non-empty string) and its value (any object, converted to text). Sets the
-    value as a system property so that it overrides the corresponding base configuration
-    parameter at run-time. Returns true when applied, false for invalid input. See details below.
+| Type                | Plugin `name`   | Expected Inputs                                                                                                       |
+|:--------------------|:----------------|:----------------------------------------------------------------------------------------------------------------------|
+| **Arithmetic**      | add             | At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)                                           |
+| **Arithmetic**      | subtract        | At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)                                           |
+| **Arithmetic**      | multiply        | At least two numbers (all whole ⇒ exact long result; any decimal ⇒ double)                                           |
+| **Arithmetic**      | div             | At least two numbers (all whole ⇒ integer division; any decimal ⇒ double division)                                   |
+| **Arithmetic**      | mod             | Two individual numbers (all whole ⇒ long; any decimal ⇒ double)                                                      |
+| **Arithmetic**      | increment       | A single number (whole ⇒ long; decimal ⇒ double)                                                                     |
+| **Arithmetic**      | decrement       | A single number (whole ⇒ long; decimal ⇒ double)                                                                     |
+| **Arithmetic**      | round           | A number and optional decimal places (whole ≥ 0, default 0) — half-up rounding on the decimal representation (1.005 → 1.01 at 2 places) |
+| **Generator**       | uuid            | None                                                                                                                  |
+| **Generator**       | dateTime        | None.                                                                                                                 |
+| **Generator**       | now             | text(iso), text(local) or text(ms)                                                                                    |
+| **Logical**         | eq              | Two Objects, plus up to two optional modifiers: `text(ignoreCase)` compares two strings case-insensitively; `text(ignoreType)` compares the text forms of the two values, allowing relaxed comparison of numbers and booleans so that `"123" == 123`, `"123.456" == 123.456` and `"true" == true`; use both together for a case-insensitive text-form comparison. e.g. `f:eq(model.a, model.b, text(ignoreCase))` |
+| **Logical**         | ne              | Two Objects, plus the same optional `text(ignoreCase)` / `text(ignoreType)` modifiers as `eq` — returns the exact complement of `eq`                                                                  |
+| **Logical**         | isNull          | A single Object                                                                                                       |
+| **Logical**         | notNull         | A single Object                                                                                                       |
+| **Logical**         | ternary         | Three variables, the first variable must evaluate to a Boolean                                                        |
+| **Logical**         | and             | At least two boolean                                                                                                  |
+| **Logical**         | or              | At least two boolean                                                                                                  |
+| **Logical**         | not             | A single boolean                                                                                                      |
+| **Logical**         | gt              | Two individual whole numbers                                                                                          |
+| **Logical**         | lt              | Two individual whole numbers                                                                                          |
+| **Logical**         | startsWith      | Two strings, case insensitive.                                                                                        |
+| **Logical**         | endsWith        | Two strings, case insensitive.                                                                                        |
+| **Logical**         | includes        | Two strings, case insensitive OR one list and one string                                                              |
+| **Collection**      | isEmpty         | A single Collection, Map, String or array — true when it has no elements. Use `isNull` / `notNull` for null checks; a null or unsupported input is an error. |
+| **Collection**      | getFirst        | A single non-empty List — returns its first element.                                                                  |
+| **Collection**      | getLast         | A single non-empty List — returns its last element.                                                                   |
+| **Type Conversion** | b64             | Either a base64 encoded String, OR a byte array.                                                                      |
+| **Type Conversion** | binary          | Either a byte[], Map or String                                                                                        |
+| **Type Conversion** | length          | Either a byte[], List or String                                                                                       |
+| **Type Conversion** | substring       | Two to three variables.<br/>The first must be a String;<br/>the second must be an integer;<br/>the third is optional. |
+| **Type Conversion** | concat          | At least two Strings to be concatenated                                                                               |
+| **Type Conversion** | boolean         | A list of variables that can evaluate to a boolean                                                                    |
+| **Type Conversion** | double          | A list of variables that can evaluate to a double                                                                     |
+| **Type Conversion** | float           | A list of variables that can evaluate to a float                                                                      |
+| **Type Conversion** | int             | A list of variables that can evaluate to an integer                                                                   |
+| **Type Conversion** | long            | A list of variables that can evaluate to a long integer                                                               |
+| **Type Conversion** | text            | A list of variables that can evaluate to a String                                                                     |
+| **Type Conversion** | json            | A single JSON text (String or byte[]) — an object `{...}` becomes a map, an array `[...]` becomes a list. See details below. |
+| **Type Conversion** | listOfMap       | Convert "a map of lists" to "a list of maps" — **order-preserving**: list order follows array index order (guaranteed) |
+| **Type Conversion** | updateListOfMap | Update "a list of maps" with "maps of lists"                                                                          |
+| **Type Conversion** | removeKey       | Remove one or more keys from a map or "list of maps". Syntax: `f:removeKey(source, text(key1), text(key2), …)` — see the worked example below. |
+| **Type Conversion** | defaultValue    | If the first argument is null, return the 2nd argument                                                                |
+| **Type Conversion** | parseDate       | Parse a date string to ISO, Local or Milliseconds.                                                                    |
+| **Type Conversion** | parseDateTime   | Parse a date-time string to ISO, Local or Milliseconds.                                                               |
+| **Type Conversion** | validate        | Perform simple field validation. See details below.                                                                   |
+| **Configuration**   | setConfig       | A parameter name (non-empty string) and its value (any object, converted to text). Sets the value as a system property so that it overrides the corresponding base configuration parameter at run-time. Returns true when applied, false for invalid input. See details below. |
 
 *DateTime plugins*
 

--- a/memory/sessions/2026-09-08-230157.md
+++ b/memory/sessions/2026-09-08-230157.md
@@ -1,0 +1,31 @@
+# Session (2026-09-08T23:01:57.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Docs format alignment (Eric's direction, branch `docs/syntax-plugin-table`): the
+Built-in Plugins catalog in `docs/guides/event-script/syntax.md` converted from the
+per-category `####` heading + definition-list layout to the Rust repo's single
+3-column table (Type | Plugin `name` | Expected Inputs) — his rule of thumb: tables
+are easier to read; avoid them only for complex content, and this catalog is three
+columns with one variable-width column. 47 rows transplanted from the Rust table
+(names, order and 42 descriptions already byte-identical); the five divergent entries
+resolved deliberately — `eq`/`ne`/`substring` adopt the Rust cell phrasing (pure
+style), while `json` keeps "byte[]" and `setConfig` keeps "system property" (Java
+wording; the Rust twins say "byte array" / "process override" by engine design).
+Category sub-headings leave the page ToC, matching the Rust site.
+
+Safety checks: both claims-registry sentences anchored to syntax.md live outside the
+replaced section; only `#simple-plugins` / `#tasks-and-data-mapping` anchors are
+referenced repo-wide (no links to the removed category anchors); `mkdocs build
+--strict` clean; rendered page verified on the local mkdocs server via DOM inspection
+(47-row table, correct header, ToC shape) — the browser pane was hidden, so
+verification was structural rather than screenshot.
+
+## Memory References
+
+- claims-fixture-gate (consulted — checked the registry's syntax.md-anchored claim
+  sentences before rewriting the section they could have lived in)
+- conv-telemetry-presentation-parity (consulted — cross-engine consistency extends to
+  the doc surface; the Rust table is the format donor while per-engine wording stays)


### PR DESCRIPTION
## What

Convert the **Built-in Plugins** section of the Event Script syntax guide from
per-category `####` headings + definition lists to the Rust repo's single
3-column table (`Type | Plugin name | Expected Inputs`). All 47 entries carry
over; `json` keeps "byte[]" and `setConfig` keeps "system property" — the Java
wording where the engines legitimately differ (the Rust twins say "byte array" /
"process override"). The page ToC loses the six category sub-headings, matching
the Rust site.

## Why

A table reads better for a simple enumeration — three columns with only one of
variable width — and the two engines' doc sites now share the same shape for the
same catalog, so readers moving between them see one format.

## Validation

- 47/47 entries diffed against the Rust table before transplanting (names,
  order, and 42 descriptions already identical).
- Both claims-registry sentences anchored to `syntax.md` live outside the
  replaced section; no repo link targets the removed category anchors.
- `mkdocs build --strict` clean; rendered page verified on a local mkdocs
  server (47-row table, header, ToC shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>