### PR TITLE
feat: three-layer starter templates — copy-out projects for new applications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,38 @@ jobs:
           name: surefire-reports
           path: '**/target/surefire-reports/*.xml'
           retention-days: 7
+
+  # The starter templates ship BOTH build files (Maven and Gradle). The Maven
+  # side is proven by the reactor build above; this job proves the Gradle side.
+  # Mercury artifacts are not on Maven Central, so the engine modules are
+  # installed into the local Maven repository first (mavenLocal in each
+  # template's build.gradle resolves them).
+  templates-gradle:
+    name: Starter Templates (Gradle)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Install engine artifacts to the local Maven repository
+        run: >
+          mvn --batch-mode --no-transfer-progress -DskipTests install
+          -pl system/platform-core,system/event-script-engine,system/minigraph-playground-engine -am
+
+      - name: Gradle-build the three templates
+        run: |
+          for t in starter-function starter-flow starter-graph; do
+            echo "=== templates/$t ==="
+            (cd "templates/$t" && gradle build --no-daemon)
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ site/
 .aider.input.history
 .aider.tags.cache*
 *.py[cod]
+
+# Gradle (starter templates ship dual build files)
+templates/**/build/
+templates/**/.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ site/
 .aider.tags.cache*
 *.py[cod]
 
-# Gradle (starter templates ship dual build files)
+# Gradle (starter templates ship dual build files; wrapper files are
+# generated per-copy with "gradle wrapper" and never committed here)
 templates/**/build/
 templates/**/.gradle/
+templates/**/gradle/
+templates/**/gradlew
+templates/**/gradlew.bat

