### PR TITLE
event-script: f:camelCase and f:snakeCase key-normalization plugins

### DIFF
--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1564,6 +1564,8 @@ For example:
 | **Type Conversion** | listOfMap       | Convert "a map of lists" to "a list of maps" — **order-preserving**: list order follows array index order (guaranteed) |
 | **Type Conversion** | updateListOfMap | Update "a list of maps" with "maps of lists"                                                                          |
 | **Type Conversion** | removeKey       | Remove one or more keys from a map or "list of maps". Syntax: `f:removeKey(source, text(key1), text(key2), …)` — see the worked example below. |
+| **Key Normalization** | camelCase     | Normalize every key of a map (recursively, incl. maps inside lists) to camelCase. See the worked example below. |
+| **Key Normalization** | snakeCase     | Normalize every key of a map (recursively, incl. maps inside lists) to snake_case. See the worked example below. |
 | **Type Conversion** | defaultValue    | If the first argument is null, return the 2nd argument                                                                |
 | **Type Conversion** | parseDate       | Parse a date string to ISO, Local or Milliseconds.                                                                    |
 | **Type Conversion** | parseDateTime   | Parse a date-time string to ISO, Local or Milliseconds.                                                               |
@@ -1806,6 +1808,29 @@ for external consumption:
 
 For details, please refer to configuration example in header-and-json-path-test.yml and the unit test 
 `headerAndJsonPathTest()` in the FlowTests class of the event-script-engine module.
+
+*camelCase and snakeCase*
+
+Legacy systems — often XML-to-JSON transformations — deliver key formats that vary per source:
+`MyExampleKey`, `My_Example_key` and `my_example_Key` are the same logical key. The
+`camelCase(mapOrList)` and `snakeCase(mapOrList)` plugins segmentize each key and re-case the
+segments: underscore, hyphen and dot are separators; a lower-case-or-digit to upper-case
+transition starts a new segment; and an upper-case run followed by a lower-case letter splits
+before its last upper-case letter (the acronym rule — `myXMLKey` becomes `myXmlKey` /
+`my_xml_key`). Digits ride with their segment (`address1Line`). Values are never touched —
+only keys, at every nesting depth (including maps inside lists). Two distinct source keys can
+normalize to the same target (`MyKey` and `my_key` both become `myKey`); the later entry in
+map order wins. Normalization is idempotent, and a key with no letter or digit segments at
+all (e.g. `"___"`) is kept as-is. Both engines ship the identical algorithm and error
+messages (portable-flow contract).
+
+```yaml
+# converge a legacy payload's mixed key formats before mapping it onward
+- 'f:camelCase(input.body) -> model.normalized'
+
+# a list of maps normalizes element by element
+- 'f:snakeCase(input.body.list) -> output.body.records'
+```
 
 ### Writing your own custom Simple Plugins
 

--- a/docs/guides/event-script/syntax.md
+++ b/docs/guides/event-script/syntax.md
@@ -1824,12 +1824,20 @@ map order wins. Normalization is idempotent, and a key with no letter or digit s
 all (e.g. `"___"`) is kept as-is. Both engines ship the identical algorithm and error
 messages (portable-flow contract).
 
+Beyond legacy cleanup, the plugins also do **impedance matching** between systems with
+different key conventions: an incoming camelCase request payload can be transformed to
+snake_case for processing and forwarding to a downstream system that expects it — one
+mapping statement at either boundary, no per-field mapping.
+
 ```yaml
 # converge a legacy payload's mixed key formats before mapping it onward
 - 'f:camelCase(input.body) -> model.normalized'
 
 # a list of maps normalizes element by element
 - 'f:snakeCase(input.body.list) -> output.body.records'
+
+# impedance matching: a camelCase request payload forwarded to a snake_case system
+- 'f:snakeCase(input.body) -> model.downstream_request'
 ```
 
 ### Writing your own custom Simple Plugins

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -1020,6 +1020,25 @@ argument.
 | `f:updateListOfMap(list, extra)` | Merge additional fields into each map in the list | `f:updateListOfMap(model.rows, model.extra) -> augmented` |
 | `f:removeKey(map, key)` | Remove a key from a map or each map in a list | `f:removeKey(model.obj, text(secret)) -> clean` |
 
