### PR TITLE
docs: fresh-agent entry-point playbook — greenfield and AI-enabling an existing repo

### DIFF
--- a/docs/guides/ai-developer-guide.md
+++ b/docs/guides/ai-developer-guide.md
@@ -18,6 +18,9 @@ related:
 >
 > - **Read this first** if you are an AI agent joining a mercury-composable project,
 >   whether greenfield or brownfield.
+> - **Starting a collaboration?** Recognize the two typical entry points — a greenfield
+>   project, or an existing repository that is not yet AI-enabled — and drive the
+>   development-path conversation: [Starting a collaboration](#entry-points).
 > - **One mental model:** a composable function is *plain Java* — the framework constrains
 >   only *coupling*, not coding style.
 > - **Three layers, one decision tree** — choose the layer before writing code; the DSL guides
@@ -48,6 +51,58 @@ on how it is wired:
 | **service** | Mapped directly to an HTTP endpoint | `rest.yaml` `service:` entry |
 | **task** | A step in an Event Script flow | `flows/*.yml` + `flows.yaml` |
 | **skill** | Attached to a Knowledge Graph node | node's `skill=` property in graph JSON |
+
+---
+
+## Starting a collaboration — two typical entry points {#entry-points}
+
+Mercury's development methodology is [Intent-Driven Development](methodology.md): humans own
+the intent; the AI partner refines it and translates it into governed artifacts. When a human
+first engages you on a project, recognize which of two situations you are in — and drive the
+conversation with questions, never assumptions.
+
+### Case 1 — greenfield: a new project {#entry-greenfield}
+
+1. **Confirm the intent first.** What should the service do, and who will certify its
+   behavior? Capture purpose and constraints before proposing any technology.
+2. **Offer to AI-enable the project.** Ask whether to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   **Vision** — human-confirmed, never fabricated — then derive the **Blueprint** and plan
+   increments. Every session thereafter starts oriented.
+3. **Recommend the path — as a question.** The default recommendation is Layer 3: *"Shall I
+   set up the project with the knowledge-graph engine, so the service is modeled as a
+   graph, dry-run in the Playground, and deployed behind the CompileGraph gate?"* Offer the
+   dial explicitly: Event Script when the shape is a known transaction flow; a
+   platform-core function when the need is genuinely custom logic
+   ([Choosing the right layer](#layer-choice)).
+4. **Scaffold on a yes — never on silence.** Start from the chosen layer's reference
+   application in `examples/` —
+   [`lambda-example`](https://github.com/Accenture/mercury-composable/tree/main/examples/lambda-example)
+   (Layer 1 functions),
+   [`composable-example`](https://github.com/Accenture/mercury-composable/tree/main/examples/composable-example)
+   (Layer 2 flows, the primary demo), or
+   [`minigraph-playground`](https://github.com/Accenture/mercury-composable/tree/main/examples/minigraph-playground)
+   (Layer 3 graphs with the Playground) — and pin the Mercury version the environment
+   reports (`GET /api/discovery` → `mercury_version`) rather than assuming one.
+5. **Hand off to the layer's guide.** The [DSL-specific AI guides](#dsl-guides) carry the
+   authoring contracts from here.
+
+### Case 2 — an existing repository that is not yet AI-enabled {#entry-existing-repo}
+
+The tell: the repository has no shared memory layer. AI context, if it exists at all, lives
+in hand-written per-tool files — a `CLAUDE.md`, editor rules, prompt snippets — that no
+other agent or contributor shares: traditional context engineering.
+
+1. **Offer AI-enablement first, before feature work.** Install the
+   [shared memory layer](https://accenture.github.io/mercury-go/), co-write the **Vision**
+   of the *current* system with the human — confirmed, never fabricated — and derive the
+   Blueprint from the real current state.
+2. **Fold the existing context in.** Migrate the durable parts of the hand-maintained
+   context files into the shared layer, so every agent and every contributor reads one
+   source of truth instead of per-tool copies.
+3. **Then orient and work.** Follow [Orienting in an existing project](#brownfield), choose
+   the layer per feature — and if the team is adopting Mercury in this repository, continue
+   with the greenfield path's step 3.
 
 ---
 
@@ -245,6 +300,7 @@ DSL artifacts — not this overview:
 
 ## See also {#see-also}
 
+- [Methodology](methodology.md) — Intent-Driven Development and the design principles beneath it.
 - [Write your first function](event-driven/write-your-first-function.md) — step-by-step Layer 1 tutorial.
 - [Event-driven Foundation](event-driven/index.md) — Layer 1 overview: functions, PostOffice, EventEnvelope.
 - [Composable Orchestration](event-script/index.md) — Layer 2 overview: flows, tasks, state machine.

--- a/docs/guides/methodology.md
+++ b/docs/guides/methodology.md
@@ -76,6 +76,10 @@ partners fell back to reading source.
 
 > To an AI partner, undocumented capability is absent capability.
 
+If you are an AI agent starting a collaboration, the
+[AI developer guide](ai-developer-guide.md) carries the entry-point playbook — the greenfield
+conversation, and AI-enabling an existing repository first.
+
 ## Knowledge graph — model as the application
 
 The recommended altitude for applications is the top of the ladder: capture business intent,

--- a/memory/open-threads/thread-ot-three-layer-starter-templates.md
+++ b/memory/open-threads/thread-ot-three-layer-starter-templates.md
@@ -1,0 +1,13 @@
+- [ ] **First-class starter templates for the three layers.** Eric's ruling (2026-09-10,
+  the fresh-agent greenfield discussion): "A first class template for the 3 layers is the
+  right move." A fresh AI agent driving the entry-point playbook (AI developer guide,
+  "Starting a collaboration") should scaffold from purpose-built starters rather than
+  copying reference examples. Open design decisions for a proposal to Eric: WHERE they
+  live (starter modules under `examples/`, separate template repositories in the Mercury
+  family, or a Maven archetype with a `cargo generate` twin); WHAT each contains (Layer 1:
+  functions + rest.yaml; Layer 2: flows + flows.yaml; Layer 3: knowledge-graph app with a
+  CompileGraph manifest and Playground dry-run wiring — and whether each ships AI-enabled
+  with agent-memory out of the box); and the Rust lock-step shape. Interim state: the
+  playbook scaffolds from `lambda-example` / `composable-example` / `minigraph-playground`.
+  Next step: design proposal.
+  <!-- id: ot-three-layer-starter-templates | created: 2026-09-10 | last_used: 2026-09-10 | uses: 1 | tier: working | origin: 2026-09-10-234940 -->

--- a/memory/sessions/2026-09-10-234940.md
+++ b/memory/sessions/2026-09-10-234940.md
@@ -1,0 +1,43 @@
+# Session (2026-09-10T23:49:40.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Fresh-agent entry points: the IDD playbook becomes agent-addressed** (Eric's
+ruling after my gap assessment — the docs taught IDD descriptively but nothing
+instructed an agent to DRIVE the development-path conversation):
+
+- `guides/ai-developer-guide.md` gains **"Starting a collaboration — two
+  typical entry points"**: Case 1 greenfield (confirm intent → offer
+  AI-enablement/agent-memory → recommend Layer 3 as a question → scaffold on a
+  yes from lambda-example / composable-example / minigraph-playground, pinning
+  `mercury_version` from /api/discovery → hand off to the DSL guides) and
+  Case 2 an existing repository not yet AI-enabled (the tell: hand-written
+  per-tool context files, "traditional context engineering" — offer
+  AI-enablement FIRST, fold existing context into the shared layer, then
+  orient). At-a-glance bullet + See-also Methodology link added; the guide's
+  greenfield promise is now kept. Every step is an ask, never an assumption.
+- Java `guides/methodology.md` IDD section points agents at the playbook; the
+  Rust twin (which has NO ai-developer-guide — its agent surface is the
+  per-layer guides) carries the compact playbook inside its methodology IDD
+  section instead. Asymmetry is deliberate and noted.
+- Both pages are packaged in the AI contract, so the playbook reaches fresh
+  agents through the contract provider and the exported mercury-platform
+  skill, version-matched. (Snapshot link checker verified fragment-safe:
+  SkillSnapshot strips `#fragment`/`?query` before closure validation.)
+- **New Open Thread [[ot-three-layer-starter-templates]]** — Eric: "A first
+  class template for the 3 layers is the right move." Design decisions open
+  (where they live, contents, AI-enabled out of the box, Rust twin shape);
+  next step is a design proposal. The playbook scaffolds from the reference
+  examples in the interim.
+
+Verified: strict builds both engines, Java grammar/canon checks, Rust
+claims + llms-links checks, contract snapshot gates both engines (19 Java
+tests; endpoints_e2e), rendered TOC/content check.
+
+## Memory References
+
+- ot-three-layer-starter-templates (created)
+- eric-release-rhythm (consulted — branch/commit/push and PR text prepared;
+  PR-open and merge stay Eric's steps)


### PR DESCRIPTION
## What

The AI developer guide gains **"Starting a collaboration — two typical entry points"** — an agent-addressed playbook:

- **Case 1, greenfield:** confirm the intent first; offer to AI-enable the project (shared memory, human-confirmed Vision); recommend the path as a question — Layer 3 knowledge graph by default, with the Event Script / platform-core dial; scaffold on a yes from `lambda-example` / `composable-example` / `minigraph-playground`, pinning the `mercury_version` reported by `/api/discovery`; hand off to the DSL guides.
- **Case 2, an existing repository that is not yet AI-enabled** (context lives in hand-written per-tool files — traditional context engineering): offer AI-enablement first, fold the durable context into the shared layer, then orient and work.

The methodology's IDD section points agents at the playbook; the guide's See-also gains the Methodology link. New open thread: first-class starter templates for the three layers (design proposal next).

## Why

Today's docs teach Intent-Driven Development descriptively, but nothing instructed an agent to *drive* the development-path conversation — so a fresh agent would never volunteer "shall I AI-enable this repo?" or "want a boilerplate with the knowledge-graph engine?". The guide is packaged in the AI contract and the exported `mercury-platform` skill, so the playbook reaches fresh agents version-matched. Lock-step in substance with Accenture/mercury (its methodology page carries the compact playbook — that repo has no separate AI developer guide).

Verified: strict builds, grammar/canon checks, and the contract snapshot gates on both engines.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>