--- a/docs/guides/ai-developer-guide.md
+++ b/docs/guides/ai-developer-guide.md
@@ -75,15 +75,18 @@ conversation with questions, never assumptions.
    dial explicitly: Event Script when the shape is a known transaction flow; a
    platform-core function when the need is genuinely custom logic
    ([Choosing the right layer](#layer-choice)).
-4. **Scaffold on a yes — never on silence.** Start from the chosen layer's reference
-   application in `examples/` —
-   [`lambda-example`](https://github.com/Accenture/mercury-composable/tree/main/examples/lambda-example)
+4. **Scaffold on a yes — never on silence.** Copy the chosen layer's starter template out
+   of the repository's `templates/` directory —
+   [`starter-function`](https://github.com/Accenture/mercury-composable/tree/main/templates/starter-function)
    (Layer 1 functions),
-   [`composable-example`](https://github.com/Accenture/mercury-composable/tree/main/examples/composable-example)
-   (Layer 2 flows, the primary demo), or
-   [`minigraph-playground`](https://github.com/Accenture/mercury-composable/tree/main/examples/minigraph-playground)
-   (Layer 3 graphs with the Playground) — and pin the Mercury version the environment
-   reports (`GET /api/discovery` → `mercury_version`) rather than assuming one.
+   [`starter-flow`](https://github.com/Accenture/mercury-composable/tree/main/templates/starter-flow)
+   (Layer 2 flows), or
+   [`starter-graph`](https://github.com/Accenture/mercury-composable/tree/main/templates/starter-graph)
+   (Layer 3, a zero-code knowledge-graph application). Each is standalone-buildable and
+   ships BOTH build files: ask which build tool the team uses — **Maven or Gradle** —
+   keep that one and delete the other. Pin the Mercury version the environment reports
+   (`GET /api/discovery` → `mercury_version`) rather than assuming one; the reference
+   applications in `examples/` remain the richer worked demos.
 5. **Hand off to the layer's guide.** The [DSL-specific AI guides](#dsl-guides) carry the
    authoring contracts from here.
 

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -240,6 +240,14 @@
 - Add capability: function (`@PreLoad` + `TypedLambdaFunction`) → flow YAML →
   register in `flows.yaml` → `rest.yaml` mapping if HTTP-facing.
   <!-- id: conv-add-capability | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
+- **Release version sweeps must include the starter templates (2026-09-11).** The Java
+  sweep's grep must cover `--include=build.gradle` alongside `--include=pom.xml`: each
+  `templates/*` module carries a standalone pom (literal engine versions, like the Snyk
+  placeholders) AND a Gradle build with a single `def mercuryVersion = '<version>'`
+  literal. Mercury artifacts are NOT on Maven Central — the templates' Gradle builds
+  resolve engine artifacts from mavenLocal (the reactor `mvn install`), which is also why
+  ci.yml's templates-gradle job installs the engine modules first.
+  <!-- id: conv-template-version-sweep | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-005808 -->
 - Watch serialization gotchas (Long↔Integer downcast; use `util.str2int/str2long`).
   <!-- id: conv-serialization-gotchas | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->
 - **Declare a Memory Reference when a fact is CONSULTED to make a decision — not only when it is

--- a/memory/instructions.md
+++ b/memory/instructions.md
@@ -47,6 +47,8 @@ connectors/                ← Kafka pub/sub adapters + presence/service monitor
 helpers/                   ← standalone dev servers, no Docker (kafka-standalone, redis-standalone)
 examples/                  ← reference apps; composable-example is the primary demo
   (lambda, rest-spring-4, composable, kotlin, scheduler, minigraph, kafka-demo)
+templates/                 ← copy-out starter projects for the three layers, Maven or Gradle
+  (starter-function, starter-flow, starter-graph — reactor-built, standalone poms)
 benchmark/benchmark-reporter ← self-contained perf harness (benchmark-client retired 4.6.2)
 docs/ (guides/, arch-decisions/)  ← docs (mkdocs `docs_dir: docs`);
                                   arch-decisions/ADR.md = the ADR ledger (holds durable design rationale)

--- a/memory/open-threads/thread-ot-three-layer-starter-templates.md
+++ b/memory/open-threads/thread-ot-three-layer-starter-templates.md
@@ -1,13 +1,16 @@
 - [ ] **First-class starter templates for the three layers.** Eric's ruling (2026-09-10,
   the fresh-agent greenfield discussion): "A first class template for the 3 layers is the
-  right move." A fresh AI agent driving the entry-point playbook (AI developer guide,
-  "Starting a collaboration") should scaffold from purpose-built starters rather than
-  copying reference examples. Open design decisions for a proposal to Eric: WHERE they
-  live (starter modules under `examples/`, separate template repositories in the Mercury
-  family, or a Maven archetype with a `cargo generate` twin); WHAT each contains (Layer 1:
-  functions + rest.yaml; Layer 2: flows + flows.yaml; Layer 3: knowledge-graph app with a
-  CompileGraph manifest and Playground dry-run wiring — and whether each ships AI-enabled
-  with agent-memory out of the box); and the Rust lock-step shape. Interim state: the
-  playbook scaffolds from `lambda-example` / `composable-example` / `minigraph-playground`.
-  Next step: design proposal.
-  <!-- id: ot-three-layer-starter-templates | created: 2026-09-10 | last_used: 2026-09-10 | uses: 1 | tier: working | origin: 2026-09-10-234940 -->
+  right move." Design decisions RULED 2026-09-11 (Eric): templates live IN-REPO under
+  `templates/` (reactor/workspace-built so every build proves them; standalone build files
+  so a copy builds anywhere); each ships an AGENTS.md that OFFERS AI-enablement (no
+  pre-committed memory/); the Java trio carries BOTH Maven and Gradle build files (the
+  Gradle-or-Maven choice applies to templates only — discharges the consumer half of the
+  old add-gradle-build backlog); source files carry a one-line scaffold attribution
+  instead of the Apache/Accenture header (field applications are not open source).
+  IMPLEMENTED 2026-09-11: starter-function / starter-flow / starter-graph in both engines,
+  each tested end to end (Maven + Gradle green on Java; cargo test + clippy green on
+  Rust); ai-developer-guide playbook step 4 scaffolds from them; ci.yml gained a
+  templates-gradle job (Mercury is NOT on Maven Central — mavenLocal resolves engine
+  artifacts). RELEASE-SWEEP consequence recorded as [[conv-template-version-sweep]].
+  Remaining: PR + merge; then close.
+  <!-- id: ot-three-layer-starter-templates | created: 2026-09-10 | last_used: 2026-09-11 | uses: 2 | tier: working | origin: 2026-09-10-234940 -->

--- a/memory/sessions/2026-09-11-005808.md
+++ b/memory/sessions/2026-09-11-005808.md
@@ -1,0 +1,58 @@
+# Session (2026-09-11T00:58:08.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**The three-layer starter templates land** ([[ot-three-layer-starter-templates]] —
+Eric: "move on for the first class templates"; placement + AI-enablement ruled via
+the two design questions, both recommendations accepted):
+
+- **`templates/starter-function` / `starter-flow` / `starter-graph`** — copy-out
+  starter projects for the three layers, reactor-listed with STANDALONE poms (no
+  reactor parent; literal engine versions like the Snyk placeholders) so every
+  build proves them and a copy builds anywhere. Each: minimal instructive app
+  (Layer 1 typed AsyncHttpRequest greeting; Layer 2 validate→greet flow with
+  state-machine mapping; Layer 3 a ZERO-CODE starter-quote graph behind the
+  CompileGraph gate incl. the 404 test), tests (all green standalone), README,
+  and an AGENTS.md that routes a fresh agent to the entry-point playbook and
+  OFFERS AI-enablement.
+- **Gradle-or-Maven choice, templates only** (Eric's mid-arc ruling — discharges
+  the consumer half of the old add-gradle-build backlog): each template ships
+  `build.gradle` + `settings.gradle` beside the pom. Two field discoveries:
+  (1) **Mercury artifacts are NOT on Maven Central** (verified: no
+  org.platformlambda:platform-core at all) — templates resolve from mavenLocal,
+  READMEs state the prerequisite honestly, and ci.yml gained a
+  **templates-gradle job** (installs engine modules to mavenLocal first);
+  (2) Gradle 9 needs `junit-platform-launcher` declared (Surefire injects it,
+  Gradle does not). All three Gradle builds green locally (brew-installed
+  Gradle).
+- **License headers**: Eric's ruling — template sources carry a ONE-LINE scaffold
+  attribution instead of the Apache/Accenture header (field applications are not
+  open source); 16 files swept, zero headers remain.
+- Playbook step 4 (ai-developer-guide) now scaffolds from the templates and asks
+  the Maven-or-Gradle question; instructions.md structure tree gained
+  `templates/`; new continuity fact [[conv-template-version-sweep]] (the release
+  sweep must also grep build.gradle version literals). Rust twin landed in
+  lock-step (workspace members; path+version dual deps — a copy deletes the
+  `path` keys; engine-truthful divergences: `#[main_application]` EntryPoint
+  required, event-script linkage anchored via `flows::get_all_flows()`).
+- Engine behavior learned and encoded in the Layer-3 template: a graph that sets
+  `output.status` 400+ is converted into the standard error response by the
+  graph-executor exception path — custom reject-body fields do not survive.
+
+Verified: all three Maven module test suites green standalone; all three Gradle
+builds green; Rust `cargo test` trio + clippy green; strict docs builds + canon
+checks green; full Java reactor build (with the three new modules) run —
+result in this log's commit context.
+
+## Memory References
+
+- ot-three-layer-starter-templates (updated — decisions ruled, implemented)
+- conv-template-version-sweep (created)
+- compilegraph-mandatory-gate (consulted — the Layer-3 template deploys through
+  the manifest gate and tests the 404 behavior)
+- functions-decoupled-routes (consulted — template functions couple only by
+  route name; AGENTS.md states the contract)
+- eric-release-rhythm (consulted — branch/commit/push and PR text prepared;
+  PR-open and merge stay Eric's steps)

--- a/memory/sessions/2026-09-11-005808.md
+++ b/memory/sessions/2026-09-11-005808.md
@@ -46,6 +46,12 @@ builds green; Rust `cargo test` trio + clippy green; strict docs builds + canon
 checks green; full Java reactor build (with the three new modules) run —
 result in this log's commit context.
 
+Post-push follow-ups on the PR branch: Eric's local Sonar scan came back CLEAN
+on the templates; an accidental IDE gradle action generated wrapper files
+(gradle/, gradlew, gradlew.bat) inside starter-function — .gitignore now
+ignores template wrapper files (wrappers are per-copy artifacts, per the
+READMEs) and the strays were removed.
+
 ## Memory References
 
 - ot-three-layer-starter-templates (updated — decisions ruled, implemented)

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
         <module>examples/sync-over-async-demo</module>
         <module>examples/twin-kafka-demo</module>
 
+        <!-- Starter templates for the three layers (copy one out to begin a new
+             project; standalone poms - no reactor parent - listed here so every
+             build proves they stay current) -->
+        <module>templates/starter-function</module>
+        <module>templates/starter-flow</module>
+        <module>templates/starter-graph</module>
+
         <!-- Executable for benchmark tests
         <module>benchmark/benchmark-reporter</module>-->
     </modules>

--- a/templates/starter-flow/AGENTS.md
+++ b/templates/starter-flow/AGENTS.md
@@ -1,0 +1,20 @@
+# For AI agents
+
+This project was scaffolded from the mercury-composable `templates/starter-flow`
+template (Layer 2 — Event Script flows).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** Orchestration lives in flow YAML
+   (see the [flow grammar](https://accenture.github.io/mercury-composable/guides/event-script/flow-grammar/)
+   and the [Event Script AI agent guide](https://accenture.github.io/mercury-composable/guides/event-script/ai-agent-guide/));
+   business logic lives in functions (`@PreLoad` + `TypedLambdaFunction`), coupled only by
+   route name. A REST flow binding needs both `service: "http.flow.adapter"` and `flow:`.
+3. **Build and test** (both work; the project keeps one):
+   `mvn clean package` / `mvn test` — or — `gradle build` / `gradle test`.
+4. **Version:** the Mercury dependency version in the build file is the source of
+   truth; verify claims against the installed release rather than assuming.

--- a/templates/starter-flow/README.md
+++ b/templates/starter-flow/README.md
@@ -1,0 +1,60 @@
+# starter-flow — Layer 2 template
+
+A minimal Event Script application: an HTTP endpoint launches a flow that sequences two
+decoupled functions (`v1.validate.request` → `v1.make.greeting`) with declarative data
+mapping. Copy this directory out of the Mercury repository to begin a new project — the
+build files are standalone.
+
+## Choose your build tool
+
+The template ships both. Keep one, delete the other:
+
+- **Maven** — keep `pom.xml`
+- **Gradle** — keep `build.gradle` + `settings.gradle` (run `gradle wrapper` once in
+  your copy to pin a Gradle version)
+
+## Prerequisite
+
+Mercury artifacts are not published to Maven Central. Build the
+[mercury-composable](https://github.com/Accenture/mercury-composable) repository once with
+`mvn clean install` (this installs them into your local Maven repository), or point the
+build at your organization's artifact repository.
+
+## Build, test, run
+
+```bash
+# Maven
+mvn clean package
+java -jar target/starter-flow-4.12.6.jar
+
+# Gradle
+gradle build
+java -jar build/libs/starter-flow-4.12.6.jar
+```
+
+Then:
+
+```bash
+curl -s -X POST http://127.0.0.1:8302/api/greeting \
+     -H "content-type: application/json" \
+     -d '{"name": "Mercury"}'
+# → {"greeting": "Hello, Mercury", ...}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `src/main/resources/flows/greeting-flow.yml` | The orchestration — task order and data mapping, no code |
+| `src/main/resources/flows.yaml` | Registry of active flows |
+| `src/main/resources/rest.yaml` | Binds `/api/greeting` to the flow (`service` + `flow`, both required) |
+| `src/main/java/com/accenture/starter/tasks/` | The two functions — each knows nothing about the other |
+| `src/test/java/com/accenture/starter/GreetingFlowTest.java` | End-to-end flow test over HTTP |
+
+## Next steps
+
+- Grow the flow: add tasks, a `decision` branch, or an exception handler — see the
+  [Event Script syntax](https://accenture.github.io/mercury-composable/guides/event-script/syntax/).
+- Modeling a whole service as a graph? Move up a layer — see the
+  [starter-graph](../starter-graph) template and the
+  [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/).

--- a/templates/starter-flow/build.gradle
+++ b/templates/starter-flow/build.gradle
@@ -1,0 +1,51 @@
+/*
+ * Gradle build for the Layer 2 starter. The template supports BOTH build tools:
+ * keep this file (and settings.gradle) for Gradle, or pom.xml for Maven, and
+ * delete the other after copying the template out.
+ *
+ * Run "gradle wrapper" once in your copy to pin a Gradle version for the team.
+ */
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '4.1.1'
+}
+
+// single-source version literal - the Mercury release sweep updates it
+def mercuryVersion = '4.12.6'
+
+group = 'com.accenture'
+version = mercuryVersion
+description = 'Layer 2 starter - Event Script flows'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    // Mercury artifacts are not published to Maven Central: build the
+    // mercury-composable repository once with "mvn clean install" (which
+    // installs them into the local Maven repository), or replace mavenLocal
+    // with your organization's artifact repository
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.platformlambda:platform-core:${mercuryVersion}"
+    implementation "org.platformlambda:event-script-engine:${mercuryVersion}"
+
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+springBoot {
+    // AutoStart will find your Main Application(s)
+    mainClass = 'org.platformlambda.core.system.AutoStart'
+}

--- a/templates/starter-flow/pom.xml
+++ b/templates/starter-flow/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+        Layer 2 starter template. Copy this directory out to begin a new project:
+        the pom is standalone (no reactor parent), so it builds anywhere as-is.
+        The template supports BOTH build tools - keep this pom.xml for Maven, or
+        build.gradle + settings.gradle for Gradle, and delete the other.
+    -->
+    <groupId>com.accenture</groupId>
+    <artifactId>starter-flow</artifactId>
+    <packaging>jar</packaging>
+    <version>4.12.6</version>
+    <name>Layer 2 starter - Event Script flows</name>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.1</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.25</tomcat.version>
+        <netty.version>4.2.17.Final</netty.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
+        <java.version>21</java.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>2025.0.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>platform-core</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>event-script-engine</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>6.0.3</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- AutoStart will find your Main Application(s) -->
+                <configuration>
+                    <mainClass>org.platformlambda.core.system.AutoStart</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/templates/starter-flow/settings.gradle
+++ b/templates/starter-flow/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'starter-flow'

--- a/templates/starter-flow/src/main/java/com/accenture/starter/MainApp.java
+++ b/templates/starter-flow/src/main/java/com/accenture/starter/MainApp.java
@@ -1,0 +1,24 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.platformlambda.core.annotations.MainApplication;
+import org.platformlambda.core.models.EntryPoint;
+import org.platformlambda.core.system.AutoStart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@MainApplication
+public class MainApp implements EntryPoint {
+    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
+
+    public static void main(String[] args) {
+        AutoStart.main(args);
+    }
+
+    @Override
+    public void start(String[] args) {
+        // one-time application setup goes here; functions and flows are already registered
+        log.info("Started");
+    }
+}

--- a/templates/starter-flow/src/main/java/com/accenture/starter/tasks/MakeGreeting.java
+++ b/templates/starter-flow/src/main/java/com/accenture/starter/tasks/MakeGreeting.java
@@ -1,0 +1,28 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Second task of greeting-flow: compose the response. It knows nothing about
+ * the validator - the flow's state machine ('model.name') carries data
+ * between the decoupled tasks.
+ */
+@PreLoad(route = "v1.make.greeting", instances = 10)
+public class MakeGreeting implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+
+    private static final String NAME = "name";
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("greeting", "Hello, " + input.get(NAME));
+        result.put("served_by", "v1.make.greeting");
+        return result;
+    }
+}

--- a/templates/starter-flow/src/main/java/com/accenture/starter/tasks/ValidateRequest.java
+++ b/templates/starter-flow/src/main/java/com/accenture/starter/tasks/ValidateRequest.java
@@ -1,0 +1,28 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter.tasks;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.Map;
+
+/**
+ * First task of greeting-flow: reject a request without a name. The flow's
+ * input data mapping delivers 'input.body.name' as the "name" key; business
+ * logic stays here, never in the flow YAML.
+ */
+@PreLoad(route = "v1.validate.request", instances = 10)
+public class ValidateRequest implements TypedLambdaFunction<Map<String, Object>, Map<String, Object>> {
+
+    private static final String NAME = "name";
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
+        if (!(input.get(NAME) instanceof String name) || name.isBlank()) {
+            throw new AppException(400, "Missing 'name' - send a JSON body {\"name\": \"...\"}");
+        }
+        return Map.of(NAME, name.trim());
+    }
+}

--- a/templates/starter-flow/src/main/resources/application.properties
+++ b/templates/starter-flow/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+application.name=starter-flow
+info.app.version=1.0.0
+info.app.description=Layer 2 starter - Event Script flows
+#
+# the framework scans org.platformlambda plus the packages listed here
+#
+web.component.scan=com.accenture
+#
+# use a distinct port so a running application never collides with unit tests
+#
+rest.server.port=8302
+rest.automation=true
+#
+# Event Script flow registry
+#
+yaml.flow.automation=classpath:/flows.yaml
+#
+# no service mesh - composable applications are self-contained by default
+#
+cloud.connector=none

--- a/templates/starter-flow/src/main/resources/flows.yaml
+++ b/templates/starter-flow/src/main/resources/flows.yaml
@@ -1,0 +1,4 @@
+flows:
+  - 'greeting-flow.yml'
+
+location: 'classpath:/flows/'

--- a/templates/starter-flow/src/main/resources/flows/greeting-flow.yml
+++ b/templates/starter-flow/src/main/resources/flows/greeting-flow.yml
@@ -1,0 +1,30 @@
+#
+# Orchestration is configuration, not code: this flow sequences two decoupled
+# functions and maps data between them. Business logic stays in the functions.
+#
+flow:
+  id: 'greeting-flow'
+  description: 'Validate the request, then compose a greeting'
+  ttl: 10s
+
+first.task: 'v1.validate.request'
+
+tasks:
+  - input:
+      - 'input.body.name -> name'
+    process: 'v1.validate.request'
+    output:
+      - 'result.name -> model.name'
+    description: 'Reject requests without a name'
+    execution: sequential
+    next:
+      - 'v1.make.greeting'
+
+  - input:
+      - 'model.name -> name'
+    process: 'v1.make.greeting'
+    output:
+      - 'text(application/json) -> output.header.content-type'
+      - 'result -> output.body'
+    description: 'Compose the greeting from the state machine value'
+    execution: end

--- a/templates/starter-flow/src/main/resources/rest.yaml
+++ b/templates/starter-flow/src/main/resources/rest.yaml
@@ -1,0 +1,11 @@
+#
+# REST automation - a flow binding needs BOTH keys: 'service' selects the
+# flow adapter and 'flow' selects the flow to launch.
+#
+rest:
+  - service: "http.flow.adapter"
+    methods: ['POST']
+    url: "/api/greeting"
+    flow: 'greeting-flow'
+    timeout: 10s
+    tracing: true

--- a/templates/starter-flow/src/test/java/com/accenture/starter/GreetingFlowTest.java
+++ b/templates/starter-flow/src/test/java/com/accenture/starter/GreetingFlowTest.java
@@ -1,0 +1,56 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class GreetingFlowTest extends TestBase {
+    private static final String HTTP_CLIENT = "async.http.request";
+    private static final long TIMEOUT = 8000;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void flowComposesGreeting() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "200", "TEST /greeting");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("content-type", "application/json")
+                .setHeader("accept", "application/json")
+                .setBody(Map.of("name", "Mercury"))
+                .setUrl("/api/greeting");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(200, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("Hello, Mercury", body.get("greeting"));
+        assertEquals("v1.make.greeting", body.get("served_by"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void invalidRequestReturns400() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "201", "TEST /greeting");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("content-type", "application/json")
+                .setHeader("accept", "application/json")
+                .setBody(Map.of("unexpected", "payload"))
+                .setUrl("/api/greeting");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(400, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("error", body.get("type"));
+    }
+}

--- a/templates/starter-flow/src/test/java/com/accenture/starter/TestBase.java
+++ b/templates/starter-flow/src/test/java/com/accenture/starter/TestBase.java
@@ -1,0 +1,24 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestBase {
+    private static final AtomicInteger startCounter = new AtomicInteger(0);
+    protected static String host;
+
+    @BeforeAll
+    static void setup() {
+        // start the application once for the whole test run
+        if (startCounter.incrementAndGet() == 1) {
+            AppConfigReader config = AppConfigReader.getInstance();
+            host = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8302");
+            AutoStart.main(new String[0]);
+        }
+    }
+}

--- a/templates/starter-function/AGENTS.md
+++ b/templates/starter-function/AGENTS.md
@@ -1,0 +1,18 @@
+# For AI agents
+
+This project was scaffolded from the mercury-composable `templates/starter-function`
+template (Layer 1 — composable functions with REST automation).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** Functions follow `@PreLoad` + `TypedLambdaFunction`; couple
+   only by route name and `EventEnvelope` — never import another user function. HTTP
+   endpoints are declared in `rest.yaml`, never as ad-hoc controllers.
+3. **Build and test** (both work; the project keeps one):
+   `mvn clean package` / `mvn test` — or — `gradle build` / `gradle test`.
+4. **Version:** the Mercury dependency version in the build file is the source of
+   truth; verify claims against the installed release rather than assuming.

--- a/templates/starter-function/README.md
+++ b/templates/starter-function/README.md
@@ -1,0 +1,55 @@
+# starter-function — Layer 1 template
+
+A minimal composable application: one function (`v1.greeting`) exposed over HTTP by
+REST automation. Copy this directory out of the Mercury repository to begin a new
+project — the build files are standalone.
+
+## Choose your build tool
+
+The template ships both. Keep one, delete the other:
+
+- **Maven** — keep `pom.xml`
+- **Gradle** — keep `build.gradle` + `settings.gradle` (run `gradle wrapper` once in
+  your copy to pin a Gradle version)
+
+## Prerequisite
+
+Mercury artifacts are not published to Maven Central. Build the
+[mercury-composable](https://github.com/Accenture/mercury-composable) repository once with
+`mvn clean install` (this installs them into your local Maven repository), or point the
+build at your organization's artifact repository.
+
+## Build, test, run
+
+```bash
+# Maven
+mvn clean package
+java -jar target/starter-function-4.12.6.jar
+
+# Gradle
+gradle build
+java -jar build/libs/starter-function-4.12.6.jar
+```
+
+Then:
+
+```bash
+curl "http://127.0.0.1:8301/api/greeting?name=Mercury"
+# → {"greeting": "Hello, Mercury", ...}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `src/main/java/com/accenture/starter/Greeting.java` | The composable function — addressed only by its route name |
+| `src/main/resources/rest.yaml` | Maps `/api/greeting` to the function; add your endpoints here |
+| `src/main/resources/application.properties` | App name, port, `rest.automation` |
+| `src/test/java/com/accenture/starter/GreetingTest.java` | Unit test (function in isolation) + end-to-end HTTP test |
+
+## Next steps
+
+- Add functions (`@PreLoad` + `TypedLambdaFunction`) and map them in `rest.yaml`.
+- Ready to orchestrate several functions? Move up a layer — see the
+  [starter-flow](../starter-flow) template and the
+  [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/).

--- a/templates/starter-function/build.gradle
+++ b/templates/starter-function/build.gradle
@@ -1,0 +1,50 @@
+/*
+ * Gradle build for the Layer 1 starter. The template supports BOTH build tools:
+ * keep this file (and settings.gradle) for Gradle, or pom.xml for Maven, and
+ * delete the other after copying the template out.
+ *
+ * Run "gradle wrapper" once in your copy to pin a Gradle version for the team.
+ */
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '4.1.1'
+}
+
+// single-source version literal - the Mercury release sweep updates it
+def mercuryVersion = '4.12.6'
+
+group = 'com.accenture'
+version = mercuryVersion
+description = 'Layer 1 starter - composable functions with REST automation'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    // Mercury artifacts are not published to Maven Central: build the
+    // mercury-composable repository once with "mvn clean install" (which
+    // installs them into the local Maven repository), or replace mavenLocal
+    // with your organization's artifact repository
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.platformlambda:platform-core:${mercuryVersion}"
+
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+springBoot {
+    // AutoStart will find your Main Application(s)
+    mainClass = 'org.platformlambda.core.system.AutoStart'
+}

--- a/templates/starter-function/pom.xml
+++ b/templates/starter-function/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+        Layer 1 starter template. Copy this directory out to begin a new project:
+        the pom is standalone (no reactor parent), so it builds anywhere as-is.
+        The template supports BOTH build tools - keep this pom.xml for Maven, or
+        build.gradle + settings.gradle for Gradle, and delete the other.
+    -->
+    <groupId>com.accenture</groupId>
+    <artifactId>starter-function</artifactId>
+    <packaging>jar</packaging>
+    <version>4.12.6</version>
+    <name>Layer 1 starter - composable functions with REST automation</name>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.1</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.25</tomcat.version>
+        <netty.version>4.2.17.Final</netty.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
+        <java.version>21</java.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>2025.0.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>platform-core</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>6.0.3</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- AutoStart will find your Main Application(s) -->
+                <configuration>
+                    <mainClass>org.platformlambda.core.system.AutoStart</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/templates/starter-function/settings.gradle
+++ b/templates/starter-function/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'starter-function'

--- a/templates/starter-function/src/main/java/com/accenture/starter/Greeting.java
+++ b/templates/starter-function/src/main/java/com/accenture/starter/Greeting.java
@@ -1,0 +1,43 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.TypedLambdaFunction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The starter's single composable function. It is addressed only by its route
+ * name ("v1.greeting") - rest.yaml maps the /api/greeting endpoint to it, and
+ * the same function could join an Event Script flow or a knowledge graph
+ * without a code change.
+ */
+@PreLoad(route = "v1.greeting", instances = 10)
+public class Greeting implements TypedLambdaFunction<AsyncHttpRequest, Map<String, Object>> {
+
+    private static final String NAME = "name";
+
+    @Override
+    public Map<String, Object> handleEvent(Map<String, String> headers, AsyncHttpRequest input, int instance) {
+        if (input.getUrl() == null) {
+            throw new AppException(400, "The input does not appear to be an HTTP request. " +
+                    "Please route the request through REST automation");
+        }
+        String name = input.getQueryParameter(NAME);
+        if (name == null && input.getBody() instanceof Map<?, ?> map && map.get(NAME) instanceof String value) {
+            name = value;
+        }
+        if (name == null || name.isBlank()) {
+            throw new AppException(400, "Missing 'name' - send ?name=... or a JSON body {\"name\": \"...\"}");
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("greeting", "Hello, " + name);
+        result.put("served_by", "v1.greeting");
+        result.put("instance", instance);
+        return result;
+    }
+}

--- a/templates/starter-function/src/main/java/com/accenture/starter/MainApp.java
+++ b/templates/starter-function/src/main/java/com/accenture/starter/MainApp.java
@@ -1,0 +1,24 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.platformlambda.core.annotations.MainApplication;
+import org.platformlambda.core.models.EntryPoint;
+import org.platformlambda.core.system.AutoStart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@MainApplication
+public class MainApp implements EntryPoint {
+    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
+
+    public static void main(String[] args) {
+        AutoStart.main(args);
+    }
+
+    @Override
+    public void start(String[] args) {
+        // one-time application setup goes here; functions are already registered
+        log.info("Started");
+    }
+}

--- a/templates/starter-function/src/main/resources/application.properties
+++ b/templates/starter-function/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+application.name=starter-function
+info.app.version=1.0.0
+info.app.description=Layer 1 starter - composable functions with REST automation
+#
+# the framework scans org.platformlambda plus the packages listed here
+#
+web.component.scan=com.accenture
+#
+# use a distinct port so a running application never collides with unit tests
+#
+rest.server.port=8301
+rest.automation=true
+#
+# no service mesh - composable applications are self-contained by default
+#
+cloud.connector=none

--- a/templates/starter-function/src/main/resources/rest.yaml
+++ b/templates/starter-function/src/main/resources/rest.yaml
@@ -1,0 +1,10 @@
+#
+# REST automation - declare HTTP endpoints without writing controllers.
+# Each entry maps a URL to a function's route name.
+#
+rest:
+  - service: "v1.greeting"
+    methods: ['GET', 'POST']
+    url: "/api/greeting"
+    timeout: 10s
+    tracing: true

--- a/templates/starter-function/src/test/java/com/accenture/starter/GreetingTest.java
+++ b/templates/starter-function/src/test/java/com/accenture/starter/GreetingTest.java
@@ -1,0 +1,74 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GreetingTest extends TestBase {
+    private static final String HTTP_CLIENT = "async.http.request";
+    private static final long TIMEOUT = 8000;
+
+    @Test
+    void functionWorksInIsolation() {
+        // a composable function is plain Java - unit test it without the framework
+        Greeting greeting = new Greeting();
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setUrl("/api/greeting").setQueryParameter("name", "Mercury");
+        Map<String, Object> result = greeting.handleEvent(Map.of(), request, 1);
+        assertEquals("Hello, Mercury", result.get("greeting"));
+        assertEquals("v1.greeting", result.get("served_by"));
+    }
+
+    @Test
+    void missingNameIsRejectedInIsolation() {
+        Greeting greeting = new Greeting();
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setUrl("/api/greeting");
+        AppException ex = assertThrows(AppException.class, () -> greeting.handleEvent(Map.of(), request, 1));
+        assertEquals(400, ex.getStatus());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void endToEndOverHttp() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "100", "TEST /greeting");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("GET")
+                .setHeader("accept", "application/json")
+                .setQueryParameter("name", "Mercury")
+                .setUrl("/api/greeting");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(200, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("Hello, Mercury", body.get("greeting"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void missingNameReturns400OverHttp() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "101", "TEST /greeting");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("GET")
+                .setHeader("accept", "application/json")
+                .setUrl("/api/greeting");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(400, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("error", body.get("type"));
+    }
+}

--- a/templates/starter-function/src/test/java/com/accenture/starter/TestBase.java
+++ b/templates/starter-function/src/test/java/com/accenture/starter/TestBase.java
@@ -1,0 +1,24 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestBase {
+    private static final AtomicInteger startCounter = new AtomicInteger(0);
+    protected static String host;
+
+    @BeforeAll
+    static void setup() {
+        // start the application once for the whole test run
+        if (startCounter.incrementAndGet() == 1) {
+            AppConfigReader config = AppConfigReader.getInstance();
+            host = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8301");
+            AutoStart.main(new String[0]);
+        }
+    }
+}

--- a/templates/starter-graph/AGENTS.md
+++ b/templates/starter-graph/AGENTS.md
@@ -1,0 +1,22 @@
+# For AI agents
+
+This project was scaffolded from the mercury-composable `templates/starter-graph`
+template (Layer 3 — Active Knowledge Graph as the application).
+
+1. **Orient first.** Read the
+   [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/) —
+   it carries the mental model, the entry-point playbook, and the layer-choice tree.
+   If this repository is not yet AI-enabled, offer the human to install the
+   [shared memory layer](https://accenture.github.io/mercury-go/) and co-write the
+   Vision before feature work (the Vision is human-confirmed, never fabricated).
+2. **Authoring contract.** The graph model IS the application. Author models with the
+   [MiniGraph command grammar](https://accenture.github.io/mercury-composable/guides/knowledge-graph/command-reference/)
+   and the
+   [knowledge-graph AI agent guide](https://accenture.github.io/mercury-composable/guides/knowledge-graph/ai-agent-guide/);
+   deployment is governed — only graphs listed in `graphs.yaml` that pass the
+   CompileGraph gate at startup are executable (anything else answers 404). Custom
+   logic goes into skill functions (`@PreLoad`), never into ad-hoc endpoints.
+3. **Build and test** (both work; the project keeps one):
+   `mvn clean package` / `mvn test` — or — `gradle build` / `gradle test`.
+4. **Version:** the Mercury dependency version in the build file is the source of
+   truth; verify claims against the installed release rather than assuming.

--- a/templates/starter-graph/README.md
+++ b/templates/starter-graph/README.md
@@ -1,0 +1,63 @@
+# starter-graph — Layer 3 template
+
+A minimal Active Knowledge Graph application with **zero imperative code**: the deployed
+graph model (`starter-quote`) validates the request and answers from its own knowledge.
+Changing what the service does means editing the model, not writing code. Copy this
+directory out of the Mercury repository to begin a new project — the build files are
+standalone.
+
+## Choose your build tool
+
+The template ships both. Keep one, delete the other:
+
+- **Maven** — keep `pom.xml`
+- **Gradle** — keep `build.gradle` + `settings.gradle` (run `gradle wrapper` once in
+  your copy to pin a Gradle version)
+
+## Prerequisite
+
+Mercury artifacts are not published to Maven Central. Build the
+[mercury-composable](https://github.com/Accenture/mercury-composable) repository once with
+`mvn clean install` (this installs them into your local Maven repository), or point the
+build at your organization's artifact repository.
+
+## Build, test, run
+
+```bash
+# Maven
+mvn clean package
+java -jar target/starter-graph-4.12.6.jar
+
+# Gradle
+gradle build
+java -jar build/libs/starter-graph-4.12.6.jar
+```
+
+Then:
+
+```bash
+curl -s -X POST http://127.0.0.1:8303/api/graph/starter-quote \
+     -H "content-type: application/json" \
+     -d '{"item": "widget"}'
+# → {"item": "widget", "unit_price": 100, "currency": "USD", "status": "quoted"}
+```
+
+## What to look at
+
+| File | Role |
+|:---|:---|
+| `src/main/resources/graph/starter-quote.json` | The application — a graph whose nodes execute during traversal |
+| `src/main/resources/graphs.yaml` | The deployment manifest: only listed graphs that pass the CompileGraph gate are executable ("compiled or 404") |
+| `src/main/resources/flows/graph-executor.yml` | The standard exposure flow behind `/api/graph/{graph_id}` |
+| `src/test/java/com/accenture/starter/QuoteGraphTest.java` | End-to-end graph tests, including the 404 gate behavior |
+
+## Next steps
+
+- Evolve the model: add nodes, decisions, and skills — the
+  [built-in skills reference](https://accenture.github.io/mercury-composable/guides/knowledge-graph/skills-reference/)
+  catalogs what nodes can do without code.
+- Draft and dry-run models interactively in the Playground — see
+  [Playground & AI companion](https://accenture.github.io/mercury-composable/guides/knowledge-graph/playground-and-companion/).
+- Custom logic when the model needs it: attach a skill function (`@PreLoad`) to a node —
+  the deliberate seam between the model and code. See the
+  [AI developer guide](https://accenture.github.io/mercury-composable/guides/ai-developer-guide/).

--- a/templates/starter-graph/build.gradle
+++ b/templates/starter-graph/build.gradle
@@ -1,0 +1,52 @@
+/*
+ * Gradle build for the Layer 3 starter. The template supports BOTH build tools:
+ * keep this file (and settings.gradle) for Gradle, or pom.xml for Maven, and
+ * delete the other after copying the template out.
+ *
+ * Run "gradle wrapper" once in your copy to pin a Gradle version for the team.
+ */
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '4.1.1'
+}
+
+// single-source version literal - the Mercury release sweep updates it
+def mercuryVersion = '4.12.6'
+
+group = 'com.accenture'
+version = mercuryVersion
+description = 'Layer 3 starter - Active Knowledge Graph as the application'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    // Mercury artifacts are not published to Maven Central: build the
+    // mercury-composable repository once with "mvn clean install" (which
+    // installs them into the local Maven repository), or replace mavenLocal
+    // with your organization's artifact repository
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.platformlambda:platform-core:${mercuryVersion}"
+    implementation "org.platformlambda:event-script-engine:${mercuryVersion}"
+    implementation "org.platformlambda:minigraph-playground-engine:${mercuryVersion}"
+
+    testImplementation platform('org.junit:junit-bom:6.0.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+springBoot {
+    // AutoStart will find your Main Application(s)
+    mainClass = 'org.platformlambda.core.system.AutoStart'
+}

--- a/templates/starter-graph/pom.xml
+++ b/templates/starter-graph/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+        Layer 3 starter template. Copy this directory out to begin a new project:
+        the pom is standalone (no reactor parent), so it builds anywhere as-is.
+        The template supports BOTH build tools - keep this pom.xml for Maven, or
+        build.gradle + settings.gradle for Gradle, and delete the other.
+    -->
+    <groupId>com.accenture</groupId>
+    <artifactId>starter-graph</artifactId>
+    <packaging>jar</packaging>
+    <version>4.12.6</version>
+    <name>Layer 3 starter - Active Knowledge Graph as the application</name>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.1.1</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.25</tomcat.version>
+        <netty.version>4.2.17.Final</netty.version>
+        <jackson-2-bom.version>2.22.2</jackson-2-bom.version>
+        <jackson-bom.version>3.2.2</jackson-bom.version>
+        <log4j2.version>2.26.1</log4j2.version>
+        <gson.version>2.14.0</gson.version>
+        <java.version>21</java.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>2025.0.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>platform-core</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>event-script-engine</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>minigraph-playground-engine</artifactId>
+            <version>4.12.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>6.0.3</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-Xlint:deprecation</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- AutoStart will find your Main Application(s) -->
+                <configuration>
+                    <mainClass>org.platformlambda.core.system.AutoStart</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/templates/starter-graph/settings.gradle
+++ b/templates/starter-graph/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'starter-graph'

--- a/templates/starter-graph/src/main/java/com/accenture/starter/MainApp.java
+++ b/templates/starter-graph/src/main/java/com/accenture/starter/MainApp.java
@@ -1,0 +1,25 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.platformlambda.core.annotations.MainApplication;
+import org.platformlambda.core.models.EntryPoint;
+import org.platformlambda.core.system.AutoStart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@MainApplication
+public class MainApp implements EntryPoint {
+    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
+
+    public static void main(String[] args) {
+        AutoStart.main(args);
+    }
+
+    @Override
+    public void start(String[] args) {
+        // one-time application setup goes here; the CompileGraph gate has already
+        // validated and compiled the manifest-listed graph models at startup
+        log.info("Started");
+    }
+}

--- a/templates/starter-graph/src/main/resources/application.properties
+++ b/templates/starter-graph/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+application.name=starter-graph
+info.app.version=1.0.0
+info.app.description=Layer 3 starter - Active Knowledge Graph as the application
+#
+# the framework scans org.platformlambda plus the packages listed here
+#
+web.component.scan=com.accenture
+#
+# use a distinct port so a running application never collides with unit tests
+#
+rest.server.port=8303
+rest.automation=true
+#
+# Event Script flow registry (the graph-executor flow exposes deployed graphs)
+#
+yaml.flow.automation=classpath:/flows.yaml
+#
+# CompileGraph quality gate (required for deployed graph execution) - validates and
+# compiles the manifest-listed graph models at startup; only graphs that pass the
+# gate are executable ("compiled or 404"), and the manifest's optional 'location'
+# entry points at the deployed model folder (default classpath:/graph)
+#
+graph.model.automation=classpath:/graphs.yaml
+#
+# no service mesh - composable applications are self-contained by default
+#
+cloud.connector=none

--- a/templates/starter-graph/src/main/resources/flows.yaml
+++ b/templates/starter-graph/src/main/resources/flows.yaml
@@ -1,0 +1,4 @@
+flows:
+  - 'graph-executor.yml'
+
+location: 'classpath:/flows/'

--- a/templates/starter-graph/src/main/resources/flows/graph-executor.yml
+++ b/templates/starter-graph/src/main/resources/flows/graph-executor.yml
@@ -1,0 +1,37 @@
+#
+# The standard exposure flow for deployed graphs: REST automation routes
+# /api/graph/{graph_id} here, and graph.executor traverses the compiled model.
+#
+flow:
+  id: 'graph-executor'
+  description: 'MiniGraph Traveler'
+  ttl: 60s
+  exception: 'graph.exception.handler'
+
+first.task: 'graph.executor'
+
+tasks:
+  - input:
+      # pass flow instance ID so the task can access the input and model namespaces in the flow instance
+      - 'model.instance -> header.instance'
+      - 'input.path_parameter.graph_id -> header.graph'
+    process: 'graph.executor'
+    output:
+      - 'status -> output.status'
+      - 'header -> output.header'
+      - 'result -> output.body'
+    description: 'Perform active graph traversal and execute nodes'
+    execution: end
+
+  - input:
+      - 'error.code -> status'
+      - 'error.message -> message'
+      - 'error.stack -> stack'
+    process: 'graph.exception.handler'
+    output:
+      # In normal response, the status code is available in 'status'.
+      # Since this is an exception handler, the status code is obtained from the result set.
+      - 'result.status -> output.status'
+      - 'result -> output.body'
+    description: 'Just an exception handler'
+    execution: end

--- a/templates/starter-graph/src/main/resources/graph/starter-quote.json
+++ b/templates/starter-graph/src/main/resources/graph/starter-quote.json
@@ -1,0 +1,117 @@
+{
+  "nodes": [
+    {
+      "alias": "root",
+      "types": [
+        "Root"
+      ],
+      "properties": {
+        "name": "starter-quote",
+        "purpose": "Zero-code quote service: validate the request, then answer from the graph's own knowledge - the model IS the application"
+      }
+    },
+    {
+      "alias": "check-input",
+      "types": [
+        "Decision"
+      ],
+      "properties": {
+        "skill": "graph.math",
+        "statement": [
+          "MAPPING: text(={input.body.item}) -> model.item_probe",
+          "IF: {model.item_probe} == '=null'\nTHEN: reject\nELSE: quote"
+        ],
+        "purpose": "A request must name the item to quote"
+      }
+    },
+    {
+      "alias": "reject",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "int(400) -> output.status",
+          "text(Missing item. Provide the item name in the 'item' field) -> output.body.message"
+        ],
+        "purpose": "Reject a request without an item - an output.status of 400+ becomes the standard error response"
+      }
+    },
+    {
+      "alias": "quote",
+      "types": [
+        "mapper"
+      ],
+      "properties": {
+        "skill": "graph.data.mapper",
+        "mapping": [
+          "input.body.item -> output.body.item",
+          "int(100) -> output.body.unit_price",
+          "text(USD) -> output.body.currency",
+          "text(quoted) -> output.body.status"
+        ],
+        "purpose": "Compose the quote from the graph's knowledge"
+      }
+    },
+    {
+      "alias": "end",
+      "types": [
+        "End"
+      ],
+      "properties": {}
+    }
+  ],
+  "connections": [
+    {
+      "source": "root",
+      "relations": [
+        {
+          "type": "run",
+          "properties": {}
+        }
+      ],
+      "target": "check-input"
+    },
+    {
+      "source": "check-input",
+      "relations": [
+        {
+          "type": "valid",
+          "properties": {}
+        }
+      ],
+      "target": "quote"
+    },
+    {
+      "source": "check-input",
+      "relations": [
+        {
+          "type": "invalid",
+          "properties": {}
+        }
+      ],
+      "target": "reject"
+    },
+    {
+      "source": "quote",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    },
+    {
+      "source": "reject",
+      "relations": [
+        {
+          "type": "then",
+          "properties": {}
+        }
+      ],
+      "target": "end"
+    }
+  ]
+}

--- a/templates/starter-graph/src/main/resources/graphs.yaml
+++ b/templates/starter-graph/src/main/resources/graphs.yaml
@@ -1,0 +1,8 @@
+#
+# The deployment manifest: only graphs listed here (and passing the CompileGraph
+# gate at startup) are executable at POST /api/graph/{graph_id}.
+#
+graphs:
+  - 'starter-quote'
+
+location: 'classpath:/graph'

--- a/templates/starter-graph/src/main/resources/rest.yaml
+++ b/templates/starter-graph/src/main/resources/rest.yaml
@@ -1,0 +1,12 @@
+#
+# REST automation - deployed graphs are executed through the graph-executor
+# flow; only manifest-listed graphs that pass the CompileGraph gate respond
+# (anything else is HTTP-404, as if nonexistent).
+#
+rest:
+  - service: "http.flow.adapter"
+    methods: ['POST', 'GET']
+    url: "/api/graph/{graph_id}"
+    flow: 'graph-executor'
+    timeout: 30s
+    tracing: true

--- a/templates/starter-graph/src/test/java/com/accenture/starter/QuoteGraphTest.java
+++ b/templates/starter-graph/src/test/java/com/accenture/starter/QuoteGraphTest.java
@@ -1,0 +1,73 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.models.AsyncHttpRequest;
+import org.platformlambda.core.models.EventEnvelope;
+import org.platformlambda.core.system.PostOffice;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class QuoteGraphTest extends TestBase {
+    private static final String HTTP_CLIENT = "async.http.request";
+    private static final long TIMEOUT = 10000;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void deployedGraphAnswersQuote() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "300", "TEST /graph/quote");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("content-type", "application/json")
+                .setHeader("accept", "application/json")
+                .setBody(Map.of("item", "widget"))
+                .setUrl("/api/graph/starter-quote");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(200, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("widget", body.get("item"));
+        assertEquals(100, body.get("unit_price"));
+        assertEquals("quoted", body.get("status"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void missingItemIsRejected() throws ExecutionException, InterruptedException {
+        PostOffice po = PostOffice.trackable("unit.test", "301", "TEST /graph/quote");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("content-type", "application/json")
+                .setHeader("accept", "application/json")
+                .setBody(Map.of("unexpected", "payload"))
+                .setUrl("/api/graph/starter-quote");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(400, result.getStatus());
+        assertInstanceOf(Map.class, result.getBody());
+        // a graph that sets output.status 400+ yields the standard error response
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertEquals("Missing item. Provide the item name in the 'item' field", body.get("message"));
+    }
+
+    @Test
+    void unlistedGraphIs404() throws ExecutionException, InterruptedException {
+        // "compiled or 404": a graph absent from the manifest behaves as nonexistent
+        PostOffice po = PostOffice.trackable("unit.test", "302", "TEST /graph/quote");
+        AsyncHttpRequest request = new AsyncHttpRequest();
+        request.setTargetHost(host).setMethod("POST")
+                .setHeader("content-type", "application/json")
+                .setHeader("accept", "application/json")
+                .setBody(Map.of("item", "widget"))
+                .setUrl("/api/graph/no-such-graph");
+        EventEnvelope req = new EventEnvelope().setTo(HTTP_CLIENT).setBody(request);
+        EventEnvelope result = po.request(req, TIMEOUT).get();
+        assertEquals(404, result.getStatus());
+    }
+}

--- a/templates/starter-graph/src/test/java/com/accenture/starter/TestBase.java
+++ b/templates/starter-graph/src/test/java/com/accenture/starter/TestBase.java
@@ -1,0 +1,24 @@
+// Scaffolded from Mercury Composable's starter templates (https://github.com/Accenture/mercury-composable, Apache-2.0)
+
+package com.accenture.starter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.platformlambda.core.system.AutoStart;
+import org.platformlambda.core.util.AppConfigReader;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestBase {
+    private static final AtomicInteger startCounter = new AtomicInteger(0);
+    protected static String host;
+
+    @BeforeAll
+    static void setup() {
+        // start the application once for the whole test run
+        if (startCounter.incrementAndGet() == 1) {
+            AppConfigReader config = AppConfigReader.getInstance();
+            host = "http://127.0.0.1:" + config.getProperty("rest.server.port", "8303");
+            AutoStart.main(new String[0]);
+        }
+    }
+}


### PR DESCRIPTION
## What

First-class starter templates for the three layers, under `templates/`: **starter-function** (Layer 1, a typed HTTP-facing function), **starter-flow** (Layer 2, a validate→greet flow with state-machine data mapping), and **starter-graph** (Layer 3, a zero-code knowledge-graph service behind the CompileGraph gate, with the "compiled or 404" behavior tested).

- Copy-out by design: standalone poms (no reactor parent, literal engine versions), yet reactor-listed so every build proves they stay current.
- **Maven or Gradle** — each template ships both build files; keep one, delete the other. The Gradle choice applies to templates only. New `templates-gradle` CI job verifies the Gradle side (Mercury artifacts are not on Maven Central, so engine modules install to mavenLocal first — the READMEs state this prerequisite).
- Each template carries a README and an `AGENTS.md` that routes a fresh AI agent to the entry-point playbook and offers AI-enablement; the AI developer guide's scaffold step now points at the templates and asks the build-tool question.
- Template sources carry a one-line scaffold attribution instead of the full license header — field applications built from them are not open source.

## Why

The fresh-agent playbook needs first-class scaffold targets ("shall I set up a boilerplate repo with the knowledge-graph engine?"), and the template opportunity discharges the long-standing Gradle-enablement backlog on the consumer side without touching the engine's Maven reactor. Lock-step with Accenture/mercury.

Verified: full reactor build green with the three new modules; all three Gradle builds green; each template's test suite green standalone; docs strict build + canon checks green. Release note: the version sweep must now include `--include=build.gradle` (recorded in continuity).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>