### PR TITLE
minigraph-playground: tighten graph fit padding, raise max zoom, make pinch/scroll zoom explicit

### DIFF
--- a/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
+++ b/system/minigraph-playground-engine/webapp/src/components/GraphView/GraphView.tsx
@@ -300,7 +300,7 @@ export default function GraphView({
     // Re-fit even when nothing moved: a detail-mode toggle changes the graph
     // bounds drastically while the estimate layout may already be exact.
     requestAnimationFrame(() => {
-      rfInstanceRef.current?.fitView({ padding: 0.25 });
+      rfInstanceRef.current?.fitView({ padding: 0.1 });
     });
   }, [compactNodes, graphData, nodes, setNodes]);
 
@@ -467,7 +467,7 @@ export default function GraphView({
     let innerFrame: number | null = null;
     const outerFrame = requestAnimationFrame(() => {
       innerFrame = requestAnimationFrame(() => {
-        rfInstanceRef.current?.fitView({ padding: 0.25 });
+        rfInstanceRef.current?.fitView({ padding: 0.1 });
       });
     });
     return () => {
@@ -558,9 +558,18 @@ export default function GraphView({
               onBeforeDelete={handleBeforeDelete}
               nodeTypes={nodeTypes}
               fitView
-              fitViewOptions={{ padding: 0.25 }}
+              fitViewOptions={{ padding: 0.1 }}
               minZoom={0.2}
-              maxZoom={2.5}
+              maxZoom={4}
+              // Trackpad pinch sends wheel events with ctrlKey set; zoomOnPinch
+              // (mobile/tablet multi-touch) and zoomOnScroll (desktop wheel +
+              // trackpad pinch) are spelled out explicitly here — rather than
+              // left as library defaults — so a future React Flow upgrade
+              // can't silently change this behaviour.
+              zoomOnScroll
+              zoomOnPinch
+              zoomOnDoubleClick
+              panOnScroll={false}
               selectionKeyCode="Shift"
               multiSelectionKeyCode={NODE_MULTI_SELECTION_KEYS}
               selectionOnDrag={false}


### PR DESCRIPTION
## What

Three small tweaks to the Minigraph Playground graph view (`GraphView.tsx`), on top of the layout work in #330/#331:

- `fitView` padding `0.25` → `0.1` (the initial fit and both imperative re-fit calls, kept consistent) — a freshly loaded graph fills more of the panel instead of leaving a wide empty margin.
- `maxZoom` `2.5` → `4` — lets you zoom in further to read a dense node's full property list even after #330's overlap-free relayout.
- `zoomOnScroll`, `zoomOnPinch`, `zoomOnDoubleClick`, `panOnScroll={false}` made explicit instead of relying on React Flow's implicit defaults — no behavior change today, just a guard so a future library upgrade can't silently change trackpad pinch-to-zoom without showing up in a diff.

## Why

Dry-running a real contract graph model with 15 nodes after #330/#331 landed, a freshly loaded graph still started more zoomed-out than it needed to, and the zoom ceiling made it hard to get close enough to read a node's full statement/mapping list. This started as a larger PR, but #330/#331 (merged the same day) had already shipped a better version of everything else it touched — the console toggle, content-sized/overlap-free nodes, and a full replacement of the old border-drag connection affordance — so this is just the one piece those didn't cover.

Related to: https://github.com/Accenture/mercury-composable/pull/338

---
Co-Authored-By: Claude Code <noreply@anthropic.com>