### PR TITLE
health checks: hardening round - kernel threads for Kafka, structured 503 message, scan fixes

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -635,7 +635,7 @@ Timeout for the `kafka.health` probe - a single Kafka Metadata request (`KafkaCo
 |------|---------|
 | `String` (duration) | `30s` |
 
-Start-up grace period for `kafka.health`: within it the check reports a placeholder healthy status while the Kafka client warms up in the background, so `/health` never fails or blocks during application start-up. After the first successful probe (or once the grace expires) every check is live and an unreachable cluster fails the check with a 503 status and a key-value message (`text` + `status`).
+Start-up grace period for `kafka.health`: within it the check reports a placeholder healthy status while the Kafka client warms up in the background, so `/health` never fails or blocks during application start-up. After the first successful probe (or once the grace expires) every check is live and an unreachable cluster fails the check with a 503 status and a key-value message (`text` + `code`).
 
 ### `otel.trace.forwarder.enabled`
 
@@ -1298,7 +1298,7 @@ Timeout for the `redis.health` probe - a single Redis PING on a dedicated connec
 |------|---------|
 | `duration` | `30s` |
 
-Start-up grace period for `redis.health`: within it the check reports a placeholder healthy status while the Redis client warms up in the background, so `/health` never fails or blocks during application start-up. The probe's configuration is resolved lazily and re-resolved on every rebuild, and an unusable configuration (unbuildable values, or credentials the server rejects - the signature of a vault-published password that has not landed yet) is a passing `Waiting for Redis connection` status; only a genuine connectivity failure fails the check, with a 503 status and a key-value message (`text` + `status`).
+Start-up grace period for `redis.health`: within it the check reports a placeholder healthy status while the Redis client warms up in the background, so `/health` never fails or blocks during application start-up. The probe's configuration is resolved lazily and re-resolved on every rebuild, and an unusable configuration (unbuildable values, or credentials the server rejects - the signature of a vault-published password that has not landed yet) is a passing `Waiting for Redis connection` status; only a genuine connectivity failure fails the check, with a 503 status and a key-value message (`text` + `code`).
 
 ### `sync.return.channel.prefix`
 

--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -635,7 +635,7 @@ Timeout for the `kafka.health` probe - a single Kafka Metadata request (`KafkaCo
 |------|---------|
 | `String` (duration) | `30s` |
 
-Start-up grace period for `kafka.health`: within it the check reports a placeholder healthy status while the Kafka client warms up in the background, so `/health` never fails or blocks during application start-up. After the first successful probe (or once the grace expires) every check is live and an unreachable cluster fails `/health` with 503.
+Start-up grace period for `kafka.health`: within it the check reports a placeholder healthy status while the Kafka client warms up in the background, so `/health` never fails or blocks during application start-up. After the first successful probe (or once the grace expires) every check is live and an unreachable cluster fails the check with a 503 status and a key-value message (`text` + `status`).
 
 ### `otel.trace.forwarder.enabled`
 
@@ -1298,7 +1298,7 @@ Timeout for the `redis.health` probe - a single Redis PING on a dedicated connec
 |------|---------|
 | `duration` | `30s` |
 
-Start-up grace period for `redis.health`: within it the check reports a placeholder healthy status while the Redis client warms up in the background, so `/health` never fails or blocks during application start-up. The probe's configuration is resolved lazily and re-resolved on every rebuild, and an unusable configuration (unbuildable values, or credentials the server rejects - the signature of a vault-published password that has not landed yet) is a passing `Waiting for Redis connection` status; only a genuine connectivity failure fails `/health` with 503.
+Start-up grace period for `redis.health`: within it the check reports a placeholder healthy status while the Redis client warms up in the background, so `/health` never fails or blocks during application start-up. The probe's configuration is resolved lazily and re-resolved on every rebuild, and an unusable configuration (unbuildable values, or credentials the server rejects - the signature of a vault-published password that has not landed yet) is a passing `Waiting for Redis connection` status; only a genuine connectivity failure fails the check, with a 503 status and a key-value message (`text` + `status`).
 
 ### `sync.return.channel.prefix`
 

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -603,7 +603,7 @@ topics the principal may Describe rather than rejecting the request, so under a 
 principal the probe still succeeds (with a visible topic count of 0) - the successful round trip proves
 connectivity, TLS/SASL authentication, and a served API request. A reachable cluster reports a status map
 (including the visible topic count, which may be 0 under restrictive ACLs); an unreachable one fails the
-check with a **503** status and a key-value message (`text` for the DevOps reader, `status` for the code),
+check with a **503** status and a key-value message (`text` for the DevOps reader, `code` for the status code),
 so `/health` marks the dependency down and the endpoint answers non-2xx while the application is DOWN.
 
 During application start-up the check returns a **placeholder healthy** status while the Kafka client

--- a/docs/guides/minimalist-kafka.md
+++ b/docs/guides/minimalist-kafka.md
@@ -602,8 +602,9 @@ no admin privileges. The Metadata request itself requires **no ACL**: brokers fi
 topics the principal may Describe rather than rejecting the request, so under a fully locked-down
 principal the probe still succeeds (with a visible topic count of 0) - the successful round trip proves
 connectivity, TLS/SASL authentication, and a served API request. A reachable cluster reports a status map
-(including the visible topic count, which may be 0 under restrictive ACLs); an unreachable one fails
-`/health` with HTTP 503.
+(including the visible topic count, which may be 0 under restrictive ACLs); an unreachable one fails the
+check with a **503** status and a key-value message (`text` for the DevOps reader, `status` for the code),
+so `/health` marks the dependency down and the endpoint answers non-2xx while the application is DOWN.
 
 During application start-up the check returns a **placeholder healthy** status while the Kafka client
 warms up in the background - `/health` neither fails nor blocks before the client and the rest of the
@@ -621,7 +622,7 @@ the first probe after the credential lands simply succeeds; nothing needs a rest
 template is still incomplete - the client cannot even be built from it - `type=health` reports a
 **passing** `Waiting for Kafka connection` status rather than a failure: failing `/health` would
 invite the container orchestrator to restart the pod, and a restart cannot produce the credential.
-Only a real connectivity failure (client built, cluster unreachable) fails `/health` with HTTP 503.
+Only a real connectivity failure (client built, cluster unreachable) fails the check with status 503.
 The same applies to `secondary.kafka.health`.
 
 > **On a produce-only leg the probe uses the producer template.** With

--- a/docs/guides/sync-over-async.md
+++ b/docs/guides/sync-over-async.md
@@ -114,7 +114,9 @@ mandatory.health.dependencies=redis.health
 The probe is a single Redis **PING** on a dedicated connection built from the `redis.*` parameters -
 the lightest round trip the protocol offers, and one successful call proves connectivity, TLS, and
 authentication in a single request. A reachable server reports a status map; an unreachable one fails
-`/health` with HTTP 503. During application start-up the check returns a **placeholder healthy** status
+the check with a **503** status and a key-value message (`text` for the DevOps reader, `status` for the
+code), so `/health` marks the dependency down and the endpoint answers non-2xx while the application is
+DOWN. During application start-up the check returns a **placeholder healthy** status
 while the client warms up in the background (`redis.health.startup.grace`, default `30s`), and
 `redis.health.timeout` (default `5s`) bounds the probe's connect and command round trips.
 
@@ -127,7 +129,7 @@ the client cannot be built from it, or the server rejects the credentials (`NOAU
 the signature of a password that has not landed yet) - `type=health` reports a **passing**
 `Waiting for Redis connection` status rather than a failure: failing `/health` would invite the
 container orchestrator to restart the pod, and a restart cannot produce the credential. Only a genuine
-connectivity failure (connection refused, timed-out round trip) fails `/health` with HTTP 503. The
+connectivity failure (connection refused, timed-out round trip) fails the check with status 503. The
 check goes live on the first probe after the real values land; nothing needs a restart. Same design as
 [`kafka.health`](minimalist-kafka.md#health).
 

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
  * endpoint will include the Redis server status. The function follows the standard health
  * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
  * map when the server is reachable and a 503 response carrying a key-value map
- * ({@code text} + {@code status}) when it is not - the status code is what the health
+ * ({@code text} + {@code code}) when it is not - the status code is what the health
  * aggregation (and Kubernetes) detects; the map is for the DevOps reader. While the
  * client configuration is still incomplete - a late credential not yet published, or not yet
  * accepted by the server - it returns a passing {@code Waiting for Redis connection} status
@@ -104,6 +104,7 @@ public class RedisHealthCheck implements LambdaFunction {
     private static final String HREF = "href";
     private static final String STATUS = "status";
     private static final String TEXT = "text";
+    private static final String CODE = "code";
     private static final String TIMEOUT_KEY = "redis.health.timeout";
     private static final String GRACE_KEY = "redis.health.startup.grace";
     private static final String DEFAULT_TIMEOUT = "5s";
@@ -247,7 +248,7 @@ public class RedisHealthCheck implements LambdaFunction {
             // detects; the key-value body keeps the code visible to the DevOps reader too
             Map<String, Object> down = new HashMap<>();
             down.put(TEXT, "Redis is not reachable - " + rootCause(e));
-            down.put(STATUS, 503);
+            down.put(CODE, 503);
             return new EventEnvelope().setStatus(503).setBody(down);
         } finally {
             lock.unlock();

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -108,13 +109,14 @@ public class RedisHealthCheck implements LambdaFunction {
     private final AtomicBoolean warmingUp = new AtomicBoolean(false);
     private final Supplier<RedisConfig> probeConfig;
     // what the current probe client was built from; also the href source - replaced on every rebuild
-    private volatile RedisConfig currentConfig;
+    private final AtomicReference<RedisConfig> currentConfig = new AtomicReference<>();
     private final long timeoutMs;
     private final long graceDeadline;
     private RedisClient client;
     private StatefulRedisConnection<String, String> connection;
     private volatile boolean ready = false;
 
+    /** Instantiated reflectively when the platform's {@code @PreLoad} scanner registers the route. */
     public RedisHealthCheck() {
         this(() -> RedisConfig.from(AppConfigReader.getInstance()),
              resolveDurationMs(TIMEOUT_KEY, DEFAULT_TIMEOUT),
@@ -202,7 +204,7 @@ public class RedisHealthCheck implements LambdaFunction {
                 // re-resolved, not cached from the constructor: a credential published by a later
                 // @MainApplication bootstrap is not visible while this @PreLoad function is constructed
                 RedisConfig config = probeConfig.get();
-                currentConfig = config;
+                currentConfig.set(config);
                 RedisURI uri = config.toUri();
                 uri.setTimeout(Duration.ofMillis(timeoutMs));
                 client = RedisClient.create(uri);
@@ -261,10 +263,10 @@ public class RedisHealthCheck implements LambdaFunction {
      * depend on a late credential, so the first resolve's answer stays valid.
      */
     private String href() {
-        RedisConfig config = currentConfig;
+        RedisConfig config = currentConfig.get();
         if (config == null) {
             config = probeConfig.get();
-            currentConfig = config;
+            currentConfig.set(config);
         }
         return config.host() + ":" + config.port();
     }

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -83,6 +83,11 @@ import java.util.function.Supplier;
  * successful probe - or once the grace period ({@code redis.health.startup.grace}, default
  * {@code 30s}) has elapsed - every check is a live probe. {@code redis.health.timeout}
  * (default {@code 5s}) bounds the probe's connect and command round trips.
+ *
+ * <p>This function deliberately stays on virtual threads (no {@code @KernelThreadRunner}, unlike
+ * {@code kafka.health}): Lettuce performs network I/O on its own event-loop threads, and the calling
+ * thread merely awaits a future - which unmounts a virtual thread cleanly instead of pinning its
+ * carrier.
  */
 // multiple workers because /health is polled concurrently (operations tooling plus the container
 // platform's liveness/readiness probes): info and placeholder responses run in parallel, while the

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -22,7 +22,7 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import org.platformlambda.core.annotations.PreLoad;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
@@ -46,7 +46,9 @@ import java.util.function.Supplier;
  * {@code optional.health.dependencies}) in application.properties and the {@code /health}
  * endpoint will include the Redis server status. The function follows the standard health
  * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
- * map when the server is reachable and throws {@code AppException} when it is not. While the
+ * map when the server is reachable and a 503 response carrying a key-value map
+ * ({@code text} + {@code status}) when it is not - the status code is what the health
+ * aggregation (and Kubernetes) detects; the map is for the DevOps reader. While the
  * client configuration is still incomplete - a late credential not yet published, or not yet
  * accepted by the server - it returns a passing {@code Waiting for Redis connection} status
  * instead of failing (see below).
@@ -96,6 +98,7 @@ public class RedisHealthCheck implements LambdaFunction {
     private static final String SERVICE = "service";
     private static final String HREF = "href";
     private static final String STATUS = "status";
+    private static final String TEXT = "text";
     private static final String TIMEOUT_KEY = "redis.health.timeout";
     private static final String GRACE_KEY = "redis.health.startup.grace";
     private static final String DEFAULT_TIMEOUT = "5s";
@@ -203,7 +206,7 @@ public class RedisHealthCheck implements LambdaFunction {
     // S2093 (try-with-resources): the try/finally releases the ReentrantLock; the Redis connection is
     // deliberately long-lived - cached across health checks and closed via closeQuietly on failure
     @SuppressWarnings("java:S2093")
-    private Map<String, Object> probe() throws AppException {
+    private Object probe() {
         lock.lock();
         try {
             if (connection == null) {
@@ -235,7 +238,12 @@ public class RedisHealthCheck implements LambdaFunction {
                 result.put(STATUS, WAITING);
                 return result;
             }
-            throw new AppException(503, "Redis is not reachable - " + rootCause(e));
+            // a genuine outage: the 503 status is what the health aggregation (and Kubernetes)
+            // detects; the key-value body keeps the code visible to the DevOps reader too
+            Map<String, Object> down = new HashMap<>();
+            down.put(TEXT, "Redis is not reachable - " + rootCause(e));
+            down.put(STATUS, 503);
+            return new EventEnvelope().setStatus(503).setBody(down);
         } finally {
             lock.unlock();
         }

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -130,12 +131,16 @@ public class RedisHealthCheck implements LambdaFunction {
      * sequence (e.g. a vault-fetched {@code redis.password}) is resolved correctly on the next probe
      * instead of being frozen at construction time.
      *
+     * <p>The supplier itself must not be null (enforced here, at construction) and must return a
+     * non-null config: when the real values have not been published yet, return your best-known
+     * ones - an unusable result is handled by the waiting semantics, never by returning null.
+     *
      * @param probeConfig supplies the Redis connection parameters, re-invoked on every rebuild
      * @param timeoutMs   probe timeout in milliseconds (bounds connect and command round trips)
      * @param graceMs     start-up grace period in milliseconds (0 = probe immediately)
      */
     public RedisHealthCheck(Supplier<RedisConfig> probeConfig, long timeoutMs, long graceMs) {
-        this.probeConfig = probeConfig;
+        this.probeConfig = Objects.requireNonNull(probeConfig, "probeConfig supplier is required");
         this.timeoutMs = timeoutMs;
         this.graceDeadline = System.currentTimeMillis() + graceMs;
     }
@@ -259,9 +264,14 @@ public class RedisHealthCheck implements LambdaFunction {
     }
 
     /**
-     * The dependency's href - the configured host:port. Reported before the first probe too, so it
-     * resolves the configuration on demand when no client has been built yet; host and port do not
-     * depend on a late credential, so the first resolve's answer stays valid.
+     * The dependency's href - the configured host:port. Lifecycle: {@code probeConfig} is the
+     * supplier itself, assigned final in the constructor, so it always exists by the time any event
+     * arrives (the platform registers the route only after construction) - what starts out null is
+     * the RESOLVED config in {@code currentConfig}, because nothing is resolved at {@code @PreLoad}
+     * time by design. A {@code type=info} call that arrives before the first probe therefore
+     * resolves on demand (the supplier's first invocation) and caches the answer; every probe that
+     * builds a client overwrites the cache with its own fresh resolve. Host and port do not depend
+     * on a late credential, so one resolve serves every info call between rebuilds.
      */
     private String href() {
         RedisConfig config = currentConfig.get();

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/support/RedisHealthCheck.java
@@ -24,6 +24,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
@@ -176,7 +177,7 @@ public class RedisHealthCheck implements LambdaFunction {
 
     private void warmUp() {
         if (warmingUp.compareAndSet(false, true)) {
-            Thread.startVirtualThread(() -> {
+            Platform.getInstance().getVirtualThreadExecutor().execute(() -> {
                 try {
                     probe();
                     if (ready) {

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
@@ -64,6 +64,13 @@ class RedisHealthCheckLazyConfigTest {
     }
 
     @Test
+    void aNullSupplierFailsFastAtConstruction() {
+        NullPointerException error = assertThrows(NullPointerException.class,
+                () -> new RedisHealthCheck(null, TIMEOUT_MS, PROBE_IMMEDIATELY));
+        assertEquals("probeConfig supplier is required", error.getMessage());
+    }
+
+    @Test
     void constructionResolvesNothing() {
         AtomicInteger resolves = new AtomicInteger();
         probing(() -> {

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
@@ -21,7 +21,7 @@ package org.platformlambda.support;
 import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisConnectionException;
 import org.junit.jupiter.api.Test;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 
 import java.net.ConnectException;
 import java.util.Map;
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -89,8 +90,14 @@ class RedisHealthCheckLazyConfigTest {
             return unreachable();
         });
         Map<String, String> probe = Map.of("type", "health");
-        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
-        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        Object first = health.handleEvent(probe, null, 1);
+        // an outage is a 503 response carrying a key-value map - the status code for the health
+        // aggregation to detect, text + status for the DevOps reader
+        assertInstanceOf(EventEnvelope.class, first);
+        assertEquals(503, ((EventEnvelope) first).getStatus());
+        Map<String, Object> body = asMap(((EventEnvelope) first).getBody());
+        assertEquals(503, body.get("status"));
+        assertInstanceOf(EventEnvelope.class, health.handleEvent(probe, null, 1));
         assertEquals(2, resolves.get(),
                 "a failed probe closes the client, so the next one re-resolves and the check can heal");
     }

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/support/RedisHealthCheckLazyConfigTest.java
@@ -92,11 +92,11 @@ class RedisHealthCheckLazyConfigTest {
         Map<String, String> probe = Map.of("type", "health");
         Object first = health.handleEvent(probe, null, 1);
         // an outage is a 503 response carrying a key-value map - the status code for the health
-        // aggregation to detect, text + status for the DevOps reader
+        // aggregation to detect, text + code for the DevOps reader
         assertInstanceOf(EventEnvelope.class, first);
         assertEquals(503, ((EventEnvelope) first).getStatus());
         Map<String, Object> body = asMap(((EventEnvelope) first).getBody());
-        assertEquals(503, body.get("status"));
+        assertEquals(503, body.get("code"));
         assertInstanceOf(EventEnvelope.class, health.handleEvent(probe, null, 1));
         assertEquals(2, resolves.get(),
                 "a failed probe closes the client, so the next one re-resolves and the check can heal");

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
@@ -114,12 +114,12 @@ class RedisHealthCheckTest extends RedisTestBase {
                 () -> new RedisConfig("127.0.0.1", 1, "", false, 0, TIMEOUT_MS), TIMEOUT_MS, 0);
         Object result = health.handleEvent(HEALTH, null, 1);
         // an outage is a 503 response carrying a key-value map - the status code for the health
-        // aggregation to detect, text + status for the DevOps reader
+        // aggregation to detect, text + code for the DevOps reader
         assertInstanceOf(EventEnvelope.class, result);
         EventEnvelope offline = (EventEnvelope) result;
         assertEquals(503, offline.getStatus());
         Map<String, Object> body = (Map<String, Object>) offline.getBody();
-        assertEquals(503, body.get("status"));
+        assertEquals(503, body.get("code"));
         assertTrue(body.get("text").toString().contains("not reachable"));
     }
 

--- a/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
+++ b/extensions/sync-over-async/src/test/java/org/platformlambda/sync/RedisHealthCheckTest.java
@@ -19,7 +19,7 @@
 package org.platformlambda.sync;
 
 import org.junit.jupiter.api.Test;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.util.Utility;
 import org.platformlambda.support.RedisConfig;
 import org.platformlambda.support.RedisHealthCheck;
@@ -106,15 +106,21 @@ class RedisHealthCheckTest extends RedisTestBase {
         assertEquals("127.0.0.1:" + redisPort, live.get("href"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void unreachableRedisFailsTheHealthCheck() {
         // closed port = fast connection-refused failure: a genuine outage, not a waiting condition
         var health = new RedisHealthCheck(
                 () -> new RedisConfig("127.0.0.1", 1, "", false, 0, TIMEOUT_MS), TIMEOUT_MS, 0);
-        AppException offline = assertThrows(AppException.class,
-                () -> health.handleEvent(HEALTH, null, 1));
+        Object result = health.handleEvent(HEALTH, null, 1);
+        // an outage is a 503 response carrying a key-value map - the status code for the health
+        // aggregation to detect, text + status for the DevOps reader
+        assertInstanceOf(EventEnvelope.class, result);
+        EventEnvelope offline = (EventEnvelope) result;
         assertEquals(503, offline.getStatus());
-        assertTrue(offline.getMessage().contains("not reachable"));
+        Map<String, Object> body = (Map<String, Object>) offline.getBody();
+        assertEquals(503, body.get("status"));
+        assertTrue(body.get("text").toString().contains("not reachable"));
     }
 
     @Test

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -122,8 +122,8 @@
   the client cannot even be BUILT, report a passing "Waiting for Kafka connection" status instead of
   failing /health — a pod restart cannot produce a credential (Eric's ruling); only a real round-trip
   failure (client built, cluster unreachable) fails /health with 503. (Shipped via PR #360.) Applied
-  again by `redis.health` (sync-over-async; one probe also covers minigraph-state-redis — same
-  `redis.*` keys), with the Redis wrinkle: a late credential surfaces as a server-side auth rejection
+  again by `redis.health` (PR #361; sync-over-async — one probe also covers minigraph-state-redis,
+  same `redis.*` keys), with the Redis wrinkle: a late credential surfaces as a server-side auth rejection
   (NOAUTH/WRONGPASS) at connect time, not at client construction, so those classify as waiting too.
   Eric's standing rule: every critical infrastructure component needs a health check service.
   <!-- id: preload-before-mainapp-lazy-config | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-185752 -->

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -94,6 +94,22 @@ non-2xx while DOWN"). Lesson: pkill on a standalone-helper JVM can orphan its
 native redis-server child - the port stays open and a probe truthfully
 reports reachable; kill the child too when tearing down.
 
+**IDE two-issue round (Eric's screenshots, standalone per-module windows).**
+(1) The twin window's red "constructor cannot be applied (String, Supplier,
+long, long)" was a STALE library model: javap proved the installed
+minimalist-kafka-4.12.7 jar carries the Supplier constructor and Maven builds
+the twin green - remedy is a Maven reload in that window (jar also freshly
+reinstalled). Lesson: Eric opens each module as its own IntelliJ project, so
+sibling-module changes are seen through mavenLocal jars - reinstall after
+base-class changes, and expect cross-module "never used" false hints.
+(2) The "resolveDurationMs(3-arg) never used" hint got the true fix: the
+fallback-convention overload moved from KafkaHealthCheck to its only user,
+SecondaryKafkaHealthCheck (private static; minor narrowing of a protected
+base member introduced this same release cycle). Also: probe()'s nested try
+extracted to buildClient(...) (Sonar S1141 class), dictionary-noise rewords
+("tunables"->"tuning keys", "Health-check function"->"Health check"), and
+Eric's cosmetic javadoc wording edits folded in.
+
 ## Doc Gaps
 
 (none - sync-over-async guide had no health section because the function did

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -43,7 +43,10 @@ was created earlier today on the PR #360 branch. After #360 merged (squash
 `5dd4eb73`, title clean), this branch was rebased onto main and the fact
 update (redis.health application + the auth-rejection wrinkle + Eric's
 standing every-critical-component-needs-a-health-check rule) was folded in
-here, so no post-merge memory commit is needed.
+here, so the only post-merge memory work was adding the PR refs.
+
+**Merged:** PR #361, squash `ff01747b` (title clean). Same-day pair with the
+kafka.health fix: PR #360, squash `5dd4eb73`. Both merged branches deleted.
 
 ## Doc Gaps
 

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -77,6 +77,23 @@ a clear message), a documented non-null contract for the supplier's RESULT
 semantics' job), href() javadoc now narrates the full lifecycle, and each
 engine gained a fail-fast guard test (health classes re-verified green).
 
+**Dry run + message-shape ruling (Eric).** Live dry-run on the demo app
+(README regression stack: redis-standalone, kafka-standalone, facade :8400)
+validated all four states: placeholder-then-live, waiting on unusable config
+(HTTP 200/UP - pod survives, one clean warn line), outage (dependency 503,
+app DOWN), and live self-heal on the same JVM twice. Surfaced that the
+/health ENVELOPE answers 400 when DOWN (ActuatorServices `up? 200 : 400` -
+pre-existing, uniform). Eric's ruling: keep the platform; the FAILURE message
+becomes a key-value map so the code is visible to the DevOps reader - the
+checks now return `EventEnvelope(503)` with body `{text, status: 503}`
+instead of throwing AppException (the aggregation still keys on the envelope
+status; verified live: `"message": {"text": "Redis is not reachable -
+Connection refused", "status": 503}`). Applied to both engines + tests; guide
+wording aligned ("fails the check with status 503... endpoint answers
+non-2xx while DOWN"). Lesson: pkill on a standalone-helper JVM can orphan its
+native redis-server child - the port stays open and a probe truthfully
+reports reachable; kill the child too when tearing down.
+
 ## Doc Gaps
 
 (none - sync-over-async guide had no health section because the function did

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -57,10 +57,13 @@ AtomicReference in both engines' checks (behavior identical; volatile-on-
 immutable was safe for Redis but the field gate counts smells, and the Kafka
 twin held a MUTABLE Properties). The no-arg constructors gained a one-line
 javadoc noting reflective @PreLoad instantiation (the "never used" hint is a
-false positive). Kept deliberately against IDE hints: the warm-up virtual
-thread (virtual threads are the framework's execution invariant and the
-warm-up probe is exactly their workload; pinning already addressed in the
-ReentrantLock comment), and the NOAUTH/WRONGPASS "typo" flags (Redis protocol
+false positive). Eric's own edit resolved the "use a platform thread" finding
+the right way: the warm-up stays ON a virtual thread but goes through the
+framework's managed executor - `Platform.getInstance().getVirtualThreadExecutor()
+.execute(...)` instead of a raw `Thread.startVirtualThread` (the engine's own
+idiom; the invariant holds, the lifecycle is platform-owned) - mirrored into
+KafkaHealthCheck for lock-step parity, leaving no raw virtual-thread spawn in
+main code. Left as-is: the NOAUTH/WRONGPASS "typo" flags (Redis protocol
 words).
 
 ## Doc Gaps

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -110,6 +110,22 @@ extracted to buildClient(...) (Sonar S1141 class), dictionary-noise rewords
 ("tunables"->"tuning keys", "Health-check function"->"Health check"), and
 Eric's cosmetic javadoc wording edits folded in.
 
+**Thread-model ruling (Eric's question: is KafkaConsumer thread-safe /
+virtual-thread compatible?).** Thread-safety: NOT thread-safe by contract,
+already correct - the ReentrantLock serializes all access, and sequential
+multi-thread use under external sync is what the consumer allows. Virtual
+threads: NOT a good fit on Java 21 - the consumer does its network I/O on the
+CALLING thread inside synchronized sections, so a probe blocking out the
+timeout pins a carrier (JEP 491 removes that only in JDK 24+; build target
+and field run 21). Module precedent already existed: SimpleKafkaNotification/
+SchemaCodec/SecondaryKafkaNotification carry @KernelThreadRunner. Fix went
+BEYOND Eric's line-252 suggestion: @KernelThreadRunner on KafkaHealthCheck +
+SecondaryKafkaHealthCheck (live probes run on function workers, not just
+warm-up) AND the warm-up spawn moved to getKernelThreadExecutor().
+redis.health deliberately STAYS virtual: Lettuce does I/O on its own netty
+event loops, the caller only awaits a future (unmounts cleanly) - asymmetry
+documented in both classes' javadoc.
+
 ## Doc Gaps
 
 (none - sync-over-async guide had no health section because the function did

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -48,6 +48,21 @@ here, so the only post-merge memory work was adding the PR refs.
 **Merged:** PR #361, squash `ff01747b` (title clean). Same-day pair with the
 kafka.health fix: PR #360, squash `5dd4eb73`. Both merged branches deleted.
 
+**Post-merge smell round (Eric's local Sonar/IDE scan, branch
+`fix/health-check-volatile-smell`):** the volatile reference fields introduced
+today (`volatile Properties consumerProperties` in KafkaHealthCheck, `volatile
+RedisConfig currentConfig` in RedisHealthCheck) flagged as the S3077-class
+smell "volatile is not enough to make this field thread-safe" - replaced with
+AtomicReference in both engines' checks (behavior identical; volatile-on-
+immutable was safe for Redis but the field gate counts smells, and the Kafka
+twin held a MUTABLE Properties). The no-arg constructors gained a one-line
+javadoc noting reflective @PreLoad instantiation (the "never used" hint is a
+false positive). Kept deliberately against IDE hints: the warm-up virtual
+thread (virtual threads are the framework's execution invariant and the
+warm-up probe is exactly their workload; pinning already addressed in the
+ReentrantLock comment), and the NOAUTH/WRONGPASS "typo" flags (Redis protocol
+words).
+
 ## Doc Gaps
 
 (none - sync-over-async guide had no health section because the function did
@@ -59,3 +74,6 @@ not exist; created alongside the code)
   is built on; created earlier today, origin 2026-09-11-185752)
 - eric-release-rhythm (consulted - branch/commit/PR text prepared; Eric
   creates the PR and gates merge)
+- virtual-threads-rpc (consulted - kept the warm-up virtual thread against
+  the IDE's platform-thread suggestion; virtual threads are the framework's
+  execution model and the blocking warm-up probe is their intended workload)

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -124,7 +124,9 @@ SecondaryKafkaHealthCheck (live probes run on function workers, not just
 warm-up) AND the warm-up spawn moved to getKernelThreadExecutor().
 redis.health deliberately STAYS virtual: Lettuce does I/O on its own netty
 event loops, the caller only awaits a future (unmounts cleanly) - asymmetry
-documented in both classes' javadoc.
+documented in both classes' javadoc. Follow-up polish per Eric: the
+multiple-workers line comments above @PreLoad absorbed into both classes'
+javadoc.
 
 ## Doc Gaps
 

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -87,8 +87,11 @@ pre-existing, uniform). Eric's ruling: keep the platform; the FAILURE message
 becomes a key-value map so the code is visible to the DevOps reader - the
 checks now return `EventEnvelope(503)` with body `{text, status: 503}`
 instead of throwing AppException (the aggregation still keys on the envelope
-status; verified live: `"message": {"text": "Redis is not reachable -
-Connection refused", "status": 503}`). Applied to both engines + tests; guide
+status; verified live). Key rename per Eric's follow-up: the numeric entry is
+`code`, not `status` - the healthy shape already uses `status` for the human
+string, and `"status": {"status"...}` read redundantly. Final failure shape:
+`"message": {"text": "Redis is not reachable - Connection refused",
+"code": 503}`. Applied to both engines + tests; guide
 wording aligned ("fails the check with status 503... endpoint answers
 non-2xx while DOWN"). Lesson: pkill on a standalone-helper JVM can orphan its
 native redis-server child - the port stays open and a probe truthfully

--- a/memory/sessions/2026-09-11-191200.md
+++ b/memory/sessions/2026-09-11-191200.md
@@ -66,6 +66,17 @@ KafkaHealthCheck for lock-step parity, leaving no raw virtual-thread spawn in
 main code. Left as-is: the NOAUTH/WRONGPASS "typo" flags (Redis protocol
 words).
 
+**PR held for review clarifications (Eric).** First question: can
+`probeConfig.get()` in href() run against a null supplier? Answer: no - the
+supplier is a final constructor-assigned field and routes register only after
+construction; the null that href() tests is the RESOLVED config (nothing may
+resolve at @PreLoad time by design). Made the guarantee explicit in both
+engines: `Objects.requireNonNull` on the Supplier constructors (fail fast with
+a clear message), a documented non-null contract for the supplier's RESULT
+(return best-known values, never null - unusable values are the waiting
+semantics' job), href() javadoc now narrates the full lifecycle, and each
+engine gained a fail-fast guard test (health classes re-verified green).
+
 ## Doc Gaps
 
 (none - sync-over-async guide had no health section because the function did

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -49,7 +49,7 @@ import java.util.function.Supplier;
  * endpoint will include the Kafka cluster status. The function follows the standard health
  * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
  * map when the cluster is reachable and a 503 response carrying a key-value map
- * ({@code text} + {@code status}) when it is not - the status code is what the health
+ * ({@code text} + {@code code}) when it is not - the status code is what the health
  * aggregation (and Kubernetes) detects; the map is for the DevOps reader. While the
  * client configuration is still incomplete - a late credential not yet published - it returns a
  * passing {@code Waiting for Kafka connection} status instead of failing (see below).
@@ -125,6 +125,7 @@ public class KafkaHealthCheck implements LambdaFunction {
     private static final String HREF = "href";
     private static final String STATUS = "status";
     private static final String TEXT = "text";
+    private static final String CODE = "code";
     private static final String TOPICS = "topics";
     private static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
     private static final String TIMEOUT_KEY = "kafka.health.timeout";
@@ -298,7 +299,7 @@ public class KafkaHealthCheck implements LambdaFunction {
             // detects; the key-value body keeps the code visible to the DevOps reader too
             Map<String, Object> down = new HashMap<>();
             down.put(TEXT, "Kafka cluster is not reachable - " + e.getMessage());
-            down.put(STATUS, 503);
+            down.put(CODE, 503);
             return new EventEnvelope().setStatus(503).setBody(down);
         } finally {
             lock.unlock();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -21,6 +21,7 @@ package org.platformlambda.mini.kafka;
 import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
+import org.platformlambda.core.annotations.KernelThreadRunner;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.LambdaFunction;
@@ -94,10 +95,22 @@ import java.util.function.Supplier;
  * successful probe - or once the grace period ({@code kafka.health.startup.grace}, default
  * {@code 30s}) has elapsed - every check is a live probe and an unreachable cluster fails
  * the check with status 503.
+ *
+ * <p><b>{@code @KernelThreadRunner}.</b> The Kafka consumer performs its network I/O on the CALLING
+ * thread inside {@code synchronized} sections, and on Java 21 a virtual thread that blocks inside
+ * {@code synchronized} pins its carrier - a probe waiting out {@code kafka.health.timeout} against an
+ * unreachable cluster would pin a carrier for the full wait. Kernel threads avoid that, matching the
+ * module convention for functions that drive Kafka clients ({@code SimpleKafkaNotification},
+ * {@code SchemaCodec}); the warm-up probe uses the kernel-thread executor for the same reason.
+ * (JDK 24's JEP 491 removes synchronized pinning, but the build targets Java 21 and field
+ * installations run it.) Contrast {@code redis.health}, which deliberately stays on virtual threads:
+ * Lettuce does its I/O on its own event-loop threads and the caller merely awaits a future, which
+ * unmounts a virtual thread cleanly.
  */
 // multiple workers because /health is polled concurrently (operations tooling plus the container
 // platform's liveness/readiness probes): info and placeholder responses run in parallel, while the
 // non-thread-safe KafkaConsumer stays protected - every probe serializes on the ReentrantLock below
+@KernelThreadRunner
 @PreLoad(route = "kafka.health", instances = 5)
 public class KafkaHealthCheck implements LambdaFunction {
     private static final Logger log = LoggerFactory.getLogger(KafkaHealthCheck.class);
@@ -120,9 +133,9 @@ public class KafkaHealthCheck implements LambdaFunction {
     private static final String WAITING = "Waiting for Kafka connection";
     private static final String REACHABLE = "Kafka cluster is reachable";
 
-    // virtual-thread friendly: a ReentrantLock does not pin the carrier thread like 'synchronized'.
-    // The lock also serializes access to the KafkaConsumer, which is not thread-safe (the health
-    // worker and the background warm-up thread would otherwise race).
+    // the ReentrantLock serializes access to the KafkaConsumer, which is NOT thread-safe: the health
+    // workers and the background warm-up thread would otherwise race. Sequential multi-thread access
+    // under external synchronization is what the consumer's contract allows.
     private final ReentrantLock lock = new ReentrantLock();
     private final AtomicBoolean warmingUp = new AtomicBoolean(false);
     private final String serviceName;
@@ -229,7 +242,8 @@ public class KafkaHealthCheck implements LambdaFunction {
 
     private void warmUp() {
         if (warmingUp.compareAndSet(false, true)) {
-            Platform.getInstance().getVirtualThreadExecutor().execute(() -> {
+            // kernel thread, not virtual: the consumer's calling-thread I/O would pin a carrier
+            Platform.getInstance().getKernelThreadExecutor().execute(() -> {
                 try {
                     probe();
                     if (ready) {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -77,7 +77,7 @@ import java.util.function.Supplier;
  * {@code @MainApplication} start-up logic runs. A credential bootstrap that fetches secrets from a
  * vault and publishes them as system properties has therefore not executed yet, and a template whose
  * {@code sasl.jaas.config} interpolates such a credential would be frozen with the credential
- * missing - every probe then fails forever with Kafka's {@code ConfigException: The OAuth
+ * missing. Every probe then fails forever with Kafka's {@code ConfigException: The OAuth
  * configuration option clientId value is required}, no matter what the environment does. Because a
  * failed probe closes the client, the next probe re-resolves the template and the check heals
  * itself as soon as the credential lands.
@@ -170,8 +170,8 @@ public class KafkaHealthCheck implements LambdaFunction {
     /**
      * Reuse seam for a library probing ANOTHER Kafka cluster (e.g. twin-kafka's
      * {@code secondary.kafka.health}): subclass with the other cluster's probe template, a distinct
-     * service name for the /health dependency list, and its own tunables. The supplier is invoked
-     * when the probe client is built - and again on every rebuild after a failure - so a template
+     * service name for the /health dependency list, and its own tuning keys. The supplier is invoked
+     * when the probe client is built - and again on every rebuild after a failure. Therefore, a template
      * that interpolates a credential published later in the start-up sequence is resolved correctly
      * on the next probe instead of being frozen at construction time.
      *
@@ -190,21 +190,6 @@ public class KafkaHealthCheck implements LambdaFunction {
         this.probeConfig = Objects.requireNonNull(probeConfig, "probeConfig supplier is required");
         this.timeoutMs = timeoutMs;
         this.graceDeadline = System.currentTimeMillis() + graceMs;
-    }
-
-    /**
-     * Resolve a duration configuration key to milliseconds, consulting an optional fallback key
-     * before the built-in default - the twin-kafka convention where secondary.* keys fall back
-     * to the primary cluster's globals.
-     *
-     * @param key          the configuration key (e.g. "secondary.kafka.health.timeout")
-     * @param fallbackKey  optional fallback key (e.g. "kafka.health.timeout"); null for none
-     * @param defaultValue the built-in default duration (e.g. "5s")
-     * @return the resolved duration in milliseconds
-     */
-    protected static long resolveDurationMs(String key, String fallbackKey, String defaultValue) {
-        var config = AppConfigReader.getInstance();
-        return resolveDurationMs(key, config.getProperty(fallbackKey, defaultValue));
     }
 
     /**
@@ -273,15 +258,12 @@ public class KafkaHealthCheck implements LambdaFunction {
                 // @MainApplication bootstrap is not visible while this @PreLoad function is constructed
                 Properties config = probeConfig.get();
                 consumerProperties.set(config);
-                try {
-                    consumer = new KafkaConsumer<>(config);
-                } catch (KafkaException e) {
+                consumer = buildClient(config);
+                if (consumer == null) {
                     // the template is still incomplete (e.g. that credential has not landed yet):
                     // report a PASSING waiting status - failing /health would invite the container
                     // orchestrator to restart the pod, and a restart cannot produce the credential.
                     // The next probe re-resolves, so the check goes live once construction succeeds.
-                    log.warn("{} health check waiting for a usable client configuration - {}",
-                            serviceName, rootCause(e));
                     Map<String, Object> result = new HashMap<>();
                     result.put(STATUS, WAITING);
                     return result;
@@ -324,6 +306,21 @@ public class KafkaHealthCheck implements LambdaFunction {
             consumerProperties.set(config);
         }
         return config.getProperty(BOOTSTRAP_SERVERS, PRIMARY_SERVICE_NAME);
+    }
+
+    /**
+     * Build the probe client from a freshly resolved template - or null when the client cannot even
+     * be constructed from it, i.e. the template is still incomplete (a late credential not yet
+     * published). The caller reports that as the passing waiting status.
+     */
+    private KafkaConsumer<String, byte[]> buildClient(Properties config) {
+        try {
+            return new KafkaConsumer<>(config);
+        } catch (KafkaException e) {
+            log.warn("{} health check waiting for a usable client configuration - {}",
+                    serviceName, rootCause(e));
+            return null;
+        }
     }
 
     /** The most specific reason - client construction failures arrive wrapped in a generic KafkaException. */

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -96,6 +96,11 @@ import java.util.function.Supplier;
  * {@code 30s}) has elapsed - every check is a live probe and an unreachable cluster fails
  * the check with status 503.
  *
+ * <p><b>Multiple workers.</b> {@code /health} is polled concurrently - operations tooling plus the
+ * container platform's liveness/readiness probes - so the function runs several worker instances:
+ * info and placeholder responses serve in parallel, while the non-thread-safe {@code KafkaConsumer}
+ * stays protected because every probe serializes on the internal lock.
+ *
  * <p><b>{@code @KernelThreadRunner}.</b> The Kafka consumer performs its network I/O on the CALLING
  * thread inside {@code synchronized} sections, and on Java 21 a virtual thread that blocks inside
  * {@code synchronized} pins its carrier - a probe waiting out {@code kafka.health.timeout} against an
@@ -107,9 +112,6 @@ import java.util.function.Supplier;
  * Lettuce does its I/O on its own event-loop threads and the caller merely awaits a future, which
  * unmounts a virtual thread cleanly.
  */
-// multiple workers because /health is polled concurrently (operations tooling plus the container
-// platform's liveness/readiness probes): info and placeholder responses run in parallel, while the
-// non-thread-safe KafkaConsumer stays protected - every probe serializes on the ReentrantLock below
 @KernelThreadRunner
 @PreLoad(route = "kafka.health", instances = 5)
 public class KafkaHealthCheck implements LambdaFunction {

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -122,12 +123,13 @@ public class KafkaHealthCheck implements LambdaFunction {
     private final String serviceName;
     private final Supplier<Properties> probeConfig;
     // what the current probe client was built from; also the href source - replaced on every rebuild
-    private volatile Properties consumerProperties;
+    private final AtomicReference<Properties> consumerProperties = new AtomicReference<>();
     private final long timeoutMs;
     private final long graceDeadline;
     private KafkaConsumer<String, byte[]> consumer;
     private volatile boolean ready = false;
 
+    /** Instantiated reflectively when the platform's {@code @PreLoad} scanner registers the route. */
     public KafkaHealthCheck() {
         this(PRIMARY_SERVICE_NAME,
              () -> KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance()),
@@ -261,7 +263,7 @@ public class KafkaHealthCheck implements LambdaFunction {
                 // re-resolved, not cached from the constructor: a credential published by a later
                 // @MainApplication bootstrap is not visible while this @PreLoad function is constructed
                 Properties config = probeConfig.get();
-                consumerProperties = config;
+                consumerProperties.set(config);
                 try {
                     consumer = new KafkaConsumer<>(config);
                 } catch (KafkaException e) {
@@ -297,10 +299,10 @@ public class KafkaHealthCheck implements LambdaFunction {
      * not depend on a late credential, so the first resolve's answer stays valid.
      */
     private String href() {
-        Properties config = consumerProperties;
+        Properties config = consumerProperties.get();
         if (config == null) {
             config = probeConfig.get();
-            consumerProperties = config;
+            consumerProperties.set(config);
         }
         return config.getProperty(BOOTSTRAP_SERVERS, PRIMARY_SERVICE_NAME);
     }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.consumer.CloseOptions;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.platformlambda.core.annotations.PreLoad;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.LambdaFunction;
 import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
@@ -47,7 +47,9 @@ import java.util.function.Supplier;
  * {@code optional.health.dependencies}) in application.properties and the {@code /health}
  * endpoint will include the Kafka cluster status. The function follows the standard health
  * contract: {@code type=info} describes the dependency, {@code type=health} returns a status
- * map when the cluster is reachable and throws {@code AppException} when it is not. While the
+ * map when the cluster is reachable and a 503 response carrying a key-value map
+ * ({@code text} + {@code status}) when it is not - the status code is what the health
+ * aggregation (and Kubernetes) detects; the map is for the DevOps reader. While the
  * client configuration is still incomplete - a late credential not yet published - it returns a
  * passing {@code Waiting for Kafka connection} status instead of failing (see below).
  *
@@ -91,7 +93,7 @@ import java.util.function.Supplier;
  * Kafka client and the rest of the start-up sequence are still coming up. After the first
  * successful probe - or once the grace period ({@code kafka.health.startup.grace}, default
  * {@code 30s}) has elapsed - every check is a live probe and an unreachable cluster fails
- * {@code /health} with HTTP 503.
+ * the check with status 503.
  */
 // multiple workers because /health is polled concurrently (operations tooling plus the container
 // platform's liveness/readiness probes): info and placeholder responses run in parallel, while the
@@ -107,6 +109,7 @@ public class KafkaHealthCheck implements LambdaFunction {
     private static final String SERVICE = "service";
     private static final String HREF = "href";
     private static final String STATUS = "status";
+    private static final String TEXT = "text";
     private static final String TOPICS = "topics";
     private static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
     private static final String TIMEOUT_KEY = "kafka.health.timeout";
@@ -262,7 +265,7 @@ public class KafkaHealthCheck implements LambdaFunction {
     // S2093 (try-with-resources): the try/finally releases the ReentrantLock; the KafkaConsumer is
     // deliberately long-lived - cached across health checks and closed via closeQuietly on failure
     @SuppressWarnings("java:S2093")
-    private Map<String, Object> probe() throws AppException {
+    private Object probe() {
         lock.lock();
         try {
             if (consumer == null) {
@@ -293,7 +296,12 @@ public class KafkaHealthCheck implements LambdaFunction {
             return result;
         } catch (Exception e) {
             closeQuietly();
-            throw new AppException(503, "Kafka cluster is not reachable - " + e.getMessage());
+            // a genuine outage: the 503 status is what the health aggregation (and Kubernetes)
+            // detects; the key-value body keeps the code visible to the DevOps reader too
+            Map<String, Object> down = new HashMap<>();
+            down.put(TEXT, "Kafka cluster is not reachable - " + e.getMessage());
+            down.put(STATUS, 503);
+            return new EventEnvelope().setStatus(503).setBody(down);
         } finally {
             lock.unlock();
         }

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -171,6 +172,10 @@ public class KafkaHealthCheck implements LambdaFunction {
      * that interpolates a credential published later in the start-up sequence is resolved correctly
      * on the next probe instead of being frozen at construction time.
      *
+     * <p>The supplier itself must not be null (enforced here, at construction) and must return a
+     * non-null template: when the real values have not been published yet, return your best-known
+     * ones - an unusable result is handled by the waiting semantics, never by returning null.
+     *
      * @param serviceName the dependency name reported by type=info (e.g. "secondary.kafka")
      * @param probeConfig supplies this cluster's probe client configuration, re-invoked on every rebuild
      * @param timeoutMs   probe timeout in milliseconds
@@ -179,7 +184,7 @@ public class KafkaHealthCheck implements LambdaFunction {
     protected KafkaHealthCheck(String serviceName, Supplier<Properties> probeConfig,
                                long timeoutMs, long graceMs) {
         this.serviceName = serviceName;
-        this.probeConfig = probeConfig;
+        this.probeConfig = Objects.requireNonNull(probeConfig, "probeConfig supplier is required");
         this.timeoutMs = timeoutMs;
         this.graceDeadline = System.currentTimeMillis() + graceMs;
     }
@@ -295,9 +300,14 @@ public class KafkaHealthCheck implements LambdaFunction {
     }
 
     /**
-     * The dependency's href - this cluster's bootstrap.servers. Reported before the first probe too,
-     * so it resolves the template on demand when no client has been built yet; bootstrap.servers does
-     * not depend on a late credential, so the first resolve's answer stays valid.
+     * The dependency's href - this cluster's bootstrap.servers. Lifecycle: {@code probeConfig} is the
+     * supplier itself, assigned final in the constructor, so it always exists by the time any event
+     * arrives (the platform registers the route only after construction) - what starts out null is
+     * the RESOLVED template in {@code consumerProperties}, because nothing is resolved at
+     * {@code @PreLoad} time by design. A {@code type=info} call that arrives before the first probe
+     * therefore resolves on demand (the supplier's first invocation) and caches the answer; every
+     * probe that builds a client overwrites the cache with its own fresh resolve. bootstrap.servers
+     * does not depend on a late credential, so one resolve serves every info call between rebuilds.
      */
     private String href() {
         Properties config = consumerProperties.get();

--- a/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
+++ b/system/minimalist-kafka/src/main/java/org/platformlambda/mini/kafka/KafkaHealthCheck.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.KafkaException;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.exception.AppException;
 import org.platformlambda.core.models.LambdaFunction;
+import org.platformlambda.core.system.Platform;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.core.util.Utility;
 import org.slf4j.Logger;
@@ -235,7 +236,7 @@ public class KafkaHealthCheck implements LambdaFunction {
 
     private void warmUp() {
         if (warmingUp.compareAndSet(false, true)) {
-            Thread.startVirtualThread(() -> {
+            Platform.getInstance().getVirtualThreadExecutor().execute(() -> {
                 try {
                     probe();
                     if (ready) {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
@@ -87,11 +87,11 @@ class KafkaHealthCheckLazyConfigTest {
         Map<String, String> probe = Map.of("type", "health");
         Object first = health.handleEvent(probe, null, 1);
         // an outage is a 503 response carrying a key-value map - the status code for the health
-        // aggregation to detect, text + status for the DevOps reader
+        // aggregation to detect, text + code for the DevOps reader
         assertInstanceOf(EventEnvelope.class, first);
         assertEquals(503, ((EventEnvelope) first).getStatus());
         Map<String, Object> body = asMap(((EventEnvelope) first).getBody());
-        assertEquals(503, body.get("status"));
+        assertEquals(503, body.get("code"));
         assertInstanceOf(EventEnvelope.class, health.handleEvent(probe, null, 1));
         assertEquals(2, resolves.get(),
                 "a failed probe closes the client, so the next one re-resolves and the check can heal");

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
@@ -59,6 +59,13 @@ class KafkaHealthCheckLazyConfigTest {
     }
 
     @Test
+    void aNullSupplierFailsFastAtConstruction() {
+        NullPointerException error = assertThrows(NullPointerException.class,
+                () -> new KafkaHealthCheck("kafka", (Supplier<Properties>) null, TIMEOUT_MS, PROBE_IMMEDIATELY));
+        assertEquals("probeConfig supplier is required", error.getMessage());
+    }
+
+    @Test
     void constructionResolvesNothing() {
         AtomicInteger resolves = new AtomicInteger();
         probing(() -> {

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckLazyConfigTest.java
@@ -19,7 +19,7 @@
 package org.platformlambda.mini.kafka;
 
 import org.junit.jupiter.api.Test;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 
 import java.util.Map;
 import java.util.Properties;
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -84,8 +85,14 @@ class KafkaHealthCheckLazyConfigTest {
             return unreachable();
         });
         Map<String, String> probe = Map.of("type", "health");
-        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
-        assertThrows(AppException.class, () -> health.handleEvent(probe, null, 1));
+        Object first = health.handleEvent(probe, null, 1);
+        // an outage is a 503 response carrying a key-value map - the status code for the health
+        // aggregation to detect, text + status for the DevOps reader
+        assertInstanceOf(EventEnvelope.class, first);
+        assertEquals(503, ((EventEnvelope) first).getStatus());
+        Map<String, Object> body = asMap(((EventEnvelope) first).getBody());
+        assertEquals(503, body.get("status"));
+        assertInstanceOf(EventEnvelope.class, health.handleEvent(probe, null, 1));
         assertEquals(2, resolves.get(),
                 "a failed probe closes the client, so the next one re-resolves and the check can heal");
     }

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
@@ -21,7 +21,7 @@ package org.platformlambda.mini.kafka;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.util.Utility;
 
 import java.util.Map;
@@ -118,6 +118,7 @@ class KafkaHealthCheckTest {
         assertEquals(kafka.bootstrapServers(), live.get("href"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void unreachableClusterFailsTheHealthCheck() {
         // closed port + short client timeouts = fast failure
@@ -125,10 +126,15 @@ class KafkaHealthCheckTest {
         bad.setProperty("request.timeout.ms", "1000");
         bad.setProperty("default.api.timeout.ms", "2000");
         var health = new KafkaHealthCheck(bad, 0);
-        AppException offline = assertThrows(AppException.class,
-                () -> health.handleEvent(HEALTH, null, 1));
+        Object result = health.handleEvent(HEALTH, null, 1);
+        // an outage is a 503 response carrying a key-value map - the status code for the health
+        // aggregation to detect, text + status for the DevOps reader
+        assertInstanceOf(EventEnvelope.class, result);
+        EventEnvelope offline = (EventEnvelope) result;
         assertEquals(503, offline.getStatus());
-        assertTrue(offline.getMessage().contains("not reachable"));
+        Map<String, Object> body = (Map<String, Object>) offline.getBody();
+        assertEquals(503, body.get("status"));
+        assertTrue(body.get("text").toString().contains("not reachable"));
     }
 
     @Test

--- a/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
+++ b/system/minimalist-kafka/src/test/java/org/platformlambda/mini/kafka/KafkaHealthCheckTest.java
@@ -128,12 +128,12 @@ class KafkaHealthCheckTest {
         var health = new KafkaHealthCheck(bad, 0);
         Object result = health.handleEvent(HEALTH, null, 1);
         // an outage is a 503 response carrying a key-value map - the status code for the health
-        // aggregation to detect, text + status for the DevOps reader
+        // aggregation to detect, text + code for the DevOps reader
         assertInstanceOf(EventEnvelope.class, result);
         EventEnvelope offline = (EventEnvelope) result;
         assertEquals(503, offline.getStatus());
         Map<String, Object> body = (Map<String, Object>) offline.getBody();
-        assertEquals(503, body.get("status"));
+        assertEquals(503, body.get("code"));
         assertTrue(body.get("text").toString().contains("not reachable"));
     }
 

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
@@ -44,10 +44,11 @@ import java.util.function.Supplier;
  * {@code secondary.kafka.health.startup.grace} fall back to the {@code kafka.health.*}
  * globals, then to the built-in defaults (5s / 30s).
  *
- * <p>Runs on kernel threads like its twin - see the {@code @KernelThreadRunner} note on
- * {@link KafkaHealthCheck} (the consumer's calling-thread I/O would pin a virtual-thread carrier).
+ * <p>Multiple workers serve concurrent {@code /health} callers - the same lock-guarded consumer as
+ * {@code kafka.health}. Runs on kernel threads like its twin - see the {@code @KernelThreadRunner}
+ * note on {@link KafkaHealthCheck} (the consumer's calling-thread I/O would pin a virtual-thread
+ * carrier).
  */
-// multiple workers for concurrent /health callers - same lock-guarded consumer as kafka.health
 @KernelThreadRunner
 @PreLoad(route = "secondary.kafka.health", instances = 5)
 public class SecondaryKafkaHealthCheck extends KafkaHealthCheck {

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
@@ -58,6 +58,7 @@ public class SecondaryKafkaHealthCheck extends KafkaHealthCheck {
     private static final String PRIMARY_TIMEOUT_KEY = "kafka.health.timeout";
     private static final String PRIMARY_GRACE_KEY = "kafka.health.startup.grace";
 
+    /** Instantiated reflectively when the platform's {@code @PreLoad} scanner registers the route. */
     public SecondaryKafkaHealthCheck() {
         this(() -> KafkaClientConfig.healthProbeProperties(AppConfigReader.getInstance(),
                         SecondaryKafkaAutoStart.CONSUMER_ENABLED, CONSUMER_LOCATION, DEFAULT_CONSUMER,

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 import java.util.function.Supplier;
 
 /**
- * Health-check function for the SECONDARY Kafka cluster - the twin of minimalist-kafka's
+ * Health check for the SECONDARY Kafka cluster - the twin of minimalist-kafka's
  * {@code kafka.health}, probing the cluster configured by the secondary consumer template.
  *
  * <p>A dual-cluster bridge application lists both clusters as health dependencies:
@@ -39,8 +39,7 @@ import java.util.function.Supplier;
  * grace with a placeholder healthy status, HTTP 503 when unreachable) - including the
  * produce-only fallback: with {@code secondary.kafka.consumer.enabled=false} the probe is built
  * from the secondary PRODUCER template instead, so a one-way bridge leg stays health-checkable.
- * Tunables follow the
- * twin-kafka fallback convention: {@code secondary.kafka.health.timeout} and
+ * Tuning keys follow the twin-kafka fallback convention: {@code secondary.kafka.health.timeout} and
  * {@code secondary.kafka.health.startup.grace} fall back to the {@code kafka.health.*}
  * globals, then to the built-in defaults (5s / 30s).
  */
@@ -85,5 +84,21 @@ public class SecondaryKafkaHealthCheck extends KafkaHealthCheck {
     SecondaryKafkaHealthCheck(Properties consumerProperties, long graceMs) {
         super(SERVICE_NAME, consumerProperties,
               resolveDurationMs(TIMEOUT_KEY, PRIMARY_TIMEOUT_KEY, DEFAULT_TIMEOUT), graceMs);
+    }
+
+    /**
+     * Resolve a duration configuration key to milliseconds, consulting the primary cluster's key
+     * before the built-in default - the twin-kafka convention where secondary.* keys fall back to
+     * the kafka.health.* globals. Lives here (not in the base class) because this fallback
+     * convention is the twin's own concern - and this class is its only user.
+     *
+     * @param key          the configuration key (e.g. "secondary.kafka.health.timeout")
+     * @param fallbackKey  the primary cluster's fallback key (e.g. "kafka.health.timeout")
+     * @param defaultValue the built-in default duration (e.g. "5s")
+     * @return the resolved duration in milliseconds
+     */
+    private static long resolveDurationMs(String key, String fallbackKey, String defaultValue) {
+        var config = AppConfigReader.getInstance();
+        return resolveDurationMs(key, config.getProperty(fallbackKey, defaultValue));
     }
 }

--- a/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
+++ b/system/twin-kafka/src/main/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheck.java
@@ -18,6 +18,7 @@
 
 package org.platformlambda.twin.kafka;
 
+import org.platformlambda.core.annotations.KernelThreadRunner;
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.util.AppConfigReader;
 import org.platformlambda.mini.kafka.KafkaClientConfig;
@@ -42,8 +43,12 @@ import java.util.function.Supplier;
  * Tuning keys follow the twin-kafka fallback convention: {@code secondary.kafka.health.timeout} and
  * {@code secondary.kafka.health.startup.grace} fall back to the {@code kafka.health.*}
  * globals, then to the built-in defaults (5s / 30s).
+ *
+ * <p>Runs on kernel threads like its twin - see the {@code @KernelThreadRunner} note on
+ * {@link KafkaHealthCheck} (the consumer's calling-thread I/O would pin a virtual-thread carrier).
  */
 // multiple workers for concurrent /health callers - same lock-guarded consumer as kafka.health
+@KernelThreadRunner
 @PreLoad(route = "secondary.kafka.health", instances = 5)
 public class SecondaryKafkaHealthCheck extends KafkaHealthCheck {
 

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
@@ -99,12 +99,12 @@ class SecondaryKafkaHealthCheckTest {
         bad.setProperty("default.api.timeout.ms", "2000");
         var offline = new SecondaryKafkaHealthCheck(bad, 0);
         Object result = offline.handleEvent(HEALTH, null, 1);
-        // an outage is a 503 response carrying a key-value map (text + status)
+        // an outage is a 503 response carrying a key-value map (text + code)
         assertInstanceOf(EventEnvelope.class, result);
         EventEnvelope down = (EventEnvelope) result;
         assertEquals(503, down.getStatus());
         Map<String, Object> body = (Map<String, Object>) down.getBody();
-        assertEquals(503, body.get("status"));
+        assertEquals(503, body.get("code"));
         assertTrue(body.get("text").toString().contains("not reachable"));
         Map<String, Object> alive = (Map<String, Object>) healthy.handleEvent(HEALTH, null, 1);
         assertEquals("Kafka cluster is reachable", alive.get("status"));

--- a/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
+++ b/system/twin-kafka/src/test/java/org/platformlambda/twin/kafka/SecondaryKafkaHealthCheckTest.java
@@ -21,7 +21,7 @@ package org.platformlambda.twin.kafka;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.platformlambda.core.exception.AppException;
+import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.util.Utility;
 
 import java.util.Map;
@@ -98,10 +98,14 @@ class SecondaryKafkaHealthCheckTest {
         bad.setProperty("request.timeout.ms", "1000");
         bad.setProperty("default.api.timeout.ms", "2000");
         var offline = new SecondaryKafkaHealthCheck(bad, 0);
-        AppException down = assertThrows(AppException.class,
-                () -> offline.handleEvent(HEALTH, null, 1));
+        Object result = offline.handleEvent(HEALTH, null, 1);
+        // an outage is a 503 response carrying a key-value map (text + status)
+        assertInstanceOf(EventEnvelope.class, result);
+        EventEnvelope down = (EventEnvelope) result;
         assertEquals(503, down.getStatus());
-        assertTrue(down.getMessage().contains("not reachable"));
+        Map<String, Object> body = (Map<String, Object>) down.getBody();
+        assertEquals(503, body.get("status"));
+        assertTrue(body.get("text").toString().contains("not reachable"));
         Map<String, Object> alive = (Map<String, Object>) healthy.handleEvent(HEALTH, null, 1);
         assertEquals("Kafka cluster is reachable", alive.get("status"));
     }


### PR DESCRIPTION
## What

The post-#360/#361 hardening round for the three health checks (`kafka.health`,
`secondary.kafka.health`, `redis.health`), driven by a local Sonar/IDE scan, a live dry run on the
sync-over-async demo, and review questions. Behavior contracts (lazy config resolution, the passing
waiting status, 503 on genuine outage) are unchanged; how they are implemented and reported is
tightened.

## Thread model (the headline)

**Is KafkaConsumer thread-safe?** No - by contract - and the checks were already correct: the
internal `ReentrantLock` serializes every access, and sequential multi-thread use under external
synchronization is exactly what the consumer's contract allows. The lock comment now states this.

**Is it virtual-thread compatible?** Not on Java 21. The consumer performs its network I/O on the
CALLING thread inside `synchronized` sections, so a probe blocking out `kafka.health.timeout`
against an unreachable cluster pins a virtual-thread carrier for the full wait (JEP 491 removes
synchronized pinning only in JDK 24+; the build targets Java 21 and the field runs it). The module
had already ruled on this class of problem - `SimpleKafkaNotification`, `SchemaCodec` and
`SecondaryKafkaNotification` carry `@KernelThreadRunner` - so the health checks now match:

- `@KernelThreadRunner` on `KafkaHealthCheck` AND `SecondaryKafkaHealthCheck` (live probes run on
  the platform's function workers, so the annotation - not just the warm-up executor - is the fix)
- the background warm-up probe spawns on `Platform.getKernelThreadExecutor()`
- `redis.health` deliberately STAYS on virtual threads: Lettuce performs I/O on its own event-loop
  threads and the caller merely awaits a future, which unmounts cleanly - the asymmetry is
  documented in both classes' javadoc

## Structured failure message

On a genuine outage the checks now return `EventEnvelope(503)` with a key-value body instead of
throwing: the status code is what the health aggregation (and Kubernetes) detects; the map is for
the DevOps reader - `text` for the human words, `code` for the status code (the healthy shape
already uses `status` for its human-readable string, so the numeric key is deliberately not
`status`). Verified live on the demo facade:

    "message": { "text": "Redis is not reachable - Connection refused", "code": 503 }

Guides aligned: the check fails with status 503 and a key-value message; `/health` answers non-2xx
while the application is DOWN (the endpoint's envelope behavior is platform-core's, unchanged).

## Scan and review fixes

- `volatile` reference fields → `AtomicReference` in both engines (S3077-class smell; the Kafka
  field held a mutable `Properties`).
- The probe-config `Supplier` constructors now `Objects.requireNonNull` with a clear message, the
  seam javadoc states the non-null result contract (return best-known values - unusable values are
  the waiting semantics' job, never null), and `href()`'s javadoc narrates the resolve lifecycle.
- `probe()`'s nested try extracted into `buildClient(...)` (S1141 class).
- The twin's fallback helper `resolveDurationMs(key, fallbackKey, default)` moved from
  `KafkaHealthCheck` to its only user, `SecondaryKafkaHealthCheck` (minor narrowing of a protected
  base member introduced earlier this same release cycle).
- No-arg constructors documented as reflectively instantiated by the `@PreLoad` scanner; the
  multiple-workers rationale absorbed into the class javadoc; dictionary-noise rewords.

## Tests and verification

- New fail-fast guard tests (null supplier) in both engines; failure-shape assertions
  (envelope 503 + `{text, code}` body) across five test classes.
- Suites green throughout: minimalist-kafka 203 / twin-kafka 13 (full module incl. its coverage
  gate) / sync-over-async 45; doc canon + strict mkdocs OK.
- Live dry run on the demo facade validated all four states end to end: placeholder → live,
  waiting on unusable config (HTTP 200, pod survives), outage (dependency 503, app DOWN), and
  self-heal on the same JVM with no restart.

Includes this working session's memory log and the #361 continuity closure commit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)