### PR TITLE
release: version 4.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.12.6, 9/10/2026
+
+### Added
+
+1. `f:camelCase` and `f:snakeCase` key-normalization simple plugins: legacy systems —
+   often XML-to-JSON transformations — deliver the same logical key as `MyExampleKey`,
+   `My_Example_key`, or `my_example_Key`. The plugins segmentize each key (underscore,
+   hyphen and dot separators; case transitions with the acronym rule — `myXMLKey`
+   becomes `myXmlKey` / `my_xml_key`) and re-case recursively through nested maps and
+   lists; values are never touched, and normalization is idempotent. Beyond legacy
+   cleanup they do impedance matching between key conventions (e.g. a camelCase request
+   payload transformed to snake_case for a downstream system). Lock-step with the Rust
+   engine — identical algorithm, error messages, and shared flow fixture.
+
+2. Stepwise traversal logging for deployed graph execution (field request): the
+   production `graph.executor` emits the same trail the Playground dry-run narrates —
+   `Walk to {node}`, `Executed {node} with skill {skill} in {time} ms`,
+   `Graph traversal completed in {time} ms`, `Graph traversal aborted: {reason}` — as
+   INFO structured records (`{id, text, graph}`, where `id` is the run's trace id,
+   falling back to the flow instance id) so OpenTelemetry dashboards can join app logs
+   with exported spans, and log-analytics platforms index the keys directly in the
+   json/compact formats. Gated by `graph.traversal.log` (default `true`;
+   `-Dgraph.traversal.log=false` to reduce log volume). The executor runs zero-traced,
+   so the app-log-context block never accompanies these lines — the record's `id` key
+   is the correlation surface. Lock-step with the Rust engine.
+
+3. MiniGraph Playground UX modernization (community contribution, PR #341, refined
+   through maintainer-guided rounds): the Help panel, minimap, and graph run controls
+   forward-ported to the modernized webapp — node create/edit and mock graph input as
+   in-place left-slot panels (no modals) with per-mode default widths, the minimap as a
+   draggable floating island with a `Ctrl+M` toggle, JSON-Path simplified to a
+   payload-only tool, and frontend-only undo via compensating commands.
+
+### Fixed
+
+1. The temp graph-model endpoint (`GET /api/graph/model/{graph_id}/{sequence}`)
+   answered 400 for a nonexistent or housekeeping-expired draft — a missing resource
+   now answers **404** as if it is not there, matching the deployed-graph
+   "compiled or 404" precedent. The `{sequence}` path parameter is documented as what
+   it is: an artificial cache-buster minted per describe/export reply, deliberately not
+   part of the resource identity.
+
+2. Playground webapp build: the vendor-router chunk had silently vanished from the
+   bundle chunking after the react-router v8 package consolidation — the matcher is
+   fixed and the chunk restored; nanoid is bumped past a high-severity npm audit
+   finding (dev tooling and bundle hygiene, no runtime behavior change).
+
+### Changed
+
+1. The Playground UI reads the **live session graph** (`GET /api/graph/session/{id}`)
+   as its single graph source — initial load, navigation restore, and mutation
+   auto-refresh fetch it directly, with no `describe graph` round-trip and no temp-file
+   link for the view. `describe graph` / `export graph` stay human-operator (and
+   companion-agent) console commands with their snapshot + link unchanged; clicking a
+   console link row brings the current graph forward. The packaged webapp bundle
+   carries the change.
+
+---
 ## Version 4.12.5, 9/9/2026
 
 ### Fixed

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/memory/open-threads/thread-ot-simple-plugin-gate-body-scan.md
+++ b/memory/open-threads/thread-ot-simple-plugin-gate-body-scan.md
@@ -1,0 +1,18 @@
+- [ ] (hardening) **Simple-plugin allowlist gate: scan method bodies, not just signatures**
+  (Eric's backlog ruling 2026-09-10: after the v4.12.6 release). Finding (field-spotted by
+  Eric, confirmed in code): `SimplePluginLoader` parses plugin classes with
+  `ClassReader.SKIP_CODE` and `RecursiveClassTypeExaminer.visitMethod` returns null, so the
+  ALLOWED_PACKAGES check sees only superclass/interfaces/field/method-signature types —
+  method-BODY references are invisible. That is why `TypeConversionUtils` (since the gate's
+  birth) and `KeyNormalizationUtils` (v4.12.6) pass unlisted, and why a USER plugin could
+  call java.io/java.net/threads inside `calculate()` and still register: the sub-millisecond
+  containment the allowlist exists for is declared, not enforced. Agreed fix shape: give the
+  examiner a real MethodVisitor (method-call owners, field owners, new/cast/instanceof
+  types, invokedynamic handles, class-literal constants, try/catch types), drop SKIP_CODE
+  (keep SKIP_DEBUG|SKIP_FRAMES); add TypeConversionUtils + KeyNormalizationUtils to
+  ALLOWED_PACKAGES (with body scanning on, the ~50 built-ins all pass through
+  `shouldRegisterPlugin` and become the regression net); align the flow-schema-reference
+  sentence ("Mercury framework packages") with the enforced list. Java-only — the Rust
+  engine's no-allowlist divergence stands (compiled/linked code, no runtime class loading).
+  Not a release blocker: the gap predates v4.12.6 entirely.
+  <!-- id: ot-simple-plugin-gate-body-scan | created: 2026-09-10 | last_used: 2026-09-10 | uses: 1 | tier: working | origin: 2026-09-10-150848 -->

