### PR TITLE
release: version 4.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## Version 4.12.8, 9/12/2026
+
+### Added
+
+1. `redis.health` — a ready-made health check for the Redis used by the sync-over-async
+   extension (route auto-registers when the jar is on the classpath; opt in via
+   `mandatory.health.dependencies` / `optional.health.dependencies`). One PING on a
+   dedicated connection proves connectivity, TLS and authentication; the
+   `minigraph-state-redis` extension reads the same `redis.*` parameters, so one probe
+   covers a deployment using either or both. Tunables: `redis.health.timeout` (5s) and
+   `redis.health.startup.grace` (30s). Every critical infrastructure component needs a
+   health check service.
+
+### Fixed
+
+1. `kafka.health` and `secondary.kafka.health` resolve their probe client configuration
+   **lazily** — at client build time, re-resolved on every rebuild — never in the
+   constructor (upstreamed from a field merge request). A `@PreLoad` function is
+   constructed before any `@MainApplication` credential bootstrap publishes its system
+   properties (the vault pattern), so a constructor-resolved `sasl.jaas.config` template
+   froze the credential as missing for the life of the instance and every probe failed
+   forever with Kafka's `ConfigException: The OAuth configuration option clientId value
+   is required`; deployments had to demote `kafka.health` out of
+   `mandatory.health.dependencies`. The check now heals on the first probe after the
+   credential lands — no restart.
+
+2. While a health probe's configuration is still **unusable** — the client cannot be
+   built from it, or the server rejects the credentials (Redis `NOAUTH`/`WRONGPASS`, the
+   signature of a password that has not landed yet) — `type=health` reports a **passing**
+   `Waiting for ... connection` status instead of failing `/health`: an orchestrator
+   restart cannot produce a missing credential. Only a genuine connectivity failure
+   (client built, server unreachable) fails the check with status 503.
+
+### Changed
+
+1. The Kafka health checks run on **kernel threads** (`@KernelThreadRunner`), joining
+   `SimpleKafkaNotification` and `SchemaCodec`: the Kafka consumer performs network I/O
+   on the calling thread inside `synchronized` sections, which pins a virtual-thread
+   carrier on Java 21 (JEP 491 lifts that only in JDK 24+). `redis.health` deliberately
+   stays on virtual threads — Lettuce does its I/O on its own event-loop threads and the
+   caller merely awaits a future, which unmounts cleanly.
+
+2. A failed health probe returns a 503 response carrying a key-value message —
+   `{"text": "<reason>", "code": 503}` — instead of a bare exception string: the status
+   code is what the health aggregation (and Kubernetes) detects; the map is for the
+   DevOps reader.
+
+3. Health-check hardening from the review round: `AtomicReference` instead of volatile
+   reference fields, fail-fast `Objects.requireNonNull` on the probe-config suppliers
+   (with the non-null result contract documented), the background warm-up on the
+   platform's managed executors, and the twin's fallback tunable helper relocated to its
+   only user (`SecondaryKafkaHealthCheck`).
+
+---
 ## Version 4.12.7, 9/11/2026
 
 ### Added

--- a/benchmark/benchmark-reporter/pom.xml
+++ b/benchmark/benchmark-reporter/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>benchmark-reporter</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Benchmark reporter</name>
     <description>Self-contained, single-JVM end-to-end performance harness (callback + RPC) that emits an
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
     </dependencies>
 

--- a/connectors/adapters/kafka/kafka-connector/pom.xml
+++ b/connectors/adapters/kafka/kafka-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Cloud connector for Kafka cluster</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-standalone</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
             <scope>test</scope>
         </dependency>
 

--- a/connectors/adapters/kafka/kafka-presence/pom.xml
+++ b/connectors/adapters/kafka/kafka-presence/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-presence</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Presence monitor for Kafka</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>service-monitor</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/cloud-connector/pom.xml
+++ b/connectors/core/cloud-connector/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>cloud-connector</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Cloud connector module</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/connectors/core/service-monitor/pom.xml
+++ b/connectors/core/service-monitor/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>service-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Presence monitor module</name>
 
     <parent>
@@ -50,13 +50,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>cloud-connector</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/docs/guides/twin-kafka.md
+++ b/docs/guides/twin-kafka.md
@@ -174,6 +174,8 @@ topology in one process - set `dual.servers=true` (in its `application.propertie
 `-Ddual.servers=true`) and it starts broker 1 on `127.0.0.1:9092` and broker 2 on `127.0.0.1:8092`
 with separate log directories:
 
