### PR TITLE
minimalist-kafka: kafka.health resolves probe config lazily, waits for late credentials

### DIFF
--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -612,6 +612,18 @@ check is live. Two keys tune the behavior: `kafka.health.timeout` (default `5s`)
 `kafka.health.startup.grace` (default `30s`) - see the
 [Configuration Reference](configuration-reference.md#observability).
 
+The probe's client configuration is resolved **lazily** - when the probe client is built, and again
+whenever a failed probe forces a rebuild - never at construction time. `kafka.health` is registered
+before your `@MainApplication` runs, so a bootstrap that fetches secrets and publishes them as system
+properties (the vault pattern) has not executed yet - a config template frozen at construction would
+interpolate such a credential as *missing* and fail every probe from then on. With lazy resolution
+the first probe after the credential lands simply succeeds; nothing needs a restart. While the
+template is still incomplete - the client cannot even be built from it - `type=health` reports a
+**passing** `Waiting for Kafka connection` status rather than a failure: failing `/health` would
+invite the container orchestrator to restart the pod, and a restart cannot produce the credential.
+Only a real connectivity failure (client built, cluster unreachable) fails `/health` with HTTP 503.
+The same applies to `secondary.kafka.health`.
+
 > **On a produce-only leg the probe uses the producer template.** With
 > [`kafka.consumer.enabled=false`](#opt-out) there are no consumer credentials to build a probe from,
 > yet a bridge is healthy only when both clusters are reachable. So the probe follows whichever client

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -113,6 +113,17 @@
   executes (deployment = explicit act). Full detail: origin log.
   <!-- id: compilegraph-mandatory-gate | created: 2026-07-29 | last_used: 2026-09-11 | uses: 19 | tier: active | origin: 2026-07-29-190328 -->
 
+- **@PreLoad functions are constructed BEFORE @MainApplication runs — never freeze late-arriving
+  config in a @PreLoad constructor (2026-09-11, upstreamed field MR + Eric's ruling).** AppStarter's
+  order is BeforeApplication → preload() → MainApplication, so a constructor-resolved template that
+  interpolates system properties published by a start-up credential bootstrap (vault pattern) freezes
+  them as missing for the life of the instance. `kafka.health`/`secondary.kafka.health` now resolve
+  probe config through a `Supplier` at client build time (re-resolved on every rebuild) and, while
+  the client cannot even be BUILT, report a passing "Waiting for Kafka connection" status instead of
+  failing /health — a pod restart cannot produce a credential (Eric's ruling); only a real round-trip
+  failure (client built, cluster unreachable) fails /health with 503.
+  <!-- id: preload-before-mainapp-lazy-config | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-185752 -->
+
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker
   returns.** `EventEmitter.traces` is keyed by `Thread.currentThread().threadId()+instance+route`, and
   `WorkerHandler` calls `stopTracing` (removing it) as soon as `processEvent` returns. So any work that

--- a/memory/sessions/2026-09-11-185752.md
+++ b/memory/sessions/2026-09-11-185752.md
@@ -1,0 +1,63 @@
+# Session (2026-09-11T18:57:52.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Field MR upstreamed: kafka.health no longer freezes its probe config at
+@PreLoad construction (branch `fix/kafka-health-lazy-probe-config`).** A field
+installation contributed a merge request showing `kafka.health` unusable when
+Kafka credentials arrive from a `@MainApplication` bootstrap (the vault
+pattern: secrets fetched at start-up and published as system properties).
+Premise verified against `AppStarter` (BeforeApplication → preload() →
+MainApplication), so a `@PreLoad` constructor is guaranteed to run before the
+bootstrap: the constructor-resolved `sasl.jaas.config` template interpolated
+the credential as missing and every probe failed forever with Kafka's "The
+OAuth configuration option clientId value is required". In the field the
+credential landed ~31s after construction - just past the 30s default grace -
+producing hundreds of ConfigExceptions per retained log window plus
+consumer-churn (each failed probe rebuilds the client), and services had to
+demote kafka.health out of `mandatory.health.dependencies` to deploy.
+
+Ported the field fix: probe config resolved through a `Supplier<Properties>`
+at client build time, re-invoked on every rebuild (a failed probe already
+closes the client, so this is the natural re-resolve hook). Fixed-Properties
+constructors kept as delegating seams - subclasses/tests untouched. Same seam
+in twin-kafka's `SecondaryKafkaHealthCheck`, whose templates can interpolate
+the same late-published credential.
+
+**Eric's ruling added on top of the MR:** while the client cannot even be
+BUILT from the template (KafkaException at construction = config still
+incomplete), `type=health` reports a passing "Waiting for Kafka connection"
+status instead of 503, so Kubernetes does not restart the pod - a restart
+cannot produce the credential. Only a real round trip failure (client built,
+cluster unreachable) fails /health. `warmUp()` now allows retries while
+construction is still waiting instead of logging ready prematurely.
+
+Validation: minimalist-kafka 203 tests green - new
+`KafkaHealthCheckLazyConfigTest` (supplier consulted 0 times at construction,
+once per rebuild, passing waiting status on unbuildable config, type=info
+resolves once) and `KafkaHealthCheckTest` gained the e2e heal test (waiting →
+template completes → "Kafka cluster is reachable", no restart in between);
+twin-kafka 13 green; check-doc-canon OK; mkdocs --strict OK. Guide
+`minimalist-kafka.md#health` documents lazy resolution + waiting semantics.
+Rust untouched: the Kafka library family is Java-only. Field-specific
+product, pod, and service names paraphrased out of all repository text per
+the compartmentalization practice; the field contribution acknowledged
+generically in the PR (Eric's direction).
+
+## Doc Gaps
+
+(none - the health-check guide section already covered this surface; extended
+in place)
+
+## Memory References
+
+- eric-release-rhythm (consulted - branch/commit/PR text prepared; Eric
+  creates the PR and gates merge)
+- stack-messaging-kafka (consulted - the touched modules are the in-repo
+  Kafka family: minimalist-kafka + twin-kafka)
+- conv-telemetry-presentation-parity (consulted - lock-step scope check: the
+  cross-engine contract covers the Event Script surface and telemetry
+  presentation; this Kafka library fix is Java-only, so no Rust twin)
+- preload-before-mainapp-lazy-config (created, tier: working)

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -20,6 +20,7 @@ package org.platformlambda.mini.kafka;
 
 import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.LambdaFunction;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 /**
  * Kafka health check function for the platform's health endpoint.
@@ -42,7 +44,9 @@ import java.util.concurrent.locks.ReentrantLock;
  * {@code optional.health.dependencies}) in application.properties and the {@code /health}
  * endpoint will include the Kafka cluster status. The function follows the standard health
  * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
- * map when the cluster is reachable and throws {@code AppException} when it is not.
+ * map when the cluster is reachable and throws {@code AppException} when it is not. While the
+ * client configuration is still incomplete - a late credential not yet published - it returns a
+ * passing {@code Waiting for Kafka connection} status instead of failing (see below).
  *
  * <p>The probe is a single Kafka <b>Metadata</b> request ({@code KafkaConsumer.listTopics})
  * issued from a dedicated consumer built from the module's consumer template - the most
@@ -61,6 +65,23 @@ import java.util.concurrent.locks.ReentrantLock;
  * grants no consumer credentials to build a probe from - see
  * {@code KafkaClientConfig.healthProbeProperties}. A bridge is healthy only when both clusters are
  * reachable, so each leg stays probeable whichever direction it runs in.
+ *
+ * <p>The probe's client configuration is resolved <b>lazily - when the probe client is built, and
+ * again whenever a failed probe forces a rebuild</b> - never in the constructor. This function is
+ * {@code @PreLoad}, so it is constructed while the platform registers routes, before any
+ * {@code @MainApplication} start-up logic runs. A credential bootstrap that fetches secrets from a
+ * vault and publishes them as system properties has therefore not executed yet, and a template whose
+ * {@code sasl.jaas.config} interpolates such a credential would be frozen with the credential
+ * missing - every probe then fails forever with Kafka's {@code ConfigException: The OAuth
+ * configuration option clientId value is required}, no matter what the environment does. Because a
+ * failed probe closes the client, the next probe re-resolves the template and the check heals
+ * itself as soon as the credential lands.
+ *
+ * <p>Until it lands, a template the client cannot even be <b>built</b> from is reported as a
+ * passing {@code Waiting for Kafka connection} status rather than a failure: failing {@code /health}
+ * would invite the container orchestrator to restart the pod, and a restart cannot produce the
+ * missing credential. Only a real network round trip that fails - the client built, the cluster
+ * unreachable - fails {@code /health}.
  *
  * <p>During application start-up the function returns a <b>placeholder healthy</b> status and
  * warms up the client in the background, so {@code /health} does not fail (or block) while the
@@ -90,6 +111,7 @@ public class KafkaHealthCheck implements LambdaFunction {
     protected static final String DEFAULT_TIMEOUT = "5s";
     protected static final String DEFAULT_GRACE = "30s";
     private static final String PLACEHOLDER = "Kafka client is starting up";
+    private static final String WAITING = "Waiting for Kafka connection";
     private static final String REACHABLE = "Kafka cluster is reachable";
 
     // virtual-thread friendly: a ReentrantLock does not pin the carrier thread like 'synchronized'.
@@ -98,14 +120,17 @@ public class KafkaHealthCheck implements LambdaFunction {
     private final ReentrantLock lock = new ReentrantLock();
     private final AtomicBoolean warmingUp = new AtomicBoolean(false);
     private final String serviceName;
-    private final Properties consumerProperties;
+    private final Supplier<Properties> probeConfig;
+    // what the current probe client was built from; also the href source - replaced on every rebuild
+    private volatile Properties consumerProperties;
     private final long timeoutMs;
     private final long graceDeadline;
     private KafkaConsumer<String, byte[]> consumer;
     private volatile boolean ready = false;
 
     public KafkaHealthCheck() {
-        this(PRIMARY_SERVICE_NAME, KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance()),
+        this(PRIMARY_SERVICE_NAME,
+             () -> KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance()),
              resolveDurationMs(TIMEOUT_KEY, DEFAULT_TIMEOUT),
              resolveDurationMs(GRACE_KEY, DEFAULT_GRACE));
     }
@@ -122,9 +147,9 @@ public class KafkaHealthCheck implements LambdaFunction {
     }
 
     /**
-     * Reuse seam for a library probing ANOTHER Kafka cluster (e.g. twin-kafka's
-     * {@code secondary.kafka.health}): subclass with the other cluster's consumer template,
-     * a distinct service name for the /health dependency list, and its own tunables.
+     * Reuse seam with a FIXED, pre-resolved client configuration - the config is frozen for the life
+     * of the instance (the test seams build on it). Prefer the {@link Supplier} form for anything
+     * resolved from application config, so a credential published late in start-up is still picked up.
      *
      * @param serviceName        the dependency name reported by type=info (e.g. "secondary.kafka")
      * @param consumerProperties the Kafka consumer client configuration to probe with
@@ -132,8 +157,26 @@ public class KafkaHealthCheck implements LambdaFunction {
      * @param graceMs            start-up grace period in milliseconds (0 = probe immediately)
      */
     protected KafkaHealthCheck(String serviceName, Properties consumerProperties, long timeoutMs, long graceMs) {
+        this(serviceName, () -> consumerProperties, timeoutMs, graceMs);
+    }
+
+    /**
+     * Reuse seam for a library probing ANOTHER Kafka cluster (e.g. twin-kafka's
+     * {@code secondary.kafka.health}): subclass with the other cluster's probe template, a distinct
+     * service name for the /health dependency list, and its own tunables. The supplier is invoked
+     * when the probe client is built - and again on every rebuild after a failure - so a template
+     * that interpolates a credential published later in the start-up sequence is resolved correctly
+     * on the next probe instead of being frozen at construction time.
+     *
+     * @param serviceName the dependency name reported by type=info (e.g. "secondary.kafka")
+     * @param probeConfig supplies this cluster's probe client configuration, re-invoked on every rebuild
+     * @param timeoutMs   probe timeout in milliseconds
+     * @param graceMs     start-up grace period in milliseconds (0 = probe immediately)
+     */
+    protected KafkaHealthCheck(String serviceName, Supplier<Properties> probeConfig,
+                               long timeoutMs, long graceMs) {
         this.serviceName = serviceName;
-        this.consumerProperties = consumerProperties;
+        this.probeConfig = probeConfig;
         this.timeoutMs = timeoutMs;
         this.graceDeadline = System.currentTimeMillis() + graceMs;
     }
@@ -171,7 +214,7 @@ public class KafkaHealthCheck implements LambdaFunction {
         if (INFO.equals(headers.get(TYPE))) {
             Map<String, Object> result = new HashMap<>();
             result.put(SERVICE, serviceName);
-            result.put(HREF, consumerProperties.getProperty(BOOTSTRAP_SERVERS, PRIMARY_SERVICE_NAME));
+            result.put(HREF, href());
             return result;
         }
         if (HEALTH.equals(headers.get(TYPE))) {
@@ -193,7 +236,12 @@ public class KafkaHealthCheck implements LambdaFunction {
             Thread.startVirtualThread(() -> {
                 try {
                     probe();
-                    log.info("{} health check is ready", serviceName);
+                    if (ready) {
+                        log.info("{} health check is ready", serviceName);
+                    } else {
+                        // the client configuration is still incomplete - allow another warm-up attempt
+                        warmingUp.set(false);
+                    }
                 } catch (Exception e) {
                     // stay in placeholder mode until the grace period ends
                     warmingUp.set(false);
@@ -210,14 +258,30 @@ public class KafkaHealthCheck implements LambdaFunction {
         lock.lock();
         try {
             if (consumer == null) {
-                consumer = new KafkaConsumer<>(consumerProperties);
+                // re-resolved, not cached from the constructor: a credential published by a later
+                // @MainApplication bootstrap is not visible while this @PreLoad function is constructed
+                Properties config = probeConfig.get();
+                consumerProperties = config;
+                try {
+                    consumer = new KafkaConsumer<>(config);
+                } catch (KafkaException e) {
+                    // the template is still incomplete (e.g. that credential has not landed yet):
+                    // report a PASSING waiting status - failing /health would invite the container
+                    // orchestrator to restart the pod, and a restart cannot produce the credential.
+                    // The next probe re-resolves, so the check goes live once construction succeeds.
+                    log.warn("{} health check waiting for a usable client configuration - {}",
+                            serviceName, rootCause(e));
+                    Map<String, Object> result = new HashMap<>();
+                    result.put(STATUS, WAITING);
+                    return result;
+                }
             }
             var topics = consumer.listTopics(Duration.ofMillis(timeoutMs));
             ready = true;
             Map<String, Object> result = new HashMap<>();
             result.put(STATUS, REACHABLE);
             result.put(TOPICS, topics.size());
-            result.put(HREF, consumerProperties.getProperty(BOOTSTRAP_SERVERS, PRIMARY_SERVICE_NAME));
+            result.put(HREF, href());
             return result;
         } catch (Exception e) {
             closeQuietly();
@@ -225,6 +289,29 @@ public class KafkaHealthCheck implements LambdaFunction {
         } finally {
             lock.unlock();
         }
+    }
+
+    /**
+     * The dependency's href - this cluster's bootstrap.servers. Reported before the first probe too,
+     * so it resolves the template on demand when no client has been built yet; bootstrap.servers does
+     * not depend on a late credential, so the first resolve's answer stays valid.
+     */
+    private String href() {
+        Properties config = consumerProperties;
+        if (config == null) {
+            config = probeConfig.get();
+            consumerProperties = config;
+        }
+        return config.getProperty(BOOTSTRAP_SERVERS, PRIMARY_SERVICE_NAME);
+    }
+
+    /** The most specific reason - client construction failures arrive wrapped in a generic KafkaException. */
+    private static String rootCause(Throwable e) {
+        Throwable t = e;
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t.getMessage();
     }
 
     private void closeQuietly() {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
@@ -1,0 +1,121 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.mini.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.exception.AppException;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * WHEN the probe's client configuration is resolved. This function is {@code @PreLoad}, so it is
+ * constructed before a {@code @MainApplication} credential bootstrap (e.g. fetching secrets from a
+ * vault and publishing them as system properties) has run - resolving the template in the
+ * constructor would freeze a template that interpolates such a credential with the credential
+ * missing, and every later probe would fail with Kafka's
+ * "The OAuth configuration option clientId value is required" no matter what the environment does.
+ *
+ * <p>No broker is involved: the probe is pointed at a closed port with a 1ms timeout, so each
+ * attempt fails immediately and the assertions are about how often the supplier is consulted.
+ */
+class KafkaHealthCheckLazyConfigTest {
+
+    private static final long PROBE_IMMEDIATELY = 0L;
+    private static final long TIMEOUT_MS = 1L;
+
+    /** A probe config pointed at a closed port - constructing the client works, the round trip does not. */
+    private static Properties unreachable() {
+        Properties p = new Properties();
+        p.setProperty("bootstrap.servers", "localhost:1");
+        p.setProperty("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        p.setProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        return p;
+    }
+
+    private static KafkaHealthCheck probing(Supplier<Properties> config) {
+        return new KafkaHealthCheck("kafka", config, TIMEOUT_MS, PROBE_IMMEDIATELY);
+    }
+
+    @Test
+    void constructionResolvesNothing() {
+        AtomicInteger resolves = new AtomicInteger();
+        probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        assertEquals(0, resolves.get(),
+                "a @PreLoad constructor runs before the credential bootstrap - it must not resolve the template");
+    }
+
+    @Test
+    void everyRebuildResolvesAgainSoALateCredentialIsPickedUp() {
+        AtomicInteger resolves = new AtomicInteger();
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        Map<String, String> probe = Map.of("type", "health");
+        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        assertEquals(2, resolves.get(),
+                "a failed probe closes the client, so the next one re-resolves and the check can heal");
+    }
+
+    @Test
+    void incompleteConfigIsAPassingWaitingStatusNotAFailure() {
+        AtomicInteger resolves = new AtomicInteger();
+        // an empty template stands in for one whose values have not been published yet:
+        // the Kafka client cannot even be constructed from it
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return new Properties();
+        });
+        Map<String, String> probe = Map.of("type", "health");
+        assertEquals("Waiting for Kafka connection", asMap(health.handleEvent(probe, null, 1)).get("status"),
+                "an unbuildable client is a start-up condition, not an outage - /health must pass");
+        assertEquals("Waiting for Kafka connection", asMap(health.handleEvent(probe, null, 1)).get("status"));
+        assertEquals(2, resolves.get(),
+                "each waiting probe re-resolves the template so a late credential is picked up");
+    }
+
+    @Test
+    void typeInfoResolvesOnDemandAndKeepsTheAnswer() {
+        AtomicInteger resolves = new AtomicInteger();
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        Map<String, String> info = Map.of("type", "info");
+        assertEquals("localhost:1", asMap(health.handleEvent(info, null, 1)).get("href"));
+        assertEquals("localhost:1", asMap(health.handleEvent(info, null, 1)).get("href"));
+        assertEquals(1, resolves.get(),
+                "bootstrap.servers does not depend on a late credential, so one resolve serves every info call");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object result) {
+        return (Map<String, Object>) result;
+    }
+}

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
@@ -26,6 +26,7 @@ import org.platformlambda.core.util.Utility;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -98,6 +99,23 @@ class KafkaHealthCheckTest {
         var health = new KafkaHealthCheck(consumerProps(kafka.bootstrapServers()), 0);
         Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
         assertEquals("Kafka cluster is reachable", result.get("status"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void reportsWaitingUntilTheLateCredentialLandsThenGoesLive() {
+        // simulate a @MainApplication credential bootstrap that has not run yet: the template is
+        // unusable at first (the client cannot be built), then completes while the app is running
+        AtomicReference<Properties> template = new AtomicReference<>(new Properties());
+        var health = new KafkaHealthCheck("kafka", template::get, 5000, 0);
+        Map<String, Object> waiting = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Waiting for Kafka connection", waiting.get("status"));
+        // the bootstrap publishes the missing values - the next probe re-resolves and goes live,
+        // with no restart and no failed /health in between
+        template.set(consumerProps(kafka.bootstrapServers()));
+        Map<String, Object> live = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Kafka cluster is reachable", live.get("status"));
+        assertEquals(kafka.bootstrapServers(), live.get("href"));
     }
 
     @Test

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
@@ -24,6 +24,7 @@ import org.platformlambda.mini.kafka.KafkaClientConfig;
 import org.platformlambda.mini.kafka.KafkaHealthCheck;
 
 import java.util.Properties;
+import java.util.function.Supplier;
 
 /**
  * Health-check function for the SECONDARY Kafka cluster - the twin of minimalist-kafka's
@@ -58,10 +59,20 @@ public class SecondaryKafkaHealthCheck extends KafkaHealthCheck {
     private static final String PRIMARY_GRACE_KEY = "kafka.health.startup.grace";
 
     public SecondaryKafkaHealthCheck() {
-        this(KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance(),
+        this(() -> KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance(),
                         SecondaryKafkaAutoStart.CONSUMER_ENABLED, CONSUMER_LOCATION, DEFAULT_CONSUMER,
                         SecondaryKafkaAutoStart.PRODUCER_ENABLED, PRODUCER_LOCATION, DEFAULT_PRODUCER),
              resolveDurationMs(GRACE_KEY, PRIMARY_GRACE_KEY, DEFAULT_GRACE));
+    }
+
+    /**
+     * A supplier rather than a resolved snapshot: the secondary cluster's templates can interpolate a
+     * credential that a {@code @MainApplication} bootstrap publishes long after this {@code @PreLoad}
+     * function is constructed - see the note on lazy resolution in {@link KafkaHealthCheck}.
+     */
+    private SecondaryKafkaHealthCheck(Supplier<Properties> probeConfig, long graceMs) {
+        super(SERVICE_NAME, probeConfig,
+              resolveDurationMs(TIMEOUT_KEY, PRIMARY_TIMEOUT_KEY, DEFAULT_TIMEOUT), graceMs);
     }
 
     /**


### PR DESCRIPTION
## What

`kafka.health` (and twin-kafka's `secondary.kafka.health`) no longer resolves its probe client
configuration at construction time. The config template is resolved through a `Supplier<Properties>`
when the probe client is built - and re-resolved on every rebuild after a failed probe. While the
client cannot even be **built** from the template (config still incomplete), `type=health` reports a
passing `Waiting for Kafka connection` status instead of failing `/health`; a real round-trip failure
(client built, cluster unreachable) still fails with HTTP 503.

## Why

These health checks are `@PreLoad`, so they are constructed while the platform registers routes -
guaranteed to be before any `@MainApplication` start-up logic runs (`AppStarter`: BeforeApplication →
preload → MainApplication). An application whose Kafka credentials arrive from a `@MainApplication`
bootstrap (the vault pattern: secrets fetched at start-up and published as system properties) had its
`sasl.jaas.config` template frozen with the credential missing, and every probe failed forever with
Kafka's `ConfigException: The OAuth configuration option clientId value is required`. In the field the
credential landed ~31s after construction - just past the 30s default grace - producing hundreds of
exceptions per retained log window (each failed probe also rebuilds the client) and forcing
deployments to demote `kafka.health` out of `mandatory.health.dependencies`.

And because failing `/health` invites the container orchestrator to restart the pod - which cannot
produce the credential - an incomplete config is reported as a passing "waiting" condition, not a
failure. The check goes live on the first probe after the credential lands; nothing needs a restart.

The lazy-resolution fix was contributed by a field installation's merge request; this PR upstreams it
and adds the waiting-status semantics on top.

## Changes

- `KafkaHealthCheck`: new primary `Supplier<Properties>` constructor; the fixed-`Properties`
  constructors are kept as delegating seams, so subclasses and tests are untouched. The consumer
  build site re-resolves the template on every rebuild; a construction failure (`KafkaException`)
  returns the passing waiting status with a one-line warn (no stack-trace churn); `type=info`
  resolves `bootstrap.servers` on demand and keeps the answer; `warmUp()` retries while construction
  is still waiting instead of logging ready prematurely.
- `SecondaryKafkaHealthCheck`: same seam - its no-arg constructor now passes a supplier.
- Guide `minimalist-kafka.md#health`: lazy resolution + waiting semantics documented.
- Note: a permanently broken template now surfaces as a visibly waiting `/health` dependency with a
  logged reason, rather than an exception at route registration - consistent with the check's
  self-healing design.

## Tests

- New `KafkaHealthCheckLazyConfigTest` (no broker needed): construction resolves the supplier zero
  times; each rebuild re-resolves, so a late credential is picked up; an unbuildable config is a
  passing waiting status; `type=info` resolves once and keeps the answer.
- `KafkaHealthCheckTest` gained the end-to-end heal test against the embedded broker: waiting while
  the template is unusable, then `Kafka cluster is reachable` on the next probe once the template
  completes - no restart and no failed `/health` in between.
- minimalist-kafka 203 tests green; twin-kafka 13 green; doc canon + strict mkdocs OK.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)