--- a/memory/sessions/2026-09-10-150848.md
+++ b/memory/sessions/2026-09-10-150848.md
@@ -1,0 +1,50 @@
+# Session (2026-09-10T15:08:48.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**v4.12.6 release prep** (branch `release/v4.12.6`; Rust twin prepared the
+same morning on its sibling branch). Version sweep 4.12.5 → 4.12.6 across all
+34 poms — the reactor modules plus the non-reactor Snyk placeholder manifests
+(system/rest-spring-3, examples/rest-spring-3-example), included deliberately
+per the placeholder convention. The packaged Playground bundle is already
+current (last rebuilt in #347; nothing webapp-side merged after it), so no
+bundle rebuild rides this release.
+
+CHANGELOG rolls to Version 4.12.6, 9/10/2026. Contents = the seven PRs merged
+since the v4.12.5 release commit: #341 (Playground UX modernization — community
+contribution with maintainer-guided rounds), #344 (vendor-router chunk fix +
+nanoid audit bump), #345 + #348 (stepwise traversal logging, shipped as
+structured records `{id, text, graph}` with trace-id correlation), #346 (temp
+graph-model endpoint 404), #347 (the UI reads the live session graph), #349
+(f:camelCase / f:snakeCase key-normalization plugins). Rust twin carries the
+same content as PRs #247–#252.
+
+Gates: full `mvn clean install` (all modules, with tests) run for release
+verification on the swept versions. First run went red in the
+minigraph-playground example module (8 tests, 404s on graphs that compile and
+pass in isolation) — root cause was SELF-INFLICTED local contention: the full
+Java reactor and the full Rust workspace suite ran simultaneously on this
+laptop, the documented contention pattern. Serialized rerun is the gate.
+
+**Plugin-gate loose end investigated (Eric's field observation, screenshot of
+ALLOWED_PACKAGES): CONFIRMED.** The simple-plugin allowlist gate reads only
+SIGNATURES — `ClassReader.SKIP_CODE` plus `RecursiveClassTypeExaminer.visitMethod`
+returning null — so method-body references (TypeConversionUtils since the
+gate's birth, KeyNormalizationUtils now, or a user plugin calling
+java.io/java.net) are invisible to it. Eric's ruling: backlog, fix AFTER the
+v4.12.6 release → Open Thread ot-simple-plugin-gate-body-scan created with
+the agreed fix shape (real MethodVisitor, drop SKIP_CODE, allowlist the two
+helpers, built-ins as the regression net; Java-only).
+
+## Memory References
+
+- eric-release-rhythm (consulted — prep only: branch/sweep/CHANGELOG/build
+  verification; PR-open, merge, tag and Maven Central publish are each Eric's
+  gates)
+- snyk-retired-manifest-placeholders (consulted — the two non-reactor
+  placeholder poms swept deliberately)
+- conv-telemetry-presentation-parity (consulted — Java and Rust v4.12.6 ship
+  lock-step same-day)
+- ot-simple-plugin-gate-body-scan (created)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.5</version>
+            <version>4.12.6</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with


### PR DESCRIPTION
## What

Version sweep 4.12.5 → 4.12.6 across all 34 poms — the reactor modules plus the non-reactor Snyk placeholder manifests (system/rest-spring-3, examples/rest-spring-3-example), included deliberately per the placeholder convention. CHANGELOG rolls to Version 4.12.6, 9/10/2026. The packaged Playground bundle is already current (last rebuilt in #347), so no rebuild rides this release. Also carries the backlog Open Thread for the simple-plugin allowlist gate hardening (post-release work by maintainer ruling).

## Why

Patch release carrying the seven PRs merged since v4.12.5: the Playground UX modernization (community contribution #341, with #344's bundle housekeeping), stepwise traversal logging shipped as structured records (#345 + #348), the temp graph-model endpoint 404 fix (#346), the UI's switch to the live session graph (#347), and the f:camelCase/f:snakeCase key-normalization plugins (#349). Lock-step with Rust v4.12.6 prepared the same morning.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>