### PR TITLE
event-script: simple-plugin allowlist gate scans method bodies

### DIFF
--- a/docs/guides/flow-schema-reference.md
+++ b/docs/guides/flow-schema-reference.md
@@ -1062,8 +1062,13 @@ mapping statement at either boundary, no per-field mapping.
 > flow. The typical use case is hydrating secrets from a secret manager at start-up; components
 > that already consumed a parameter will not see a later override.
 
-> Plugins are validated at compile time. They may only use classes from `java.lang`,
-> `java.util`, `java.math`, `java.time`, and Mercury framework packages.
+> Plugins are validated at application startup by the loader's allowlist gate, which scans
+> the full class — method bodies included — before registration. A plugin may only reference
+> `java.lang`, `java.util`, `java.math`, `java.time`, and the framework's plugin surface
+> (`SimplePlugin`, `PluginFunction`, `MultiLevelMap`, `SimplePluginUtils`,
+> `TypeConversionUtils`, `KeyNormalizationUtils`). Anything else — `java.io`, `java.net`,
+> threads — causes the plugin to be skipped with a warning. This enforces the design goal
+> that every simple plugin executes in sub-millisecond time with no side effects.
 
 ---
 

--- a/memory/open-threads/thread-ot-simple-plugin-gate-body-scan.md
+++ b/memory/open-threads/thread-ot-simple-plugin-gate-body-scan.md
@@ -15,4 +15,11 @@
   sentence ("Mercury framework packages") with the enforced list. Java-only — the Rust
   engine's no-allowlist divergence stands (compiled/linked code, no runtime class loading).
   Not a release blocker: the gap predates v4.12.6 entirely.
-  <!-- id: ot-simple-plugin-gate-body-scan | created: 2026-09-10 | last_used: 2026-09-10 | uses: 2 | tier: working | origin: 2026-09-10-150848 -->
+  IMPLEMENTED 2026-09-11 per the ruled shape (origin of the implementation record:
+  2026-09-11-024330): real MethodVisitor incl. invokedynamic/ldc/try-catch; SKIP_CODE
+  dropped; the two helpers allowlisted; two soundness rules added by the body scan —
+  analyzed classes excluded from the disallowed set (self/lambda references) and nested
+  classes recursively analyzed; SimplePluginGateTest + three fixtures prove skip/register
+  behavior through the real loader; registry ≥ 50 pins the built-ins; doc sentence
+  aligned. Module 224 tests green. Pending PR + merge; close then.
+  <!-- id: ot-simple-plugin-gate-body-scan | created: 2026-09-10 | last_used: 2026-09-11 | uses: 3 | tier: working | origin: 2026-09-10-150848 -->