+### Key normalization
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `f:camelCase(mapOrList)` | Normalize every key of a map (recursively, incl. maps inside lists) to camelCase | `f:camelCase(input.body) -> normalized` |
+| `f:snakeCase(mapOrList)` | Normalize every key of a map (recursively, incl. maps inside lists) to snake_case | `f:snakeCase(input.body.list) -> normalized` |
+
+Legacy systems — often XML-to-JSON transformations — deliver key formats that vary per
+source: `MyExampleKey`, `My_Example_key` and `my_example_Key` are the same logical key.
+Both plugins segmentize each key and re-case the segments: underscore, hyphen and dot are
+separators; a lower-case-or-digit to upper-case transition starts a new segment; and an
+upper-case run followed by a lower-case letter splits before its last upper-case letter
+(the acronym rule — `myXMLKey` becomes `myXmlKey` / `my_xml_key`). Digits ride with their
+segment (`address1Line`). Values are never touched — only keys, at every nesting depth.
+Two distinct source keys can normalize to the same target (`MyKey` and `my_key` both
+become `myKey`); the later entry in map order wins. Normalization is idempotent, and a
+key with no letter or digit segments at all (e.g. `"___"`) is kept as-is. Both engines
+ship the identical algorithm and error messages (portable-flow contract).
+
 ### Generators
 
 | Function | Description | Example |

--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -1039,6 +1039,11 @@ become `myKey`); the later entry in map order wins. Normalization is idempotent,
 key with no letter or digit segments at all (e.g. `"___"`) is kept as-is. Both engines
 ship the identical algorithm and error messages (portable-flow contract).
 
+Beyond legacy cleanup, the plugins also do **impedance matching** between systems with
+different key conventions: an incoming camelCase request payload can be transformed to
+snake_case for processing and forwarding to a downstream system that expects it — one
+mapping statement at either boundary, no per-field mapping.
+
 ### Generators
 
 | Function | Description | Example |

--- a/memory/sessions/2026-09-10-052011.md
+++ b/memory/sessions/2026-09-10-052011.md
@@ -35,6 +35,11 @@ event-script/syntax.md table rows and worked section (mirrored to Rust).
 Gates: full event-script-engine module suite green (exit 0); Rust
 fmt/clippy/lib/flow_runtime green (Increment 115 there).
 