+> **Note**: `x.y.z` denotes the current Mercury version shown in the root `pom.xml`.
+
 ```shell
 cd helpers/kafka-standalone && java -Ddual.servers=true -jar target/kafka-standalone-x.y.z-exec.jar
 ```

--- a/examples/composable-example/pom.xml
+++ b/examples/composable-example/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>composable-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Composable example using Event Script</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/kafka-demo/pom.xml
+++ b/examples/kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Worked example: minimalist-kafka consumer + producer</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/kotlin-example/pom.xml
+++ b/examples/kotlin-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kotlin-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Composable example written in Kotlin</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/lambda-example/pom.xml
+++ b/examples/lambda-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>lambda-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Lambda example using platform-core</name>
 
     <parent>
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/minigraph-playground/pom.xml
+++ b/examples/minigraph-playground/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>minigraph-playground</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground</name>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Redis state store for graph suspend/resume: including this jar registers
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-state-redis</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Embedded Redis (real redis-server binary, incl. arm64 macOS) for the

--- a/examples/pg-example/pom.xml
+++ b/examples/pg-example/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>pg-example</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>reactive-postgres</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/rest-spring-3-example/pom.xml
+++ b/examples/rest-spring-3-example/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-3-example</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 example (see ADR-0017)</name>
     <description>
@@ -26,7 +26,7 @@
         <relocation>
             <groupId>com.accenture</groupId>
             <artifactId>rest-spring-4-example</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
             <message>
                 rest-spring-3-example is retired along with the rest-spring-3 library: Spring
                 Framework 6.2.x is out of security support. Use rest-spring-4-example, the

--- a/examples/rest-spring-4-example/pom.xml
+++ b/examples/rest-spring-4-example/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.accenture</groupId>
     <artifactId>rest-spring-4-example</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Spring Boot 4 example using platform-core</name>
 
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Optionally, select your optional cloud connector -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>kafka-connector</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/scheduler-example/pom.xml
+++ b/examples/scheduler-example/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>scheduler-example</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Example app for mini-scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>mini-scheduler</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Worked example: sync-over-async REST facade over Kafka + Redis</name>
 
     <parent>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/examples/twin-kafka-demo/pom.xml
+++ b/examples/twin-kafka-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka-demo</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Worked example: profile management bridged across two Kafka clusters</name>
 
     <parent>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>twin-kafka</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/extensions/api-playground/pom.xml
+++ b/extensions/api-playground/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>api-playground</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>API playground using OpenAPI</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/extensions/minigraph-state-redis/pom.xml
+++ b/extensions/minigraph-state-redis/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-state-redis</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>MiniGraph Redis state store extension</name>
     <description>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Reactor-native, battle-tested Redis client with auto-reconnect.

--- a/extensions/opentelemetry-forwarder/pom.xml
+++ b/extensions/opentelemetry-forwarder/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>opentelemetry-forwarder</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>OpenTelemetry trace forwarder extension</name>
     <description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions/reactive-postgres/pom.xml
+++ b/extensions/reactive-postgres/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>reactive-postgres</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Reactive R2DBC sample module</name>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>sync-over-async</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Sync-over-async (Redis-assisted Kafka request/reply)</name>
     <description>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/helpers/kafka-standalone/pom.xml