--- a/memory/sessions/2026-09-11-024330.md
+++ b/memory/sessions/2026-09-11-024330.md
@@ -1,0 +1,48 @@
+# Session (2026-09-11T02:43:30.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Simple-plugin allowlist gate hardened: method bodies are now scanned**
+([[ot-simple-plugin-gate-body-scan]] — Eric's "proceed"; the ruled fix shape
+implemented exactly):
+
+- `RecursiveClassTypeExaminer` gained a real `MethodVisitor`: method-call and
+  field owners, NEW/ANEWARRAY/CHECKCAST/INSTANCEOF types, invokedynamic
+  bootstrap + handle arguments (lambdas and method references — including
+  ConstantDynamic recursion), `ldc` class literals, multianewarray
+  descriptors, try/catch types, and declared `throws` exceptions.
+- `SimplePluginLoader`: `SKIP_CODE` dropped (now `SKIP_DEBUG | SKIP_FRAMES`);
+  `TypeConversionUtils` and `KeyNormalizationUtils` join ALLOWED_PACKAGES
+  (their bodies are what built-ins legitimately call); two soundness rules the
+  body scan made necessary — (1) analyzed classes are excluded from the
+  disallowed check (`allTypes.removeAll(visitedClasses)`) so self-references
+  from lambdas/private helpers are not foreign types, and (2) NESTED classes
+  (`Outer$Inner`) are recursively analyzed as part of the plugin, so their
+  bodies are validated rather than flagged.
+- Proof: new `SimplePluginGateTest` + three gate fixtures in test sources —
+  `disallowedIo` (java.io in the method body, signature clean) and
+  `disallowedLambda` (java.net hidden in a never-invoked lambda) are SKIPPED
+  by the real loader with the warning; `gateInnerOk` (nested helper + lambda
+  within the allowlist) registers; camelCase/snakeCase register (bodies use
+  the newly allowlisted helpers); registry size ≥ 50 pins the built-in
+  inventory as the regression net. Module: 224 tests green.
+- `flow-schema-reference.md` allowlist sentence aligned with the enforced
+  behavior (startup gate, full-class scan incl. bodies, the exact six
+  framework classes, skip-with-warning; sub-millisecond design goal stated).
+  No claims-registry pin on that sentence (verified); canon checks + strict
+  docs build green. The page is packaged in the AI contract — the reactor run
+  re-validates the snapshot.
+- Java-only by design: the Rust engine has no runtime plugin loading
+  (compile-time registration), so its no-allowlist divergence stands.
+
+## Memory References
+
+- ot-simple-plugin-gate-body-scan (consulted — the ruled fix shape was the
+  implementation spec; thread to close at merge)
+- conv-telemetry-presentation-parity (consulted — confirmed this arc is
+  OUTSIDE the lock-step contract: the gate is a Java runtime-loading concern,
+  no Event Script surface or message text changed)
+- eric-release-rhythm (consulted — branch/commit/push and PR text prepared;
+  PR-open and merge stay Eric's steps)

--- a/system/event-script-engine/src/main/java/com/accenture/automation/SimplePluginLoader.java
+++ b/system/event-script-engine/src/main/java/com/accenture/automation/SimplePluginLoader.java
@@ -19,8 +19,10 @@
 package com.accenture.automation;
 
 import com.accenture.models.SimplePlugin;
+import com.accenture.util.KeyNormalizationUtils;
 import com.accenture.util.RecursiveClassTypeExaminer;
 import com.accenture.util.SimplePluginUtils;
+import com.accenture.util.TypeConversionUtils;
 import io.github.classgraph.ClassInfo;
 import org.objectweb.asm.*;
 import org.platformlambda.core.annotations.BeforeApplication;
@@ -60,7 +62,9 @@ public class SimplePluginLoader implements EntryPoint {
                                                             SimplePlugin.class.getName(),
                                                             PluginFunction.class.getName(),
                                                             MultiLevelMap.class.getName(),
-                                                            SimplePluginUtils.class.getName());
+                                                            SimplePluginUtils.class.getName(),
+                                                            TypeConversionUtils.class.getName(),
+                                                            KeyNormalizationUtils.class.getName());
     /**
      * Internal API that returns loaded Plugins
      *
@@ -110,7 +114,8 @@ public class SimplePluginLoader implements EntryPoint {
             try (stream) {
                 ClassReader reader = new ClassReader(stream);
                 RecursiveClassTypeExaminer visitor = new RecursiveClassTypeExaminer();
-                reader.accept(visitor, ClassReader.SKIP_CODE);
+                // method BODIES are scanned too - keep the code attribute, skip only debug/frames
+                reader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
                 // Add types from this class
                 allTypes.addAll(visitor.getTypes());
                 // Recursively analyze superclass
@@ -120,6 +125,13 @@ public class SimplePluginLoader implements EntryPoint {
                 // Recursively analyze interfaces
                 for (String iFace : visitor.getInterfaces()) {
                     analyzeClass(iFace, allTypes, visitedClasses);
+                }
+                // Recursively analyze nested classes - they are part of the plugin, so their
+                // bodies are validated instead of being flagged as foreign types
+                for (String type : visitor.getTypes()) {
+                    if (type.startsWith(className + "$")) {
+                        analyzeClass(type, allTypes, visitedClasses);
+                    }
                 }
             } catch (IOException e) {
                 log.error("Unable to analyze class ({})", className, e);
@@ -131,12 +143,18 @@ public class SimplePluginLoader implements EntryPoint {
         Set<String> allTypes = new HashSet<>();
         Set<String> visitedClasses = new HashSet<>();
         analyzeClass(clazz.getName(), allTypes, visitedClasses);
+        // every analyzed class had its own body validated, so self-references
+        // (lambdas, private helpers, nested classes) are not foreign types
+        allTypes.removeAll(visitedClasses);
         return allTypes;
     }
 
     /**
      * Determines whether we should register plugin. This method is designed to be future-proof.
-     * Currently, the only restriction is based on the type of packages included.
+     * Currently, the only restriction is based on the type of packages included. The scan covers
+     * the FULL class - superclass, interfaces, signatures and method bodies (call/field owners,
+     * new/cast types, lambda handles, class literals, catch types) - so a plugin cannot reach
+     * outside the allowlist from inside its calculate() body.
      * @param clazz The clazz we are introspecting
      * @return true if we should register this plugin, false otherwise
      */

