### PR TITLE
release: version 4.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.12.7, 9/11/2026
+
+### Added
+
+1. Three-layer starter templates under `templates/` — `starter-function` (Layer 1),
+   `starter-flow` (Layer 2) and `starter-graph` (Layer 3, a zero-code knowledge-graph
+   service behind the CompileGraph gate): copy-out projects with standalone build files
+   that ship BOTH Maven and Gradle (keep one, delete the other — the Gradle option
+   applies to templates only; the engine reactor stays Maven). Each template carries a
+   README and an AGENTS.md that routes a fresh AI agent to the entry-point playbook.
+   Reactor-listed so every build proves them, with a new `templates-gradle` CI job
+   verifying the Gradle side. Lock-step with the Rust engine's template crates — the
+   Layer 2 flow YAML and the Layer 3 graph model are byte-identical across engines.
+
+2. Fresh-agent entry-point playbook in the AI developer guide ("Starting a
+   collaboration — two typical entry points"): the greenfield conversation (confirm
+   intent, offer AI-enablement, recommend the knowledge-graph path as a question,
+   scaffold from a starter template) and the existing-repository case (offer
+   AI-enablement first, fold hand-written per-tool context into the shared memory
+   layer, then orient). Packaged in the AI contract, so fresh agents receive it
+   version-matched.
+
+3. The Mercury Family page (`docs/mercury-family.md`) — the five-member family
+   (agent-memory, mercury-composable, mercury, mercury-python, mercury-nodejs) with a
+   home-page hero button and an Orientation nav entry, following agent-memory's
+   promotion into the family at github.com/Accenture/mercury-go.
+
+### Fixed
+
+1. The simple-plugin allowlist gate now scans method bodies, not just class shape:
+   `RecursiveClassTypeExaminer` walks call and field owners, `new`/cast/`instanceof`
+   types, lambda and method-reference handles (invokedynamic, including
+   `ConstantDynamic`), class literals and try/catch types, and the loader keeps the
+   code attribute (`SKIP_CODE` dropped). A plugin whose signature is clean can no
+   longer reach `java.io`, `java.net` or threads from inside `calculate()` — the
+   sub-millisecond, no-side-effects containment the allowlist declares is now
+   enforced. `TypeConversionUtils` and `KeyNormalizationUtils` are formally
+   allowlisted; nested classes are analyzed as part of the plugin. Proven through the
+   real loader by `SimplePluginGateTest`, with the ~50 built-ins as the regression net.
+
+### Changed
+
+1. The Methodology guide is synthesized around Intent-Driven Development — IDD leads
+   (the three developer steps and the grammar-composition recursion from the story
+   deck), followed by the knowledge-graph path, the composable design principles and
+   the event-driven core. The flow-schema-reference plugin-allowlist note now states
+   the enforced behavior.
+
+2. Documentation site polish: two-column home page with default-size hero buttons and
+   a relaxed layered-ascent table; story-deck slide 7 states its essence in plain
+   language ("Change what AI generates: artifacts a human can read."); the Orientation
+   nav label simplified to "White Paper".
+
+---
 ## Version 4.12.6, 9/10/2026
 
 ### Added

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/memory/sessions/2026-09-11-040631.md
+++ b/memory/sessions/2026-09-11-040631.md
@@ -1,0 +1,45 @@
+# Session (2026-09-11T04:06:31.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Release v4.12.7 prepared for the field** (Eric's request; same-day lock-step
+pair with the Rust engine). Release content since v4.12.6: PRs #352–#358 —
+the field headline is the simple-plugin allowlist gate scanning METHOD BODIES
+(#358, the containment fix) plus the three-layer starter templates (#357,
+Maven or Gradle); the docs wave (Mercury Family, IDD methodology synthesis,
+plain-English slide 7, fresh-agent entry playbook) rides along.
+
+- **Version sweep**: 40 build files (37 poms — the 34 established sweep incl.
+  the non-reactor Snyk placeholders, PLUS the 3 template poms — and the 3
+  template build.gradle `mercuryVersion` literals per
+  [[conv-template-version-sweep]], its first exercise) + the 3 template
+  READMEs' jar-name examples. Zero 4.12.6 stragglers verified by grep.
+- **CHANGELOG** Version 4.12.7, 9/11/2026 — Added: starter templates,
+  entry-point playbook, Mercury Family page; Fixed: the allowlist gate body
+  scan (the enforced-not-declared containment); Changed: IDD methodology
+  synthesis, docs polish.
+- **Verified**: full reactor `mvn clean install` at 4.12.7 green (templates
+  included). The webapp bundle was NOT rebuilt — no webapp source changes
+  since the committed bundle (v4.12.6 rule).
+- python/node packs stay at 4.12.1 — no wrapper changes this cycle.
+- Rust twin prepared in the same session: 8 manifests + 3 READMEs swept
+  (the grown edit list per its template fact), CHANGELOG 4.12.7 (docs +
+  templates; no engine behavior change — the gate fix is Java-only),
+  INCREMENTS 116 (starter templates) and 117 (AI developer guide) appended,
+  Cargo.lock regenerated, full workspace suite green. One self-inflicted
+  hiccup: the first suite invocation piped through two greps ran the suite
+  TWICE and outlived the timeout — killed and re-run as a single clean pass
+  (lesson: tee to a file, grep the file).
+
+## Memory References
+
+- eric-release-rhythm (consulted — prep only: PR-open, merge, tag/publish
+  are each Eric's gated steps)
+- conv-template-version-sweep (consulted — first release exercising the
+  grown sweep surface; build.gradle literals included)
+- snyk-retired-manifest-placeholders (consulted — the non-reactor
+  placeholder poms swept deliberately)
+- conv-squash-title-prefill-check (consulted — release PR title isolated in
+  the handoff text)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with

--- a/templates/starter-flow/README.md
+++ b/templates/starter-flow/README.md
@@ -25,11 +25,11 @@ build at your organization's artifact repository.
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-flow-4.12.6.jar
+java -jar target/starter-flow-4.12.7.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-flow-4.12.6.jar
+java -jar build/libs/starter-flow-4.12.7.jar
 ```
 
 Then:

--- a/templates/starter-flow/build.gradle
+++ b/templates/starter-flow/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.6'
+def mercuryVersion = '4.12.7'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-flow/pom.xml
+++ b/templates/starter-flow/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-flow</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Layer 2 starter - Event Script flows</name>
 
     <parent>
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/templates/starter-function/README.md
+++ b/templates/starter-function/README.md
@@ -24,11 +24,11 @@ build at your organization's artifact repository.
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-function-4.12.6.jar
+java -jar target/starter-function-4.12.7.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-function-4.12.6.jar
+java -jar build/libs/starter-function-4.12.7.jar
 ```
 
 Then:

--- a/templates/starter-function/build.gradle
+++ b/templates/starter-function/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.6'
+def mercuryVersion = '4.12.7'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-function/pom.xml
+++ b/templates/starter-function/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-function</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Layer 1 starter - composable functions with REST automation</name>
 
     <parent>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>

--- a/templates/starter-graph/README.md
+++ b/templates/starter-graph/README.md
@@ -26,11 +26,11 @@ build at your organization's artifact repository.
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-graph-4.12.6.jar
+java -jar target/starter-graph-4.12.7.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-graph-4.12.6.jar
+java -jar build/libs/starter-graph-4.12.7.jar
 ```
 
 Then:

--- a/templates/starter-graph/build.gradle
+++ b/templates/starter-graph/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.6'
+def mercuryVersion = '4.12.7'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-graph/pom.xml
+++ b/templates/starter-graph/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-graph</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <name>Layer 3 starter - Active Knowledge Graph as the application</name>
 
     <parent>
@@ -56,19 +56,19 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.6</version>
+            <version>4.12.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What

Version 4.12.7 — the field release carrying PRs #352–#358. The sweep covers 37 poms (including the non-reactor Snyk placeholders), the three template `build.gradle` version literals, and the template README examples; CHANGELOG carries the 4.12.7 section. Full reactor build green at the new version.

## Why

Two field-relevant deliverables since v4.12.6, plus the documentation wave:

- **Fixed — simple-plugin allowlist gate scans method bodies** (#358): a plugin can no longer reach `java.io`/`java.net`/threads from inside `calculate()`; the sub-millisecond containment the allowlist declares is now enforced.
- **Added — three-layer starter templates** (#357): copy-out projects for the three layers, Maven or Gradle, CI-verified.
- Docs: the Mercury Family page (#352), IDD methodology synthesis + plain-language slide 7 (#354/#355), fresh-agent entry-point playbook (#356), home-page polish (#353).

python/node packs stay at 4.12.1 — no wrapper changes. Lock-step with Accenture/mercury v4.12.7.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>