### PR TITLE
sync-over-async: self-contained cid key - minimalist-kafka becomes test scope

### DIFF
--- a/docs/guides/sync-over-async.md
+++ b/docs/guides/sync-over-async.md
@@ -27,7 +27,9 @@ Redis return route.*
 In a cloud-native deployment the REST caller and the backend that answers may be different pods, and the
 backend is reached **asynchronously** over Kafka. Sync-over-async bridges that gap: the HTTP thread waits
 while the request fans out over Kafka and the answer is routed back — without coupling the two pods beyond a
-shared Redis and topic pair. It builds on the [Minimalist Kafka](minimalist-kafka.md) for the Kafka legs.
+shared Redis and topic pair. It builds on the [Minimalist Kafka](minimalist-kafka.md) for the Kafka legs —
+by composition, not by dependency: the extension carries no Kafka library of its own, so the application
+declares `minimalist-kafka` alongside `sync-over-async`.
 
 > **Opt-in.** The return-route coordinator eagerly connects to Redis, so it starts only when
 > `sync.over.async.enabled=true`. Leave it off unless you are using the pattern.
@@ -58,6 +60,13 @@ The correlation-id threads the whole round trip. Redis holds two short-lived key
 (which pod's channel to wake) and the **response** payload.
 
 ## Enabling and configuring {#config}
+
+The extension is **transport-neutral**: it brings only platform-core and the Lettuce Redis client, so the
+application declares its Kafka library (`minimalist-kafka`) alongside `sync-over-async` in the build. The
+facade tasks exchange the correlation-id through the module's own flow-level `cid` key (the
+`model.cid -> header.cid` flow mappings) — deliberately independent of the transport's configurable wire
+header (`kafka.correlation.id.header`), which the flow adapter maps into `model.cid` whatever its name.
+Then enable the coordinator and point it at Redis:
 
 ```properties
 sync.over.async.enabled=true

--- a/examples/sync-over-async-demo/pom.xml
+++ b/examples/sync-over-async-demo/pom.xml
@@ -49,9 +49,9 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Converge Guava to platform-core's version: Confluent's serdes (via sync-over-async ->
-                 minimalist-kafka) otherwise win with an older 32.0.1. The failureaccess companion already
-                 arrives transitively; this keeps the demo on the same Guava as the reactor. -->
+            <!-- Converge Guava to platform-core's version: Confluent's serdes (via minimalist-kafka)
+                 otherwise win with an older 32.0.1. The failureaccess companion already arrives
+                 transitively; this keeps the demo on the same Guava as the reactor. -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
@@ -62,10 +62,20 @@
 
     <dependencies>
         <!-- sync-over-async brings the facade tasks (sync.prepare/sync.await/soa.reply) + the Redis
-             return-route coordinator, and transitively minimalist-kafka + event-script + platform-core. -->
+             return-route coordinator (platform-core arrives transitively). It is transport-neutral,
+             so the application declares its Kafka library itself - see minimalist-kafka below. -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>sync-over-async</artifactId>
+            <version>4.12.8</version>
+        </dependency>
+
+        <!-- The Kafka legs: notification function + flow adapter (brings event-script-engine and the
+             Kafka client). Composed with the facade by this application - the extension does not
+             impose a transport. -->
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>minimalist-kafka</artifactId>
             <version>4.12.8</version>
         </dependency>
 

--- a/extensions/sync-over-async/pom.xml
+++ b/extensions/sync-over-async/pom.xml
@@ -29,7 +29,8 @@
         <jackson-bom.version>3.2.2</jackson-bom.version>
         <log4j2.version>2.26.1</log4j2.version>
         <!-- Security override for the transitive httpcore5/httpcore5-h2 (Snyk HIGH, CWE-770) pulled
-             in via minimalist-kafka's Confluent registry client. Spring Boot's dependencyManagement
+             in via minimalist-kafka's Confluent registry client - a test-classpath path here now that
+             minimalist-kafka is test scope, kept patched all the same. Spring Boot's dependencyManagement
              pins the vulnerable 5.4.2 (management beats nearest-wins), so each module resolving the
              Confluent chain must override the property itself - see minimalist-kafka's pom. -->
         <httpcore5.version>5.4.3</httpcore5.version>
@@ -47,9 +48,9 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Converge Guava to platform-core's version: Confluent's serdes (via minimalist-kafka)
-                 otherwise win with an older 32.0.1, leaving this module on a different Guava (and
-                 failureaccess) than the rest of the reactor. Pinning here keeps one Guava companion. -->
+            <!-- Converge Guava to platform-core's version: Confluent's serdes (via the test-scoped
+                 minimalist-kafka) otherwise win with an older 32.0.1 on the test classpath, leaving
+                 the tests on a different Guava (and failureaccess) than the runtime. -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
@@ -66,19 +67,30 @@
     </repositories>
 
     <dependencies>
-        <!-- The minimalist-kafka building blocks (Kafka notification function + flow adapter). It brings
-             event-script-engine (flow runtime + REST automation, and platform-core) and the Kafka client
-             transitively, so the facade only adds the Redis return-route engine on top. -->
+        <!-- The facade is transport-neutral: production code speaks only the module's self-contained
+             correlation-id key (SyncRuntime.CID) and the platform-core function contract, so the
+             application declares its own Kafka library next to this extension (minimalist-kafka;
+             twin-kafka for a second cluster). platform-core supplies the function runtime here. -->
+        <dependency>
+            <groupId>org.platformlambda</groupId>
+            <artifactId>platform-core</artifactId>
+            <version>4.12.8</version>
+        </dependency>
+
+        <!-- Kafka building blocks for the end-to-end regression only (notification function + flow
+             adapter, bringing event-script-engine and the Kafka client onto the test classpath).
+             Test scope keeps the published artifact free of any transport dependency. -->
         <dependency>
             <groupId>org.platformlambda</groupId>
             <artifactId>minimalist-kafka</artifactId>
             <version>4.12.8</version>
+            <scope>test</scope>
         </dependency>
 
-        <!-- Guava's failureaccess companion is required at runtime by Confluent's serdes (Guava
-             LocalCache -> InternalFutureFailureAccess), reached transitively via minimalist-kafka.
-             Declared explicitly so it is a first-class classpath entry and cannot be dropped by
-             strict/curated dependency resolution in the field. -->
+        <!-- Guava's failureaccess companion is required at runtime by Guava itself (arriving with
+             platform-core; Confluent's serdes exercise the same Guava LocalCache path on the test
+             classpath). Declared explicitly so it is a first-class classpath entry and cannot be
+             dropped by strict/curated dependency resolution in the field. -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/sync/SyncRuntime.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/sync/SyncRuntime.java
@@ -27,6 +27,16 @@ import io.lettuce.core.RedisClient;
  */
 public final class SyncRuntime {
 
+    /**
+     * The module's self-contained correlation-id key ({@code "cid"}) - the flow-level contract shared by
+     * the facade tasks ({@code sync.prepare}, {@code sync.await}, {@code soa.reply}) and the flow data
+     * mappings ({@code model.cid -> header.cid}). Deliberately NOT the transport's wire header name: the
+     * Kafka header that carries the id between pods belongs to the Kafka library and is configurable there
+     * ({@code kafka.correlation.id.header}, default also {@code cid}); inbound flow adapters seed
+     * {@code model.cid} from the effective wire header, whatever it is named.
+     */
+    public static final String CID = "cid";
+
     private static ReturnRouteCoordinator coordinator;
     private static RedisClient client;
 

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SoaReplyTask.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SoaReplyTask.java
@@ -20,7 +20,6 @@ package org.platformlambda.tasks;
 
 import org.platformlambda.core.annotations.PreLoad;
 import org.platformlambda.core.models.TypedLambdaFunction;
-import org.platformlambda.mini.kafka.KafkaHeaders;
 import org.platformlambda.sync.SyncRuntime;
 
 import java.nio.charset.StandardCharsets;
@@ -32,6 +31,10 @@ import java.util.Map;
  * coordinator, which completes the awaiting REST request - cross-pod via the Redis return route, so the
  * pod that consumed the reply need not be the one that originated the request.
  *
+ * <p>The reply flow's input mapping supplies the correlation-id under the module's self-contained
+ * {@link SyncRuntime#CID} key ({@code model.cid -> header.cid}; the flow adapter seeds {@code model.cid}
+ * from its configured wire header), so this task never reads the transport's header name.</p>
+ *
  * <p>This is generic boilerplate every sync-over-async application needs, so it ships with the extension
  * alongside {@link SyncPrepareTask} and {@link SyncAwaitTask}; an application only supplies its own
  * backend (system-of-record) logic. Sized for user-facing concurrency ({@code instances = 250}).</p>
@@ -41,9 +44,9 @@ public class SoaReplyTask implements TypedLambdaFunction<byte[], Map<String, Obj
 
     @Override
     public Map<String, Object> handleEvent(Map<String, String> headers, byte[] input, int instance) {
-        String cid = headers.get(KafkaHeaders.CORRELATION_ID);
+        String cid = headers.get(SyncRuntime.CID);
         String payload = new String(input, StandardCharsets.UTF_8);
         boolean delivered = SyncRuntime.coordinator().deliver(cid, payload);
-        return Map.of("cid", cid, "delivered", delivered);
+        return Map.of(SyncRuntime.CID, cid, "delivered", delivered);
     }
 }

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SyncAwaitTask.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SyncAwaitTask.java
@@ -50,7 +50,7 @@ public class SyncAwaitTask implements TypedLambdaFunction<Map<String, Object>, M
     @SuppressWarnings("unchecked")
     public Map<String, Object> handleEvent(Map<String, String> headers, Map<String, Object> input, int instance)
             throws InterruptedException {
-        String businessCorrelationId = String.valueOf(input.get("cid"));
+        String businessCorrelationId = String.valueOf(input.get(SyncRuntime.CID));
         long timeoutMillis = parseTimeout(headers.get(TIMEOUT_HEADER));
         try {
             String responseJson = SyncRuntime.coordinator().awaitResponse(businessCorrelationId, timeoutMillis);

--- a/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SyncPrepareTask.java
+++ b/extensions/sync-over-async/src/main/java/org/platformlambda/tasks/SyncPrepareTask.java
@@ -23,7 +23,6 @@ import org.platformlambda.core.models.EventEnvelope;
 import org.platformlambda.core.models.TypedLambdaFunction;
 import org.platformlambda.core.serializers.SimpleMapper;
 import org.platformlambda.core.util.Utility;
-import org.platformlambda.mini.kafka.KafkaHeaders;
 import org.platformlambda.sync.SyncRuntime;
 
 import java.util.Map;
@@ -39,6 +38,10 @@ import java.util.Map;
  * at the edge: REST automation reads the configured {@code http.correlation.id.header} (default
  * {@code X-Correlation-Id}) and generates a fresh UUID when it is absent. So the upstream correlation-id
  * threads the round trip with no extra config.</p>
+ *
+ * <p>{@code cid} is the module's own key ({@link SyncRuntime#CID}), self-contained by design: the Kafka
+ * wire header that carries the id between pods belongs to the transport and is configurable there
+ * ({@code kafka.correlation.id.header}), so these tasks never reference the transport's header name.</p>
  *
  * <p>Deployments that use a proprietary correlation-id header can either set {@code http.correlation.id.header}
  * to that name, or override the mapping in the flow YAML. For example:
@@ -61,9 +64,9 @@ public class SyncPrepareTask implements TypedLambdaFunction<Map<String, Object>,
     public EventEnvelope handleEvent(Map<String, String> headers, Map<String, Object> input, int instance) {
         // model.cid is the business correlation-id captured at the edge (from http.correlation.id.header,
         // default X-Correlation-Id, or a fresh UUID). The flow maps it here as header.cid.
-        String businessCorrelationId = headers.getOrDefault("cid", Utility.getInstance().getUuid());
+        String businessCorrelationId = headers.getOrDefault(SyncRuntime.CID, Utility.getInstance().getUuid());
         SyncRuntime.coordinator().begin(businessCorrelationId);   // register the return route before publishing
         byte[] payload = SimpleMapper.getInstance().getMapper().writeValueAsBytes(input);
-        return new EventEnvelope().setHeader(KafkaHeaders.CORRELATION_ID, businessCorrelationId).setBody(payload);
+        return new EventEnvelope().setHeader(SyncRuntime.CID, businessCorrelationId).setBody(payload);
     }
 }

--- a/memory/continuity.md
+++ b/memory/continuity.md
@@ -143,6 +143,17 @@
   sequential multi-thread access under external sync (the checks' ReentrantLock) is its contract.
   <!-- id: kafka-clients-kernel-threads | created: 2026-09-11 | last_used: 2026-09-11 | uses: 1 | tier: working | origin: 2026-09-11-191200 -->
 
+- **sync-over-async is transport-neutral — its correlation-id key is self-contained (Eric's direction,
+  2026-09-12).** The facade tasks speak only the module's own flow-level `cid` key (`SyncRuntime.CID`);
+  the Kafka wire header belongs to the transport and is configurable there
+  (`kafka.correlation.id.header`, with per-binding overrides — inbound flow adapters seed `model.cid`
+  from the effective wire header, whatever its name), so the tasks never reference the transport's
+  constant. minimalist-kafka is test scope (e2e regression only); platform-core is the declared compile
+  backbone; applications compose the facade with their own Kafka library (the demo shows the shape).
+  Consumer note for the next release: apps that leaned on the transitive minimalist-kafka must now
+  declare it. Extends [[functions-decoupled-routes]] to the dependency graph.
+  <!-- id: soa-transport-neutral-cid | created: 2026-09-12 | last_used: 2026-09-12 | uses: 1 | tier: working | origin: 2026-09-12-011438 -->
+
 - **platform-core gotcha: the per-function trace context is thread-id-keyed and torn down when the worker
   returns.** `EventEmitter.traces` is keyed by `Thread.currentThread().threadId()+instance+route`, and
   `WorkerHandler` calls `stopTracing` (removing it) as soon as `processEvent` returns. So any work that

--- a/memory/sessions/2026-09-12-011438.md
+++ b/memory/sessions/2026-09-12-011438.md
@@ -1,0 +1,61 @@
+# Session (2026-09-12T01:14:38.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**sync-over-async decoupled from minimalist-kafka (branch
+`refactor/soa-self-contained-cid`, commit `04d2037c`; PR pending at handoff).**
+Eric noticed the module's only production-code import of minimalist-kafka was
+`KafkaHeaders.CORRELATION_ID` and directed: use the module's own `"cid"` key so
+minimalist-kafka can demote to test scope — refining mid-investigation that the
+key "should be self-contained within sync-over-async because kafka cid header
+can be overridden by configuration."
+
+The evidence proved his point exactly: the constant appeared in TWO tasks
+(SyncPrepareTask stamps the outbound envelope header; SoaReplyTask reads the
+inbound one), but neither ever touches the wire — every task receives `cid`
+through flow input mappings (`model.cid -> header.cid`), and minimalist-kafka's
+wire header is configurable at two levels (global `kafka.correlation.id.header`,
+per-binding `correlation.id.header`) with inbound flow adapters seeding
+`model.cid` from the effective wire header regardless of its name. Borrowing
+the transport's constant misrepresented a flow-level contract as wire coupling.
+
+Shipped shape:
+
+- `SyncRuntime.CID = "cid"` — the module's self-contained correlation-id key,
+  javadoc'd as deliberately NOT the transport's wire header name. All three
+  facade tasks (sync.prepare, sync.await, soa.reply) now use it, including the
+  previously bare `"cid"` literals (flow-mapped input keys, reply result map).
+- pom: minimalist-kafka -> `test` scope (the e2e regression still drives real
+  Kafka legs over the embedded broker); `platform-core` declared directly as
+  the compile backbone (main source imports only org.platformlambda.core.* +
+  Lettuce). failureaccess keeps its field-hardening purpose via platform-core's
+  Guava (comment updated); Guava pin + httpcore5 override retained for the test
+  classpath (comments updated).
+- Published artifact's compile/runtime footprint is now platform-core + Guava
+  companions + Lettuce — zero Kafka (dependency:tree verified).
+- Demo app declares minimalist-kafka itself (it inherited it transitively
+  before) — the composition example for field apps.
+- Guide (sync-over-async.md): intro notes "by composition, not by dependency";
+  #config opens with the transport-neutral declaration guidance and the
+  cid-vs-wire-header distinction.
+
+Verification: sync-over-async full suite 46/46 green (jacoco 0.85 gate
+passed), demo build green, dependency:tree proof, check-doc-canon OK,
+mkdocs --strict OK, zero `org.platformlambda.mini` imports left in main.
+
+**Consumer migration note for the next release's CHANGELOG:** applications
+that leaned on the transitive minimalist-kafka must now declare it themselves
+(the commit message carries this for release prep; the demo shows the shape).
+
+## Memory References
+
+- functions-decoupled-routes (consulted - the invariant extended from route
+  coupling to the dependency graph: the facade couples to the transport only
+  through the flow-level cid contract)
+- eric-release-rhythm (consulted - branch/commit/push prepared; PR creation
+  and merge are Eric's gates)
+- conv-squash-title-prefill-check (consulted - PR title handed off on its own
+  line in a code block per the agent-side guard)
+- soa-transport-neutral-cid (created, tier: working)


### PR DESCRIPTION
## What

- `SyncRuntime.CID` ("cid") is the module's own correlation-id key; `sync.prepare`, `sync.await` and `soa.reply` use it instead of minimalist-kafka's `KafkaHeaders.CORRELATION_ID` (and instead of bare `"cid"` literals).
- `minimalist-kafka` demoted to **test scope** — it now serves only the end-to-end regression (embedded broker + Redis). `platform-core` is declared directly as the compile backbone.
- The published `sync-over-async` artifact's compile/runtime footprint is now platform-core + Guava companions + Lettuce — zero Kafka (dependency:tree verified).
- The demo app declares `minimalist-kafka` itself, showing the composition; the guide's intro and `#config` section document the transport-neutral contract.

## Why

The facade tasks never touch the Kafka wire: they receive the correlation-id through flow input mappings (`model.cid -> header.cid`), and the wire header name belongs to the transport — configurable via `kafka.correlation.id.header` (global) and `correlation.id.header` (per-binding), with inbound flow adapters seeding `model.cid` from the effective header whatever its name. Borrowing the transport's constant misrepresented a flow-level contract as wire coupling and forced a compile-time Kafka dependency onto a module whose engine is Redis. The `cid` key is now self-contained within sync-over-async, extending the framework's decoupling principle from route names to the dependency graph.

**Migration note:** applications that relied on `sync-over-async` transitively supplying `minimalist-kafka` must now declare their Kafka library themselves (see the demo pom).

## Verification

- `extensions/sync-over-async`: full suite 46/46 green, JaCoCo 0.85 gate passed
- `examples/sync-over-async-demo`: build green with the direct dependency
- `mvn dependency:tree`: minimalist-kafka and its entire Confluent/broker chain in `test` scope only
- check-doc-canon OK; mkdocs --strict OK

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)