### PR TITLE
docs: home polish for the two-column width — default hero buttons, relaxed table

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -18,12 +18,3 @@
   overflow-wrap: break-word;
   white-space: normal;
 }
-
-/* Home hero buttons — compact size so all four ("Get started" through
- * "The Mercury Family") fit the content column on one row. Horizontal
- * padding is em-based, so it scales down with the font size. */
-.md-typeset .hero-buttons .md-button {
-  font-size: 0.64rem;
-  padding: 0.5em 1.4em;
-  white-space: nowrap;
-}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,12 +18,10 @@ virtual threads, so straightforward synchronous code performs on par with reacti
 event-driven core descends from the **Scala/Akka actor model**, realized on the **Eclipse Vert.x**
 event bus.
 
-<div class="hero-buttons" markdown>
 [Get started](guides/getting-started.md){ .md-button .md-button--primary }
 [Read the white paper](https://accenture.github.io/mercury-composable/mercury-story/){ .md-button }
 [View the deck](https://accenture.github.io/mercury-composable/presentations/mercury-story.html){ .md-button }
 [The Mercury Family](https://accenture.github.io/mercury-composable/mercury-family/){ .md-button }
-</div>
 
 *The white paper — **Intent-Driven Development and the Architecture of Human-AI Collaboration** —
 presents the collaboration model the AI era needs and the Mercury story that proved it: shared
@@ -36,9 +34,9 @@ application — drop down a layer exactly where you need more control, and no fu
 
 | Layer | You express behavior as… | What you write |
 |:------|:--------------------------|:---------------|
-| **Event-driven**<br>[Platform Core](guides/event-driven/index.md) | decoupled functions reacting<br>to events | Java functions,<br>addressed by route name |
-| **Composable**<br>[Event Script](guides/event-script/index.md) | YAML flows that choreograph<br>functions | ~50% config,<br>50% code |
-| **Semantic**<br>[Active Knowledge Graph](guides/knowledge-graph/index.md) | a graph whose nodes *execute*<br>during traversal | a model —<br>little or no code |
+| **Event-driven** — [Platform Core](guides/event-driven/index.md) | decoupled functions reacting to events | Java functions, addressed by route name |
+| **Composable** — [Event Script](guides/event-script/index.md) | YAML flows that choreograph functions | ~50% config, 50% code |
+| **Semantic** — [Active Knowledge Graph](guides/knowledge-graph/index.md) | a graph whose nodes *execute* during traversal | a model — little or no code |
 
 ## Knowledge Graph as application
 

--- a/memory/sessions/2026-09-10-215302.md
+++ b/memory/sessions/2026-09-10-215302.md
@@ -38,6 +38,14 @@ absolute). Verified: ai-contract-provider module tests green (19); the Rust
 twin's `endpoints_e2e` green. Durable rule of thumb: a relative link on the
 home page must stay inside the contract's `files.list` closure.
 
+**Touch-up (same session, after the #352 merge):** with the home page now
+two-column, the compact hero-button CSS lost its reason to exist — Eric asked
+for readability at the wider column. The `.hero-buttons` block and its div
+wrapper are removed (buttons back at the Material default size, matching the
+agent-memory home), and the layered-ascent table dropped its forced `<br>`
+breaks — name—link pairs inlined in the house "—" style — so rows read as
+single lines. Strict builds, canon/claims checks green; verified at 1440px.
+
 ## Memory References
 
 - eric-release-rhythm (consulted — branch/commit/push and PR text prepared;


### PR DESCRIPTION
## What

Follow-up polish to #352 now that the home page is two-column:

- The compact hero-button sizing (`.hero-buttons` in `docs/css/extra.css`) is removed — the four buttons render at the Material default size, matching the agent-memory home.
- The "A layered ascent" table drops its forced `<br>` line breaks; the layer name and module link are inlined (`**Event-driven** — Platform Core`), so each row reads as a single line.

## Why

The compact sizing existed to fit four buttons in the old three-column layout's narrow content column. With the left sidebar hidden, the wider column fits the default size — readability wins. Same reasoning relaxes the table. Lock-step with Accenture/mercury.

Verified at 1440px: one-row buttons, single-line table rows; `mkdocs build --strict` and the canon checks green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>