### PR TITLE
minigraph: stepwise traversal logging for deployed graph execution

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -323,6 +323,21 @@ call answers 404 ("compiled or 404", ADR-0011).
 Where the Playground's `export graph` command writes model JSON. Must be a local filesystem
 path (read/write requirement).
 
+### `graph.traversal.log`
+
+| Type | Default |
+|------|---------|
+| `boolean` | `true` |
+
+Stepwise traversal logging for deployed graph execution (`graph.executor`) — the same trail
+the Playground dry-run prints to its console (`Walk to {node}`, `Executed {node} with skill
+{skill} in {time} ms`, `Graph traversal completed in {time} ms`, and `Graph traversal
+aborted: {reason}` on error), emitted as INFO log lines suffixed with the graph id and the
+run's **trace id** (fallback: the flow instance id when tracing is off) — so an
+OpenTelemetry dashboard can join these app-log lines with the exported spans and metrics.
+On by default; set it to `false` (for example with the runtime override
+`-Dgraph.traversal.log=false`) to reduce log volume on busy installations.
+
 ---
 
 ## Component Scanning & Startup

--- a/examples/minigraph-playground/src/main/resources/application.properties
+++ b/examples/minigraph-playground/src/main/resources/application.properties
@@ -76,6 +76,14 @@ location.graph.temp=file:/tmp/graph
 #
 graph.model.automation=classpath:/graphs.yaml
 #
+# stepwise traversal logging for deployed graph execution (graph.executor) -
+# the same trail the Playground dry-run prints, as INFO log lines labeled
+# with the graph id and the trace id (fallback: flow instance id) so OTel
+# dashboards can join logs with spans. Set to false (e.g. -Dgraph.traversal.log=false)
+# to reduce log noise.
+#
+graph.traversal.log=true
+#
 # Declarative Event-over-HTTP: routes served by polyglot peers (the support-triage
 # demo graph's llm.chat AI node runs on the mercury-python demo app)
 #

