### PR TITLE
Release v4.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.12.4, 9/8/2026
+
+### Added
+
+1. The `eq` and `ne` simple plugins accept **optional `ignoreCase` / `ignoreType`
+   modifiers** in argument positions 3 and 4: `text(ignoreCase)` compares two strings
+   case-insensitively; `text(ignoreType)` compares the text forms of the two values,
+   allowing the relaxed comparison of numbers and booleans — `"123" == 123`,
+   `"123.456" == 123.456` and `"true" == true`; both together compare the text forms
+   case-insensitively. This removes the need for `:text` cast workarounds when
+   serialization type drift makes strict cross-type equality brittle. Lock-step with
+   the Rust engine, including error messages.
+
+2. **MiniGraph Playground UI overhaul (part 1 — editing).** A console hide/restore
+   toggle; an overlap-free, content-sized graph layout with measured relayout (nodes
+   never overlap regardless of content); thumbnail/expanded node detail modes with a
+   view-control toggle; and an in-place "magnified node" editor for both **Edit Node
+   and Create Node** — a side panel that renders like a node with sorted keys,
+   `[]` array-append signatures and drag-to-reorder — replacing the old pop-up
+   dialogs. The Playground now has zero modal dialogs.
+
+3. **MiniGraph Playground UI overhaul (part 2 — connections).** Neo4j-style connection
+   authoring: the node body moves the node while a halo ring around it starts a
+   connection drag (with a context-menu "Connect to…" click-to-connect alternative),
+   ending in a relation popover anchored at the drop point with one-click relation
+   chips. Connections are selectable and deletable — Delete/Backspace removes selected
+   edges, and a right-click edge menu offers **per-relation deletion**
+   (`Delete 'fetch'` / `Delete 'test'` / `Delete all (n)`), planned as
+   direction-correct compounds so removing one direction never disturbs the reverse
+   connection. Every UI edit is undoable — Ctrl/Cmd+Z and per-toast Undo buttons replay
+   compensating console commands, keeping the backend a lightweight command executor.
+   The graph auto-fits when panel toggles reshape its pane.
+
+4. **Claims-fixture gate (ADR-0023).** `docs/guides/claims-registry.json` registers
+   high-value documentation behavior claims; each claim names the engine test that pins
+   it, the `Claim*Test` pins run in the normal build, and the doc-canon check verifies
+   the normative sentence still appears on its page and the pin still exists. Born from
+   the AI-grammar coverage study's finding that doc drift lives in ungated prose.
+   Engine-neutral format shared with the Rust repo.
+
+### Changed
+
+1. **`eq` and `ne` compare exactly two values**, consistent with `gt`/`lt`. The
+   previous open-ended chained form (three or more plain values, all equal to the
+   first) is removed — a 3rd/4th argument must now be a modifier. Breaking only for
+   flows that used the chained form; none exist in the repository, and the two-value
+   form is unchanged.
+
+2. Dependency updates for the field security gate (merged 2026-09-04, deliberately
+   riding main until this regular release): vertx-core 5.1.6 and Jackson 2 BOM 2.22.2
+   clear the reported CVEs; proactive Jackson 3 BOM 3.2.2 and Tomcat 11.0.25 pins stay
+   ahead of the next scan wave.
+
+3. Documentation: the white paper and deck are finalized as **the Mercury Story**
+   (`docs/mercury-story.md` + `docs/mercury-story.html`, retitled Intent-Driven
+   Development with agent-memory attribution and a cross-engine benchmark study); the
+   Event Script syntax guide presents the simple-plugin catalog as a single 3-column
+   table matching the Rust documentation site; and the flow-schema reference gains the
+   previously missing `f:ne` row.
+
+---
 ## Version 4.12.3, 9/4/2026
 
 ### Added

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-09-08-232247.md
+++ b/memory/sessions/2026-09-08-232247.md
@@ -1,0 +1,47 @@
+# Session (2026-09-08T23:22:47.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Release prep for **v4.12.4** (Eric's ask; branch `release/v4.12.4`), the regular release
+that the 2026-09-04 field Snyk remediation (PR #320) was deliberately parked for — the
+field catches up with this patch after publishing 4.12.3 to their Artifactory.
+
+- **Version sweep 4.12.3 → 4.12.4 across all 34 poms** — the reactor modules plus the
+  non-reactor Snyk placeholder manifests (system/rest-spring-3,
+  examples/rest-spring-3-example), included deliberately per the placeholder convention.
+  Verified zero non-mercury `4.12.3` matches before the sweep; the claims-registry
+  `"since": "4.12.3+"` markers are historical birth versions and stay untouched.
+- **CHANGELOG**: new `Version 4.12.4, 9/8/2026` section — Added: eq/ne optional
+  `ignoreCase`/`ignoreType` modifiers (lock-step with Rust incl. error messages), the
+  two MiniGraph Playground UI arcs (in-place magnified-node editor / zero modals;
+  Neo4j-style connection authoring with per-relation deletion and compensating-command
+  undo), the claims-fixture gate (ADR-0023). Changed: eq/ne two-value semantics
+  (chained form removed — breaking only for the unused chained form), the parked
+  dependency updates (vertx-core 5.1.6, Jackson-2 BOM 2.22.2, proactive Jackson-3 BOM
+  3.2.2 + Tomcat 11.0.25), docs finalization (the Mercury Story naming, plugin catalog
+  as a table, missing `f:ne` row).
+- Full reactor `mvn clean install` (with tests) run as the release verification gate —
+  result recorded below.
+- Release notes text prepared for the GitHub release page; PR-open and tag/publish stay
+  gated on Eric per the release rhythm. Continuity `latest_release` will be updated
+  only after Eric publishes (the 4.12.3 pattern: a post-release memory commit).
+
+## Validation
+
+- Full reactor `mvn clean install` (with tests) completed: every module installed at
+  4.12.4 in the local repository (install runs after test, so all module tests passed)
+  and the end-of-reactor example jars (composable-example, minigraph-playground) exist
+  at 4.12.4, five minutes after the first module — the whole chain ran. Capture lesson:
+  the summary line was lost because the build log was piped through `head -N`, which
+  closed the pipe after N matches; pipe a release build to a file, then grep the file.
+
+## Memory References
+
+- eric-release-rhythm (consulted — prepared branch/sweep/build/CHANGELOG/notes; merge,
+  tag and publish each individually gated on Eric)
+- snyk-retired-manifest-placeholders (consulted — the two non-reactor placeholder poms
+  are part of the version sweep deliberately)
+- jackson-dual-lane-coexistence (consulted — the CHANGELOG dependency entry names both
+  Jackson lanes and their per-pom BOM properties correctly)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.3</version>
+    <version>4.12.4</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.3</version>
+            <version>4.12.4</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version sweep 4.12.3 → 4.12.4 across all 34 poms — the reactor modules plus the
non-reactor Snyk placeholder manifests (`system/rest-spring-3`,
`examples/rest-spring-3-example`), included deliberately per the placeholder
convention. New CHANGELOG section for Version 4.12.4, 9/8/2026. The
claims-registry `"since": "4.12.3+"` markers are historical birth versions and
stay untouched.

## Why

The regular release the 2026-09-04 field Snyk remediation was deliberately
parked for — the field publishes 4.12.3 to their Artifactory and catches up
with this patch. It also ships this week's Event Script and Playground work:

- **eq/ne optional modifiers** — `text(ignoreCase)` / `text(ignoreType)` for
  case-insensitive and type-lenient comparison; eq/ne now compare exactly two
  values, consistent with gt/lt (the unused chained form is removed). Lock-step
  with the Rust engine, including error messages.
- **MiniGraph Playground UI overhaul** — in-place magnified-node editor for
  create and edit (zero modal dialogs), console toggle, thumbnail/expanded
  modes, overlap-free content-sized layout; Neo4j-style connection authoring
  with per-relation right-click deletion, direction-correct removal compounds,
  compensating-command undo (Ctrl/Cmd+Z + toast), and panel-aware auto-fit.
- **Claims-fixture gate (ADR-0023)** — documentation behavior claims registered
  and drift-tested in CI against named engine test pins.
- **Dependency updates** (parked since 2026-09-04): vertx-core 5.1.6 and
  Jackson 2 BOM 2.22.2 clear the reported CVEs; proactive Jackson 3 BOM 3.2.2
  and Tomcat 11.0.25.
- **Docs** — the Mercury Story finalization, the simple-plugin catalog as a
  3-column table matching the Rust site, the missing `f:ne` reference row.

## Validation

- Full reactor `mvn clean install` with tests: every module installed at
  4.12.4 (install follows test) through the end-of-reactor example jars.
- All constituent PRs (#320–#333) merged with green CI individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>