### PR TITLE
fix: minute-boundary ISO date parsing + null operands in text conversion

### DIFF
--- a/memory/sessions/2026-09-09-155833.md
+++ b/memory/sessions/2026-09-09-155833.md
@@ -1,0 +1,56 @@
+# Session (2026-09-09T15:58:33.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+Two field issues, branch `fix/field-fixes`:
+
+**1. "Flaky" CI test was a real engine bug — minute-boundary date strings parsed to the
+epoch.** `EventEnvelopeTest.offsetDateTimeTest` failed rarely with "expected <…01:26:00…>
+but was <…1970>". Diagnosis: `OffsetDateTime.toString()` (the wire format the
+`SimpleMapper` serializer emits) omits the ":ss" component when second==0 and nano==0
+("2026-09-09T01:26+08:00"), and `Utility.str2date`'s ISO branch fails that form → falls
+back to `new Date(0)`. The test flaked only when `now()` landed in the first millisecond
+of a minute; the DESERIALIZER had the same hole for any minute-boundary value. A jshell
+probe against compiled classes then exposed a SECOND pre-existing hole: the no-fractional
+path never strips the colon from a "+HH:MM" zone offset and the `ISO_DATE` pattern (`Z`)
+rejects colons — so ANY second-precision, non-UTC ISO string (nano==0, the other shape
+java.time emits) also parsed to epoch; it went unnoticed because `now()` virtually always
+carries nanos and the ms branch strips the colon. Fix in `str2date`: insert ":00" when
+the seconds component is absent, and strip the zone colon on the no-ms path too.
+Pinned by `UtilityTests.secondlessIso8601Test` (4 second-less forms + the
+second-precision colon-offset form) and `EventEnvelopeTest.offsetDateTimeMinuteBoundaryTest`
+(round-trips `now().truncatedTo(MINUTES)` through EventEnvelope bytes).
+
+**2. `f:concat` NPE on a null operand (field regression vs the 4.4.x built-ins).**
+`TypeConversionUtils.getTextValue` is a Java 21 pattern switch — null-hostile without an
+explicit `case null` (the `default -> String.valueOf(value)` arm never sees null), so a
+flow feeding an unset model variable into concat threw NPE where the old built-in
+appended "null". Fix per Eric's rulings: `getTextValue(null)` → `"null"`
+(String.valueOf semantics — also exactly the Rust engine's existing `display(Nil)`
+behavior, so this RESTORES cross-engine parity) and `getBinaryValue(null)` → empty byte
+array ("in byte arrays, null can be treated as empty array" — Eric; his initial
+"default path handles it" note was the classic-switch intuition — a pattern switch
+throws before any arm on a null selector, surfaced and confirmed). Pinned by
+`TextValueNullHandlingTest` + a `types.yml` flow row (`concat_null` →
+"Hellonull World!") asserted in FlowTests and mirrored byte-identical to the Rust
+fixture (the Rust engine needed NO code change — its tests now pin the shared behavior).
+
+**Utility touch-up (Eric's ask, IDE/Sonar findings):** the fix pushed `str2date` to
+cognitive complexity 16 (>15, a field-Sonar-gate concern) — extracted
+`normalizeIso8601` + a shared `zoneSeparator` helper (also removing the duplicated
+sign-lookup block), moved the formatter-selection ternary inside `ZonedDateTime.parse`,
+and fixed three doc-comment grammar nits ("an RFC" ×2, the sleep param wording).
+
+## Validation
+
+- Full platform-core suite: 485 tests, 0 failures (+2 new). Full event-script-engine
+  suite: 212 tests, 0 failures (+3 new).
+- Empirical probes via jshell against compiled classes drove both str2date diagnoses.
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — the concat fix restores Java to the
+  Rust engine's existing null rendering; fixtures mirrored to pin it on both sides)
+- eric-release-rhythm (consulted — branch + commits prepared; push/PR gated)

--- a/system/event-script-engine/src/main/java/com/accenture/util/TypeConversionUtils.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/TypeConversionUtils.java
@@ -124,7 +124,11 @@ public class TypeConversionUtils {
     }
 
     public static String getTextValue(Object value) {
+        // a pattern switch is null-hostile without an explicit case null: the default arm
+        // intends String.valueOf semantics, so a null operand renders as "null" - the
+        // behavior of the pre-plugin built-ins and of the Rust engine's get_text_value
         return switch (value) {
+            case null -> "null";
             case String str -> str;
             case byte[] b -> util.getUTF(b);
             case Map<?, ?> map -> SimpleMapper.getInstance().getMapper().writeValueAsString(map);
@@ -133,7 +137,10 @@ public class TypeConversionUtils {
     }
 
     public static byte[] getBinaryValue(Object value) {
+        // same pattern-switch null-hostility as getTextValue; for byte arrays a
+        // null operand relaxes to an empty array
         return switch (value) {
+            case null -> new byte[0];
             case byte[] b -> b;
             case String str -> util.getUTF(str);
             case Map<?, ?> map -> SimpleMapper.getInstance().getMapper().writeValueAsBytes(map);

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -2053,6 +2053,8 @@ class FlowTests extends TestBase {
         assertEquals("World!", result.get("substring_one"));
         assertEquals("World", result.get("substring_two"));
         assertEquals("Hello World!", result.get("concat"));
+        // a null operand renders as "null" (String.valueOf semantics; Rust-engine parity)
+        assertEquals("Hellonull World!", result.get("concat_null"));
         var b64String = "SGVsbG8=";
         var bytes = Base64.getDecoder().decode(b64String);
         List<Integer> byteList = IntStream.range(0, bytes.length)

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/TextValueNullHandlingTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/TextValueNullHandlingTest.java
@@ -1,0 +1,53 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import com.accenture.util.TypeConversionUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A null operand renders as the text "null" ({@code String.valueOf} semantics —
+ * the behavior of the pre-plugin built-ins and of the Rust engine's
+ * {@code get_text_value}). The text/binary conversions are pattern switches,
+ * which are null-hostile without an explicit case null: a flow feeding an
+ * unset model variable into f:concat used to throw NPE instead.
+ */
+class TextValueNullHandlingTest {
+
+    @Test
+    void nullOperandConcatenatesAsText() {
+        assertEquals("anullb", new ConcatenateStringsPlugin().calculate("a", null, "b"));
+        assertEquals("nullnull", new ConcatenateStringsPlugin().calculate(null, null));
+    }
+
+    @Test
+    void textConversionOfNullYieldsText() {
+        assertEquals("null", TypeConversionUtils.getTextValue(null));
+        assertEquals("null", new TextConversion().calculate((Object) null));
+    }
+
+    @Test
+    void binaryConversionOfNullYieldsEmptyArray() {
+        // for byte arrays a null operand relaxes to an empty array, not "null" text
+        assertArrayEquals(new byte[0], TypeConversionUtils.getBinaryValue(null));
+    }
+}

--- a/system/event-script-engine/src/test/resources/flows/pluggableFunctions/types.yml
+++ b/system/event-script-engine/src/test/resources/flows/pluggableFunctions/types.yml
@@ -64,6 +64,7 @@ tasks:
       - 'f:substring(model.text_two, model.substring_start) -> substring_one'
       - 'f:substring(model.text_two, model.substring_start, model.substring_end) -> substring_two'
       - 'f:concat(model.text_one, model.text_two) -> concat'
+      - 'f:concat(model.text_one, model.none, model.text_two) -> concat_null'
       - 'f:b64(model.b64_str) -> model.to_b64_bytes'
       - 'model.to_b64_bytes -> to_b64_bytes'
       - 'f:b64(model.to_b64_bytes) -> to_bytestring'

--- a/system/platform-core/src/main/java/org/platformlambda/core/util/Utility.java
+++ b/system/platform-core/src/main/java/org/platformlambda/core/util/Utility.java
@@ -112,7 +112,7 @@ public class Utility {
      * Primarily a convenience for tests that poll for an asynchronous condition, but safe for any
      * interruptible pause (e.g. a retry back-off).
      *
-     * @param ms milliseconds to wait; a value of zero or less returns immediately
+     * @param ms milliseconds to wait; zero or a negative value returns immediately
      */
     public void sleep(long ms) {
         if (ms <= 0) {
@@ -459,7 +459,7 @@ public class Utility {
     }
 
     /**
-     * Generate a RFC 7231 timestamp
+     * Generate an RFC 7231 timestamp
      * <p>
      * @param date object
      * @return timestamp for use in an HTTP header (Example: Tue, 11 May 2021 03:42:46 GMT)
@@ -470,7 +470,7 @@ public class Utility {
     }
 
     /**
-     * Parse a RFC 7231 HTML timestamp
+     * Parse an RFC 7231 HTML timestamp
      * <p>
      * @param timestamp from an HTTP header
      * @return converted date object
@@ -951,17 +951,23 @@ public class Utility {
             var local = str2LocalDateTime(str, throwException);
             return Date.from(local.atZone(ZoneId.systemDefault()).toInstant());
         }
-        /*
-         * Variances of ISO-8601
-         * 1. 2015-01-06T01:02:03Z
-         * 2. 2015-01-06T01:02:03+0000
-         * 3. 2015-01-06T01:02:03+00:00
-         * 4. 2015-01-06T01:02:03.123Z
-         * 5. 2015-01-06T01:02:03.123+0000
-         * 6. 2015-01-06T01:02:03.123+00:00
-         *
-         * DO NOT CHANGE the string substitution sequence below
-         */
+        String normalized = normalizeIso8601(str);
+        return parseZonedDateTime(normalized, normalized.lastIndexOf('.'), throwException);
+    }
+
+    /*
+     * Variances of ISO-8601
+     * 1. 2015-01-06T01:02:03Z
+     * 2. 2015-01-06T01:02:03+0000
+     * 3. 2015-01-06T01:02:03+00:00
+     * 4. 2015-01-06T01:02:03.123Z
+     * 5. 2015-01-06T01:02:03.123+0000
+     * 6. 2015-01-06T01:02:03.123+00:00
+     * 7. 2015-01-06T01:02Z (java.time toString() omits ":ss" at a minute boundary)
+     *
+     * DO NOT CHANGE the string substitution sequence below
+     */
+    private String normalizeIso8601(String str) {
         if (str.length() > 11) {
             // ensure T as a separator between date and time
             str = str.substring(0, 10) + "T" + str.substring(11);
@@ -970,26 +976,46 @@ public class Utility {
         if (str.endsWith("Z")) {
             str = str.substring(0, str.length()-1)+ZERO_TIMEZONE;
         }
+        // insert the seconds component when absent - java.time toString() omits ":ss" for a
+        // minute-boundary value (e.g. OffsetDateTime "2026-09-09T01:26+08:00"), which would
+        // otherwise fail the formatters below and fall back to the epoch
+        if (str.length() > 16 && str.charAt(16) != ':') {
+            str = str.substring(0, 16) + ":00" + str.substring(16);
+        }
         // precision up to milliseconds only and drop microseconds if any
         int dot = str.lastIndexOf('.');
+        int sep = zoneSeparator(str);
         if (dot == 19) {
             // validation for "isLocalDateTime" above guarantees there is a time zone ("Z", "+" or "-")
-            int sep = str.indexOf('+', 19);
-            if (sep == -1) {
-                sep = str.indexOf('-', 19);
-            }
             String ms = normalizeMs(sep > 0? str.substring(dot, sep) : str.substring(dot));
             // remove colon from timezone
             String timezone = str.substring(sep).replace(":", "");
             str = str.substring(0, dot) + ms + timezone;
+        } else if (sep > 0) {
+            // no fractional seconds: still remove the colon from a "+HH:MM" zone offset
+            // (the form java.time toString() emits) so the formatter below accepts it
+            str = str.substring(0, sep) + str.substring(sep).replace(":", "");
         }
-        return parseZonedDateTime(str, dot, throwException);
+        return str;
+    }
+
+    /**
+     * Position of the zone-offset sign in a normalized ISO-8601 string,
+     * or -1 when absent (the time component ends at index 18, so the
+     * sign of a zone offset never appears before index 19)
+     *
+     * @param str normalized ISO-8601 timestamp
+     * @return index of the zone sign or -1
+     */
+    private int zoneSeparator(String str) {
+        int sep = str.indexOf('+', 19);
+        return sep == -1? str.indexOf('-', 19) : sep;
     }
 
     private Date parseZonedDateTime(String str, int dot, boolean throwException) {
         // parse the normalized time string
         try {
-            ZonedDateTime zdt = dot==19? ZonedDateTime.parse(str, ISO_DATE_MS) : ZonedDateTime.parse(str, ISO_DATE);
+            ZonedDateTime zdt = ZonedDateTime.parse(str, dot == 19? ISO_DATE_MS : ISO_DATE);
             return Date.from(zdt.toInstant());
         } catch (IllegalArgumentException | DateTimeParseException e) {
             if (throwException) {

--- a/system/platform-core/src/test/java/org/platformlambda/core/EventEnvelopeTest.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/EventEnvelopeTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -55,6 +56,20 @@ class EventEnvelopeTest {
         var utc1 = util.str2date(now.toString());
         var utc2 = util.str2date(o.getOffsetDateTime().toString());
         assertEquals(utc1, utc2);
+    }
+
+    @Test
+    void offsetDateTimeMinuteBoundaryTest() {
+        // second == 0 and nano == 0 makes OffsetDateTime.toString() omit the seconds
+        // component ("2026-09-09T01:26+08:00") - this used to fail str2date and restore
+        // as the epoch, surfacing as a once-per-minute-boundary flaky round trip
+        var event = new EventEnvelope();
+        var po = new PoJo();
+        var boundary = OffsetDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        po.setOffsetDateTime(boundary);
+        event.setBody(po);
+        var restored = new EventEnvelope(event.toBytes()).getBody(PoJo.class);
+        assertEquals(boundary.toInstant(), restored.getOffsetDateTime().toInstant());
     }
 
     @Test

--- a/system/platform-core/src/test/java/org/platformlambda/core/UtilityTests.java
+++ b/system/platform-core/src/test/java/org/platformlambda/core/UtilityTests.java
@@ -260,6 +260,22 @@ class UtilityTests {
     }
 
     @Test
+    void secondlessIso8601Test() {
+        // java.time toString() omits the ":ss" component for a minute-boundary value
+        // (second == 0 and nano == 0) - the parser must accept the second-less form
+        Utility util = Utility.getInstance();
+        Date expected = util.str2date("2026-09-09T01:26:00Z");
+        assertEquals(expected, util.str2date("2026-09-09T01:26Z"));
+        assertEquals(expected, util.str2date("2026-09-09T01:26+00:00"));
+        // the offset applies: 09:26 at +08:00 is 01:26 UTC
+        assertEquals(expected, util.str2date("2026-09-09T09:26+08:00"));
+        // second precision with a colon offset and no fractional part - the other
+        // shape java.time toString() emits (nano == 0, second != 0)
+        Date withSeconds = util.str2date("2026-09-09T01:26:45Z");
+        assertEquals(withSeconds, util.str2date("2026-09-09T09:26:45+08:00"));
+    }
+
+    @Test
     void fileTest() {
         Utility util = Utility.getInstance();
         File temp = new File("/tmp");


### PR DESCRIPTION
## What

Two field fixes.

**1. `str2date` parsed two legitimate `java.time` string shapes to the epoch.**
A minute-boundary value (second==0, nano==0) serializes without the `":ss"`
component — `OffsetDateTime.toString()` emits `"2026-09-09T01:26+08:00"` — and
the ISO branch rejected it, falling back to `new Date(0)`. This surfaced as the
rare flaky `offsetDateTimeTest` in CI (the window is the first millisecond of
each minute), but the same hole corrupted any minute-boundary `OffsetDateTime`
on the wire. Diagnosis then exposed a second, older hole: the no-fractional
path never stripped the colon from a `"+HH:MM"` zone offset, so ANY
second-precision non-UTC ISO string (`"…T01:26:45+08:00"`, nano==0 — the other
shape java.time emits) also parsed to epoch; it went unnoticed because `now()`
virtually always carries nanoseconds and the milliseconds branch strips the
colon. `str2date` now inserts the missing seconds component and strips the
zone colon on both paths.

**2. `f:concat` threw NPE on a null operand.** `TypeConversionUtils.getTextValue`
is a Java 21 pattern switch, which throws on a null selector before any arm
runs — the `default -> String.valueOf(value)` arm never sees null. A flow
feeding an unset model variable into concat crashed where the 4.4.x built-in
appended `"null"`. A null operand now renders as `"null"` text
(`String.valueOf` semantics — also exactly the Rust engine's existing
behavior, so this restores cross-engine parity), and `getBinaryValue` relaxes
null to an empty byte array.

Also a Utility clean-up ride-along: the `str2date` ISO normalization is
extracted to `normalizeIso8601` with a shared `zoneSeparator` helper
(cognitive complexity back under the Sonar gate; duplicate sign-lookup block
removed), the formatter selection moved inside `ZonedDateTime.parse`, and
three doc-comment grammar nits fixed.

## Why

Both issues came from the field: the date hole fails CI runs
nondeterministically and silently corrupts minute-boundary timestamps in
production payloads; the concat NPE is a regression against the pre-plugin
built-ins that breaks flows on optional model variables. The relaxed null
rendering matches the Rust engine, so flow behavior stays portable.

## Validation

- Full platform-core suite: 485 tests, 0 failures (+2 new:
  `secondlessIso8601Test` pinning five second-less/colon-offset forms, and a
  minute-boundary EventEnvelope round trip).
- Full event-script-engine suite: 212 tests, 0 failures (+3 new:
  `TextValueNullHandlingTest`, plus a `concat_null` flow row asserted in
  FlowTests and mirrored byte-identical to the Rust fixture).
- Root causes confirmed empirically via jshell probes against compiled classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>