--- a/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * Collects every class a class file references — superclass, interfaces, field and
  * method signatures, declared exceptions, AND method-body references (call and field
  * owners, new/cast/instanceof types, lambda and method-reference handles, class
- * literals, catch types) — so the SimplePluginLoader's allowlist gate validates what
+ * literals, catch types). Therefore, the SimplePluginLoader's allowlist gate validates what
  * a plugin actually does, not just its shape.
  */
 public class RecursiveClassTypeExaminer extends ClassVisitor {

--- a/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
+++ b/system/event-script-engine/src/main/java/com/accenture/util/RecursiveClassTypeExaminer.java
@@ -23,6 +23,13 @@ import org.objectweb.asm.*;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Collects every class a class file references — superclass, interfaces, field and
+ * method signatures, declared exceptions, AND method-body references (call and field
+ * owners, new/cast/instanceof types, lambda and method-reference handles, class
+ * literals, catch types) — so the SimplePluginLoader's allowlist gate validates what
+ * a plugin actually does, not just its shape.
+ */
 public class RecursiveClassTypeExaminer extends ClassVisitor {
 
     private final Set<String> types = new HashSet<>();
@@ -53,6 +60,48 @@ public class RecursiveClassTypeExaminer extends ClassVisitor {
         }
     }
 
+    private void addInternalName(String internalName) {
+        if (internalName != null) {
+            if (internalName.charAt(0) == '[') {
+                // an array owner, e.g. String[].clone()
+                addType(Type.getType(internalName));
+            } else {
+                types.add(internalName.replace('/', '.'));
+            }
+        }
+    }
+
+    private void addMethodDescriptor(String descriptor) {
+        Type methodType = Type.getMethodType(descriptor);
+        addType(methodType.getReturnType());
+        for (Type argType : methodType.getArgumentTypes()) {
+            addType(argType);
+        }
+    }
+
+    private void addHandle(Handle handle) {
+        addInternalName(handle.getOwner());
+        String descriptor = handle.getDesc();
+        if (descriptor.startsWith("(")) {
+            addMethodDescriptor(descriptor);
+        } else {
+            addType(Type.getType(descriptor));
+        }
+    }
+
+    private void addConstant(Object value) {
+        if (value instanceof Type type) {
+            addType(type);
+        } else if (value instanceof Handle handle) {
+            addHandle(handle);
+        } else if (value instanceof ConstantDynamic constant) {
+            addHandle(constant.getBootstrapMethod());
+            for (int i = 0; i < constant.getBootstrapMethodArgumentCount(); i++) {
+                addConstant(constant.getBootstrapMethodArgument(i));
+            }
+        }
+    }
+
     @Override
     public void visit(int version, int access, String name, String signature,
                       String superName, String[] interfaceNames) {
@@ -80,11 +129,67 @@ public class RecursiveClassTypeExaminer extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(int access, String name, String descriptor,
                                      String signature, String[] exceptions) {
-        Type methodType = Type.getType(descriptor);
-        addType(methodType.getReturnType());
-        for (Type argType : methodType.getArgumentTypes()) {
-            addType(argType);
+        addMethodDescriptor(descriptor);
+        if (exceptions != null) {
+            for (String exception : exceptions) {
+                addInternalName(exception);
+            }
         }
-        return null;
+        // a real MethodVisitor: body references count toward the allowlist gate
+        return new MethodBodyTypeExaminer();
+    }
+
+    private class MethodBodyTypeExaminer extends MethodVisitor {
+
+        private MethodBodyTypeExaminer() {
+            super(Opcodes.ASM9);
+        }
+
+        @Override
+        public void visitTypeInsn(int opcode, String type) {
+            // NEW, ANEWARRAY, CHECKCAST, INSTANCEOF
+            addInternalName(type);
+        }
+
+        @Override
+        public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+            addInternalName(owner);
+            addType(Type.getType(descriptor));
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor,
+                                    boolean isInterface) {
+            addInternalName(owner);
+            addMethodDescriptor(descriptor);
+        }
+
+        @Override
+        public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle,
+                                           Object... bootstrapMethodArguments) {
+            // lambdas and method references: the bootstrap plus every handle argument
+            addMethodDescriptor(descriptor);
+            addHandle(bootstrapMethodHandle);
+            for (Object argument : bootstrapMethodArguments) {
+                addConstant(argument);
+            }
+        }
+
+        @Override
+        public void visitLdcInsn(Object value) {
+            // class literals and constant method handles
+            addConstant(value);
+        }
+
+        @Override
+        public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
+            addType(Type.getType(descriptor));
+        }
+
+        @Override
+        public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+            // type is null for a finally block
+            addInternalName(type);
+        }
     }
 }

