### PR TITLE
Updating mini graph view: collapsible console, resizable nodes

### DIFF
--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -18,7 +18,7 @@
 - **status:** active, mature framework (Maven reactor)
 - **repo:** github.com/Accenture/mercury-composable (official — source of truth)
 - **last_enabled:** 2026-06-20
-- **last_session:** 2026-08-21 | agent: Claude Code (2026-08-21-005515)
+- **last_session:** 2026-09-08 | agent: Claude Code (2026-09-08-141522)
 - **last_review:** 2026-08-21 | through 2026-08-21-005515.md
 - **last_invariant_check:** 2026-08-21 | 2026-08-21-005515.md (all 15 confirmed by Eric — one-by-one walkthrough with live-tree evidence; stack-messaging-kafka wording refreshed to name the grown Kafka family; ot-reverify-invariants-20260821 closed)
 
@@ -205,6 +205,39 @@
   approve → production), so models promote to production as standard endpoints. → serves: vision-mercury-composable
   <!-- id: bp-graph-governance-lifecycle | created: 2026-06-20 | last_used: 2026-08-14 | uses: 2 | tier: working -->
 ## Open Threads
+
+- [x] (fix — webapp-only, no PR gate run yet; committed by Roland when ready)
+  **Minigraph Playground graph visualization: node content cropping, a cramped default
+  panel, and complex-graph legibility.** Reported by Roland while dry-running the
+  `vermont-aco-py2024` model. Root cause: every React Flow node in
+  `graphTransformer.ts` carried an explicit `height` (a rough constant, only adjusted
+  for handle count, never property-row count), which defeats React Flow's own
+  auto-measure-to-content sizing and left `overflow: hidden` clipping any node whose
+  property/mapping list was taller than the estimate (confirmed against `aco_cap_amount`
+  and the `end` node's ~14-row output mapping). Fix: drop the explicit node `height` —
+  nodes now auto-size to content (width stays fixed for column layout; `data.minHeight`
+  keeps its layout-spacing/NodeResizer-floor role, matching what
+  `graphTransformer.test.ts` had already anticipated via its `node.height ?? data.minHeight`
+  fallback). Also: the left console panel gained a collapse toggle
+  (`react-resizable-panels` `collapsible`+`panelRef`) so the Graph/Payload panel can take
+  the full window; `zoomOnScroll`/`zoomOnPinch`/`panOnScroll` made explicit on the
+  `ReactFlow` element (was implicit library default) as an upgrade guard, plus a smaller
+  `fitView` padding and higher `maxZoom` so a freshly loaded complex graph starts more
+  legible. Verified: typecheck clean, 213/213 tests green, live before/after against
+  `vermont-aco-py2024`. Trackpad pinch itself unverified physically (no real trackpad in
+  the browser-automation harness used) — code-level guard only.
+  **Follow-up same session: the auto-sizing fix surfaced a pre-existing conflict** —
+  `NodeTypes.tsx`'s connection-authoring drag strips and React Flow's `NodeResizer` line
+  controls occupy the same left/right node edges, with resize (CSS z-index 4, active only
+  while `selected`) always winning over connection authoring (z-index 2) — so a selected
+  node's border always resized, never connected (Roland's report: "dragging from the
+  border is broken"). Fix: `showConnectionAuthoring` now also requires `!selected`, so
+  the authoring handles are absent from the DOM while selected — border-drag connects on
+  an unselected/hovered node, resizes on a selected one. Verified live both ways (DOM
+  `getBoundingClientRect` measurement + an actual Create Connection dialog trigger).
+  Residual known trade-off: dropping a connection's target onto an already-selected node
+  no longer works either (deselect first) — not yet reported as an issue.
+  <!-- id: minigraph-graphview-crop-and-panel-fix | created: 2026-09-08 | last_used: 2026-09-08 | uses: 2 | tier: working | origin: 2026-09-08-141522 -->
 
 - [x] **Re-verify invariants (due):** confirm stack-language-java21, stack-build-maven,
   stack-integration-spring, stack-messaging-kafka, stack-ci-gha, functions-decoupled-routes,

--- a/memory/sessions/2026-09-08-141522.md
+++ b/memory/sessions/2026-09-08-141522.md
@@ -1,0 +1,88 @@
+# Session (2026-09-08T14:15:22Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Roland asked to improve the Minigraph Playground's graph visualization (webapp under
+`system/minigraph-playground-engine/webapp/`): node content was getting cropped, the
+graph panel was cramped by default, complex graphs rendered too small to read, and
+trackpad pinch-zoom felt unreliable.
+
+Reproduced live against the deployed `vermont-aco-py2024` graph model (15 nodes) via
+`java -jar examples/minigraph-playground/target/minigraph-playground-4.11.9.jar` +
+`npm run dev` in the webapp, driven through the browser. Confirmed the crop bug
+concretely: the `aco_cap_amount` node's `statement` property was cut off mid-line by
+the node's fixed 100px height with `overflow: hidden`.
+
+**Root causes found in `src/utils/graphTransformer.ts` / `NodeTypes.tsx`:**
+- Every React Flow node was given an explicit `height: nodeHeight` (a rough constant,
+  ~100px, adjusted only for handle count — never for property-row count). `NodeTypes.tsx`'s
+  own comment already named the intended pattern ("Following the official React Flow
+  node-resizer example pattern") but the explicit `height` prevented React Flow's
+  auto-measure-to-content behavior from ever engaging — confirmed against
+  `@xyflow/react`'s `getNodeInlineStyleDimensions` (inline style height is only applied
+  when `node.height`/`node.style.height` is set). The existing test suite
+  (`graphTransformer.test.ts`) already read `node.height ?? node.data.minHeight`,
+  suggesting this exact fix had been anticipated but not applied.
+- The console/command panel and the Graph/Payload panel were both plain
+  `react-resizable-panels` `Panel`s with a fixed default split (roughly 60/40) and no
+  collapse affordance — only manual drag-resize.
+
+**Fixes applied (all in the webapp, no backend changes):**
+1. `graphTransformer.ts`: removed the top-level `height: nodeHeight` from constructed
+   nodes (kept `width` fixed for column layout, and `data.minHeight` as the layout
+   pass's spacing estimate / NodeResizer floor). Nodes now auto-size to their actual
+   rendered content — no more mid-line cropping regardless of property count.
+2. `Playground.tsx` / `Playground.module.css`: made the left console panel collapsible
+   (`react-resizable-panels`' `collapsible` + `collapsedSize="0%"` + `panelRef`), with a
+   header toggle button ("◀/▶ Console") so the Graph/Payload panel can take the full
+   window width on demand.
+3. `GraphView.tsx`: made `zoomOnScroll`/`zoomOnPinch`/`zoomOnDoubleClick`/`panOnScroll`
+   explicit on the `ReactFlow` element (previously implicit defaults) as a guard against
+   a future library upgrade silently changing pinch-to-zoom behavior; reduced
+   `fitViewOptions.padding` 0.25→0.1 and raised `maxZoom` 2.5→4 so a freshly loaded
+   complex graph starts more legible and can be zoomed in further.
+
+**Verified:** `npm run typecheck` clean; `npm test` 213/213 passed (22 files) — no
+change needed to the test suite despite the height contract change. Re-drove the same
+`vermont-aco-py2024` graph live: every previously-cropped node (including
+`aco_cap_amount` and the `end` node's ~14-row output mapping list) now renders at full,
+uncropped height; collapsing the console panel gives the graph the entire window width.
+Trackpad pinch itself could not be physically exercised from this environment (no real
+trackpad in the browser-automation harness) — the fix here is code-level assurance
+(explicit props + confirmed `touch-action: none` on the React Flow pane in
+`@xyflow/react`'s shipped CSS), not a live physical-gesture test.
+
+## Follow-up: node auto-sizing broke border-drag connection authoring
+
+Roland reported that creating connections by dragging from a node's border stopped
+working after the above fix, and guessed it might need to be restricted to the corners.
+
+**Root cause (confirmed live via `getBoundingClientRect` on the actual DOM, not
+guesswork):** `NodeTypes.tsx`'s `MinigraphNode` renders two full-height invisible drag
+strips along the left/right edges for connection authoring
+(`authoring-source`/`authoring-target`, CSS z-index 2) — this is unchanged by the height
+fix and, confirmed by measurement, still spans the node's full auto-computed height
+correctly. The real conflict: React Flow's `NodeResizer` (`isVisible={selected}`) also
+renders full-edge line controls on the same left/right borders, at CSS z-index 4 — so
+once a node is selected, the resize line always wins the same pixel real estate and a
+border-drag resizes instead of connecting. This conflict is pre-existing (not introduced
+by the height fix) but is what Roland hit in practice.
+
+**Fix:** `NodeTypes.tsx` — `showConnectionAuthoring` now also requires `!selected`, so
+the connection-drag handles (and their hover-highlight frame) are removed from the DOM
+entirely while a node is selected, leaving `NodeResizer`'s controls as the sole
+border-drag behavior in that state. Mental model going forward: hover an **unselected**
+node and drag its border to start a new connection; select a node to resize it. Verified
+live both ways after the fix (unselected border-drag → Create Connection dialog opens
+with the right source/target; selected border-drag → resize only, no dialog). Known
+residual trade-off, not yet hit by Roland: dropping a new connection's *target* onto a
+node that happens to already be selected will no longer work either, since the target
+handle is hidden too — deselecting first (click empty canvas) works around it.
+
+`npm run typecheck` clean, `npm test` 213/213 passed after this change too.
+
+## Memory References
+
+(none)

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -373,9 +373,18 @@ export default function GraphView({
               onConnectEnd={handleConnectEnd}
               nodeTypes={nodeTypes}
               fitView
-              fitViewOptions={{ padding: 0.25 }}
+              fitViewOptions={{ padding: 0.1 }}
               minZoom={0.2}
-              maxZoom={2.5}
+              maxZoom={4}
+              // Trackpad pinch sends wheel events with ctrlKey set; zoomOnPinch
+              // (mobile/tablet multi-touch) and zoomOnScroll (desktop wheel +
+              // trackpad pinch) are spelled out explicitly here — rather than
+              // left as library defaults — so a future React Flow upgrade
+              // can't silently change this behaviour.
+              zoomOnScroll
+              zoomOnPinch
+              zoomOnDoubleClick
+              panOnScroll={false}
               selectionKeyCode="Shift"
               multiSelectionKeyCode={NODE_MULTI_SELECTION_KEYS}
               selectionOnDrag={false}

--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/NodeTypes.tsx
@@ -21,7 +21,13 @@ export const AUTHORING_TARGET_HANDLE_ID = 'authoring-target';
 //     .react-flow__node-default, overflow:visible hacks, etc.).
 function MinigraphNode({ data, isConnectable, selected }: NodeProps<MinigraphRFNode>) {
   const [isResizing, setIsResizing] = useState(false);
-  const showConnectionAuthoring = data.supportsConnectionAuthoring && !isResizing;
+  // NodeResizer's edge/corner controls (visible only while selected) sit on
+  // the same full-height left/right strip as the connection-drag handles,
+  // above them in z-index — so a selected node's border always resizes,
+  // never connects. Hiding connection authoring while selected removes the
+  // ambiguity: hover an unselected node to draw a connection from its
+  // border; select it to resize.
+  const showConnectionAuthoring = data.supportsConnectionAuthoring && !isResizing && !selected;
 
   return (
     <>

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.module.css
@@ -62,6 +62,29 @@
   border-color: var(--primary-color);
 }
 
+/* ── Console panel collapse toggle ── */
+.consoleToggle {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.consoleToggle:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.consoleToggle[aria-pressed="true"] {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
 /* ── Help toggle button ── */
 .helpToggle {
   background: none;

--- a/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/Playground.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
-import { Group, Panel, Separator, useDefaultLayout } from 'react-resizable-panels';
+import { Group, Panel, Separator, useDefaultLayout, type PanelImperativeHandle } from 'react-resizable-panels';
 import styles from './Playground.module.css';
 import { validatePayload, formatJSON } from '../utils/validators';
 import { useToast } from '../hooks/useToast';
@@ -423,6 +423,24 @@ export default function Playground({ config }: PlaygroundProps) {
     storage: localStorage,
   });
 
+  // ── Console panel collapse ──────────────────────────────────────────────
+  // The left panel (console + command input) can be collapsed to give the
+  // Graph/Payload tabs on the right the full window width — useful for
+  // complex graphs that need more room than the default 60/40 split leaves.
+  // `leftCollapsed` mirrors the panel's own size (derived in onResize) so the
+  // header button's label/icon stays correct even if the user drags the
+  // resize handle to 0 manually instead of clicking the button.
+  const leftPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+
+  const toggleLeftPanel = useCallback(() => {
+    if (leftPanelRef.current?.isCollapsed()) {
+      leftPanelRef.current.expand();
+    } else {
+      leftPanelRef.current?.collapse();
+    }
+  }, []);
+
   const handleFormatPayload = useCallback(() => setPayload(formatJSON(payload)), [payload]);
 
   const handleClearMessages = useCallback(() => {
@@ -491,6 +509,15 @@ export default function Playground({ config }: PlaygroundProps) {
               Workspace{clipboardCtx.items.length > 0 ? ` (${clipboardCtx.items.length})` : ''}
             </button>
           )}
+          <button
+            className={styles.consoleToggle}
+            onClick={toggleLeftPanel}
+            aria-label={leftCollapsed ? 'Show console panel' : 'Hide console panel, giving the Graph/Payload panel the full window'}
+            aria-pressed={leftCollapsed}
+            title={leftCollapsed ? 'Show console' : 'Hide console for more graph room'}
+          >
+            {leftCollapsed ? '▶ Console' : '◀ Console'}
+          </button>
           <Navigation
             addToast={addToast}
             sessionCollaboration={supportsSessionCollaboration ? sessionCollaboration : null}
@@ -548,7 +575,14 @@ export default function Playground({ config }: PlaygroundProps) {
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
       >
-        <Panel defaultSize={(helpOpen || clipboardOpen) ? "50%" : "60%"} minSize="25%">
+        <Panel
+          panelRef={leftPanelRef}
+          collapsible
+          collapsedSize="0%"
+          defaultSize={(helpOpen || clipboardOpen) ? "50%" : "60%"}
+          minSize="25%"
+          onResize={(size) => setLeftCollapsed(size.asPercentage <= 0.5)}
+        >
           <LeftPanel
             messages={ws.messages}
             classificationMap={classificationMap}

--- a/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
+++ b/system/minigraph-playground-engine/webapp/src/utils/graphTransformer.ts
@@ -1320,7 +1320,12 @@ export function transformGraphData(
       className: 'nokey',
       position: positions.get(n.alias) ?? { x: 0, y: 0 },
       width:  NODE_WIDTH,
-      height: nodeHeight,
+      // No explicit `height` here: an unset height lets React Flow size the
+      // wrapper to its actual rendered content (the official "node-resizer"
+      // pattern — see the comment on MinigraphNode in NodeTypes.tsx). A fixed
+      // height cropped node bodies whenever a node had more properties than
+      // the layout's rough estimate assumed. `nodeHeight` remains the layout
+      // pass's spacing estimate, carried via `data.minHeight` below.
       style: getMinigraphNodeShellStyle(n.types[0] ?? 'unknown'),
       data: {
         alias:         n.alias,


### PR DESCRIPTION
## What

The Minigraph Playground's graph view (`system/minigraph-playground-engine/webapp`) had three related usability problems:

- Node content was silently cropped whenever a node had more properties/mappings than a rough fixed-height estimate assumed.
- The graph panel was stuck in a cramped default split with no way to reclaim more window width.
- A freshly loaded complex graph rendered too small to read, and trackpad pinch-zoom behavior relied on implicit library defaults.

Fixes:
- Nodes now auto-size to their actual rendered content instead of a fixed ~100px height, so property/mapping lists are never cut off.
- The left console panel gained a collapse toggle so the graph/payload panel can take the full window width on demand.
- Zoom/pinch behavior on the graph canvas is now explicit rather than implicit, and a freshly loaded graph starts less zoomed-out.
- Fixed a side effect the auto-sizing change surfaced: dragging a *selected* node's border always resized it instead of creating a connection, because React Flow's resize controls and the connection-authoring drag handles occupy the same edges. Connection authoring now hides itself while a node is selected, so border-drag means resize when selected and connect when hovered-but-unselected.

<img width="1282" height="720" alt="image" src="https://github.com/user-attachments/assets/7e86190e-1730-4ca9-ad80-827fd2c3b533" />


## Why

Dry-running real contract graph models (e.g.  one with  15 nodes) surfaced these as real blockers to inspecting and authoring graphs in the Playground — cropped node text hides the very data the tool exists to show, and a small, fixed graph panel makes anything beyond a trivial graph hard to work with.

---
Co-Authored-By: Claude Code <noreply@anthropic.com>