+Follow-up doc round (Eric, same day): the plugins are not only legacy-cleanup
+— they do **impedance matching** between key conventions (e.g. a camelCase
+request payload transformed to snake_case for processing and forwarding).
+Recorded in all three guide sections with a worked example.
+
 ## Memory References
 
 - conv-telemetry-presentation-parity (consulted — new built-in simple plugins

--- a/memory/sessions/2026-09-10-052011.md
+++ b/memory/sessions/2026-09-10-052011.md
@@ -1,0 +1,43 @@
+# Session (2026-09-10T05:20:11.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Key-normalization simple plugins: f:camelCase / f:snakeCase** (branch
+`feature/key-normalization-plugins`; Rust twin on the sibling branch). Eric's
+field proposal — legacy XML-to-JSON systems deliver mixed key formats
+(MyExampleKey, My_Example_key, my_example_Key) — reviewed for viability first:
+the PluginFunction SPI already passes whole Maps/Lists (getFirst precedent),
+so no mapping-engine change was needed. Ratified refinements: the acronym rule
+(an upper-case run followed by a lower-case letter splits before its last
+upper: myXMLKey → myXmlKey / my_xml_key) and hyphen + dot as separators
+alongside underscore.
+
+Implementation: `KeyNormalizationUtils` (segments/toCamelCase/toSnakeCase +
+recursive normalize; Locale.ROOT lowercasing for the Sonar locale rule) +
+`CamelCaseNormalization`/`SnakeCaseNormalization` under plugins/types.
+Semantics: recursion through nested maps and lists (values untouched);
+collisions last-wins (LinkedHashMap); idempotent; keys with no segments kept
+as-is; top-level non-Map/List rejected with plugin-named messages, byte-
+matched in Rust. **Loader note verified:** the SimplePluginLoader's bytecode
+gate reads signatures only (ClassReader.SKIP_CODE), so helper calls in method
+bodies (KeyNormalizationUtils, like the existing TypeConversionUtils) are
+invisible to ALLOWED_PACKAGES — proven empirically by the end-to-end flow
+test compiling and executing the f: names through the real loader.
+
+Pins: `KeyNormalizationTest` (10 unit cases incl. Eric's three variants,
+acronyms, separators, digits, recursion, collision, idempotency, errors) +
+the pluggableFunctions/types.yml fixture extended (shared byte-identical with
+the Rust engine) with `checkKeyNormalizationAssertion` in FlowTests. Docs:
+flow-schema-reference.md "Key normalization" section +
+event-script/syntax.md table rows and worked section (mirrored to Rust).
+Gates: full event-script-engine module suite green (exit 0); Rust
+fmt/clippy/lib/flow_runtime green (Increment 115 there).
+
+## Memory References
+
+- conv-telemetry-presentation-parity (consulted — new built-in simple plugins
+  ship lock-step on both engines with matching messages, or flows stop being
+  portable; the shared fixture is the instrument)
+- eric-release-rhythm (consulted — branches/commits/push prep; PRs are Eric's)

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/CamelCaseNormalization.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/CamelCaseNormalization.java
@@ -1,0 +1,43 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+import com.accenture.util.KeyNormalizationUtils;
+
+/**
+ * f:camelCase(mapOrList) - normalize every key of a map (recursively, including maps
+ * inside lists) to camelCase. For legacy payloads whose key formats vary per source
+ * (MyExampleKey, My_Example_key, my_example_Key all become myExampleKey). Values are
+ * never touched. Algorithm and edge cases: {@link KeyNormalizationUtils}.
+ */
+@SimplePlugin
+public class CamelCaseNormalization implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "camelCase";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        return KeyNormalizationUtils.normalize(input, getName(), KeyNormalizationUtils::toCamelCase);
+    }
+}

--- a/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/SnakeCaseNormalization.java
+++ b/system/event-script-engine/src/main/java/com/accenture/services/plugins/types/SnakeCaseNormalization.java
@@ -1,0 +1,43 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+import com.accenture.util.KeyNormalizationUtils;
+
+/**
+ * f:snakeCase(mapOrList) - normalize every key of a map (recursively, including maps
+ * inside lists) to snake_case. For legacy payloads whose key formats vary per source
+ * (MyExampleKey, My_Example_key, my_example_Key all become my_example_key). Values are
+ * never touched. Algorithm and edge cases: {@link KeyNormalizationUtils}.
+ */
+@SimplePlugin
+public class SnakeCaseNormalization implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "snakeCase";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        return KeyNormalizationUtils.normalize(input, getName(), KeyNormalizationUtils::toSnakeCase);
+    }
+}

