### PR TITLE
docs: agent-memory attribution locators — official Mercury-family home

### DIFF
--- a/docs/mercury-story.md
+++ b/docs/mercury-story.md
@@ -781,6 +781,9 @@ And the working posture follows from it:
     <https://arxiv.org/abs/2211.09110>
 19. C. E. Jimenez et al., *SWE-bench: Can Language Models Resolve Real-World GitHub Issues?*,
     ICLR 2024. <https://arxiv.org/abs/2310.06770>
+20. E. Law, *agent-memory: A Lightweight, Vendor-Neutral Memory + Cognitive-Loop System for
+    Predictable AI–Human Delivery*, whitepaper v1.7, September 2026.
+    <https://accenture.github.io/mercury-go/agent-memory-whitepaper/>
 
 ---
 
@@ -794,5 +797,6 @@ reproducible from the cited artifacts.*
 
 *Mercury Composable is an official Accenture open-source project (github.com/Accenture/mercury-composable),
 with an official Rust port. agent-memory is a lightweight, vendor-neutral shared-memory and
-cognitive-loop tool for human-AI collaboration; it installs and maintains this repository's
-shared `memory/` layer.*
+cognitive-loop tool for human-AI collaboration and part of the Mercury family
+(github.com/Accenture/mercury-go); it installs and maintains this repository's shared `memory/`
+layer.*

--- a/memory/open-threads/thread-ot-agent-memory-attribution-locators.md
+++ b/memory/open-threads/thread-ot-agent-memory-attribution-locators.md
@@ -1,10 +1,7 @@
-- [ ] (docs) **Add the agent-memory locators to the white paper once agent-memory is promoted
-  to official Accenture open source** — the deferred half of the agent-memory-maintainer
-  review (`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`):
-  F3 option A (append the official repository URL to the closing note's agent-memory
-  sentence) and F4 (References entry #20 for the agent-memory whitepaper, at the official
-  URL). Apply to BOTH engines' `docs/mercury-story.md` in lock-step. The now-phase
-  (F1/F2/F3-B/F5 — naming and describing the tool, no links) shipped 2026-09-05 on Eric's
-  ruling: no direct URLs to personal-GitHub research inside an official Accenture
-  publication until the promotion lands. Trigger: Eric announces the promotion.
+- [x] **(docs) agent-memory locators — DONE 2026-09-10.** agent-memory joined the Mercury family
+  (official home `github.com/Accenture/mercury-go`); F3 option A (closing note: "part of the
+  Mercury family (github.com/Accenture/mercury-go)") and F4 (References #20 → the agent-memory
+  whitepaper v1.7 at accenture.github.io/mercury-go) landed in both engines' `docs/mercury-story.md`
+  via `docs/agent-memory-official-locators` PRs. Lesson: deferring the locators until the official
+  URL existed cost nothing and avoided a rewrite. origin: 2026-09-10-164247
   <!-- id: ot-agent-memory-attribution-locators | created: 2026-09-05 | last_used: 2026-09-06 | uses: 2 | tier: working | origin: 2026-09-05-174738 -->

--- a/memory/sessions/2026-09-10-164247.md
+++ b/memory/sessions/2026-09-10-164247.md
@@ -1,0 +1,22 @@
+# Session (2026-09-10T16:42:47.188Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**agent-memory attribution — locators phase (F3 option A + F4).** The trigger fired: Eric
+promoted agent-memory into the Mercury family today (official home
+`github.com/Accenture/mercury-go`, docs `accenture.github.io/mercury-go`, Copyright 2026
+Accenture, Apache-2.0). Per the deferred half of the maintainer review
+(`draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`),
+`docs/mercury-story.md` now: the closing note's agent-memory sentence reads "…and part of the
+Mercury family (github.com/Accenture/mercury-go)"; References gains #20 — the agent-memory
+whitepaper v1.7 at the official site. The Rust twin was updated in lock-step (same branch
+name). Branch `docs/agent-memory-official-locators` cut from `main`; PR per the org policy.
+No other content changed.
+
+Thread `ot-agent-memory-attribution-locators` closed (close record in its file).
+
+## Memory References
+
+- ot-agent-memory-attribution-locators (closed)


### PR DESCRIPTION
## What

`docs/mercury-story.md`: the closing note's agent-memory sentence now reads "…and part of the Mercury family (github.com/Accenture/mercury-go)", and References gains #20 — the agent-memory whitepaper v1.7 at https://accenture.github.io/mercury-go/agent-memory-whitepaper/. Session log added; the `ot-agent-memory-attribution-locators` thread is closed with its record. Rust twin: the same-named branch on Accenture/mercury.

## Why

The deferred half of the agent-memory attribution review (F3 option A + F4 in `draft-design-specs/review-ai-grammar-methodology-agent-memory-attribution.md`) was gated on agent-memory becoming official Accenture open source. That happened today — agent-memory joined the Mercury family at github.com/Accenture/mercury-go — so the paper can now cite it at its official URL. No other content changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