+++ b/helpers/kafka-standalone/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>kafka-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Standalone kafka system for dev</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/helpers/redis-standalone/pom.xml
+++ b/helpers/redis-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>redis-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Standalone redis server for dev</name>
 
     <parent>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Bundles a real redis-server binary (macOS/Linux, arm64+amd64) and runs it as a subprocess,

--- a/helpers/schema-registry-standalone/pom.xml
+++ b/helpers/schema-registry-standalone/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>schema-registry-standalone</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Standalone Schema Registry server for dev</name>
 
     <parent>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -243,7 +243,10 @@
   placeholders) AND a Gradle build with a single `def mercuryVersion = '<version>'`
   literal. Mercury artifacts are NOT on Maven Central — the templates' Gradle builds
   resolve engine artifacts from mavenLocal (the reactor `mvn install`), which is also why
-  ci.yml's templates-gradle job installs the engine modules first.
+  ci.yml's templates-gradle job installs the engine modules first. Since v4.12.8 the sweep
+  is BUILD FILES ONLY (40 at that release): template READMEs and all guide prose use the
+  `x.y.z` placeholder with an explainer line (Eric's direction — prose never needs a
+  version bump again).
   <!-- id: conv-template-version-sweep | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-005808 -->
 - Watch serialization gotchas (Long↔Integer downcast; use `util.str2int/str2long`).
   <!-- id: conv-serialization-gotchas | created: 2026-06-20 | last_used: 2026-06-24 | uses: 2 | tier: core -->

