### PR TITLE
sync-over-async: redis.health check - lazy config, waiting status for late credentials

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -1284,6 +1284,22 @@ Logical Redis database index.
 
 Default Redis command timeout.
 
+### `redis.health.timeout`
+
+| Type | Default |
+|------|---------|
+| `duration` | `5s` |
+
+Timeout for the `redis.health` probe - a single Redis PING on a dedicated connection built from the `redis.*` parameters (one successful call proves connectivity, TLS, and authentication). Add `redis.health` to `mandatory.health.dependencies` (or the optional list) to include the server in `/health`.
+
+### `redis.health.startup.grace`
+
+| Type | Default |
+|------|---------|
+| `duration` | `30s` |
+
+Start-up grace period for `redis.health`: within it the check reports a placeholder healthy status while the Redis client warms up in the background, so `/health` never fails or blocks during application start-up. The probe's configuration is resolved lazily and re-resolved on every rebuild, and an unusable configuration (unbuildable values, or credentials the server rejects - the signature of a vault-published password that has not landed yet) is a passing `Waiting for Redis connection` status; only a genuine connectivity failure fails `/health` with 503.
+
 ### `sync.return.channel.prefix`
 
 | Type | Default |

--- a/docs/guides/sync-over-async.md
+++ b/docs/guides/sync-over-async.md
@@ -78,6 +78,8 @@ id, from discrete `redis.*` connection parameters and `sync.*` engine tunables. 
 | `redis.ssl` | `false` | Use TLS (`rediss://`). |
 | `redis.database` | `0` | Logical database index. |
 | `redis.timeout.ms` | `5000` | Default command timeout. |