--- a/memory/sessions/2026-09-10-000519.md
+++ b/memory/sessions/2026-09-10-000519.md
@@ -1,0 +1,60 @@
+# Session (2026-09-10T00:05:19.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Stepwise traversal logging for GraphExecutor** (field enhancement request,
+branch `feature/graph-traversal-logging`, commits `40110e43` + `5e122f4f`).
+The field likes GraphTraveler's dry-run narration and asked for the same on
+the production walker. Eric's rulings, gathered across the round:
+
+1. **Option 3 — property-gated at INFO**: `graph.traversal.log` (default
+   true); DevOps overrides the runtime parameter (`-Dgraph.traversal.log=false`)
+   to reduce noise, and ops can always retune log4j.
+2. **Correlation label = the run's trace id, fallback flow instance id** — so
+   the OTel dashboard joins these app-log lines with exported spans/metrics.
+   `GraphInstance` gained a `traceId` captured once from the initiating event
+   (the executor is a zero-tracing interceptor, so its own records carry no
+   ambient trace).
+3. **No conflict with app-context-log**: with `log.format=json|compact` each
+   record additionally carries the structured context (span id, business cid);
+   app-context-log is DISABLED in text format to reduce volume — exactly where
+   the inline label keeps the correlation visible. Documented in the
+   configuration reference.
+4. **Code smell fixed** (Eric's IDE finding): the property gate alone still
+   evaluated log arguments when the logger level sits above INFO
+   (IDEA/Sonar S2629) — guards are now `traversalLog && log.isInfoEnabled()`.
+   The Rust twin needs no guard change: `log::info!` evaluates arguments
+   inside the macro's own level check.
+
+The four lines (traveler vocabulary + correlation suffix):
+`Walk to {node} - {graphId} ({trace})`,
+`Executed {node} with skill {skill} in {time} ms - …` (envelope
+executionTime — no new timing bookkeeping),
+`Graph traversal completed in {elapsed} ms - …` (GraphInstance startTime),
+`Graph traversal aborted: {reason} - …` (both error terminals; the looping
+detector keeps its existing ERROR). Pinned by `GraphTraversalLoggingTest`
+(log4j2 capturing appender over a real `/api/graph/hello` run — live lines
+showed 32-hex trace ids). Rust twin shipped the same arc in
+`feature/graph-traversal-logging` (mercury repo): `executor.rs` byte-matched
+lines behind `traversal_log()`, `model.rs` trace-id metadata +
+`correlation_label()` with a unit pin, Increment 111 (+ Increment 110
+catch-up for the #247 webapp lock-step), config + docs twins.
+
+Gates: Java `GraphTraversalLoggingTest` + full engine suite green; Rust fmt,
+clippy clean, knowledge-graph suites 10/10 (one local flake on first run —
+`playground_command_grammar_and_companion` failed under parallel-suite +
+compile contention, deterministic-looking until a clean-baseline bisect
+proved the identical diff green; same laptop-contention pattern as the
+v4.12.5 TLS 408).
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — log presentation ships
+  Java-reference + Rust twin with byte-matched wording, same arc)
+- eric-release-rhythm (consulted — branches/commits/pushes as prep; PRs and
+  merges stay Eric's gated steps)
+- field-sonar-gate-covers-overall-code [personal memory] (consulted — S2629
+  is a Sonar major; the field gate holds overall code to zero majors, so the
+  guard fix was mandatory, not cosmetic)

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/models/GraphInstance.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/models/GraphInstance.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class GraphInstance {
     private static final String FLOW_INSTANCE = "flow_instance";
     private static final String REPLY_TO = "reply_to";
+    private static final String TRACE_ID = "trace_id";
     private static final String WS_INSTANCE = "ws_instance";
     private static final String RUN_WATCHER = "run_watcher";
     private static final String CID = "cid";
@@ -56,6 +57,22 @@ public class GraphInstance {
 
     public String getFlowInstanceId() {
         return metadata.get(FLOW_INSTANCE) instanceof String v? v : NONE;
+    }
+
+    /**
+     * The distributed trace id of the event that started this run, when tracing
+     * is on — the traversal log's preferred correlation label.
+     *
+     * @return the trace id, or null when the run is untraced
+     */
+    public String getTraceId() {
+        return metadata.get(TRACE_ID) instanceof String v? v : null;
+    }
+
+    public void setTraceId(String traceId) {
+        if (traceId != null && !traceId.isBlank()) {
+            metadata.put(TRACE_ID, traceId);
+        }
     }
 
     public void setFlowInstanceId(String instanceId) {

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
@@ -48,10 +48,18 @@ public class GraphExecutor extends GraphLambdaFunction {
     private static final Logger log = LoggerFactory.getLogger(GraphExecutor.class);
     private static final String INSTANCE = "instance";
     private final boolean isDevEnv;
+    // Stepwise traversal logging (field request 2026-09-09): the same trail the
+    // dry-run GraphTraveler prints to the Playground console, as INFO log lines
+    // labeled with the graph id and the run's trace id (fallback: flow instance
+    // id) so OTel dashboards can join app logs with exported spans. On by
+    // default; DevOps can override the runtime parameter
+    // (graph.traversal.log=false) to reduce log noise.
+    private final boolean traversalLog;
 
     public GraphExecutor() {
         var config = AppConfigReader.getInstance();
         this.isDevEnv = "dev".equals(config.getProperty("app.env", "dev"));
+        this.traversalLog = "true".equals(config.getProperty("graph.traversal.log", "true"));
     }
 
     @Override
@@ -74,6 +82,9 @@ public class GraphExecutor extends GraphLambdaFunction {
         var parentSpanId = event.getSpanId();
         try {
             var graphInstance = createInstance(headers, event.getReplyTo(), event.getCorrelationId());
+            // the traversal log labels each line with the run's trace id (fallback:
+            // flow instance id when tracing is off) - capture it once at the start
+            graphInstance.setTraceId(event.getTraceId());
             var flowInstanceId = headers.get(INSTANCE);
             var flowInstance = Flows.getFlowInstance(flowInstanceId);
             beginTraversal(po, flowInstance, graphInstance, parentSpanId);
@@ -159,6 +170,10 @@ public class GraphExecutor extends GraphLambdaFunction {
         var stateMachine = graphInstance.stateMachine;
         var node = graphInstance.graph.findNodeByAlias(nodeName);
         checkFrequency(po, graphInstance, nodeName, parentSpanId);
+        if (traversalLog) {
+            log.info("Executed {} with skill {} in {} ms - {} ({})", nodeName, node.getProperty(SKILL),
+                    response.getExecutionTime(), graphInstance.graphId, correlationLabel(graphInstance));
+        }
         // Skill handler can also set status and error in its node properties instead of throwing exception
         var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
         var resultError = stateMachine.getElement(nodeName + "." + ERROR);
@@ -234,6 +249,10 @@ public class GraphExecutor extends GraphLambdaFunction {
             var isJoin = GraphJoin.ROUTE.equals(skill);
             var seen = graphInstance.nodeSeen.putIfAbsent(nodeName, true) != null;
             if (isJoin || !seen) {
+                if (traversalLog) {
+                    log.info("Walk to {} - {} ({})", nodeName,
+                            graphInstance.graphId, correlationLabel(graphInstance));
+                }
                 walkTo(po, skill, graphInstance, node, from, parentSpanId);
             }
         }
@@ -279,6 +298,11 @@ public class GraphExecutor extends GraphLambdaFunction {
         }
         po.send(response.setBody(body));
         graphInstance.complete.set(true);
+        if (traversalLog) {
+            var elapsed = System.currentTimeMillis() - graphInstance.getStartTime();
+            log.info("Graph traversal completed in {} ms - {} ({})",
+                    elapsed, graphInstance.graphId, correlationLabel(graphInstance));
+        }
     }
 
     private void executeSkill(PostOffice po, String skill, GraphInstance graphInstance, SimpleNode node,
@@ -399,6 +423,7 @@ public class GraphExecutor extends GraphLambdaFunction {
                                         .setSpanId(parentSpanId);
         po.send(error);
         graphInstance.complete.set(true);
+        logAborted(graphInstance, String.valueOf(response.getBody()));
     }
 
     private void sendError(PostOffice po, GraphInstance graphInstance, String message, String parentSpanId) {
@@ -407,5 +432,26 @@ public class GraphExecutor extends GraphLambdaFunction {
                             .setSpanId(parentSpanId);
         po.send(error);
         graphInstance.complete.set(true);
+        logAborted(graphInstance, message);
+    }
+
+    private void logAborted(GraphInstance graphInstance, String reason) {
+        if (traversalLog) {
+            log.info("Graph traversal aborted: {} - {} ({})",
+                    reason, graphInstance.graphId, correlationLabel(graphInstance));
+        }
+    }
+
+    /**
+     * The traversal log's correlation label: the run's distributed trace id, so an
+     * OTel dashboard can join these app-log lines with the exported spans and
+     * metrics; falls back to the flow instance id when tracing is off.
+     *
+     * @param graphInstance the running graph instance
+     * @return trace id, or flow instance id when the run is untraced
+     */
+    private String correlationLabel(GraphInstance graphInstance) {
+        var traceId = graphInstance.getTraceId();
+        return traceId != null? traceId : graphInstance.getFlowInstanceId();
     }
 }

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
@@ -170,7 +170,7 @@ public class GraphExecutor extends GraphLambdaFunction {
         var stateMachine = graphInstance.stateMachine;
         var node = graphInstance.graph.findNodeByAlias(nodeName);
         checkFrequency(po, graphInstance, nodeName, parentSpanId);
-        if (traversalLog) {
+        if (traversalLog && log.isInfoEnabled()) {
             log.info("Executed {} with skill {} in {} ms - {} ({})", nodeName, node.getProperty(SKILL),
                     response.getExecutionTime(), graphInstance.graphId, correlationLabel(graphInstance));
         }
@@ -249,7 +249,7 @@ public class GraphExecutor extends GraphLambdaFunction {
             var isJoin = GraphJoin.ROUTE.equals(skill);
             var seen = graphInstance.nodeSeen.putIfAbsent(nodeName, true) != null;
             if (isJoin || !seen) {
-                if (traversalLog) {
+                if (traversalLog && log.isInfoEnabled()) {
                     log.info("Walk to {} - {} ({})", nodeName,
                             graphInstance.graphId, correlationLabel(graphInstance));
                 }
@@ -298,7 +298,7 @@ public class GraphExecutor extends GraphLambdaFunction {
         }
         po.send(response.setBody(body));
         graphInstance.complete.set(true);
-        if (traversalLog) {
+        if (traversalLog && log.isInfoEnabled()) {
             var elapsed = System.currentTimeMillis() - graphInstance.getStartTime();
             log.info("Graph traversal completed in {} ms - {} ({})",
                     elapsed, graphInstance.graphId, correlationLabel(graphInstance));
@@ -436,7 +436,7 @@ public class GraphExecutor extends GraphLambdaFunction {
     }
 
     private void logAborted(GraphInstance graphInstance, String reason) {
-        if (traversalLog) {
+        if (traversalLog && log.isInfoEnabled()) {
             log.info("Graph traversal aborted: {} - {} ({})",
                     reason, graphInstance.graphId, correlationLabel(graphInstance));
         }

--- a/system/minigraph-playground-engine/src/main/resources/application.properties
+++ b/system/minigraph-playground-engine/src/main/resources/application.properties
@@ -73,6 +73,15 @@ show.application.properties=rest.server.port, spring.application.name
 #
 location.graph.temp=file:/tmp/graph
 #
+# stepwise traversal logging for deployed graph execution (graph.executor) -
+# the same trail the Playground dry-run prints ("Walk to {node}",
+# "Executed {node} with skill {skill} in {time} ms", "Graph traversal completed
+# in {time} ms"), as INFO log lines labeled with the graph id and the trace id
+# (fallback: flow instance id) so OTel dashboards can join logs with spans.
+# Set to false (e.g. -Dgraph.traversal.log=false) to reduce log noise.
+#
+graph.traversal.log=true
+#
 # set this value to an environment variable in the deployed environment to disable websocket endpoints
 # when the app.env is not 'dev'. e.g. app.env={$ENV_NAME}
 #

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/GraphTraversalLoggingTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/GraphTraversalLoggingTest.java
@@ -1,0 +1,117 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.minigraph.playground;
+
+import com.accenture.minigraph.services.GraphExecutor;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.system.PostOffice;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the stepwise traversal log trail of the production walker
+ * (graph.traversal.log=true, the default): the same vocabulary the dry-run
+ * GraphTraveler prints to the Playground console, suffixed with the graph id
+ * and the run's trace id (fallback: flow instance id when tracing is off) so
+ * OTel dashboards can join app logs with exported spans. The Rust engine
+ * emits the identical lines (telemetry presentation parity).
+ */
+class GraphTraversalLoggingTest {
+    private static final String ASYNC_HTTP_CLIENT = "async.http.request";
+    private static final long TIMEOUT = 8000;
+    private static final CapturingAppender appender = new CapturingAppender();
+    private static String target;
+
+    @BeforeAll
+    static void setup() {
+        AutoStart.main(new String[0]);
+        var config = AppConfigReader.getInstance();
+        var port = config.getProperty("rest.server.port");
+        target = "http://localhost:" + port;
+        appender.start();
+        var context = (LoggerContext) LogManager.getContext(false);
+        context.getLogger(GraphExecutor.class.getName()).addAppender(appender);
+        Configurator.setLevel(GraphExecutor.class.getName(), Level.INFO);
+    }
+
+    @AfterAll
+    static void teardown() {
+        var context = (LoggerContext) LogManager.getContext(false);
+        context.getLogger(GraphExecutor.class.getName()).removeAppender(appender);
+        appender.stop();
+    }
+
+    @Test
+    void traversalTrailIsLoggedWithGraphAndInstanceCorrelation() throws ExecutionException, InterruptedException {
+        var request = new AsyncHttpRequest().setMethod("POST").setTargetHost(target);
+        request.setHeader("Accept", "application/json");
+        request.setHeader("Content-Type", "application/json");
+        request.setUrl("/api/graph/hello").setBody(Map.of("person_id", 100));
+        var po = PostOffice.trackable("unit.test", "3000", "TEST /api/graph/hello traversal logging");
+        var event = new EventEnvelope().setTo(ASYNC_HTTP_CLIENT).setBody(request.toMap());
+        var response = po.request(event, TIMEOUT).get();
+        assertEquals(200, response.getStatus());
+
+        List<String> lines = appender.messages.stream()
+                .filter(line -> line.contains(" - hello (")).toList();
+        // The trail starts at the root node...
+        assertTrue(lines.stream().anyMatch(line -> line.startsWith("Walk to root - hello (")),
+                "expected a 'Walk to root' line, got: " + lines);
+        // ...reports each skill with its execution time (same wording as the dry-run console)...
+        assertTrue(lines.stream().anyMatch(line ->
+                        line.matches("Executed \\S+ with skill \\S+ in \\S+ ms - hello \\(.+\\)")),
+                "expected an 'Executed {node} with skill {skill} in {time} ms' line, got: " + lines);
+        // ...and closes with the total elapsed time.
+        assertTrue(lines.stream().anyMatch(line ->
+                        line.matches("Graph traversal completed in \\d+ ms - hello \\(.+\\)")),
+                "expected a 'Graph traversal completed in {time} ms' line, got: " + lines);
+    }
+
+    private static class CapturingAppender extends AbstractAppender {
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        CapturingAppender() {
+            super("graph-traversal-capture", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent logEvent) {
+            messages.add(logEvent.getMessage().getFormattedMessage());
+        }
+    }
+}


### PR DESCRIPTION
## What

`graph.executor` now logs the same trail the Playground dry-run prints — `Walk to {node}`, `Executed {node} with skill {skill} in {time} ms`, `Graph traversal completed in {time} ms`, and `Graph traversal aborted: {reason}` on error — as INFO lines labeled with the graph id and the run's **trace id** (fallback: flow instance id when tracing is off), so an OTel dashboard joins these app-log lines with exported spans and metrics. With `log.format=json|compact`, app-context-log adds the structured context alongside (it is disabled in text format, where the inline label carries the correlation).

- Gated by `graph.traversal.log` (default `true`); DevOps overrides the runtime parameter (`-Dgraph.traversal.log=false`) to reduce log noise.
- Guards are `traversalLog && log.isInfoEnabled()`, so log-argument expressions never evaluate when the line is not emitted (Sonar S2629).
- `GraphInstance` carries the initiating event's trace id (the executor is a zero-tracing interceptor); skill timing rides the envelope's existing `executionTime` — no new bookkeeping.
- Pinned by `GraphTraversalLoggingTest` (capturing appender over a real `POST /api/graph/hello` run); documented in the configuration reference and both `application.properties`.

## Why

Field enhancement request (2026-09-09): the stepwise dry-run narration is valued during development — this brings the same observability to deployed graph execution. Rust twin ships in lock-step (telemetry presentation parity).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>