--- a/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginGateTest.java
+++ b/system/event-script-engine/src/test/java/com/accenture/automation/SimplePluginGateTest.java
@@ -1,0 +1,56 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.automation;
+
+import com.accenture.setup.TestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The allowlist gate scans the FULL plugin class - method bodies included - so
+ * a plugin whose signature is clean cannot reach outside the allowlist from
+ * inside calculate(). The fixtures live in com.accenture.services.plugins.gate
+ * and are scanned by the real loader when the test application starts.
+ */
+class SimplePluginGateTest extends TestBase {
+
+    @Test
+    void gateBlocksBodyOnlyViolations() {
+        // java.io reached directly from the method body
+        assertFalse(SimplePluginLoader.containsSimplePlugin("disallowedIo"),
+                "a plugin touching java.io in its body must not register");
+        // java.net hidden inside a never-invoked lambda
+        assertFalse(SimplePluginLoader.containsSimplePlugin("disallowedLambda"),
+                "a disallowed reference inside a lambda body must not register");
+    }
+
+    @Test
+    void gateKeepsLegitimatePlugins() {
+        // nested classes and lambdas within the allowlist are analyzed, not flagged
+        assertTrue(SimplePluginLoader.containsSimplePlugin("gateInnerOk"));
+        // built-ins whose BODIES use the allowlisted engine helpers
+        assertTrue(SimplePluginLoader.containsSimplePlugin("camelCase"));
+        assertTrue(SimplePluginLoader.containsSimplePlugin("snakeCase"));
+        // the whole built-in inventory passes through the gate (regression net)
+        assertTrue(SimplePluginLoader.getLoadedSimplePlugins().size() >= 50,
+                "built-in plugins must all pass the gate");
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedIoPlugin.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedIoPlugin.java
@@ -1,0 +1,40 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.gate;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+/**
+ * Negative fixture for the allowlist gate: the signature is clean - only the
+ * METHOD BODY reaches outside the allowlist (java.io). The loader must skip it.
+ */
+@SimplePlugin
+public class DisallowedIoPlugin implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "disallowedIo";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        return new java.io.File("/tmp").exists();
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedLambdaPlugin.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedLambdaPlugin.java
@@ -38,13 +38,12 @@ public class DisallowedLambdaPlugin implements PluginFunction {
 
     @Override
     public Object calculate(Object... input) {
-        Supplier<Object> hidden = () -> {
+        return (Supplier<Object>) () -> {
             try {
                 return new java.net.Socket("127.0.0.1", 80);
             } catch (java.io.IOException e) {
                 return null;
             }
         };
-        return hidden;
     }
 }

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedLambdaPlugin.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/DisallowedLambdaPlugin.java
@@ -1,0 +1,50 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.gate;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+import java.util.function.Supplier;
+
+/**
+ * Negative fixture for the allowlist gate: the disallowed reference (java.net)
+ * hides inside a LAMBDA body that is never invoked. The compiled class carries
+ * it in a synthetic lambda method - the body scan must still find it.
+ */
+@SimplePlugin
+public class DisallowedLambdaPlugin implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "disallowedLambda";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        Supplier<Object> hidden = () -> {
+            try {
+                return new java.net.Socket("127.0.0.1", 80);
+            } catch (java.io.IOException e) {
+                return null;
+            }
+        };
+        return hidden;
+    }
+}

--- a/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/GateInnerOkPlugin.java
+++ b/system/event-script-engine/src/test/java/com/accenture/services/plugins/gate/GateInnerOkPlugin.java
@@ -1,0 +1,48 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package com.accenture.services.plugins.gate;
+
+import com.accenture.models.PluginFunction;
+import com.accenture.models.SimplePlugin;
+
+/**
+ * Positive fixture for the allowlist gate: a nested helper class and a lambda,
+ * all within the allowlist. Nested classes are analyzed with the plugin (their
+ * bodies validated) rather than flagged as foreign types - this must register.
+ */
+@SimplePlugin
+public class GateInnerOkPlugin implements PluginFunction {
+
+    @Override
+    public String getName() {
+        return "gateInnerOk";
+    }
+
+    @Override
+    public Object calculate(Object... input) {
+        java.util.function.Supplier<String> viaLambda = () -> Helper.tag(input.length);
+        return viaLambda.get();
+    }
+
+    private static class Helper {
+        private static String tag(int n) {
+            return "inner-" + n;
+        }
+    }
+}


### PR DESCRIPTION
## What

The simple-plugin allowlist gate now validates what a plugin actually **does**, not just its shape:

- `RecursiveClassTypeExaminer` gains a real `MethodVisitor` — method-call and field owners, `new`/cast/`instanceof` types, invokedynamic bootstrap + handle arguments (lambdas and method references, including `ConstantDynamic`), class literals, `multianewarray`, try/catch types, and declared `throws`.
- `SimplePluginLoader` keeps the code attribute (`SKIP_DEBUG | SKIP_FRAMES`, dropping `SKIP_CODE`) and allowlists `TypeConversionUtils` + `KeyNormalizationUtils`, the engine helpers built-in plugin bodies legitimately call.
- Two soundness rules the body scan requires: analyzed classes are excluded from the disallowed set (self-references from lambdas and private helpers), and nested classes (`Outer$Inner`) are recursively analyzed as part of the plugin — their bodies validated rather than flagged as foreign.
- `SimplePluginGateTest` proves the behavior through the **real loader**: a plugin touching `java.io` in its body and one hiding `java.net` inside a never-invoked lambda are skipped with warnings; a nested-helper plugin within the allowlist registers; `camelCase`/`snakeCase` register (their bodies use the newly allowlisted helpers); registry ≥ 50 pins the built-in inventory as the regression net.
- The `flow-schema-reference.md` allowlist sentence now states the enforced behavior (startup gate, full-class scan, the exact framework surface, skip-with-warning).

## Why

Field finding (Eric, 2026-09-10, backlogged past the v4.12.6 release): with `SKIP_CODE` and a null `MethodVisitor`, method-body references were invisible to the gate — the sub-millisecond, no-side-effects containment the allowlist exists for was declared, not enforced. A user plugin could call `java.io`/`java.net`/threads inside `calculate()` and still register — and the proof that the gap was real: `TypeConversionUtils` and `KeyNormalizationUtils` passed unlisted since their introduction. Java-only: the Rust port has no runtime plugin loading (compile-time registration) by ADR'd design.

Verified: event-script-engine module 224 tests green; full reactor build green (the packaged contract re-validates the doc change); doc canon checks and strict docs build green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>