### PR TITLE
docs: slide 7 clarity + Methodology synthesized around Intent-Driven Development

### DIFF
--- a/docs/guides/methodology.md
+++ b/docs/guides/methodology.md
@@ -1,22 +1,96 @@
 ---
 title: Methodology
-summary: The design philosophy and the four composable principles — input-process-output, zero
-  dependency, platform abstraction, and event choreography.
+summary: Intent-Driven Development — humans own intent, AI partners co-author governed
+  artifacts — realized down the layers of knowledge graph, composable design, and the
+  event-driven core.
 layer: platform-core
-audience: [architect]
-keywords: [methodology, composable, design principles, input-process-output, zero dependency, event choreography]
+audience: [business, architect, developer, ai-agent]
+keywords: [methodology, intent-driven development, ai collaboration, knowledge graph, composable, design principles, input-process-output, zero dependency, event choreography]
 ---
 
 # Methodology
 
-*Concepts: Design philosophy and principles behind Mercury Composable's event-driven architecture.*
+*Concepts: how Mercury Composable is meant to be practiced — Intent-Driven Development as the
+main theme, realized down the layers: knowledge graph, composable design, event-driven core.*
 
 > **At a glance**
 >
-> - **What** — the four composable design principles (input-process-output, zero dependency,
->   platform abstraction, event choreography) and the thinking behind them.
-> - **For** architects shaping composable systems; the [Architecture Overview](architecture.md) is
->   the technical companion.
+> - **What** — the Intent-Driven Development methodology (humans own intent; AI partners
+>   co-author governed artifacts), the knowledge-graph path it recommends, and the composable
+>   design principles beneath both.
+> - **For** product owners, architects, and developers building with AI partners; the
+>   [Architecture Overview](architecture.md) is the technical companion.
+
+## Intent-Driven Development
+
+**Intent-Driven Development (IDD)** is the collaboration model this framework is built for.
+Humans own the *intent* — purpose, constraints, priorities, and judgment. AI partners help
+refine that intent and translate it into designs, models, flows, tests, and implementation
+artifacts. Three mechanisms keep the collaboration faithful: **shared memory** preserves
+continuity across sessions, **AI grammar** makes each DSL legible to a machine so an agent
+authors from rules rather than inferring from examples, and **validation gates** keep every
+generated artifact aligned with the intent behind it. The full argument is the white paper,
+[Intent-Driven Development and the Architecture of Human-AI Collaboration](https://accenture.github.io/mercury-composable/mercury-story/).
+
+### How a developer builds with an AI partner
+
+**Step 1 — AI-enable the project.** Greenfield or existing, the first move is the same:
+install the [shared memory layer](https://accenture.github.io/mercury-go/), write the
+**Vision** with the AI partner — human-confirmed, never fabricated — derive the **Blueprint**
+of gaps, and plan increments. Every session thereafter starts oriented: the AI reads where the
+project is, where it is going, and why, before it touches anything.
+
+**Step 2 — Add the engine and choose the path.** The engine arrives carrying its own AI
+grammar, so an AI partner can author correct artifacts from the first session.
+**Recommended for applications: Layer 3** — model the service as a knowledge graph, dry-run it
+in the Playground, deploy it behind the CompileGraph gate. The path is a dial, not a wall:
+drop down to Event Script, or to a platform-core function, exactly where the problem demands
+it — and no further.
+
+**Step 3 — Build the app, or a building block.** An application travels
+**intent → model → certify → deploy**. A building block combines layer-2 and layer-3
+patterns — and then **compiles an AI grammar into its own repository**, so the block becomes
+as legible to the next AI partner as Mercury itself.
+
+> Proof point for step 1: Mercury's own Rust engine was AI-enabled *before its first line of
+> code* — about a hundred increments later, it ships in lock-step with the Java engine.
+
+### Grammar composes the way dependencies compose
+
+```mermaid
+flowchart LR
+    M["mercury-composable<br/>ships its AI grammar"]
+    B["building block<br/>compiles its own grammar"]
+    U["user application<br/>its own Vision + memory"]
+    M -- built on --> B
+    B -- depends on --> U
+    M -. grammars load into the app's AI session .-> U
+    B -.-> U
+```
+
+The session that builds the application loads Mercury's grammar **plus** each building
+block's grammar — a near-constant token cost per block, instead of an ever-growing pile of
+source to re-read. The recursion is already live inside the framework: twin-kafka is a
+building block on a building block — and while its discovery-map entry was missing, AI
+partners fell back to reading source.
+
+> To an AI partner, undocumented capability is absent capability.
+
+## Knowledge graph — model as the application
+
+The recommended altitude for applications is the top of the ladder: capture business intent,
+enterprise knowledge, and system behavior as one executable **Active Knowledge Graph**, so
+the model *is* the application. The working loop is the IDD loop made concrete —
+**intent → model → certify → deploy**: draft the graph with an AI companion, dry-run it in
+the Playground, let the product owner read and certify it, then deploy it behind the
+CompileGraph quality gate. Changing what the system does becomes **refining the model** —
+recertify, redeploy — not rewriting code.
+
+[Knowledge Graph as Application](knowledge-graph/index.md) is the layer's own guide.
+Zero-code is the default there, never a dogma: Event Script and custom functions remain
+first-class escape hatches — which is exactly why the composable principles below matter.
+
+## Composable design
 
 Software development is a long fight against complexity — and most of that complexity is *coupling*: code
 that cannot change without breaking something else. Composable methodology attacks coupling at its source.
@@ -27,11 +101,11 @@ so applications are easier to design, build, maintain, deploy, and scale.
 
 Composable architecture became an industry direction around 2022, alongside Domain-Driven Design (DDD),
 CQRS, and microservices. Mercury was among the first frameworks to realize it end-to-end for event-driven
-systems — the methodology below is how that realization works in practice.
+systems — the sections below are how that realization works in practice.
 
-## Methodology
+### Aligning product and engineering
 
-The Composable Methodology takes a different approach in software development that empowers and aligns product owners,
+The composable methodology takes a different approach in software development that empowers and aligns product owners,
 business analysts, technology architects and software engineers.
 
 Historically, there is a disconnect between product features and application design because product is user and
@@ -70,7 +144,7 @@ The product team designs a transaction flow to address a business use case and p
 Naturally, this is how a human designer thinks. We don't want to prematurely adjust the business requirements
 to any infrastructural limitation.
 
-## Events at the center of the modern enterprise
+### Events at the center of the modern enterprise
 
 In Domain Driven Design, it is well accepted that business transactions and their intermediate objects can be
 represented as "events".
@@ -80,7 +154,7 @@ or any intermediate data representation. Generally, a data object is a structure
 
 For simplicity, we will call a transaction flow diagram as "Event Flow Diagram" from now on.
 
-## First principle - "input-process-output"
+### First principle - "input-process-output"
 
 The first principle of composable application design is that each function (called a **task** when it is a step
 in an event flow) is self-contained and its input and output are immutable.
@@ -95,7 +169,7 @@ its functional scope, thus eliminating the chance of unintended side effects of 
 > *Note*: A **task** is a function in its role as a step in an event flow — the same atom, named by where it
           appears. The unit you write is always a **function**; "task" is just what we call it inside a flow diagram.
 
-## Second principle - zero to one dependency
+### Second principle - zero to one dependency
 
 The second principle is that each function should have zero dependency with other user functions.
 
@@ -107,7 +181,7 @@ A function consumes a platform component or library by sending an event to the c
 with a direct method call. Decoupling between functions and components promotes non-blocking, asynchronous and
 parallel operation that yields higher performance and throughput.
 
-## Third principle - platform abstraction
+### Third principle - platform abstraction
 
 Since composable functions are self-contained and independent, they can be reused and repackaged into different
 applications to serve different purposes. Therefore, composable functions are, by definition, plug-n-play.
@@ -117,13 +191,13 @@ Figure 1 illustrates this architectural principle by connecting an event flow to
 adapter. For example, a "HTTP Flow Adapter" serves both inbound request and outbound response. A "Kafka Flow Adapter"
 uses one topic for inbound and another topic for outbound events.
 
-## Fourth principle - event choreography
+### Fourth principle - event choreography
 
 Without direct coupling, a composable development framework must support "Event Choreography" so that we can
 connect the various user composable functions, platform components and libraries together and route the events
 according to an event flow diagram for each use case.
 
-## What composable design buys you
+### What composable design buys you
 
 Following these principles pays off in concrete ways:
 
@@ -134,7 +208,7 @@ Following these principles pays off in concrete ways:
 - **Debuggability** — independent functions make it easy to pinpoint a fault.
 - **Technology freedom** — inside a function you may use any style or library; nothing leaks across the boundary.
 
-## Application development
+### Application development
 
 Once we have drawn the event flow diagrams for different use cases, we can create user stories for each composable
 function and assign the development of each function to a developer or a pair of developers if using pair-programming.
@@ -149,25 +223,27 @@ because developers do not need to know details of dependencies, thus avoiding ha
 For integration tests, it is easy to mock platform, infrastructure, database and HTTP resources by assigning
 mock functions to some tasks in an event flow. This greatly simplifies integration mocking.
 
-## Seamless transition from product to application design
+### Seamless transition from product to application design
 
 Event flow diagram describes the product and each composable function contains the specific processing logic.
 Data attributes in an event flowing from one function to another provide the clarity for product designers and
 application engineers to communicate effectively.
 
-## Application packaging and deployment
+### Application packaging and deployment
 
 Composable functions are independent and isolated. We can package related functions for an event flow in a single
 executable. A senior developer or architect can decide how to package related functions to reduce memory footprint
 and to scale efficiently and horizontally.
 
-## Smaller memory footprint
+### Smaller memory footprint
 
 By design, composable functions are granular in nature. They are registered to an "event loop" on-demand. i.e.
 a function is executed when an event arrives. Without multiple levels of tight coupling, each piece of user code
 consumes memory efficiently. Memory is released to the system as soon as the function finishes execution.
 
-## Composable framework
+## Event-driven core
+
+### Composable framework
 
 To realize the composable design principles, a low-latency in-memory event system is available at the core
 of the Mercury-Composable framework.
@@ -208,7 +284,7 @@ be extended to an external datastore so that transaction states can be monitored
 
 > *Note*: The framework combines native Java 21 virtual thread management with the Eclipse Vert.x event bus.
 
-## Event Envelope
+### Event Envelope
 
 We use a standard "Event Envelope" to transport an event over the in-memory event bus. An event envelope contains
 three parts: (1) body, (2) headers and (3) metadata.
@@ -220,7 +296,7 @@ Headers can be used to carry additional parameters to tell the user composable f
 Examples for metadata include performance metrics, status, exception, optional tracing information, and
 correlation ID.
 
-## Language neutral
+### Language neutral
 
 The event flow configuration syntax and event envelope serialization scheme are standardized for polyglot deployment.
 The event flow configuration rides on YAML and event envelope serialization uses binary JSON ("MsgPack").
@@ -228,7 +304,7 @@ The event flow configuration rides on YAML and event envelope serialization uses
 For higher serialization efficiency, the intermediate format is using "key-value" maps. JSON string is only used at
 the inbound and outbound flow adapters.
 
-## Functional isolation
+### Functional isolation
 
 Each function must implement the Composable interface, called "TypedLambdaFunction".
 
@@ -270,4 +346,3 @@ see the [Architecture Overview](architecture.md).
 - [Architecture Overview](architecture.md) — the technical mental model behind these principles.
 - [Getting Started](getting-started.md) — the principles applied in a working app.
 - [Event-driven Foundation](event-driven/index.md) — the Layer-1 core these principles run on.
-

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,7 +17,7 @@
 
 ## Layer 1 — Event-driven foundation (Platform Core)
 - [Architecture Overview](https://accenture.github.io/mercury-composable/guides/architecture/): layers, components, the in-memory event bus, threading, core APIs.
-- [Methodology](https://accenture.github.io/mercury-composable/guides/methodology/): the four composable design principles.
+- [Methodology](https://accenture.github.io/mercury-composable/guides/methodology/): Intent-Driven Development — the human-AI collaboration methodology — then the knowledge-graph path and the four composable design principles beneath it.
 - [Event-driven Foundation](https://accenture.github.io/mercury-composable/guides/event-driven/): Layer 1 overview — functions, route names, PostOffice, EventEnvelope, the in-memory event bus.
 - [Write your first function](https://accenture.github.io/mercury-composable/guides/event-driven/write-your-first-function/): step-by-step — define a function, expose it over HTTP, call it via PostOffice, test it.
 - [Function Execution Strategies](https://accenture.github.io/mercury-composable/guides/event-driven/function-execution/): virtual vs. kernel threads, Mono/Flux.

--- a/docs/presentations/mercury-story.html
+++ b/docs/presentations/mercury-story.html
@@ -283,13 +283,15 @@
   <!-- 6 · the turn -->
   <section class="slide" aria-label="The turn">
     <p class="eyebrow">The turn</p>
-    <h2>Don't review AI code harder.<br>Change the artifact the AI authors.</h2>
-    <p class="lede">An AI that authors a <strong>flow</strong> or a <strong>graph model</strong> is
-    producing a declarative, compiler-validated, human-legible artifact. CompileFlows and
-    CompileGraph reject malformed intent at build time; the Playground dry-runs it; a product
-    owner can read it and certify it.</p>
-    <p class="quote" style="margin-top:1.2em"><span class="q">Governed nondeterminism</span> — the
-    creativity of a model author, bounded by gates.</p>
+    <h2>Change what the AI generates:<br>artifacts a human can read.</h2>
+    <p class="lede">Unbounded code generation overwhelms the human who must review it — volume
+    outruns cognition. Mercury changes the artifact instead: the AI co-authors
+    <strong>flows</strong> and <strong>graph models</strong> — declarative, compiler-validated,
+    readable by human and AI alike — so a product owner can understand and certify them.
+    CompileFlows and CompileGraph reject malformed intent at build time; the Playground
+    dry-runs it.</p>
+    <p class="quote" style="margin-top:1.2em">The creativity of a model author, bounded by
+    <span class="q">quality gates</span>.</p>
     <p class="muted" style="margin-top:1em">Never a determinism claim. A governance design.</p>
   </section>
 

--- a/memory/sessions/2026-09-10-231335.md
+++ b/memory/sessions/2026-09-10-231335.md
@@ -48,6 +48,10 @@ Rust claims + llms-links checks; contract snapshot gates on both engines
 rendered-page screenshots (slide 7, both methodology pages, mermaid
 renders).
 
+Also in this arc (Eric): the Orientation nav label
+"Intent-Driven Development (white paper)" simplified to "White Paper" — the
+page H1 and the home button carry the full context.
+
 ## Memory References
 
 - eric-release-rhythm (consulted — branch/commit/push and PR text prepared;

--- a/memory/sessions/2026-09-10-231335.md
+++ b/memory/sessions/2026-09-10-231335.md
@@ -1,0 +1,54 @@
+# Session (2026-09-10T23:13:35.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Docs polish: deck slide 7 clarity + the methodology synthesis** (Eric's
+colleague feedback and his direction; editorial license granted — "polish my
+English, don't just follow"):
+
+- **Deck slide 7 (The Turn)** rewritten for plain-language comprehension: the
+  heading now states the essence directly ("Change what the AI generates:
+  artifacts a human can read."); the body carries the volume-overwhelms-
+  cognition contrast and the co-author/certify point; the jargon term
+  "Governed nondeterminism" is REMOVED per Eric's ruling — the pull quote is
+  now "The creativity of a model author, bounded by quality gates" — and the
+  "Never a determinism claim. A governance design." line stays. NOTE: the
+  white paper (mercury-story.md, "This is **governed nondeterminism**:")
+  still introduces the term with its definition — deliberately untouched
+  (deck-scoped ask); flagged to Eric.
+- **`guides/methodology.md` synthesized** per Eric's revised ruling (the IDD
+  methodology merges INTO the original composable methodology page under
+  Foundations, not a new Orientation page): IDD is the main theme, followed
+  by knowledge graph, then composable design, then event-driven core. Deck
+  slides 15–16 (the three developer steps + the grammar-composes-like-
+  dependencies recursion, with a mermaid diagram) became the IDD section;
+  the original four-principles content sits under "Composable design" (the
+  old inner "Methodology" H2 retitled "Aligning product and engineering");
+  the framework/envelope/isolation material sits under "Event-driven core".
+  The Rust twin got the same structure, reusing its condensed sections —
+  its "Co-authoring with AI agents" moved under IDD as "Co-authoring in
+  practice". Orientation nav is untouched; no label collision.
+- The page is packaged in the AI contract
+  (`references/guides/methodology.md` in files.list), so the new white-paper
+  and agent-memory links are ABSOLUTE site URLs per the closure rule from
+  earlier today.
+- Java `llms.txt` Methodology entry description updated to the synthesized
+  scope.
+- **Gotcha caught by visual verification (strict build passes silently):** a
+  front-matter `summary:` containing ": " mid-scalar breaks the YAML block
+  and mkdocs renders the whole front matter as body text. Fixed by
+  rewording the summary. Lesson: eyeball a page after any front-matter edit
+  — the docs CI cannot catch this class of defect.
+
+Verified: `mkdocs build --strict` both engines; Java grammar/canon checks;
+Rust claims + llms-links checks; contract snapshot gates on both engines
+(Java ai-contract-provider 19 tests green, Rust `endpoints_e2e` green);
+rendered-page screenshots (slide 7, both methodology pages, mermaid
+renders).
+
+## Memory References
+
+- eric-release-rhythm (consulted — branch/commit/push and PR text prepared;
+  PR-open and merge stay Eric's steps)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ nav:
 
   - Orientation:
     - Getting Started: guides/getting-started.md
-    - Intent-Driven Development (white paper): mercury-story.md
+    - White Paper: mercury-story.md
     - The Mercury Family: mercury-family.md
 
   - Foundations:


### PR DESCRIPTION
## What

Two polish items from colleague feedback on the story deck and site:

- **Slide 7 (The Turn)** now states the essence plainly: "Change what the AI generates: artifacts a human can read." The body carries the contrast (code volume overwhelms human review) and the point (the AI co-authors flows and graph models readable by human and AI alike, so a product owner can understand and certify them). The "governed nondeterminism" jargon is removed — the pull quote is "The creativity of a model author, bounded by quality gates"; "Never a determinism claim" stays.
- **`guides/methodology.md` is synthesized around Intent-Driven Development**: IDD leads as the main theme — including the deck's "How a developer builds with an AI partner" steps and the "Grammar composes the way dependencies compose" recursion — followed by the knowledge-graph path, the original composable design principles, and the event-driven core. `llms.txt`'s entry description follows.

## Why

Reviewers found the original slide-7 heading and "governed nondeterminism" hard to interpret — the deck should communicate the essence directly. And the methodology page should teach the whole method in the order we practice it: intent first, then the layers that realize it. Lock-step with Accenture/mercury.

The methodology page is packaged into the AI contract, so its new cross-links are absolute site URLs (closure rule). Verified: strict builds, grammar/canon checks, and the contract snapshot gates on both engines.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>