--- a/memory/sessions/2026-09-12-003927.md
+++ b/memory/sessions/2026-09-12-003927.md
@@ -1,0 +1,47 @@
+# Session (2026-09-12T00:39:27.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Release v4.12.8 prepared for the field (branch `release/v4.12.8`).** The
+health-check release: everything from the 2026-09-11 field-MR arc (PRs #360,
+#361, #362 — kafka.health/secondary.kafka.health lazy config + waiting status,
+the new redis.health, kernel threads for the Kafka checks, the {text, code}
+failure message, and the hardening round). Java only — NO Rust lock-step
+(Eric's direction: Rust has no Kafka modules; sync-over-async/minigraph-state-
+redis are also Java-only). python/node packs stay 4.12.1; Rust stays 4.12.7.
+
+Version sweep 4.12.7 → 4.12.8: 40 build files (the known surface — 37 poms
+incl. the two non-reactor Snyk placeholders and 3 template poms, plus 3
+template build.gradle `def mercuryVersion` literals). CHANGELOG gained the
+4.12.8 section (Added: redis.health; Fixed: lazy probe config + waiting
+status; Changed: kernel threads, {text, code} message, hardening), dated
+9/12/2026 (UTC date, matching the 4.12.7 precedent).
+
+**Sweep surface shrunk (Eric's direction):** the 3 template READMEs now use
+the `x.y.z` placeholder with an explainer note ("the project version set in
+pom.xml / build.gradle — the current Mercury version") instead of literal
+versions, and the one bare `x.y.z` usage in the guides (twin-kafka.md) gained
+the standard explainer — audited all 10 guide pages using the convention, the
+other 9 already explained it. Future sweeps touch BUILD FILES ONLY;
+conv-template-version-sweep updated accordingly.
+
+Verification: full reactor `mvn clean install` green — 32 modules, 6:00 min
+(the templates ride in the reactor); check-doc-canon OK; mkdocs --strict OK;
+post-sweep grep shows zero 4.12.7 literals outside CHANGELOG history and
+memory. Release PR text and GitHub release notes handed to Eric; merge, tag
+and publish are his gates.
+
+## Memory References
+
+- eric-release-rhythm (consulted - prep only; PR-open, merge, tag and publish
+  are each Eric's explicit steps)
+- conv-template-version-sweep (consulted for the sweep surface; substance
+  updated - sweeps are build-files-only from v4.12.8)
+- snyk-retired-manifest-placeholders (consulted - the sweep's grep covers the
+  two non-reactor placeholder poms deliberately)
+- preload-before-mainapp-lazy-config (consulted - CHANGELOG Fixed entries
+  authored from it)
+- kafka-clients-kernel-threads (consulted - CHANGELOG Changed entry authored
+  from it)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.accenture.mercury</groupId>
     <artifactId>parent-mercury</artifactId>
     <packaging>pom</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Parent Mercury</name>
 
     <modules>

--- a/system/ai-contract-provider/pom.xml
+++ b/system/ai-contract-provider/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>ai-contract-provider</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Mercury AI contract provider</name>
     <description>
         Standalone composable app serving Mercury's version-matched operational contract for
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- test-scope only: the catalog names MiniGraph behavior classes as anchors and the
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
             <scope>test</scope>
         </dependency>
 

--- a/system/event-script-engine/pom.xml
+++ b/system/event-script-engine/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>event-script-engine</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Event Script engine</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/system/mini-scheduler/pom.xml
+++ b/system/mini-scheduler/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>mini-scheduler</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Minimalist Scheduler</name>
 
     <parent>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/system/minigraph-playground-engine/pom.xml
+++ b/system/minigraph-playground-engine/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>minigraph-playground-engine</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>MiniGraph Playground Engine</name>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/system/minimalist-kafka/pom.xml
+++ b/system/minimalist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>minimalist-kafka</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Minimalist Kafka (notification function + flow adapter)</name>
     <description>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava

--- a/system/platform-core/pom.xml
+++ b/system/platform-core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.platformlambda</groupId>
     <artifactId>platform-core</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Mercury platform-core module</name>
 
     <parent>

--- a/system/rest-spring-3/pom.xml
+++ b/system/rest-spring-3/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-3</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>pom</packaging>
     <name>Retired Spring Boot 3 module (see ADR-0017)</name>
     <description>
@@ -39,7 +39,7 @@
         <relocation>
             <groupId>org.platformlambda</groupId>
             <artifactId>rest-spring-4</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
             <message>
                 rest-spring-3 is retired: Spring Framework 6.2.x is out of security support.
                 Resolving rest-spring-4 instead, which REQUIRES Spring Boot 4. If your

--- a/system/rest-spring-4/pom.xml
+++ b/system/rest-spring-4/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.platformlambda</groupId>
     <artifactId>rest-spring-4</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
 
     <name>Pre-configured Spring Boot 4 module</name>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/system/twin-kafka/pom.xml
+++ b/system/twin-kafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.platformlambda</groupId>
     <artifactId>twin-kafka</artifactId>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <packaging>jar</packaging>
     <name>Twin Kafka (secondary cluster for dual-cluster bridging)</name>
     <description>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <!-- Embedded Kafka (real KRaft broker) for integration tests - two brokers in one JVM with

--- a/templates/starter-flow/README.md
+++ b/templates/starter-flow/README.md
@@ -22,14 +22,16 @@ build at your organization's artifact repository.
 
 ## Build, test, run
 
+> **Note**: `x.y.z` denotes the project version set in `pom.xml` / `build.gradle` — the current Mercury version.
+
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-flow-4.12.7.jar
+java -jar target/starter-flow-x.y.z.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-flow-4.12.7.jar
+java -jar build/libs/starter-flow-x.y.z.jar
 ```
 
 Then:

--- a/templates/starter-flow/build.gradle
+++ b/templates/starter-flow/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.7'
+def mercuryVersion = '4.12.8'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-flow/pom.xml
+++ b/templates/starter-flow/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-flow</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Layer 2 starter - Event Script flows</name>
 
     <parent>
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/templates/starter-function/README.md
+++ b/templates/starter-function/README.md
@@ -21,14 +21,16 @@ build at your organization's artifact repository.
 
 ## Build, test, run
 
+> **Note**: `x.y.z` denotes the project version set in `pom.xml` / `build.gradle` — the current Mercury version.
+
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-function-4.12.7.jar
+java -jar target/starter-function-x.y.z.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-function-4.12.7.jar
+java -jar build/libs/starter-function-x.y.z.jar
 ```
 
 Then:

--- a/templates/starter-function/build.gradle
+++ b/templates/starter-function/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.7'
+def mercuryVersion = '4.12.8'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-function/pom.xml
+++ b/templates/starter-function/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-function</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Layer 1 starter - composable functions with REST automation</name>
 
     <parent>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>

--- a/templates/starter-graph/README.md
+++ b/templates/starter-graph/README.md
@@ -23,14 +23,16 @@ build at your organization's artifact repository.
 
 ## Build, test, run
 
+> **Note**: `x.y.z` denotes the project version set in `pom.xml` / `build.gradle` — the current Mercury version.
+
 ```bash
 # Maven
 mvn clean package
-java -jar target/starter-graph-4.12.7.jar
+java -jar target/starter-graph-x.y.z.jar
 
 # Gradle
 gradle build
-java -jar build/libs/starter-graph-4.12.7.jar
+java -jar build/libs/starter-graph-x.y.z.jar
 ```
 
 Then:

--- a/templates/starter-graph/build.gradle
+++ b/templates/starter-graph/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 // single-source version literal - the Mercury release sweep updates it
-def mercuryVersion = '4.12.7'
+def mercuryVersion = '4.12.8'
 
 group = 'com.accenture'
 version = mercuryVersion

--- a/templates/starter-graph/pom.xml
+++ b/templates/starter-graph/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.accenture</groupId>
     <artifactId>starter-graph</artifactId>
     <packaging>jar</packaging>
-    <version>4.12.7</version>
+    <version>4.12.8</version>
     <name>Layer 3 starter - Active Knowledge Graph as the application</name>
 
     <parent>
@@ -56,19 +56,19 @@
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>platform-core</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>event-script-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minigraph-playground-engine</artifactId>
-            <version>4.12.7</version>
+            <version>4.12.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What

Version 4.12.8 — the health-check release for the field. Sweep 4.12.7 → 4.12.8 across 40 build
files (all reactor poms, the two non-reactor Snyk placeholder poms, the template poms and their
Gradle `mercuryVersion` literals), plus the CHANGELOG entry. Template READMEs and guide prose now
use the `x.y.z` placeholder with an explainer line, so future release sweeps touch build files only.

## Why

Ships the 2026-09-11 field-MR arc (#360, #361, #362) to the field as one release:

- **Fixed** — `kafka.health` / `secondary.kafka.health` resolve their probe configuration lazily
  (at client build time, re-resolved on every rebuild), so credentials published by a
  `@MainApplication` vault bootstrap after `@PreLoad` construction are picked up without a restart;
  while a probe's configuration is still unusable, the check reports a passing
  `Waiting for ... connection` status instead of failing `/health` (a pod restart cannot produce a
  credential).
- **Added** — `redis.health` for the sync-over-async extension with the same design (one PING proves
  connectivity, TLS, and auth; Redis auth rejections classify as waiting; `minigraph-state-redis`
  shares the `redis.*` keys, so one probe covers both).
- **Changed** — the Kafka checks run on kernel threads (`@KernelThreadRunner`; the consumer's
  calling-thread I/O inside `synchronized` pins virtual-thread carriers on Java 21), a failed probe
  returns the `{"text": ..., "code": 503}` key-value message, plus the review-round hardening
  (AtomicReference fields, supplier guards, S1141 un-nesting).

Java only — no Rust lock-step (the Rust engine has no Kafka modules, and sync-over-async /
minigraph-state-redis are Java-only). The python/node language packs stay at 4.12.1.

## Verification

Full reactor `mvn clean install` green (32 modules, including the starter templates); doc canon and
strict mkdocs OK; post-sweep grep shows zero stale version literals outside changelog history.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)