### PR TITLE
minigraph: temp graph-model endpoint answers 404 for a missing draft

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -335,8 +335,13 @@ the Playground dry-run prints to its console (`Walk to {node}`, `Executed {node}
 aborted: {reason}` on error), emitted as INFO log lines suffixed with the graph id and the
 run's **trace id** (fallback: the flow instance id when tracing is off) — so an
 OpenTelemetry dashboard can join these app-log lines with the exported spans and metrics.
-On by default; set it to `false` (for example with the runtime override
-`-Dgraph.traversal.log=false`) to reduce log volume on busy installations.
+The inline label complements the platform's app-context-log feature: with
+`log.format=json` or `compact`, each record additionally carries the structured `context`
+key-values (span id, business correlation id); app-context-log is disabled in plain
+`text` format (to reduce log volume), where the inline trace id keeps the correlation
+visible regardless. On by default; set it to `false` (for
+example with the runtime override `-Dgraph.traversal.log=false`) to reduce log volume on
+busy installations.
 
 ---
 

--- a/memory/sessions/2026-09-10-010026.md
+++ b/memory/sessions/2026-09-10-010026.md
@@ -1,0 +1,39 @@
+# Session (2026-09-10T01:00:26.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Temp graph-model endpoint answers 404** (branch `feature/graph-model-endpoint-404`;
+Rust twin on the sibling branch, commit `5a8997fa` there). Eric's bug ruling from
+the PR #341 verification round: `GET /api/graph/model/{graph_id}/{sequence}` gave
+400 for a nonexistent or housekeeping-expired draft — `DescribeGraph` now throws
+`AppException(404, …)` with the unchanged message, matching the deployed-graph
+"compiled or 404" precedent and the session endpoint's existing 404.
+
+**Design steer that shaped the fix (Eric, mid-round): the `{sequence}` is an
+artificial cache-buster he added against browser caching — deliberately NOT
+resource identity.** A link-registry approach (ManagedCache of minted
+`{graph_id}/{sequence}` pairs, sequence-validating 404s) was half-built and
+DROPPED on that hint — the draft file alone decides, and the endpoint now
+documents the sequence's real role. PlaygroundTest pins the new 404 (plus keeps
+the valid-draft 200); the invented-sequence-200 behavior it previously pinned
+was the by-design cache-buster semantics, not a bug.
+
+Also rode along: the app-context-log paragraph for `graph.traversal.log` in the
+configuration reference (missed the #345 commit): json/compact formats add the
+structured context key-values; app-context-log is disabled in text format,
+where the traversal log's inline trace id keeps the correlation visible.
+
+**Next arc agreed (Eric's proposal):** the Playground UI switches its graph
+source to the live session endpoint (`GET /api/graph/session/{id}`) — no
+temp-file round-trip for the UI; `describe graph` stays for the human operator
+(and companion agents) with its snapshot + link unchanged. UI-side this retires
+the pinned-model fetch as primary and generalizes `useSessionGraphRestore` into
+THE loading path; Java webapp first, then the wholesale Rust mirror.
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — REST status/message surface
+  shipped Java + Rust lock-step with byte-matched message)
+- eric-release-rhythm (consulted — branch/commit/push as prep; PRs are Eric's)

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/DescribeGraph.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/rest/DescribeGraph.java
@@ -20,6 +20,7 @@ package com.accenture.minigraph.rest;
 
 import org.platformlambda.core.annotations.OptionalService;
 import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.AsyncHttpRequest;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.serializers.SimpleMapper;
@@ -51,17 +52,22 @@ public class DescribeGraph implements TypedLambdaFunction<AsyncHttpRequest, Obje
     }
 
     @Override
-    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+    public Object handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) throws AppException {
         var filename = input.getPathParameter("graph_id");
         if (filename == null) {
             throw new IllegalArgumentException("Missing path parameter 'graph_id'");
         }
+        // The {sequence} path parameter is deliberately NOT part of the resource
+        // identity: it is an artificial counter minted per describe/export reply
+        // to defeat browser caching of this URL. The draft file alone decides.
         var file = new File(tempDir, filename + ".json");
         if (file.exists()) {
             var text = Utility.getInstance().file2str(file);
             return SimpleMapper.getInstance().getMapper().readValue(text, Map.class);
         } else {
-            throw new IllegalArgumentException(String.format("Draft graph '%s' does not exist", filename));
+            // a nonexistent (or expired) draft answers 404 as if it does not
+            // exist - the deployed-graph "compiled or 404" precedent
+            throw new AppException(404, String.format("Draft graph '%s' does not exist", filename));
         }
     }
 }

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/PlaygroundTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/PlaygroundTest.java
@@ -367,6 +367,15 @@ class PlaygroundTest {
         assertEquals(200, response3.getStatus());
         var text = String.valueOf(response3.getBody());
         log.info("Describe graph endpoint response - {} characters", text.length());
+        // the {sequence} is an artificial cache-buster (not resource identity);
+        // a draft that does not exist answers 404 as if it is not there
+        var request3b = new AsyncHttpRequest();
+        request3b.setTargetHost("http://127.0.0.1:" + port).setUrl("/api/graph/model/{graph_id}/{sequence}");
+        request3b.setHeader("accept", "application/json").setMethod("GET");
+        request3b.setPathParameter("graph_id", "no-such-draft").setPathParameter("sequence", "1");
+        var event3b = new EventEnvelope().setTo("async.http.request").setBody(request3b.toMap());
+        var response3b = po.request(event3b, 8000).get();
+        assertEquals(404, response3b.getStatus());
         var request4 = new AsyncHttpRequest();
         request4.setTargetHost("http://127.0.0.1:" + port).setUrl("/api/graph/session/{id}");
         request4.setHeader("accept", "application/json").setMethod("GET");


### PR DESCRIPTION
## What

`GET /api/graph/model/{graph_id}/{sequence}` returned 400 when the draft does not exist (never described, or expired by housekeeping) — `DescribeGraph` now answers **404** as if it is not there, matching the deployed-graph "compiled or 404" precedent and the session endpoint's existing behavior. The `{sequence}` is documented as what it is: an artificial cache-buster minted per describe/export reply, deliberately not part of the resource identity — the draft file alone decides. `PlaygroundTest` pins the 404. Also carries the app-context-log paragraph for `graph.traversal.log` in the configuration reference (missed the #345 commit).

## Why

Maintainer bug ruling from the PR #341 verification round: a nonexistent resource must answer 404. Rust twin ships in lock-step with a byte-matched message.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>