+| `redis.health.timeout` | `5s` | Timeout for the [`redis.health`](#health) probe. |
+| `redis.health.startup.grace` | `30s` | Start-up grace for [`redis.health`](#health) (placeholder healthy status while the client warms up). |
 | `sync.return.channel.prefix` | `svc-return` | Prefix for the per-pod Pub/Sub return channel. |
 | `sync.route.ttl.seconds` | `90` | TTL for the return-route key (cover the REST timeout + buffer). |
 | `sync.response.ttl.seconds` | `30` | TTL for the response key (short rendezvous window). |
@@ -96,6 +98,41 @@ The design is correct independent of Pub/Sub timing:
 - **Bounded growth.** `sync.max.pending.requests` caps in-flight requests to protect a pod under load.
 - **Timeout → 408.** A request with no answer in its budget returns HTTP 408, and its Redis keys are cleaned
   up (TTLs are the safety net for crashes).
+
+## Health check {#health}
+
+The module ships a ready-made health-check function at route **`redis.health`** (auto-registered when
+the jar is on the classpath) - every critical infrastructure dependency deserves one. Opt in by listing
+it as a health dependency in `application.properties`:
+
+```properties
+mandatory.health.dependencies=redis.health
+# or, when Redis should be reported but not fail /health:
+# optional.health.dependencies=redis.health
+```
+
+The probe is a single Redis **PING** on a dedicated connection built from the `redis.*` parameters -
+the lightest round trip the protocol offers, and one successful call proves connectivity, TLS, and
+authentication in a single request. A reachable server reports a status map; an unreachable one fails
+`/health` with HTTP 503. During application start-up the check returns a **placeholder healthy** status
+while the client warms up in the background (`redis.health.startup.grace`, default `30s`), and
+`redis.health.timeout` (default `5s`) bounds the probe's connect and command round trips.
+
+The probe's client configuration is resolved **lazily** - when the probe client is built, and again
+whenever a failed probe forces a rebuild - never at construction time. `redis.health` is registered
+before your `@MainApplication` runs, so a bootstrap that fetches secrets and publishes them as system
+properties (the vault pattern) has not executed yet - a `redis.password` frozen at construction would
+be captured as *missing* for the life of the check. And while the configuration is still unusable -
+the client cannot be built from it, or the server rejects the credentials (`NOAUTH` / `WRONGPASS`:
+the signature of a password that has not landed yet) - `type=health` reports a **passing**
+`Waiting for Redis connection` status rather than a failure: failing `/health` would invite the
+container orchestrator to restart the pod, and a restart cannot produce the credential. Only a genuine
+connectivity failure (connection refused, timed-out round trip) fails `/health` with HTTP 503. The
+check goes live on the first probe after the real values land; nothing needs a restart. Same design as
+[`kafka.health`](minimalist-kafka.md#health).
+
+> The `minigraph-state-redis` extension reads the same `redis.*` connection parameters, so one
+> `redis.health` covers a deployment using either or both modules against the same server.
 
 ## When to use it {#when}
 

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -1,0 +1,299 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.support;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.platformlambda.core.annotations.PreLoad;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.util.AppConfigReader;
+import org.platformlambda.core.util.Utility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/**
+ * Redis health check function for the platform's health endpoint.
+ *
+ * <p>Add {@code redis.health} to {@code mandatory.health.dependencies} (or
+ * {@code optional.health.dependencies}) in application.properties and the {@code /health}
+ * endpoint will include the Redis server status. The function follows the standard health
+ * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
+ * map when the server is reachable and throws {@code AppException} when it is not. While the
+ * client configuration is still incomplete - a late credential not yet published, or not yet
+ * accepted by the server - it returns a passing {@code Waiting for Redis connection} status
+ * instead of failing (see below).
+ *
+ * <p>The probe is a single Redis <b>PING</b> on a dedicated connection built from the module's
+ * discrete {@code redis.*} startup parameters ({@link RedisConfig}) - the lightest round trip
+ * the protocol offers, and one successful call proves connectivity, TLS, and authentication in
+ * a single request. The {@code minigraph-state-redis} extension reads the same {@code redis.*}
+ * parameters, so one {@code redis.health} covers a deployment using either or both modules.
+ *
+ * <p>The probe's client configuration is resolved <b>lazily - when the probe client is built,
+ * and again whenever a failed probe forces a rebuild</b> - never in the constructor. This
+ * function is {@code @PreLoad}, so it is constructed while the platform registers routes,
+ * before any {@code @MainApplication} start-up logic runs. A credential bootstrap that fetches
+ * secrets from a vault and publishes them as system properties has therefore not executed yet -
+ * a {@code redis.password} resolved at construction time would be frozen as missing for the
+ * life of the instance. Because a failed probe closes the client, the next probe re-resolves
+ * the configuration and the check heals itself as soon as the credential lands.
+ *
+ * <p>Until it lands, an unusable configuration is reported as a passing
+ * {@code Waiting for Redis connection} status rather than a failure: failing {@code /health}
+ * would invite the container orchestrator to restart the pod, and a restart cannot produce the
+ * missing credential. "Unusable" means the client cannot even be built from the resolved values
+ * (e.g. an unresolved placeholder), or the server rejects the credentials
+ * ({@code NOAUTH} / {@code WRONGPASS} - the signature of a password that has not landed yet).
+ * Only a real connectivity failure - connection refused or a timed-out round trip - fails
+ * {@code /health} with HTTP 503.
+ *
+ * <p>During application start-up the function returns a <b>placeholder healthy</b> status and
+ * warms up the client in the background, so {@code /health} does not fail (or block) while the
+ * Redis client and the rest of the start-up sequence are still coming up. After the first
+ * successful probe - or once the grace period ({@code redis.health.startup.grace}, default
+ * {@code 30s}) has elapsed - every check is a live probe. {@code redis.health.timeout}
+ * (default {@code 5s}) bounds the probe's connect and command round trips.
+ */
+// multiple workers because /health is polled concurrently (operations tooling plus the container
+// platform's liveness/readiness probes): info and placeholder responses run in parallel, while the
+// probe connection stays protected - every probe serializes on the ReentrantLock below
+@PreLoad(route = "redis.health", instances = 5)
+public class RedisHealthCheck implements LambdaFunction {
+    private static final Logger log = LoggerFactory.getLogger(RedisHealthCheck.class);
+
+    private static final String SERVICE_NAME = "redis";
+    private static final String TYPE = "type";
+    private static final String INFO = "info";
+    private static final String HEALTH = "health";
+    private static final String SERVICE = "service";
+    private static final String HREF = "href";
+    private static final String STATUS = "status";
+    private static final String TIMEOUT_KEY = "redis.health.timeout";
+    private static final String GRACE_KEY = "redis.health.startup.grace";
+    private static final String DEFAULT_TIMEOUT = "5s";
+    private static final String DEFAULT_GRACE = "30s";
+    private static final String PLACEHOLDER = "Redis client is starting up";
+    private static final String WAITING = "Waiting for Redis connection";
+    private static final String REACHABLE = "Redis is reachable";
+
+    // virtual-thread friendly: a ReentrantLock does not pin the carrier thread like 'synchronized'.
+    // The lock also serializes access to the probe connection (the health worker and the background
+    // warm-up thread would otherwise race).
+    private final ReentrantLock lock = new ReentrantLock();
+    private final AtomicBoolean warmingUp = new AtomicBoolean(false);
+    private final Supplier<RedisConfig> probeConfig;
+    // what the current probe client was built from; also the href source - replaced on every rebuild
+    private volatile RedisConfig currentConfig;
+    private final long timeoutMs;
+    private final long graceDeadline;
+    private RedisClient client;
+    private StatefulRedisConnection<String, String> connection;
+    private volatile boolean ready = false;
+
+    public RedisHealthCheck() {
+        this(() -> RedisConfig.from(AppConfigReader.getInstance()),
+             resolveDurationMs(TIMEOUT_KEY, DEFAULT_TIMEOUT),
+             resolveDurationMs(GRACE_KEY, DEFAULT_GRACE));
+    }
+
+    /**
+     * Reuse/test seam. The supplier is invoked when the probe client is built - and again on every
+     * rebuild after a failure - so a configuration whose values are published later in the start-up
+     * sequence (e.g. a vault-fetched {@code redis.password}) is resolved correctly on the next probe
+     * instead of being frozen at construction time.
+     *
+     * @param probeConfig supplies the Redis connection parameters, re-invoked on every rebuild
+     * @param timeoutMs   probe timeout in milliseconds (bounds connect and command round trips)
+     * @param graceMs     start-up grace period in milliseconds (0 = probe immediately)
+     */
+    public RedisHealthCheck(Supplier<RedisConfig> probeConfig, long timeoutMs, long graceMs) {
+        this.probeConfig = probeConfig;
+        this.timeoutMs = timeoutMs;
+        this.graceDeadline = System.currentTimeMillis() + graceMs;
+    }
+
+    /**
+     * Resolve a duration configuration key to milliseconds with a built-in default.
+     *
+     * @param key          the configuration key (e.g. "redis.health.timeout")
+     * @param defaultValue the built-in default duration (e.g. "5s")
+     * @return the resolved duration in milliseconds
+     */
+    private static long resolveDurationMs(String key, String defaultValue) {
+        var util = Utility.getInstance();
+        var config = AppConfigReader.getInstance();
+        return util.getDurationInSeconds(config.getProperty(key, defaultValue)) * 1000L;
+    }
+
+    @Override
+    public Object handleEvent(Map<String, String> headers, Object input, int instance) {
+        if (INFO.equals(headers.get(TYPE))) {
+            Map<String, Object> result = new HashMap<>();
+            result.put(SERVICE, SERVICE_NAME);
+            result.put(HREF, href());
+            return result;
+        }
+        if (HEALTH.equals(headers.get(TYPE))) {
+            if (!ready && System.currentTimeMillis() < graceDeadline) {
+                // let the Redis client and the application start-up sequence complete first:
+                // warm up in the background and report a placeholder healthy status meanwhile
+                warmUp();
+                Map<String, Object> result = new HashMap<>();
+                result.put(STATUS, PLACEHOLDER);
+                return result;
+            }
+            return probe();
+        }
+        throw new IllegalArgumentException("type must be info or health");
+    }
+
+    private void warmUp() {
+        if (warmingUp.compareAndSet(false, true)) {
+            Thread.startVirtualThread(() -> {
+                try {
+                    probe();
+                    if (ready) {
+                        log.info("{} health check is ready", SERVICE_NAME);
+                    } else {
+                        // the client configuration is still incomplete - allow another warm-up attempt
+                        warmingUp.set(false);
+                    }
+                } catch (Exception e) {
+                    // stay in placeholder mode until the grace period ends
+                    warmingUp.set(false);
+                    log.warn("{} health check warm-up pending - {}", SERVICE_NAME, e.getMessage());
+                }
+            });
+        }
+    }
+
+    // S2093 (try-with-resources): the try/finally releases the ReentrantLock; the Redis connection is
+    // deliberately long-lived - cached across health checks and closed via closeQuietly on failure
+    @SuppressWarnings("java:S2093")
+    private Map<String, Object> probe() throws AppException {
+        lock.lock();
+        try {
+            if (connection == null) {
+                // re-resolved, not cached from the constructor: a credential published by a later
+                // @MainApplication bootstrap is not visible while this @PreLoad function is constructed
+                RedisConfig config = probeConfig.get();
+                currentConfig = config;
+                RedisURI uri = config.toUri();
+                uri.setTimeout(Duration.ofMillis(timeoutMs));
+                client = RedisClient.create(uri);
+                connection = client.connect();
+            }
+            connection.sync().ping();
+            ready = true;
+            Map<String, Object> result = new HashMap<>();
+            result.put(STATUS, REACHABLE);
+            result.put(HREF, href());
+            return result;
+        } catch (Exception e) {
+            closeQuietly();
+            if (waitingOnConfig(e)) {
+                // the configuration is not yet usable (unbuildable values, or credentials the server
+                // rejects): report a PASSING waiting status - failing /health would invite the container
+                // orchestrator to restart the pod, and a restart cannot produce the credential.
+                // The next probe re-resolves, so the check goes live once the real values land.
+                log.warn("{} health check waiting for a usable client configuration - {}",
+                        SERVICE_NAME, rootCause(e));
+                Map<String, Object> result = new HashMap<>();
+                result.put(STATUS, WAITING);
+                return result;
+            }
+            throw new AppException(503, "Redis is not reachable - " + rootCause(e));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * The waiting-vs-outage boundary. True when the failure is a configuration that is not yet usable:
+     * the client cannot be built from the resolved values (IllegalArgument/IllegalState while mapping
+     * them onto a RedisURI - e.g. an unresolved placeholder port), or the server rejected the
+     * credentials ({@code NOAUTH} / {@code WRONGPASS} / {@code ERR Client sent AUTH} anywhere in the
+     * cause chain) - the signature of a password that has not landed yet, which a pod restart cannot
+     * fix. Everything else (connection refused, timeout) is a genuine outage and fails /health.
+     */
+    static boolean waitingOnConfig(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof IllegalArgumentException || t instanceof IllegalStateException) {
+                return true;
+            }
+            String message = t.getMessage();
+            if (message != null && (message.startsWith("NOAUTH") || message.startsWith("WRONGPASS")
+                    || message.startsWith("ERR Client sent AUTH"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The dependency's href - the configured host:port. Reported before the first probe too, so it
+     * resolves the configuration on demand when no client has been built yet; host and port do not
+     * depend on a late credential, so the first resolve's answer stays valid.
+     */
+    private String href() {
+        RedisConfig config = currentConfig;
+        if (config == null) {
+            config = probeConfig.get();
+            currentConfig = config;
+        }
+        return config.host() + ":" + config.port();
+    }
+
+    /** The most specific reason - Lettuce wraps connect failures in generic outer exceptions. */
+    private static String rootCause(Throwable e) {
+        Throwable t = e;
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t.getMessage();
+    }
+
+    private void closeQuietly() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception e) {
+                log.debug("Ignorable error while closing Redis health-check connection - {}", e.getMessage());
+            }
+            connection = null;
+        }
+        if (client != null) {
+            try {
+                client.shutdown(Duration.ZERO, Duration.ofSeconds(2));
+            } catch (Exception e) {
+                log.debug("Ignorable error while shutting down Redis health-check client - {}", e.getMessage());
+            }
+            client = null;
+        }
+    }
+}

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckAuthTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckAuthTest.java
@@ -1,0 +1,105 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.support;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.util.Utility;
+import redis.embedded.RedisServer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The late-credential scenario end to end, against an embedded Redis that REQUIRES a password
+ * ({@code requirepass}): a probe whose {@code redis.password} has not been published yet is a
+ * passing "waiting" status - never a failed {@code /health} - and the check goes live on the
+ * first probe after the credential lands, with no restart in between. This is the vault-bootstrap
+ * pattern: a {@code @MainApplication} fetches secrets and publishes them as system properties
+ * long after this {@code @PreLoad} function is constructed.
+ */
+class RedisHealthCheckAuthTest {
+
+    private static final String DATA_DIR = "/tmp/soa-redis-auth";
+    // fixed high port, distinct from RedisTestBase's server (both may run in one surefire JVM)
+    private static final int AUTH_PORT = 16380;
+    // an obviously local fixture credential for the embedded test server
+    private static final String PASSWORD = "local-test-secret";
+    private static final Map<String, String> HEALTH = Map.of("type", "health");
+    private static final long TIMEOUT_MS = 2000L;
+
+    private static RedisServer redisServer;
+
+    // S5443: a fixed /tmp path is intentional for this test fixture (wiped before each run)
+    @SuppressWarnings("java:S5443")
+    @BeforeAll
+    static void startRedis() throws IOException {
+        File dir = new File(DATA_DIR);
+        Utility.getInstance().cleanupDir(dir);
+        dir.mkdirs();
+        redisServer = RedisServer.newRedisServer()
+                .port(AUTH_PORT)
+                .setting("dir " + DATA_DIR)
+                .setting("save \"\"")
+                .setting("appendonly no")
+                .setting("requirepass " + PASSWORD)
+                .build();
+        redisServer.start();
+    }
+
+    @AfterAll
+    static void stopRedis() throws IOException {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    private static RedisConfig withPassword(String password) {
+        return new RedisConfig("127.0.0.1", AUTH_PORT, password, false, 0, TIMEOUT_MS);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void missingCredentialWaitsThenHealsWhenItLands() {
+        // the bootstrap has not run: redis.password resolves blank, and the server says NOAUTH
+        AtomicReference<RedisConfig> config = new AtomicReference<>(withPassword(""));
+        var health = new RedisHealthCheck(config::get, TIMEOUT_MS, 0);
+        Map<String, Object> waiting = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Waiting for Redis connection", waiting.get("status"),
+                "a credential that has not landed is a start-up condition - /health must pass");
+        // the bootstrap publishes the credential - the next probe re-resolves and authenticates
+        config.set(withPassword(PASSWORD));
+        Map<String, Object> live = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Redis is reachable", live.get("status"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void rejectedCredentialIsAlsoWaitingNotAnOutage() {
+        // WRONGPASS: still not the real credential - a pod restart cannot fix it either
+        var health = new RedisHealthCheck(() -> withPassword("not-the-real-one"), TIMEOUT_MS, 0);
+        Map<String, Object> waiting = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Waiting for Redis connection", waiting.get("status"));
+    }
+}

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
@@ -1,0 +1,141 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.support;
+
+import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisConnectionException;
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.exception.AppException;
+
+import java.net.ConnectException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * WHEN the probe's client configuration is resolved, and how failures are classified. This function
+ * is {@code @PreLoad}, so it is constructed before a {@code @MainApplication} credential bootstrap
+ * (e.g. fetching secrets from a vault and publishing them as system properties) has run - resolving
+ * the configuration in the constructor would freeze a late-published {@code redis.password} as
+ * missing for the life of the instance.
+ *
+ * <p>No Redis server is involved: probes are pointed at a closed port or at unbuildable values, so
+ * each attempt fails immediately and the assertions are about how often the supplier is consulted
+ * and which failures count as "waiting" rather than an outage.
+ */
+class RedisHealthCheckLazyConfigTest {
+
+    private static final long PROBE_IMMEDIATELY = 0L;
+    private static final long TIMEOUT_MS = 500L;
+
+    /** A probe config pointed at a closed port - building the client works, the round trip does not. */
+    private static RedisConfig unreachable() {
+        return new RedisConfig("127.0.0.1", 1, "", false, 0, TIMEOUT_MS);
+    }
+
+    /** A probe config the client cannot even be built from - e.g. an unresolved placeholder port. */
+    private static RedisConfig unbuildable() {
+        return new RedisConfig("127.0.0.1", -1, "", false, 0, TIMEOUT_MS);
+    }
+
+    private static RedisHealthCheck probing(Supplier<RedisConfig> config) {
+        return new RedisHealthCheck(config, TIMEOUT_MS, PROBE_IMMEDIATELY);
+    }
+
+    @Test
+    void constructionResolvesNothing() {
+        AtomicInteger resolves = new AtomicInteger();
+        probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        assertEquals(0, resolves.get(),
+                "a @PreLoad constructor runs before the credential bootstrap - it must not resolve the config");
+    }
+
+    @Test
+    void everyRebuildResolvesAgainSoALateCredentialIsPickedUp() {
+        AtomicInteger resolves = new AtomicInteger();
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        Map<String, String> probe = Map.of("type", "health");
+        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        assertEquals(2, resolves.get(),
+                "a failed probe closes the client, so the next one re-resolves and the check can heal");
+    }
+
+    @Test
+    void unbuildableConfigIsAPassingWaitingStatusNotAFailure() {
+        AtomicInteger resolves = new AtomicInteger();
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return unbuildable();
+        });
+        Map<String, String> probe = Map.of("type", "health");
+        assertEquals("Waiting for Redis connection", asMap(health.handleEvent(probe, null, 1)).get("status"),
+                "an unbuildable client is a start-up condition, not an outage - /health must pass");
+        assertEquals("Waiting for Redis connection", asMap(health.handleEvent(probe, null, 1)).get("status"));
+        assertEquals(2, resolves.get(),
+                "each waiting probe re-resolves the config so late-published values are picked up");
+    }
+
+    @Test
+    void typeInfoResolvesOnDemandAndKeepsTheAnswer() {
+        AtomicInteger resolves = new AtomicInteger();
+        var health = probing(() -> {
+            resolves.incrementAndGet();
+            return unreachable();
+        });
+        Map<String, String> info = Map.of("type", "info");
+        assertEquals("127.0.0.1:1", asMap(health.handleEvent(info, null, 1)).get("href"));
+        assertEquals("127.0.0.1:1", asMap(health.handleEvent(info, null, 1)).get("href"));
+        assertEquals(1, resolves.get(),
+                "host and port do not depend on a late credential, so one resolve serves every info call");
+    }
+
+    @Test
+    void authRejectionsCountAsWaitingButOutagesDoNot() {
+        // Lettuce surfaces a rejected handshake as a connection exception wrapping the server's error
+        assertTrue(RedisHealthCheck.waitingOnConfig(new RedisConnectionException("Unable to connect",
+                        new RedisCommandExecutionException("NOAUTH Authentication required."))),
+                "no credential sent yet = the bootstrap has not landed - waiting");
+        assertTrue(RedisHealthCheck.waitingOnConfig(new RedisConnectionException("Unable to connect",
+                        new RedisCommandExecutionException("WRONGPASS invalid username-password pair"))),
+                "credential rejected = not yet the real one - a restart cannot fix it - waiting");
+        assertTrue(RedisHealthCheck.waitingOnConfig(new RedisCommandExecutionException(
+                        "ERR Client sent AUTH, but no password is set")),
+                "a stale credential against an auth-less server is also a config condition - waiting");
+        assertFalse(RedisHealthCheck.waitingOnConfig(new RedisConnectionException("Unable to connect",
+                        new ConnectException("Connection refused"))),
+                "a genuine connectivity failure is an outage and must fail /health");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object result) {
+        return (Map<String, Object>) result;
+    }
+}

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
@@ -1,0 +1,128 @@
+/*
+
+    Copyright 2018-2026 Accenture Technology
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ */
+
+package org.platformlambda.sync;
+
+import org.junit.jupiter.api.Test;
+import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.util.Utility;
+import org.platformlambda.support.RedisConfig;
+import org.platformlambda.support.RedisHealthCheck;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The health contract against a real (embedded) Redis server: info, live probe, placeholder
+ * during the start-up grace, outage failure - and the self-healing path where an unusable
+ * configuration completes while the application is running.
+ */
+class RedisHealthCheckTest extends RedisTestBase {
+
+    private static final Map<String, String> INFO = Map.of("type", "info");
+    private static final Map<String, String> HEALTH = Map.of("type", "health");
+    private static final long TIMEOUT_MS = 2000L;
+
+    private static RedisConfig serverConfig() {
+        return new RedisConfig("127.0.0.1", redisPort, "", false, 0, TIMEOUT_MS);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void infoDescribesTheRedisDependency() {
+        var health = new RedisHealthCheck(RedisHealthCheckTest::serverConfig, TIMEOUT_MS, 0);
+        var result = health.handleEvent(INFO, null, 1);
+        assertInstanceOf(Map.class, result);
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertEquals("redis", map.get("service"));
+        assertEquals("127.0.0.1:" + redisPort, map.get("href"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void probesImmediatelyWhenGraceExpired() {
+        var health = new RedisHealthCheck(RedisHealthCheckTest::serverConfig, TIMEOUT_MS, 0);
+        Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Redis is reachable", result.get("status"));
+        assertEquals("127.0.0.1:" + redisPort, result.get("href"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void startupReturnsPlaceholderThenLiveStatus() {
+        var health = new RedisHealthCheck(RedisHealthCheckTest::serverConfig, TIMEOUT_MS, 60000);
+        // within the grace period, the first check is a placeholder healthy status - the Redis
+        // client warms up in the background so /health never blocks during app start-up
+        var first = health.handleEvent(HEALTH, null, 1);
+        assertInstanceOf(Map.class, first);
+        assertEquals("Redis client is starting up", ((Map<String, Object>) first).get("status"));
+        // once warm-up completes, checks report the live server status
+        Map<String, Object> live = null;
+        // generous for busy CI executors - the poll returns as soon as warm-up completes
+        long deadline = System.currentTimeMillis() + 60000;
+        while (System.currentTimeMillis() < deadline) {
+            Map<String, Object> result = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+            if ("Redis is reachable".equals(result.get("status"))) {
+                live = result;
+                break;
+            }
+            Utility.getInstance().sleep(200);
+        }
+        assertNotNull(live, "warm-up should complete and report live server status");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void reportsWaitingUntilTheConfigCompletesThenGoesLive() {
+        // simulate a @MainApplication credential bootstrap that has not run yet: the configuration is
+        // unusable at first (the client cannot be built), then completes while the app is running
+        AtomicReference<RedisConfig> config = new AtomicReference<>(
+                new RedisConfig("127.0.0.1", -1, "", false, 0, TIMEOUT_MS));
+        var health = new RedisHealthCheck(config::get, TIMEOUT_MS, 0);
+        Map<String, Object> waiting = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Waiting for Redis connection", waiting.get("status"));
+        // the bootstrap publishes the missing values - the next probe re-resolves and goes live,
+        // with no restart and no failed /health in between
+        config.set(serverConfig());
+        Map<String, Object> live = (Map<String, Object>) health.handleEvent(HEALTH, null, 1);
+        assertEquals("Redis is reachable", live.get("status"));
+        assertEquals("127.0.0.1:" + redisPort, live.get("href"));
+    }
+
+    @Test
+    void unreachableRedisFailsTheHealthCheck() {
+        // closed port = fast connection-refused failure: a genuine outage, not a waiting condition
+        var health = new RedisHealthCheck(
+                () -> new RedisConfig("127.0.0.1", 1, "", false, 0, TIMEOUT_MS), TIMEOUT_MS, 0);
+        AppException offline = assertThrows(AppException.class,
+                () -> health.handleEvent(HEALTH, null, 1));
+        assertEquals(503, offline.getStatus());
+        assertTrue(offline.getMessage().contains("not reachable"));
+    }
+
+    @Test
+    void invalidTypeIsRejected() {
+        var health = new RedisHealthCheck(RedisHealthCheckTest::serverConfig, TIMEOUT_MS, 0);
+        Map<String, String> badType = Map.of("type", "unknown");
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> health.handleEvent(badType, null, 1));
+        assertEquals("type must be info or health", error.getMessage());
+    }
+}

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -121,7 +121,11 @@
   probe config through a `Supplier` at client build time (re-resolved on every rebuild) and, while
   the client cannot even be BUILT, report a passing "Waiting for Kafka connection" status instead of
   failing /health — a pod restart cannot produce a credential (Eric's ruling); only a real round-trip
-  failure (client built, cluster unreachable) fails /health with 503.
+  failure (client built, cluster unreachable) fails /health with 503. (Shipped via PR #360.) Applied
+  again by `redis.health` (sync-over-async; one probe also covers minigraph-state-redis — same
+  `redis.*` keys), with the Redis wrinkle: a late credential surfaces as a server-side auth rejection
+  (NOAUTH/WRONGPASS) at connect time, not at client construction, so those classify as waiting too.
+  Eric's standing rule: every critical infrastructure component needs a health check service.
   <!-- id: preload-before-mainapp-lazy-config | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-185752 -->
 
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -1,0 +1,56 @@
+# Session (2026-09-11T19:12:00.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**redis.health created for sync-over-async (branch `feat/redis-health-check`,
+follow-up to the kafka.health lazy-config fix on PR #360's branch).** Eric's
+ruling: every critical infrastructure component needs a health check service -
+and the extension had none (it eagerly connects to Redis from its
+@MainApplication autoloader, but nothing served /health). minigraph-state-redis
+reads the same `redis.*` parameters, so one probe covers both Redis consumers.
+
+`RedisHealthCheck` (route `redis.health`, org.platformlambda.support) follows
+the kafka.health design and applies today's @PreLoad lesson from day one:
+standard type=info/type=health contract; single PING on a dedicated connection
+(one round trip proves connectivity, TLS, and auth); config resolved lazily
+through a `Supplier<RedisConfig>` at client build time, re-resolved on every
+rebuild; startup grace with placeholder + background warm-up;
+`redis.health.timeout` / `redis.health.startup.grace` tunables.
+
+**Waiting-vs-outage boundary, Redis edition:** unlike Kafka (where an
+incomplete template fails at client CONSTRUCTION), a late Redis credential
+surfaces as a server-side auth rejection at connect time. So "waiting" =
+unbuildable config values (IllegalArgument/IllegalState while mapping onto
+RedisURI, e.g. an unresolved placeholder port) OR auth rejections anywhere in
+the cause chain (NOAUTH / WRONGPASS / "ERR Client sent AUTH" - the signature
+of a password that has not landed; a pod restart cannot fix any of them).
+Genuine connectivity failures (connection refused, timeout) fail /health 503.
+Classifier is a package-private static (`waitingOnConfig`) with direct tests.
+
+Validation: sync-over-async 45 tests green on first run - new
+`RedisHealthCheckLazyConfigTest` (5: supplier 0 at construction / once per
+rebuild / waiting on unbuildable / info resolves once / classifier),
+`RedisHealthCheckTest` on the embedded server (6, incl. config-completes-then-
+goes-live heal path), and `RedisHealthCheckAuthTest` on a requirepass server
+(2: NOAUTH -> waiting -> password lands -> reachable with no restart between;
+WRONGPASS -> waiting). check-doc-canon OK; mkdocs --strict OK. Guide gained a
+Health check section + config rows; configuration-reference gained both keys.
+
+**Continuity note:** the governing fact `preload-before-mainapp-lazy-config`
+was created earlier today on the PR #360 branch; its substance should gain a
+"redis.health applies the same design" line AFTER both PRs merge (deferred to
+a post-merge memory commit to avoid a cross-branch continuity conflict).
+
+## Doc Gaps
+
+(none - sync-over-async guide had no health section because the function did
+not exist; created alongside the code)
+
+## Memory References
+
+- preload-before-mainapp-lazy-config (consulted - the lesson this new check
+  is built on; created earlier today, origin 2026-09-11-185752)
+- eric-release-rhythm (consulted - branch/commit/PR text prepared; Eric
+  creates the PR and gates merge)

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -39,9 +39,11 @@ WRONGPASS -> waiting). check-doc-canon OK; mkdocs --strict OK. Guide gained a
 Health check section + config rows; configuration-reference gained both keys.
 
 **Continuity note:** the governing fact `preload-before-mainapp-lazy-config`
-was created earlier today on the PR #360 branch; its substance should gain a
-"redis.health applies the same design" line AFTER both PRs merge (deferred to
-a post-merge memory commit to avoid a cross-branch continuity conflict).
+was created earlier today on the PR #360 branch. After #360 merged (squash
+`5dd4eb73`, title clean), this branch was rebased onto main and the fact
+update (redis.health application + the auth-rejection wrinkle + Eric's
+standing every-critical-component-needs-a-health-check rule) was folded in
+here, so no post-merge memory commit is needed.
 
 ## Doc Gaps
 


### PR DESCRIPTION
## What

A new health-check function at route **`redis.health`** in the sync-over-async extension,
following the standard health contract (`type=info` / `type=health`) and the same design as
`kafka.health` after #360: the probe's client configuration is resolved **lazily** through a
`Supplier<RedisConfig>` when the probe client is built - re-resolved on every rebuild after a
failed probe - and an unusable configuration is a **passing** `Waiting for Redis connection`
status rather than a failed `/health`. Only a genuine connectivity failure (connection refused,
timed-out round trip) fails `/health` with HTTP 503.

## Why

Every critical infrastructure component needs a health check service. The extension eagerly
connects to Redis from its `@MainApplication` autoloader, yet shipped nothing to list in
`mandatory.health.dependencies` - and the `minigraph-state-redis` extension reads the same
`redis.*` parameters, so one `redis.health` covers a deployment using either or both modules.

The check applies the `@PreLoad` lesson from the kafka.health fix from day one: these functions
are constructed while the platform registers routes, before any `@MainApplication` credential
bootstrap (the vault pattern) has published its system properties, so nothing may be frozen in
the constructor. Redis adds one wrinkle: a missing/blank password does not fail at client
construction like Kafka's `ConfigException` - it surfaces as a server-side rejection
(`NOAUTH` / `WRONGPASS`) at connect time. Those rejections are the signature of a credential
that has not landed yet, and a pod restart cannot produce it - so they classify as "waiting",
never as an outage.

## Design

- Probe = a single Redis **PING** on a dedicated cached connection: one round trip proves
  connectivity, TLS, and authentication.
- Waiting vs outage: unbuildable config values (e.g. an unresolved placeholder port) or auth
  rejections anywhere in the cause chain → passing waiting status with a one-line warn;
  everything else → `AppException` 503. The classifier is a small static with direct tests.
- Start-up grace with placeholder healthy status and background warm-up (retries while the
  configuration is still incomplete), mirroring kafka.health.
- Tunables `redis.health.timeout` (default `5s`) and `redis.health.startup.grace` (default
  `30s`); guide section and Configuration Reference entries included.

## Tests

- `RedisHealthCheckLazyConfigTest` (no server): supplier consulted zero times at construction,
  once per rebuild; unbuildable config is a passing waiting status; `type=info` resolves once;
  classifier verdicts (NOAUTH/WRONGPASS/stale-AUTH = waiting, connection refused = outage).
- `RedisHealthCheckTest` (embedded Redis): info, live probe, placeholder-then-live warm-up,
  the config-completes-then-goes-live heal path, 503 on a closed port, invalid-type rejection.
- `RedisHealthCheckAuthTest` (embedded Redis with `requirepass`): the field scenario end to
  end - blank password → NOAUTH → waiting, credential lands → reachable, no restart and no
  failed `/health` in between; wrong password → waiting.
- sync-over-async module: 45 tests green; doc canon + strict mkdocs OK.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)