### PR TITLE
platform-core: one INFO log per route pool registration

### DIFF
--- a/memory/sessions/2026-09-09-120045.md
+++ b/memory/sessions/2026-09-09-120045.md
@@ -1,0 +1,49 @@
+# Session (2026-09-09T12:00:45.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Correctness review + touch-ups for **Eric's route-pool logging change** (his edits to
+Platform/ServiceDef/ServiceQueue; branch `feat/route-pool-log`): registering a route pool
+now prints ONE INFO line ("Route pool {prefix} with {n} instances started as
+{kernel|virtual} thread") instead of one per member, and releasing prints "Route pool
+{prefix} stopped"; per-member start/stop lines demote to DEBUG.
+
+Mechanism verified sound and logging-only: a random negative per-JVM `POOL_SIGNATURE`
+sentinel rides the existing `register(route, lambda, isPrivate, instances)` signature
+(static-init order safe — `crypto` declared before it; outside callers cannot guess it);
+`register` normalizes non-positive instances to concurrency 1 and marks
+`ServiceDef.isPool` only for private+sentinel; `ServiceQueue.isControlRoute` (now
+including `isPool`) gates exactly the three log sites (two startup, one stop) — no
+dispatch/buffering/ready behavior touched. The summary line's kernel/virtual derivation
+reads the same `KernelThreadRunner` annotation ServiceDef uses. `Math.clamp` in
+setConcurrency is semantically identical on Java 21. The old `warnIfPoolMember` /
+`getPoolOf` guards are deleted (member-touch operations are now silent by design;
+tolerate-semantics unchanged). `registerRoutePool` now requires **count ≥ 2**; the one
+production caller (AppStarter's SSE reply-lane pool, 500 lanes) is unaffected, and the
+api-overview guide states no count minimum — docs stay truthful; no claims-registry
+claim pins route pools.
+
+Review findings applied as touch-ups: (1) RoutePoolTest's non-canonical-prefix case was
+silently defeated by the new count check (count 1 now throws before prefix validation) —
+bumped to count 2 and an explicit count-1 rejection case added, pinning the new floor;
+(2) two test comments saying member touches are "warned" corrected to "tolerated";
+(3) `@throws` javadoc updated to "count less than 2" (the `@param` was already updated).
+
+## Validation
+
+- Eric's full-reactor source build with all unit tests: SUCCESS (his run).
+- Post-touch-up `RoutePoolTest`: green.
+
+## Next
+
+Rust lock-step twin (same round): count ≥ 2 with matching error message, per-member log
+demotion, the two matching summary lines, and removal of the member-touch warning twin —
+per the cross-engine log-presentation contract.
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — log presentation is a field
+  requirement across engines; the review's primary finding is the required Rust
+  lock-step of the new log lines, count floor, and warning removal)

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/Platform.java
@@ -25,6 +25,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import org.platformlambda.core.annotations.CloudConnector;
 import org.platformlambda.core.annotations.CloudService;
+import org.platformlambda.core.annotations.KernelThreadRunner;
 import org.platformlambda.core.models.*;
 import org.platformlambda.core.util.*;
 import org.slf4j.Logger;
@@ -57,6 +58,7 @@ public class Platform {
     private static final String NOT_FOUND = " not found";
     private static final String INVALID_ROUTE = "Invalid route ";
     private static final String RELOADING = "Reloading";
+    private static final int POOL_SIGNATURE = crypto.nextInt(10_000, 1_000_000) * -1;
     private static final AtomicBoolean LOADED = new AtomicBoolean(false);
     private static final ReentrantLock SAFETY1 = new ReentrantLock();
     private static final ReentrantLock SAFETY2 = new ReentrantLock();
@@ -561,12 +563,15 @@ public class Platform {
             throw new IllegalArgumentException("Missing LambdaFunction instance");
         }
         String path = getValidatedRoute(route);
-        warnIfPoolMember("Registering", path);
         if (registry.containsKey(path)) {
             log.warn("{} LambdaFunction {}", RELOADING, path);
             release(path);
         }
-        ServiceDef service = new ServiceDef(path, lambda).setConcurrency(instances).setPrivate(isPrivate);
+        var concurrency = instances > 0? instances : 1;
+        ServiceDef service = new ServiceDef(path, lambda).setConcurrency(concurrency).setPrivate(isPrivate);
+        if (isPrivate && instances == POOL_SIGNATURE) {
+            service.setPool(true);
+        }
         ServiceQueue manager = new ServiceQueue(service);
         service.setManager(manager);
         // save into local registry
@@ -592,7 +597,6 @@ public class Platform {
             throw new IllegalArgumentException("Missing StreamFunction instance");
         }
         String path = getValidatedRoute(route);
-        warnIfPoolMember("Registering", path);
         if (registry.containsKey(path)) {
             log.warn("{} StreamFunction {}", RELOADING, path);
             release(path);
@@ -616,16 +620,16 @@ public class Platform {
      *
      * @param prefix route name base in canonical form, e.g. "async.http.response.stream"
      * @param lambda function shared by all members of the pool
-     * @param count number of lanes, at least 1
+     * @param count number of lanes, at least 2
      * @return the generated member routes in order
-     * @throws IllegalArgumentException for missing lambda, count less than 1 or an invalid prefix
+     * @throws IllegalArgumentException for missing lambda, count less than 2 or an invalid prefix
      */
     public List<String> registerRoutePool(String prefix, TypedLambdaFunction<?, ?> lambda, int count) {
         if (lambda == null) {
             throw new IllegalArgumentException("Missing LambdaFunction instance");
         }
-        if (count < 1) {
-            throw new IllegalArgumentException("Route pool count must be at least 1");
+        if (count < 2) {
+            throw new IllegalArgumentException("Route pool count must be at least 2");
         }
         // the prefix must be canonical so the generated names are exactly "{prefix}.{n}" -
         // silent name filtering would break the returned member-list contract
@@ -643,10 +647,12 @@ public class Platform {
             List<String> members = new ArrayList<>(count);
             for (int n = 0; n < count; n++) {
                 String member = prefix + "." + n;
-                register(member, lambda, true, 1);
+                register(member, lambda, true, POOL_SIGNATURE);
                 members.add(member);
             }
             poolRegistry.put(prefix, count);
+            var type = lambda.getClass().getAnnotation(KernelThreadRunner.class) != null? "kernel" : "virtual";
+            log.info("Route pool {} with {} instances started as {} thread", prefix, count, type);
             return members;
         } finally {
             POOL_LOCK.unlock();
@@ -669,6 +675,7 @@ public class Platform {
                 return false;
             }
             releasePoolMembers(prefix, count);
+            log.info("Route pool {} stopped", prefix);
             return true;
         } finally {
             POOL_LOCK.unlock();
@@ -679,33 +686,6 @@ public class Platform {
         for (int n = 0; n < count; n++) {
             release(prefix + "." + n);
         }
-    }
-
-    private void warnIfPoolMember(String action, String route) {
-        String pool = getPoolOf(route);
-        if (pool != null) {
-            log.warn("{} {} which belongs to route pool {}", action, route, pool);
-        }
-    }
-
-    private String getPoolOf(String route) {
-        int dot = route.lastIndexOf('.');
-        if (dot > 0) {
-            String prefix = route.substring(0, dot);
-            Integer count = poolRegistry.get(prefix);
-            if (count != null) {
-                String suffix = route.substring(dot + 1);
-                // a member's suffix is canonical digits (no leading zeros) within the pool's range
-                if (!suffix.isEmpty() && suffix.length() < 10 &&
-                        suffix.chars().allMatch(Character::isDigit)) {
-                    int n = Utility.getInstance().str2int(suffix);
-                    if (suffix.equals(String.valueOf(n)) && n < count) {
-                        return prefix;
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     private String getValidatedRoute(String route) {
@@ -754,7 +734,6 @@ public class Platform {
      */
     public boolean release(String route) {
         if (route != null && registry.containsKey(route)) {
-            warnIfPoolMember("Releasing", route);
             ServiceDef def = registry.get(route);
             if (!def.isPrivate()) {
                 TargetRoute cloud = EventEmitter.getInstance().getCloudRoute();

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceDef.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceDef.java
@@ -49,6 +49,7 @@ public class ServiceDef {
     private final boolean interceptor;
     private final Date created = new Date();
     private boolean isPrivateFunction = false;
+    private boolean isPool = false;
     private ServiceQueue manager;
     private Class<?> inputClass;
     private Class<?> pojoClass;
@@ -117,6 +118,10 @@ public class ServiceDef {
         return isPrivateFunction;
     }
 
+    public boolean isPool() {
+        return isPool;
+    }
+
     public boolean isTrackable() {
         return trackable;
     }
@@ -142,12 +147,17 @@ public class ServiceDef {
     }
 
     public ServiceDef setConcurrency(int instances) {
-        this.instances = Math.max(1, (Math.min(instances, MAX_INSTANCES)));
+        this.instances = Math.clamp(instances, 1, MAX_INSTANCES);
         return this;
     }
 
     public ServiceDef setPrivate(boolean isPrivateFunction) {
         this.isPrivateFunction = isPrivateFunction;
+        return this;
+    }
+
+    public ServiceDef setPool(boolean isPool) {
+        this.isPool = isPool;
         return this;
     }
 

--- a/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceQueue.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/system/ServiceQueue.java
@@ -102,7 +102,7 @@ public class ServiceQueue {
     }
 
     private static boolean isControlRoute(ServiceDef service, String route) {
-        return service.isStream()
+        return service.isStream() || service.isPool()
                 || (route.startsWith(CALLBACK_PREFIX) && route.length() == CALLBACK_LENGTH)
                 || (route.startsWith(STREAM_PREFIX) && route.length() == STREAM_IN_LENGTH && route.endsWith(STREAM_IN));
     }

--- a/system/platform-core/src/test/java/org/platformlambda/core/RoutePoolTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/RoutePoolTest.java
@@ -105,9 +105,12 @@ class RoutePoolTest extends TestBase {
                 platform.registerRoutePool("unit.test.pool.d", null, 1));
         assertThrows(IllegalArgumentException.class, () ->
                 platform.registerRoutePool("unit.test.pool.d", ECHO, 0));
+        // a pool needs at least 2 lanes - a single lane is just a private function
+        assertThrows(IllegalArgumentException.class, () ->
+                platform.registerRoutePool("unit.test.pool.d", ECHO, 1));
         // non-canonical prefixes are rejected so member names are exactly "{prefix}.{n}"
         assertThrows(IllegalArgumentException.class, () ->
-                platform.registerRoutePool("Unit.Test.Pool", ECHO, 1));
+                platform.registerRoutePool("Unit.Test.Pool", ECHO, 2));
         assertFalse(platform.hasRoute("unit.test.pool.d.0"));
     }
 
@@ -115,10 +118,10 @@ class RoutePoolTest extends TestBase {
     void individualUpdatesToMembersAreToleratedAndCleanedUp() {
         Platform platform = Platform.getInstance();
         platform.registerRoutePool("unit.test.pool.e", ECHO, 3);
-        // an individual release of a member is warned, never refused (house semantics)
+        // an individual release of a member is tolerated, never refused (house semantics)
         assertTrue(platform.release("unit.test.pool.e.1"));
         assertFalse(platform.hasRoute("unit.test.pool.e.1"));
-        // an individual re-registration over a member reloads it, also warned
+        // an individual re-registration over a member reloads it, also tolerated
         platform.registerPrivate("unit.test.pool.e.2", ECHO, 1);
         assertTrue(platform.hasRoute("unit.test.pool.e.2"));
         // pool release still cleans the remainder, holes included


### PR DESCRIPTION
## What

Registering a route pool printed one INFO line per member — 500 lines for the
SSE reply-lane pool at startup. It now prints a single summary, "Route pool
{prefix} with {n} instances started as {kernel|virtual} thread", and releasing
a pool prints "Route pool {prefix} stopped". Per-member start/stop lines demote
to DEBUG.

Mechanics: pool members are marked through a private `POOL_SIGNATURE` sentinel
(a random negative int per JVM) so the public `register` signature is
unchanged and outside callers cannot hit it; `ServiceDef.isPool` feeds
`ServiceQueue.isControlRoute`, which gates exactly the three log sites and
touches no dispatch behavior. A pool now requires **at least 2 lanes** (a
single lane is just a private function), and the member-touch warnings
(`warnIfPoolMember`/`getPoolOf`) are removed — direct member updates stay
tolerated, silently.

Review touch-ups included: RoutePoolTest pins the new count floor with an
explicit count-1 case, its non-canonical-prefix case uses count 2 so it
reaches prefix validation again (the count check now runs first), test
comments and the `@throws` javadoc follow the new semantics.

## Why

Route pools are sized for concurrency (the production SSE pool registers 500
lanes), so per-member startup logging drowned the application log at every
start. One line per pool lifecycle keeps the signal; the demoted DEBUG lines
remain available for deep diagnosis. Lock-step twin in the Rust engine
(matching count-floor error message and pool-level log lines).

## Validation

- Full reactor build with all unit tests: SUCCESS.
- `RoutePoolTest` green after the touch-ups, including the new count-floor
  case; the one production caller (AppStarter, 500 lanes) is unaffected.
- The api-overview guide states no count minimum and no member-warning
  behavior, and no claims-registry claim pins route pools — docs stay truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>