### PR TITLE
minigraph: traversal log lines become structured records for log analytics

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -330,18 +330,21 @@ path (read/write requirement).
 | `boolean` | `true` |
 
 Stepwise traversal logging for deployed graph execution (`graph.executor`) — the same trail
-the Playground dry-run prints to its console (`Walk to {node}`, `Executed {node} with skill
-{skill} in {time} ms`, `Graph traversal completed in {time} ms`, and `Graph traversal
-aborted: {reason}` on error), emitted as INFO log lines suffixed with the graph id and the
-run's **trace id** (fallback: the flow instance id when tracing is off) — so an
-OpenTelemetry dashboard can join these app-log lines with the exported spans and metrics.
-The inline label complements the platform's app-context-log feature: with
-`log.format=json` or `compact`, each record additionally carries the structured `context`
-key-values (span id, business correlation id); app-context-log is disabled in plain
-`text` format (to reduce log volume), where the inline trace id keeps the correlation
-visible regardless. On by default; set it to `false` (for
-example with the runtime override `-Dgraph.traversal.log=false`) to reduce log volume on
-busy installations.
+the Playground dry-run prints to its console, emitted as INFO **structured records**
+(`log.info("{}", map)`). Each record carries three keys: `text` — the traveler-style
+message (`Walk to {node}`, `Executed {node} with skill {skill} in {time} ms`,
+`Graph traversal completed in {time} ms`, or `Graph traversal aborted: {reason}`),
+`graph` — the graph id, and `id` — the run's **trace id** (fallback: the flow instance id
+when tracing is off), so an OpenTelemetry dashboard can join these app-log lines with the
+exported spans and metrics. With `log.format=json` or `compact` the record renders as a
+nested structure that log-analytics platforms (Dynatrace, Splunk, ...) index as
+key-values; in plain `text` format the map prints as its string form. Note that the
+executor deliberately runs as a `@ZeroTracing` interceptor (the trace is captured once
+from the initiating event, not re-spanned per node), so its worker thread holds no trace
+bracket and the app-context-log `context` block does **not** accompany these lines in any
+format — the record's `id` key is the correlation surface. On by default; set it to
+`false` (for example with the runtime override `-Dgraph.traversal.log=false`) to reduce
+log volume on busy installations.
 
 ---
 

--- a/examples/minigraph-playground/src/main/resources/application.properties
+++ b/examples/minigraph-playground/src/main/resources/application.properties
@@ -77,9 +77,10 @@ location.graph.temp=file:/tmp/graph
 graph.model.automation=classpath:/graphs.yaml
 #
 # stepwise traversal logging for deployed graph execution (graph.executor) -
-# the same trail the Playground dry-run prints, as INFO log lines labeled
-# with the graph id and the trace id (fallback: flow instance id) so OTel
-# dashboards can join logs with spans. Set to false (e.g. -Dgraph.traversal.log=false)
+# the same trail the Playground dry-run prints, as INFO structured records
+# {id, text, graph} where id is the trace id (fallback: flow instance id) so
+# OTel dashboards can join logs with spans; log.format=json/compact render the
+# record as indexable key-values. Set to false (e.g. -Dgraph.traversal.log=false)
 # to reduce log noise.
 #
 graph.traversal.log=true