--- a/system/event-script-engine/src/main/java/com/accenture/util/KeyNormalizationUtils.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/KeyNormalizationUtils.java
@@ -1,0 +1,159 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Key normalization for the f:camelCase and f:snakeCase simple plugins.
+ * <p>
+ * Legacy systems (often XML-to-JSON transformations) deliver maps whose key formats vary
+ * per source - MyExampleKey, My_Example_key, my_example_Key. Both plugins segmentize each
+ * key and re-case the segments, recursively through nested maps and lists (values are
+ * never touched; only keys).
+ * <p>
+ * Segmentation: underscore, hyphen and dot are separators; a lower-case-or-digit to
+ * upper-case transition starts a new segment; an upper-case run followed by a lower-case
+ * letter splits before its last upper-case letter (the acronym rule: XMLKey becomes
+ * XML + Key, so myXMLKey normalizes to myXmlKey / my_xml_key). Digits ride with their
+ * segment (address1Line stays address1 + Line). Empty segments are dropped; a key with
+ * no segments at all (e.g. "___") is kept as-is.
+ * <p>
+ * Two distinct source keys can normalize to the same target (MyKey and my_key both
+ * become myKey) - the later entry in map order wins, deterministically, at the first
+ * key's position. Normalization is idempotent. The Rust engine ships the identical
+ * algorithm and error messages (portable-flow contract).
+ */
+public class KeyNormalizationUtils {
+
+    private KeyNormalizationUtils() {}
+
+    /**
+     * Validate the plugin argument and normalize all keys recursively.
+     *
+     * @param input the plugin's argument list - exactly one Map or List
+     * @param plugin the plugin name (camelCase or snakeCase), for error messages
+     * @param keyMapper the per-key normalizer
+     * @return a new Map or List with normalized keys at every depth
+     */
+    public static Object normalize(Object[] input, String plugin, UnaryOperator<String> keyMapper) {
+        if (input == null || input.length != 1) {
+            throw new IllegalArgumentException("One input is required for " + plugin + " key normalization");
+        }
+        var value = input[0];
+        if (value == null) {
+            throw new IllegalArgumentException("Input cannot be null for " + plugin + " key normalization");
+        }
+        if (!(value instanceof Map) && !(value instanceof List)) {
+            throw new IllegalArgumentException("Input must be a map or a list for " + plugin + " key normalization");
+        }
+        return normalizeKeys(value, keyMapper);
+    }
+
+    private static Object normalizeKeys(Object value, UnaryOperator<String> keyMapper) {
+        if (value instanceof Map<?, ?> map) {
+            var normalized = new LinkedHashMap<String, Object>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                normalized.put(keyMapper.apply(String.valueOf(entry.getKey())),
+                        normalizeKeys(entry.getValue(), keyMapper));
+            }
+            return normalized;
+        }
+        if (value instanceof List<?> list) {
+            var normalized = new ArrayList<Object>(list.size());
+            for (Object item : list) {
+                normalized.add(normalizeKeys(item, keyMapper));
+            }
+            return normalized;
+        }
+        return value;
+    }
+
+    /**
+     * Normalize one key to camelCase.
+     *
+     * @param key the source key in any format
+     * @return the camelCase form, or the key unchanged when it has no segments
+     */
+    public static String toCamelCase(String key) {
+        var segments = segments(key);
+        if (segments.isEmpty()) {
+            return key;
+        }
+        var sb = new StringBuilder(segments.getFirst().toLowerCase(Locale.ROOT));
+        for (int i = 1; i < segments.size(); i++) {
+            var segment = segments.get(i).toLowerCase(Locale.ROOT);
+            sb.append(Character.toUpperCase(segment.charAt(0))).append(segment, 1, segment.length());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Normalize one key to snake_case.
+     *
+     * @param key the source key in any format
+     * @return the snake_case form, or the key unchanged when it has no segments
+     */
+    public static String toSnakeCase(String key) {
+        var segments = segments(key);
+        if (segments.isEmpty()) {
+            return key;
+        }
+        return String.join("_", segments.stream().map(s -> s.toLowerCase(Locale.ROOT)).toList());
+    }
+
+    private static List<String> segments(String key) {
+        var segments = new ArrayList<String>();
+        var current = new StringBuilder();
+        for (int i = 0; i < key.length(); i++) {
+            char c = key.charAt(i);
+            if (c == '_' || c == '-' || c == '.') {
+                flush(segments, current);
+                continue;
+            }
+            if (!current.isEmpty()) {
+                char previous = current.charAt(current.length() - 1);
+                boolean lowerToUpper = (Character.isLowerCase(previous) || Character.isDigit(previous))
+                        && Character.isUpperCase(c);
+                // an upper-case run followed by a lower-case letter belongs to the next
+                // segment from its last upper-case letter (XMLKey -> XML + Key)
+                boolean acronymEnd = Character.isUpperCase(previous) && Character.isUpperCase(c)
+                        && i + 1 < key.length() && Character.isLowerCase(key.charAt(i + 1));
+                if (lowerToUpper || acronymEnd) {
+                    flush(segments, current);
+                }
+            }
+            current.append(c);
+        }
+        flush(segments, current);
+        return segments;
+    }
+
+    private static void flush(List<String> segments, StringBuilder current) {
+        if (!current.isEmpty()) {
+            segments.add(current.toString());
+            current.setLength(0);
+        }
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
+++ b/system/event-script-engine/src/test/java/com/accenture/flows/FlowTests.java
@@ -2008,6 +2008,17 @@ class FlowTests extends TestBase {
         // break into another function to satisfy SonarQube requirement
         checkTypeAssertion(result);
         checkJsonPluginAssertion(result);
+        checkKeyNormalizationAssertion(result);
+    }
+
+    private void checkKeyNormalizationAssertion(Map<String, Object> result) {
+        // f:camelCase / f:snakeCase converge legacy key variants; keys normalize
+        // recursively (incl. maps inside lists) and values are never touched
+        assertEquals(Map.of("myExampleKey", "1", "customerId", "2"), result.get("camel_map"));
+        assertEquals(Map.of("my_example_key", "1", "customer_id", "2"), result.get("snake_map"));
+        assertEquals(Map.of("myExampleKey", 3,
+                "nestedList", List.of(Map.of("itemName", "Some_Value"))), result.get("camel_dotted"));
+        assertEquals(List.of(Map.of("item_name", "Some_Value")), result.get("snake_list"));
     }
 
     @SuppressWarnings("unchecked")

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/KeyNormalizationTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/types/KeyNormalizationTest.java
@@ -1,0 +1,121 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * f:camelCase / f:snakeCase - legacy systems (often XML-to-JSON transformations)
+ * deliver maps whose key formats vary per source; both plugins converge them.
+ * Segmentation: underscore/hyphen/dot separators, lower-or-digit to upper
+ * transitions, and the acronym rule (an upper-case run followed by a lower-case
+ * letter splits before its last upper: XMLKey -> XML + Key). The Rust engine
+ * pins the identical algorithm and error messages (portable-flow contract).
+ */
+class KeyNormalizationTest {
+
+    private final CamelCaseNormalization camel = new CamelCaseNormalization();
+    private final SnakeCaseNormalization snake = new SnakeCaseNormalization();
+
+    @Test
+    void legacyVariantsConvergeToOneKey() {
+        // the field's observed variance - all three forms are the same logical key
+        for (String variant : List.of("MyExampleKey", "My_Example_key", "my_example_Key")) {
+            assertEquals(Map.of("myExampleKey", 1), camel.calculate(Map.of(variant, 1)));
+            assertEquals(Map.of("my_example_key", 1), snake.calculate(Map.of(variant, 1)));
+        }
+    }
+
+    @Test
+    void acronymRunSplitsBeforeItsLastUpperCaseLetter() {
+        assertEquals(Map.of("myXmlKey", 1), camel.calculate(Map.of("myXMLKey", 1)));
+        assertEquals(Map.of("my_xml_key", 1), snake.calculate(Map.of("myXMLKey", 1)));
+        assertEquals(Map.of("xmlHttpRequest", 1), camel.calculate(Map.of("XMLHttpRequest", 1)));
+        assertEquals(Map.of("customer_id", 1), snake.calculate(Map.of("customerID", 1)));
+    }
+
+    @Test
+    void hyphenAndDotAreSeparators() {
+        assertEquals(Map.of("myExampleKey", 1), camel.calculate(Map.of("my-example.key", 1)));
+        assertEquals(Map.of("my_example_key", 1), snake.calculate(Map.of("My-Example.Key", 1)));
+    }
+
+    @Test
+    void digitsRideWithTheirSegment() {
+        assertEquals(Map.of("address1Line", 1), camel.calculate(Map.of("address1Line", 1)));
+        assertEquals(Map.of("address1_line", 1), snake.calculate(Map.of("Address1_Line", 1)));
+        assertEquals(Map.of("key2Value", 1), camel.calculate(Map.of("key2_value", 1)));
+    }
+
+    @Test
+    void normalizationRecursesThroughNestedMapsAndLists() {
+        Map<String, Object> payload = Map.of("Outer_Key",
+                Map.of("Inner_List", List.of(Map.of("Item_Name", "Some_Value"), "scalar")));
+        Object normalized = camel.calculate(payload);
+        // values are never touched - only keys; scalars inside lists pass through
+        assertEquals(Map.of("outerKey",
+                Map.of("innerList", List.of(Map.of("itemName", "Some_Value"), "scalar"))), normalized);
+    }
+
+    @Test
+    void topLevelListOfMapsIsNormalized() {
+        Object normalized = snake.calculate(List.of(Map.of("MyKey", 1), Map.of("OtherKey", 2)));
+        assertEquals(List.of(Map.of("my_key", 1), Map.of("other_key", 2)), normalized);
+    }
+
+    @Test
+    void collidingKeysResolveToTheLaterEntry() {
+        var payload = new LinkedHashMap<String, Object>();
+        payload.put("MyKey", 1);
+        payload.put("my_key", 2);
+        assertEquals(Map.of("myKey", 2), camel.calculate(payload));
+    }
+
+    @Test
+    void normalizationIsIdempotent() {
+        Map<String, Object> messy = Map.of("My_Example_Key", Map.of("customerID", 1));
+        Object once = camel.calculate(messy);
+        assertEquals(once, camel.calculate(once));
+        Object snakeOnce = snake.calculate(messy);
+        assertEquals(snakeOnce, snake.calculate(snakeOnce));
+    }
+
+    @Test
+    void keyWithoutSegmentsIsKeptAsIs() {
+        assertEquals(Map.of("___", 1), camel.calculate(Map.of("___", 1)));
+        assertEquals(Map.of("-.-", 1), snake.calculate(Map.of("-.-", 1)));
+    }
+
+    @Test
+    void invalidInputIsRejectedWithThePluginName() {
+        var noInput = assertThrows(IllegalArgumentException.class, () -> camel.calculate());
+        assertEquals("One input is required for camelCase key normalization", noInput.getMessage());
+        var nullInput = assertThrows(IllegalArgumentException.class, () -> snake.calculate((Object) null));
+        assertEquals("Input cannot be null for snakeCase key normalization", nullInput.getMessage());
+        var scalar = assertThrows(IllegalArgumentException.class, () -> camel.calculate("MyKey"));
+        assertEquals("Input must be a map or a list for camelCase key normalization", scalar.getMessage());
+    }
+}

--- a/system/event-script-engine/src/test/resources/flows/pluggableFunctions/types.yml
+++ b/system/event-script-engine/src/test/resources/flows/pluggableFunctions/types.yml
@@ -83,6 +83,13 @@ tasks:
       - 'f:json(text({"hello": [1, 2, {"nested": "demo"}]})) -> nested_json'
       - 'text([10, 20, 30]) -> model.json_text'
       - 'f:json(model.json_text) -> parsed_from_model'
+      - 'text(1) -> model.legacy.My_Example_key'
+      - 'text(2) -> model.legacy.customerID'
+      - 'f:json(text({"my-example.key": 3, "Nested_List": [{"Item_Name": "Some_Value"}]})) -> model.dotted'
+      - 'f:camelCase(model.legacy) -> camel_map'
+      - 'f:snakeCase(model.legacy) -> snake_map'
+      - 'f:camelCase(model.dotted) -> camel_dotted'
+      - 'f:snakeCase(model.dotted.Nested_List) -> snake_list'
     process: 'no.op'
     output:
       - 'text(application/json) -> output.header.content-type'


### PR DESCRIPTION
## What

Two new built-in simple plugins converge legacy JSON key formats: `f:camelCase(mapOrList)` and `f:snakeCase(mapOrList)` segmentize each key (underscore/hyphen/dot separators; a lower-case-or-digit to upper-case transition; the acronym rule — an upper-case run followed by a lower-case letter splits before its last upper, so `myXMLKey` becomes `myXmlKey` / `my_xml_key`) and re-case recursively through nested maps and lists. Values are never touched; colliding normalized keys resolve to the later entry; normalization is idempotent; a key with no segments is kept as-is. Pinned by `KeyNormalizationTest` (10 cases) and the extended `pluggableFunctions/types.yml` flow fixture, which proves loader acceptance and end-to-end mapping through the engine. Docs: `flow-schema-reference` catalog + `event-script/syntax.md` worked section.

## Why

Field proposal (2026-09-10): legacy applications — typically XML-to-JSON transformations — deliver the same logical key as `MyExampleKey`, `My_Example_key`, or `my_example_Key`, forcing per-source mapping workarounds. One normalization step at the flow boundary restores a standard key convention. Rust twin ships in lock-step with the identical algorithm, error messages, and the shared fixture.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>