--- a/memory/sessions/2026-09-10-043039.md
+++ b/memory/sessions/2026-09-10-043039.md
@@ -1,0 +1,44 @@
+# Session (2026-09-10T04:30:39.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Traversal log lines become structured records** (branch
+`feature/graph-traversal-structured-log`; Rust twin on the sibling branch).
+Eric field-tested the #345 stepwise logging and refined: log a MAP —
+`log.info("{}", Map.of("id", label, "text", message, "graph", graphId))` — so
+`JsonLogger.getMapContent` renders it as a nested structure in json/compact
+that log-analytics dashboards (Dynatrace, Splunk) index as key-values; text
+format prints the map's toString (key order immaterial — aggregators reorder
+keys on display, per LogContext's own comment). The four GraphExecutor sites
+now build `traversalRecord(text, graphInstance)`; the traveler vocabulary in
+`text` is unchanged. `GraphTraversalLoggingTest` now captures the map
+PARAMETER from the log event (order-independent, exactly what the json
+appenders receive) instead of the formatted string.
+
+**Eric's app-context-log question ANSWERED: the missing `context` block on
+executor lines IS caused by `@ZeroTracing`.** Evidence:
+`WorkerHandler.executeFunction` calls `registerLogContext` gated on the
+worker's `tracing` flag (WorkerHandler.java:108-110,144-158) — a zero-tracing
+function never starts a trace bracket, so no thread-keyed `LogContext` is
+registered and the json/compact appenders find nothing for the executor's
+thread, in ANY format. This is by design: the executor deliberately runs
+zero-traced (the run's trace is captured ONCE from the initiating event onto
+the GraphInstance rather than re-spanned per node), and the record's `id` key
+is the correlation surface. The configuration-reference paragraph from the
+#346 ride-along claimed json/compact lines "additionally carry the structured
+context key-values" — empirically false for these lines (Eric's field test);
+both engines' references now document the ZeroTracing consequence instead.
+
+Also updated: engine + example application.properties comments. Gates: full
+minigraph-playground-engine module suite green (exit 0), incl. the rewritten
+GraphTraversalLoggingTest; Rust fmt/clippy clean + unit pin
+`traversal_record_carries_id_text_graph` (Increment 114 there).
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — record keys and text values
+  byte-matched across engines; text-mode map rendering follows each engine's
+  native presentation, the existing telemetry-log precedent)
+- eric-release-rhythm (consulted — branches/commits/push prep; PRs are Eric's)

--- a/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
+++ b/system/minigraph-playground-engine/src/main/java/com/accenture/minigraph/services/GraphExecutor.java
@@ -171,8 +171,8 @@ public class GraphExecutor extends GraphLambdaFunction {
         var node = graphInstance.graph.findNodeByAlias(nodeName);
         checkFrequency(po, graphInstance, nodeName, parentSpanId);
         if (traversalLog && log.isInfoEnabled()) {
-            log.info("Executed {} with skill {} in {} ms - {} ({})", nodeName, node.getProperty(SKILL),
-                    response.getExecutionTime(), graphInstance.graphId, correlationLabel(graphInstance));
+            log.info("{}", traversalRecord("Executed " + nodeName + " with skill " + node.getProperty(SKILL) +
+                    " in " + response.getExecutionTime() + " ms", graphInstance));
         }
         // Skill handler can also set status and error in its node properties instead of throwing exception
         var processStatus = stateMachine.getElement(nodeName + "." + STATUS);
@@ -250,8 +250,7 @@ public class GraphExecutor extends GraphLambdaFunction {
             var seen = graphInstance.nodeSeen.putIfAbsent(nodeName, true) != null;
             if (isJoin || !seen) {
                 if (traversalLog && log.isInfoEnabled()) {
-                    log.info("Walk to {} - {} ({})", nodeName,
-                            graphInstance.graphId, correlationLabel(graphInstance));
+                    log.info("{}", traversalRecord("Walk to " + nodeName, graphInstance));
                 }
                 walkTo(po, skill, graphInstance, node, from, parentSpanId);
             }
@@ -300,8 +299,7 @@ public class GraphExecutor extends GraphLambdaFunction {
         graphInstance.complete.set(true);
         if (traversalLog && log.isInfoEnabled()) {
             var elapsed = System.currentTimeMillis() - graphInstance.getStartTime();
-            log.info("Graph traversal completed in {} ms - {} ({})",
-                    elapsed, graphInstance.graphId, correlationLabel(graphInstance));
+            log.info("{}", traversalRecord("Graph traversal completed in " + elapsed + " ms", graphInstance));
         }
     }
 
@@ -437,9 +435,28 @@ public class GraphExecutor extends GraphLambdaFunction {
 
     private void logAborted(GraphInstance graphInstance, String reason) {
         if (traversalLog && log.isInfoEnabled()) {
-            log.info("Graph traversal aborted: {} - {} ({})",
-                    reason, graphInstance.graphId, correlationLabel(graphInstance));
+            log.info("{}", traversalRecord("Graph traversal aborted: " + reason, graphInstance));
         }
+    }
+
+    /**
+     * A traversal log record, logged as a map ({@code log.info("{}", map)}) so the
+     * json and compact formats render it as a nested structure that log-analytics
+     * dashboards (Dynatrace, Splunk, ...) index as key-values; the text format
+     * prints the map's toString. Keys: {@code id} = the correlation label,
+     * {@code text} = the traveler-style message, {@code graph} = the graph id.
+     * <p>
+     * Note: this executor is a {@code @ZeroTracing} interceptor, so its worker
+     * thread carries no trace bracket and the app-log-context {@code context}
+     * block never accompanies these lines in any format - the record's {@code id}
+     * key is the correlation surface.
+     *
+     * @param text the traveler-style message
+     * @param graphInstance the running graph instance
+     * @return the structured record
+     */
+    private Map<String, Object> traversalRecord(String text, GraphInstance graphInstance) {
+        return Map.of("id", correlationLabel(graphInstance), "text", text, "graph", graphInstance.graphId);
     }
 
     /**

--- a/system/minigraph-playground-engine/src/main/resources/application.properties
+++ b/system/minigraph-playground-engine/src/main/resources/application.properties
@@ -76,8 +76,9 @@ location.graph.temp=file:/tmp/graph
 # stepwise traversal logging for deployed graph execution (graph.executor) -
 # the same trail the Playground dry-run prints ("Walk to {node}",
 # "Executed {node} with skill {skill} in {time} ms", "Graph traversal completed
-# in {time} ms"), as INFO log lines labeled with the graph id and the trace id
-# (fallback: flow instance id) so OTel dashboards can join logs with spans.
+# in {time} ms"), as INFO structured records {id, text, graph} where id is the
+# trace id (fallback: flow instance id) so OTel dashboards can join logs with
+# spans; log.format=json/compact render the record as indexable key-values.
 # Set to false (e.g. -Dgraph.traversal.log=false) to reduce log noise.
 #
 graph.traversal.log=true

--- a/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/GraphTraversalLoggingTest.java
+++ b/system/minigraph-playground-engine/src/test/java/com/accenture/minigraph/playground/GraphTraversalLoggingTest.java
@@ -45,11 +45,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pins the stepwise traversal log trail of the production walker
- * (graph.traversal.log=true, the default): the same vocabulary the dry-run
- * GraphTraveler prints to the Playground console, suffixed with the graph id
- * and the run's trace id (fallback: flow instance id when tracing is off) so
- * OTel dashboards can join app logs with exported spans. The Rust engine
- * emits the identical lines (telemetry presentation parity).
+ * (graph.traversal.log=true, the default): each step is logged as a structured
+ * record - log.info("{}", map) - so the json and compact formats render it as
+ * a nested structure that log-analytics dashboards index as key-values. Keys:
+ * "text" carries the same vocabulary the dry-run GraphTraveler prints to the
+ * Playground console, "graph" the graph id, and "id" the run's trace id
+ * (fallback: flow instance id when tracing is off) so OTel dashboards can join
+ * app logs with exported spans. The Rust engine emits the identical record
+ * (telemetry presentation parity).
  */
 class GraphTraversalLoggingTest {
     private static final String ASYNC_HTTP_CLIENT = "async.http.request";
@@ -87,23 +90,27 @@ class GraphTraversalLoggingTest {
         var response = po.request(event, TIMEOUT).get();
         assertEquals(200, response.getStatus());
 
-        List<String> lines = appender.messages.stream()
-                .filter(line -> line.contains(" - hello (")).toList();
+        List<Map<?, ?>> records = appender.records.stream()
+                .filter(record -> "hello".equals(record.get("graph"))).toList();
+        // Every record carries the correlation label (trace id, or flow instance id).
+        assertTrue(records.stream().allMatch(record ->
+                        record.get("id") instanceof String id && !id.isBlank()),
+                "expected every record to carry a non-blank 'id', got: " + records);
         // The trail starts at the root node...
-        assertTrue(lines.stream().anyMatch(line -> line.startsWith("Walk to root - hello (")),
-                "expected a 'Walk to root' line, got: " + lines);
+        assertTrue(records.stream().anyMatch(record -> "Walk to root".equals(record.get("text"))),
+                "expected a 'Walk to root' record, got: " + records);
         // ...reports each skill with its execution time (same wording as the dry-run console)...
-        assertTrue(lines.stream().anyMatch(line ->
-                        line.matches("Executed \\S+ with skill \\S+ in \\S+ ms - hello \\(.+\\)")),
-                "expected an 'Executed {node} with skill {skill} in {time} ms' line, got: " + lines);
+        assertTrue(records.stream().anyMatch(record -> record.get("text") instanceof String text &&
+                        text.matches("Executed \\S+ with skill \\S+ in \\S+ ms")),
+                "expected an 'Executed {node} with skill {skill} in {time} ms' record, got: " + records);
         // ...and closes with the total elapsed time.
-        assertTrue(lines.stream().anyMatch(line ->
-                        line.matches("Graph traversal completed in \\d+ ms - hello \\(.+\\)")),
-                "expected a 'Graph traversal completed in {time} ms' line, got: " + lines);
+        assertTrue(records.stream().anyMatch(record -> record.get("text") instanceof String text &&
+                        text.matches("Graph traversal completed in \\d+ ms")),
+                "expected a 'Graph traversal completed in {time} ms' record, got: " + records);
     }
 
     private static class CapturingAppender extends AbstractAppender {
-        private final List<String> messages = new CopyOnWriteArrayList<>();
+        private final List<Map<?, ?>> records = new CopyOnWriteArrayList<>();
 
         CapturingAppender() {
             super("graph-traversal-capture", null, null, true, Property.EMPTY_ARRAY);
@@ -111,7 +118,12 @@ class GraphTraversalLoggingTest {
 
         @Override
         public void append(LogEvent logEvent) {
-            messages.add(logEvent.getMessage().getFormattedMessage());
+            // the traversal log's contract is log.info("{}", map) - capture the map itself,
+            // exactly what the json/compact appenders receive as the nested message
+            var parameters = logEvent.getMessage().getParameters();
+            if (parameters != null && parameters.length > 0 && parameters[0] instanceof Map<?, ?> map) {
+                records.add(map);
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Each `graph.traversal.log` step now logs a structured record — `log.info("{}", Map.of("id", traceId, "text", message, "graph", graphId))` — instead of a single line with inline suffixes. With `log.format=json` or `compact` the record renders as a nested structure that log-analytics dashboards (Dynatrace, Splunk) index as key-values; text format prints the map's string form. The traveler vocabulary in `text` is unchanged. `GraphTraversalLoggingTest` now pins the map structure itself. Also corrects the configuration reference: the executor is a `@ZeroTracing` interceptor, so its worker thread holds no trace bracket and the app-log-context `context` block does not accompany these lines in any format — the record's `id` key is the correlation surface (the previous paragraph claimed otherwise).

## Why

Maintainer refinement after field-testing the #345 stepwise logging: inline suffixes are opaque to log aggregation, while a map is indexed as key-values for analysis. The context-block absence was field-observed in the same round and root-caused to the deliberate `@ZeroTracing` design (`WorkerHandler.registerLogContext` is gated on the worker's tracing flag). Rust twin ships in lock-step with identical record keys.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>