### PR TITLE
design spec: streaming return route ratified - decisions D1-D6 folded in

### DIFF
--- a/draft-design-specs/streaming-return-route.md
+++ b/draft-design-specs/streaming-return-route.md
@@ -1,15 +1,14 @@
 # Streaming return route — cross-pod progressive rendering — design spec
 
-**Status:** DRAFT — proposed 2026-09-12 from Eric's direction: when progressive events
-arrive over Kafka (or a similar event system), Redis Pub/Sub should bridge them to the
-pod serving the UI request, which forwards them until an end-of-transmission signal
-(itself an event). No code yet; this paper captures the design, the open questions
-(Q-series) and the staged experiment plan (E-series).
+**Status:** DESIGN RATIFIED — drafted 2026-09-12 from Eric's direction; the Q-series was
+answered by Eric the same day and is folded in below as decisions D1–D6 (§7). The
+ratified design is **simpler than the first draft**: Redis is the sole transport of the
+streaming return path (no broker leg), and segments are individually keyed values indexed
+by sequence number (no Redis Stream). Next gate: experiment E1.
 **Blueprint:** serves `bp-agent-orchestration` (Q8 second half — graph-run streaming)
 → serves `vision-mercury-composable`.
 **Repo scope:** `extensions/sync-over-async` only. Java-only like the extension itself
-(no Rust lock-step; this is not an Event Script surface). No engine change anticipated —
-Q2 is the one place a small REST-automation seam could surface.
+(no Rust lock-step; this is not an Event Script surface). No engine change.
 **Related:** [http-response-streaming.md](http-response-streaming.md) and
 [async-http-client-sse-streaming.md](async-http-client-sse-streaming.md) (the shipped
 point-to-point feature), the [HTTP Response Streaming guide](../docs/guides/http-streaming.md),
@@ -25,64 +24,60 @@ side (`async.http.request`) consumes an SSE upstream progressively. Both ride th
 caller's `reply_to` — a dedicated reply lane that is a route **on the pod holding the
 HTTP connection**.
 
-That makes the feature point-to-point. When the progressive events for one transaction
-arrive over **Kafka**, any pod's consumer may receive them — and that pod has no route to
-another pod's reply lane. Discovering "which pod holds the connection" is exactly the
-service-discovery problem the Kafka service mesh solves, and sync-over-async exists as
-the deliberately lighter alternative to the mesh. Event-over-HTTP cannot bridge it
-either: `/api/event` serves local routes only (ratified 2026-08-30), and the sender
-would still need per-pod addressing for dynamically scheduled pods.
+That makes the feature point-to-point. In a horizontally scaled deployment, the pod that
+*produces* progressive events for a transaction is generally not the pod holding the
+user's connection — and it has no route to another pod's reply lane. Discovering "which
+pod holds the connection" is exactly the service-discovery problem the Kafka service
+mesh solves, and sync-over-async exists as the deliberately lighter alternative to the
+mesh. Event-over-HTTP cannot bridge it either: `/api/event` serves local routes only
+(ratified 2026-08-30), and the sender would still need per-pod addressing for
+dynamically scheduled pods.
 
 Sync-over-async already solved this rendezvous for the **one-shot** case: the
 originating pod registers a return route in Redis (`request:{cid}`), and any pod can
 look it up and wake the right subscriber. This spec generalizes that return route from
-*one response* to *a sequence of segments with a terminal signal*.
+*one response* to *a sequence of segments with a terminal signal*. By decision D3, the
+segments ride **Redis only** — the producing server posts them straight into the return
+route, so the streaming path has no broker dependency at all (the request leg reaches
+the backend however the application likes).
 
 ## 2. Current state — the pieces already shipped
 
 | Piece | Where | What it gives this design |
 |-------|-------|---------------------------|
 | `x-event-stream: data \| eof \| exception` contract | platform-core + REST automation | The last mile out the HTTP edge: SSE/chunked framing, ordered reply lanes (pool of 500, deterministic 503 back-pressure), idle timeout with in-band 408, keep-alive pings, slow-client buffer |
-| `EventStreamWriter` (`first`/`write`/`close`/`fail`) | platform-core | The producer API the UI-pod forwarder will use verbatim |
-| SSE consumption in `async.http.request` | platform-core | Not on this path, but proves the relay idiom the forwarder mirrors |
+| `EventStreamWriter` (`first`/`write`/`close`/`fail`) | platform-core | The producer API the UI-pod forwarder uses verbatim |
 | One-shot return route (`request:{cid}`, `response:{cid}`, per-pod channel `svc-return:{origin}`) | sync-over-async `ReturnRouteCoordinator` / `ReturnRouteStore` | The rendezvous mechanism: route registry as pod discovery, store-first + wake-up invariant, final-read recovery, bounded `PendingRequests` |
-| Self-contained `cid` contract (`SyncRuntime.CID`) | sync-over-async (PR #364) | Transport-neutral correlation: the streaming route works the same whatever event system carried the segments |
+| Self-contained `cid` contract (`SyncRuntime.CID`) | sync-over-async (PR #364) | Transport-neutral correlation — and the streaming path keeps the module's footprint at platform-core + Lettuce, nothing more |
 
-## 3. Design
+## 3. Design (ratified shape)
 
 ### 3.1 Shape in one sentence
 
-Segments are **stored first** in a per-cid Redis Stream, the **wake-up stays a bare cid**
-on the originating pod's existing return channel, and the UI pod **drains and forwards**
-each new entry into the shipped `x-event-stream` edge until the terminal entry — the same
-store-first/notify-after philosophy as the one-shot route, applied to a sequence.
+Each segment is **stored first** as its own short-lived Redis value keyed by cid and
+sequence number, the **wake-up stays a bare cid** on the originating pod's existing
+return channel, and the UI pod **drains by consecutive sequence** — forwarding each
+segment into the shipped `x-event-stream` edge — until the terminal segment.
 
-Redis Pub/Sub remains a wake-up signal only. It is fire-and-forget; in the one-shot
-pattern a dropped notification is recoverable because the final read finds the single
-response, but a payload dropped mid-stream would be a silently missing segment with
-nothing left to re-read. Putting segments in a Redis Stream keeps every segment
-re-readable until the rendezvous completes.
+Redis Pub/Sub remains a wake-up signal only (D1). It is fire-and-forget; in the
+one-shot pattern a dropped notification is recoverable because the final read finds the
+single response, but a payload dropped mid-stream would be a silently missing segment
+with nothing left to re-read. Storing every segment keeps it re-readable until the
+rendezvous completes or its TTL expires.
 
 ### 3.2 Redis keys
 
 | Key | Type | Content | Lifetime |
 |-----|------|---------|----------|
 | `request:{cid}` | string (unchanged) | the originating pod's return channel | `sync.route.ttl.seconds` — for a stream this must cover the whole render, not just the first response |
-| `stream:{cid}` | Redis Stream (new) | one entry per segment (fields below) | `sync.stream.ttl.seconds`, set on first `XADD`; `XADD` with `MAXLEN ~ sync.stream.maxlen` caps growth |
+| `segment:{cid}:{seq}` | string (new; one per segment) | compact JSON `{"type":"data\|eof\|exception","name":"<optional SSE event name>","body":...}` | `SETEX sync.stream.ttl.seconds` per key — the crash safety net (D4) |
 | `response:{cid}` | string | one-shot only — unused on the streaming path | unchanged |
 
-Segment entry fields:
-
-| Field | Meaning |
-|-------|---------|
-| `type` | `data` \| `eof` \| `exception` — mirrors the `x-event-stream` marker one-to-one |
-| `name` | optional SSE event name (maps to the edge's `event:` field) |
-| `body` | the segment payload (text or compact JSON) |
-| `seq` | optional producer sequence number (see Q3 — may become the explicit stream entry id) |
-
-The `eof` (or `exception`) entry **is** the end-of-transmission signal — "the end signal
-is also an event", stored like any other segment so it can never be lost ahead of the
-data it terminates.
+The sequence number is the retrieval index (D6): the producer assigns **consecutive
+integers from 1**, and the terminal `eof` (or `exception`) segment is simply the last
+sequence — "the end signal is also an event", stored like any other segment so it can
+never outrun the data it terminates. There is no array or stream structure in Redis, so
+there is nothing to cap or trim; per-key TTL bounds every segment's lifetime.
 
 ### 3.3 Coordinator additions (`ReturnRouteCoordinator`)
 
@@ -92,145 +87,166 @@ changes behavior.
 | One-shot (today) | Streaming (new) | Notes |
 |------------------|-----------------|-------|
 | `begin(cid)` → future in `PendingRequests` | `beginStream(cid, sink)` → entry in `PendingStreams` | same `saveRoute`; sink = the forwarder callback |
-| `deliver(cid, payload)` — SETEX then publish | `deliverSegment(cid, type, name, body)` — `XADD` then publish cid | store-first invariant preserved; returns `false` for an orphan (route gone) |
-| `onResponseSignal` — GET + complete future | drain: `XREAD` from the last-delivered entry id, forward each entry to the sink, stop at `eof`/`exception` | idempotent by entry id — a duplicate wake-up re-reads nothing |
-| cleanup — DEL both keys | cleanup at terminal entry — DEL route + stream | eager cleanup; TTLs remain the crash safety net |
+| `deliver(cid, payload)` — SETEX then publish | responder posts each segment — SETEX `segment:{cid}:{seq}` then publish cid (§3.4) | store-first invariant preserved; orphan (route gone) returns `false` |
+| `onResponseSignal` — GET + complete future | drain: `GET segment:{cid}:{nextSeq}`, forward, increment, repeat until a miss; a terminal type completes the stream | idempotent — a duplicate or late wake-up re-reads nothing; a dropped wake-up is healed by the next one |
+| cleanup — DEL both keys | cleanup at the terminal segment — DEL route + `segment:{cid}:1..n` | eager cleanup; TTLs remain the crash safety net |
 
 One channel serves both patterns: the signal handler checks `PendingStreams` first, then
-`PendingRequests`. `PendingStreams` mirrors `PendingRequests` exactly — bounded with
-atomic slot reservation (`sync.max.pending.streams`), idempotent close, keyed by cid —
-plus one extra piece of state per entry: the last-delivered stream entry id, which makes
-draining resumable and duplicate-safe.
+`PendingRequests`. `PendingStreams` mirrors `PendingRequests` (bounded with atomic slot
+reservation via `sync.max.pending.streams`, idempotent close, keyed by cid) plus one
+extra piece of state per entry: `nextSeq`, which makes draining resumable, in-order by
+construction, and duplicate-safe. Drain execution stays off the Lettuce event loop (the
+existing virtual-thread `signalWorkers` hand-off), because the reads and the forward are
+blocking calls.
 
-Drain execution stays off the Lettuce event loop (the existing virtual-thread
-`signalWorkers` hand-off), because `XREAD` and the forward are blocking calls.
+### 3.4 Responder side — the segment producer API
 
-### 3.4 Responder side — `soa.progress`
+Per D3 the producing server posts segments **directly to Redis** — no broker leg, no
+consumer task. The extension ships a lightweight producer API (working name
+`StreamResponder`) that a backend application constructs from the same discrete
+`redis.*` parameters (`RedisConfig`), without the coordinator: the responder side needs
+no subscriber, no return channel, and no `sync.over.async.enabled` switch — only the key
+contract above.
 
-A new shipped task alongside `soa.reply`, wired identically in a reply flow: the Kafka
-flow adapter consumes the progressive topic, seeds `model.cid` from the wire header, and
-the flow maps `model.cid -> header.cid` into the task. The task reads the segment's
-`type`/`name`/`body` from the event and calls `deliverSegment`. The producer emits the
-terminal event through the same topic and task — no separate "end" task.
+```java
+var responder = new StreamResponder(redisConfig, ttlSeconds);
+responder.post(cid, 1, "data", null, "Hello");      // SETEX segment:{cid}:1, then PUBLISH cid
+responder.post(cid, 2, "data", "tokens", "{...}");
+boolean live = responder.post(cid, 3, "eof", null, metadata);
+// post returns false when the route is gone (orphan) - stop producing
+```
 
-### 3.5 UI-pod facade — recommended first shape
+Each `post` is store-first: SETEX the segment, GET the route, PUBLISH the cid. A `false`
+return means the originating pod is gone (disconnect, timeout, crash) — the producer
+should stop work for that cid. The producer is typically a unit of work (an LLM token
+loop, a long-running computation reporting progress), which per the code/config boundary
+is an in-function concern; a flow-task wrapper can be added later if a declarative use
+case appears.
 
-Every shipped streaming producer is an `@EventInterceptor` function addressed directly
-by a `stream: true` endpoint (`service: "v1.token.producer"`), while sync-over-async's
-one-shot facade is an Event Script flow behind `http.flow.adapter`. Whether those two
-compose — a flow task writing to the endpoint's reply lane — is an open platform
-question (Q2). The first experiment therefore uses the proven shape:
+### 3.5 UI-pod facade — interceptor by design (D2)
 
-- a `stream: true` endpoint addresses an interceptor facade function directly;
-- the facade calls `beginStream(cid, sink)` where the sink wraps an `EventStreamWriter`
-  bound to the request (`data` entry → `write`, `eof` → `close(metadata)`,
-  `exception` → `fail`), then publishes the request event (directly, or by triggering
-  the outbound flow);
-- the edge's own machinery does the rest: ordering per lane, idle timeout, disconnect
-  handling, back-pressure.
+The typical consumer is a UI application connected to a REST endpoint with SSE support.
+The facade is an `@EventInterceptor` function addressed directly by a `stream: true`
+endpoint — the same shape as every shipped streaming producer; there is no Event Script
+composition on this path (D2). The facade:
 
-On client disconnect or idle expiry, the facade calls the streaming analogue of
-`abort(cid)` so the `PendingStreams` entry never leaks — mirroring the one-shot
-fail-fast contract.
+- calls `beginStream(cid, sink)` where the sink wraps an `EventStreamWriter` bound to
+  the request (`data` → `write`, `eof` → `close(metadata)`, `exception` → `fail`);
+- initiates the backend work (publishes the request event, calls the backend — whatever
+  the application's request leg is);
+- lets the edge's own machinery do the rest: per-lane ordering, idle timeout,
+  disconnect handling, back-pressure.
 
-### 3.6 Proposed configuration keys
+On client disconnect or idle expiry the facade closes the `PendingStreams` entry (the
+streaming analogue of `abort(cid)`) so nothing leaks; the route key's disappearance is
+what tells the producer to stop. At idle expiry the facade performs **one final drain**
+before failing in-band — the streaming analogue of the one-shot "final read before
+timeout" cornerstone, so a dropped *final* notification still completes the render.
+(This is a single last-chance read, not the periodic re-drain rejected in D4 — flagged
+for Eric's confirmation.)
+
+### 3.6 Configuration keys (proposed)
 
 | Key | Default (proposed) | Meaning |
 |-----|--------------------|---------|
-| `sync.stream.ttl.seconds` | `120` | TTL of `stream:{cid}` — the crash safety net for the whole render window |
-| `sync.stream.maxlen` | `1000` | `XADD MAXLEN ~` cap per stream — bounds a producer that outruns a stalled consumer |
+| `sync.stream.ttl.seconds` | `120` | `SETEX` TTL of every `segment:{cid}:{seq}` key — the crash safety net for the render window |
 | `sync.max.pending.streams` | `1000` | per-pod ceiling on concurrently rendering streams (the reply-lane pool of 500 is the natural upper bound per pod) |
+
+(The first draft's `sync.stream.maxlen` is gone — D6 removed the stream structure it
+would have capped.)
 
 ## 4. Contracts and invariants
 
-1. **Store-first, notify-after.** A segment is `XADD`ed before its wake-up is published;
-   the payload never rides Pub/Sub. Inherited verbatim from the one-shot design.
-2. **Ordering is the producer's partition contract.** Stream entries render in insertion
-   order. If segments of one cid may be consumed by different pods (multiple
-   partitions), arrival order at Redis is not guaranteed to be generation order — so the
-   progressive reply topic must be **keyed by cid** (one partition → one consumer →
-   ordered appends). Same class of deployment contract as the existing end-to-end `cid`
-   header rule; Q3 offers an enforcement option.
-3. **The terminal signal is data, not signalling.** `eof`/`exception` are stream
-   entries, so they can never arrive "before" the segments they terminate, and a missed
-   notification still finds them on the next drain.
+1. **Store-first, notify-after (D1).** A segment is written before its wake-up is
+   published; the payload never rides Pub/Sub. Inherited verbatim from the one-shot
+   design.
+2. **One producer per cid, consecutive sequence from 1 (D3 + D6).** With no broker leg
+   there is no partition or redelivery concern; the drain loop delivers strictly in
+   sequence by construction. A gap (producer crashed mid-stream) stalls the drain and
+   ends as an idle-timeout 408 — never out-of-order delivery.
+3. **The terminal signal is data, not signalling.** `eof`/`exception` are stored
+   segments occupying the last sequence, so the terminal can never arrive "before" the
+   segments it ends.
 4. **`cid` stays the module's self-contained key.** The streaming route references only
-   `SyncRuntime.CID`; the wire header remains the transport's configurable concern.
-5. **No new timeout machinery.** The edge's idle allowance (each segment extends it;
-   stall fails in-band with 408) plus the two TTLs cover every abandonment case.
+   `SyncRuntime.CID`; how the request leg carries it remains the application's concern.
+5. **No new timeout machinery (D4).** The edge's idle allowance (each segment extends
+   it; a stall fails in-band with 408) plus the key TTLs cover every abandonment case;
+   cleanup is eager on completion and TTL-driven otherwise. No periodic sweeper.
 
 ## 5. Failure analysis
 
 | Failure | Behavior |
 |---------|----------|
-| Wake-up notification dropped | Next segment's notification triggers the drain, which reads everything since the last-delivered id; a trailing drop is bounded by the edge idle timeout (in-band 408) |
-| UI pod dies mid-stream | Route key disappears with the pod's rendezvous (or expires); `deliverSegment` returns `false` (orphan) and stops publishing; the stream ages out on its TTL |
-| Consumer pod dies mid-stream | Kafka redelivers at-least-once to a rebalanced consumer → possible duplicate `XADD`s (see Q3) |
-| Producer outruns a slow UI client | Edge buffers up to its 1 MB slow-client bound; the Redis stream is capped by `MAXLEN` (Q6 discusses trim policy) |
-| `eof` never produced | Edge idle timeout fails the render in-band with 408; keys age out on TTL |
+| Wake-up notification dropped | The next segment's notification drains everything from `nextSeq`; a dropped *final* notification is caught by the facade's single final drain at idle expiry (§3.5) |
+| UI pod dies mid-stream | Route key gone with the pod (or expired); the producer's next `post` returns `false` and it stops; orphan segment keys age out on TTL |
+| Producer dies mid-stream | No terminal segment ever arrives; the edge idle timeout fails the render in-band with 408; keys age out on TTL |
+| Producer outruns a slow UI client | The edge buffers up to its 1 MB slow-client bound; undelivered segments wait in Redis under their TTLs (per-key expiry bounds total footprint — D6/D4) |
+| Client disconnects | The edge drops late writes as no-ops; the facade closes the stream entry; the route disappears and the producer stops on its next `post` |
 | Pod at stream capacity | `beginStream` rejects deterministically, mirroring `sync.max.pending.requests` (and the edge already rejects at lane exhaustion with 503) |
 
 ## 6. Non-goals
 
 - **Not a mesh replacement.** No service discovery, no cross-pod RPC — one rendezvous
   pattern, same as the one-shot route.
-- **Not an event store.** `stream:{cid}` is a short-lived rendezvous buffer; Kafka
-  remains the system of record for the events themselves.
+- **Not an event store.** Segment keys are a short-lived rendezvous buffer; durable
+  history of progressive output, if an application needs it, is its own concern.
+- **No fan-out (D5).** One cid, one waiting pod, one render — broadcasting one
+  transaction's progress to several viewers is out of scope.
 - **Not a change to the `x-stream-id` lane.** Object streams, file downloads and `Flux`
   relays are untouched; this rides the `x-event-stream` idiom only.
-- **No fan-out.** One cid, one waiting pod, one render — multiple simultaneous viewers
-  of one transaction are out of scope (Q5 records the door).
+- **No broker on the streaming path (D3).** The return route adds no Kafka (or any
+  event-system) requirement — consistent with the module's transport-neutral footprint
+  (platform-core + Lettuce only).
 
-## 7. Open questions (Q-series)
+## 7. Decisions (D-series) — the Q-series as answered by Eric, 2026-09-12
 
-- **Q1 — Payload over Pub/Sub is rejected; confirm.** The simpler alternative (publish
-  each segment's payload on the pod channel) drops the store-first invariant and makes
-  every dropped message a silent mid-stream gap. This spec proposes rejecting it;
-  ratification makes it decision D1.
-- **Q2 — Event Script composition.** Can a `stream: true` endpoint front
-  `http.flow.adapter`, with a flow task writing to the endpoint's reply lane? If yes,
-  the facade becomes a normal flow (preferred per the config-over-code convention); if
-  not, the interceptor facade (§3.5) is the by-design shape, consistent with every
-  shipped streaming producer. First experiment proceeds with the interceptor either way.
-- **Q3 — Duplicate segments under Kafka redelivery.** Options: (a) accept duplicates
-  (SSE consumers of LLM tokens generally cannot); (b) producer-assigned `seq` used as
-  the **explicit stream entry id** (`{seq}-0`) — Redis rejects non-monotonic ids, giving
-  dedupe *and* ordering enforcement in one mechanism, at the cost of requiring the
-  producer to number its segments. (b) is the leading option.
-- **Q4 — Idle catch-up.** Rely solely on notification-triggered drains plus the edge
-  timeout, or add a slow periodic re-drain for streams with in-flight entries? Start
-  without it; E3's chaos check decides.
-- **Q5 — Multi-subscriber fan-out.** One route key holds one channel. Broadcasting one
-  render to several pods/viewers would need a different registry shape — recorded as a
-  door, proposed as out of scope.
-- **Q6 — Trim policy.** `MAXLEN ~` trims oldest entries; for a render that must be
-  complete-or-failed, trimming the head corrupts the stream — should hitting the cap
-  instead fail the stream in-band (`exception` entry)? Leaning yes.
+- **D1 (from Q1) — Pub/Sub is wake-up only; payload never rides it.** Accepted as
+  proposed. Store-first is the load-bearing invariant of the whole design.
+- **D2 (from Q2) — No Event Script composition; the facade is an interceptor.** The
+  typical use case is a UI application connecting to a REST endpoint with SSE support
+  for event notification; the `stream: true` → interceptor shape (every shipped
+  streaming producer's shape) is the design, not a fallback.
+- **D3 (from Q3) — Kafka decoupled; Redis is the sole transport of the streaming
+  return path.** The server producing a streaming response posts its events straight to
+  Redis. This removes the broker leg and, with it, the partition-ordering contract and
+  the at-least-once duplicate question of the first draft — fewer moving parts. The
+  responder gains one requirement: Redis connectivity plus the producer API (§3.4).
+- **D4 (from Q4) — No re-drain mechanism; Redis expiry serves the purpose.** TTL is
+  the cleanup and the crash backstop. The spec retains one nuance for confirmation: a
+  *single* final drain at edge idle expiry (the one-shot "final read before timeout"
+  pattern), which is a last-chance read on the failure path, not a sweeper.
+- **D5 (from Q5) — No fan-out / broadcast.** Recorded as a non-goal.
+- **D6 (from Q6) — The sequence number is the index; per-seq keys replace the Redis
+  Stream.** Each event carries a sequence number, so each segment is retrieved by key
+  (`segment:{cid}:{seq}`) — nothing appends to an array in Redis, so `MAXLEN` and the
+  trim-policy question dissolve. This supersedes the first draft's `stream:{cid}`
+  XADD/XREAD design.
 
 ## 8. Experiment plan (E-series)
 
-- **E1 — Coordinator primitives.** `PendingStreams`, `beginStream`/`deliverSegment`/
-  drain/cleanup + unit tests on the embedded Redis: in-order delivery, terminal entry,
-  orphan, missed-notification catch-up (suppress a publish, verify the next drain
-  recovers), capacity rejection, duplicate wake-up idempotence.
-- **E2 — Single-JVM end-to-end.** On the module's regression stack (embedded Kafka +
-  Redis): `stream: true` endpoint → interceptor facade → Kafka → mock backend emitting
-  N segments + `eof` → SSE out; verified with `curl -N` (and the lambda-example
-  sse-client script).
-- **E3 — Cross-pod dry-run.** Two facade JVMs against `kafka-standalone` +
-  `redis-standalone`: the UI request lands on pod A, the reply partition on pod C — the
-  actual gap scenario. Chaos checks: suppress one notification, kill the consumer pod
-  mid-stream (redelivery/dedupe), kill the UI pod (orphan path).
-- **E4 — Blueprint payoff.** An LLM/graph-run token stream through the bridge:
-  the agent-orchestration progressive-rendering demo (E0 of that concept) re-run with
-  the producer and the HTTP edge on different pods.
+- **E1 — Coordinator + responder primitives.** `PendingStreams`, `beginStream`, the
+  drain loop, `StreamResponder.post`, cleanup + unit tests on the embedded Redis:
+  in-order delivery by sequence, terminal segment, orphan stop, missed-notification
+  healing (suppress a publish, verify the next drain recovers), final drain at idle
+  expiry, capacity rejection, duplicate wake-up idempotence.
+- **E2 — Single-JVM end-to-end.** `stream: true` endpoint → interceptor facade → a
+  responder posting N segments + `eof` (no broker anywhere) → SSE out; verified with
+  `curl -N` (and the lambda-example sse-client script).
+- **E3 — Cross-pod dry-run.** Two JVMs against `redis-standalone`: the UI request lands
+  on pod A; the responder runs on pod B posting to Redis — the actual gap scenario.
+  Chaos checks: suppress one notification, kill the producer mid-stream (idle 408), kill
+  the UI pod (orphan stop on the producer).
+- **E4 — Blueprint payoff.** An LLM/graph-run token stream through the bridge: the
+  agent-orchestration wrapper posts token segments via the responder API while the HTTP
+  edge renders on a different pod (the E0 demo, made horizontal).
 
 ## 9. Relation to the blueprint
 
 The agent-orchestration concept's E0 proved progressive token rendering out the engine's
 SSE edge — on one pod. Its open question Q8 (second half) asks how a *graph run* streams
 to a UI in a horizontally scaled deployment. This spec is that transport: the graph/LLM
-wrapper publishes progress events to Kafka as it works, and the streaming return route
-delivers them to whichever pod holds the user's connection. Governance properties are
-inherited, not invented — the events are ordinary envelopes, the rendezvous is ordinary
-Redis state, and the edge contract is the one already shipped and interop-tested.
+wrapper posts progress events to the return route as it works, and whichever pod holds
+the user's connection renders them. Governance properties are inherited, not invented —
+the segments are ordinary short-lived Redis values, the rendezvous is the same registry
+the one-shot pattern ships today, and the edge contract is the one already shipped and
+interop-tested.

--- a/memory/open-threads/thread-ot-streaming-return-route.md
+++ b/memory/open-threads/thread-ot-streaming-return-route.md
@@ -5,12 +5,17 @@
   to `stream:{cid}` as the source of truth (store-first invariant kept; Pub/Sub stays a
   wake-up signal, never the payload carrier), the existing `request:{cid}` registry and
   per-pod channel reused as the pod-discovery rendezvous, eof/exception as stream entries,
-  and the UI pod draining (XREAD from last-delivered id) into the shipped x-event-stream
-  edge via EventStreamWriter. Contracts: progressive topic keyed by cid for ordering;
-  leading dedupe option is producer seq as explicit stream entry id. Q1–Q6 open (Q2:
-  Event Script composition of `stream: true` with http.flow.adapter; Q6: cap hit should
-  fail in-band, not trim). Experiments E1–E4 staged (coordinator primitives → single-JVM
-  e2e → cross-pod dry-run with chaos checks → LLM/graph-run token stream). Serves
+  and the UI pod draining into the shipped x-event-stream edge via EventStreamWriter.
+  **Direction RATIFIED 2026-09-12 — Q1–Q6 answered by Eric, folded in as D1–D6**
+  (log 2026-09-12-032830): D1 store-first/pub-sub-wake-up-only; D2 interceptor facade,
+  NO Event Script composition (UI app on an SSE-enabled REST endpoint); D3 **Kafka
+  decoupled — Redis is the sole transport**, the producing server posts segments directly
+  (new `StreamResponder` producer API; kills the ordering contract and the duplicate
+  question); D4 no re-drain, TTL expiry is the cleanup; D5 no fan-out; D6 **per-seq keys
+  `segment:{cid}:{seq}` replace the Redis Stream** (seq = retrieval index; MAXLEN/trim
+  dissolve). One nuance awaiting Eric's confirmation: a single final drain at edge idle
+  expiry (the one-shot "final read before timeout" analogue). Serves
   [[bp-agent-orchestration]] Q8 second half (graph-run streaming); inherits
-  [[soa-transport-neutral-cid]]. Next: Eric ratifies the direction (Q1 → D1), then E1.
+  [[soa-transport-neutral-cid]]. Next: E1 (coordinator + responder primitives,
+  embedded-Redis unit tests).
   <!-- id: ot-streaming-return-route | created: 2026-09-12 | last_used: 2026-09-12 | uses: 1 | tier: working | origin: 2026-09-12-021649 -->

--- a/memory/sessions/2026-09-12-032830.md
+++ b/memory/sessions/2026-09-12-032830.md
@@ -1,0 +1,55 @@
+# Session (2026-09-12T03:28:30.000Z)
+
+**Agent:** Claude Code
+
+## What happened
+
+**Streaming-return-route direction ratified — Q1–Q6 answered by Eric, folded
+into the spec as decisions D1–D6 (branch
+`design/streaming-return-route-ratified`, commit `b358d8bd`; PR pending at
+handoff).** The ratified design is SIMPLER than the first draft on two axes:
+
+- **D3 (Q3): Kafka decoupled.** Redis is the sole transport of the streaming
+  return path — the server producing a streaming response posts its events
+  straight to Redis via a new lightweight producer API (`StreamResponder`,
+  RedisConfig-constructed, no coordinator/subscriber needed). This removes the
+  broker leg and with it BOTH hard problems of the draft: the
+  partition-ordering contract and the at-least-once duplicate question. The
+  responder side gains one requirement (Redis connectivity); the path keeps
+  the module's transport-neutral footprint (platform-core + Lettuce only).
+- **D6 (Q6): per-seq keys replace the Redis Stream.** Each event carries a
+  sequence number used as the retrieval index — `SETEX segment:{cid}:{seq}`,
+  consecutive from 1, eof/exception as the last sequence. Nothing appends to
+  an array, so MAXLEN and the trim-policy question dissolve; per-key TTL
+  bounds everything. Drain = GET by nextSeq until a miss (in-order by
+  construction, duplicate-wake-up idempotent).
+
+Other rulings: D1 store-first/pub-sub-wake-up-only accepted as proposed; D2
+facade is an interceptor by design, NO Event Script composition (typical
+consumer = UI app on an SSE-enabled REST endpoint); D4 no re-drain mechanism —
+Redis expiry serves the purpose; D5 no fan-out.
+
+One nuance retained FOR ERIC'S CONFIRMATION (flagged in §3.5/D4 and the PR):
+a single final drain at edge idle expiry — the streaming analogue of the
+shipped one-shot "final read before timeout" cornerstone; a last-chance read
+on the failure path, not the rejected periodic sweeper.
+
+E-series revised to broker-free (E2/E3 need only embedded redis /
+redis-standalone; E3 = two JVMs, UI pod A + producer pod B, chaos checks).
+Next gate: E1 (coordinator + responder primitives).
+
+## Memory References
+
+- ot-streaming-return-route (thread updated - direction ratified, D1-D6
+  recorded, next: E1)
+- soa-transport-neutral-cid (consulted - D3 keeps the streaming path inside
+  the module's transport-neutral footprint)
+- kafka-mesh-opt-in (consulted - D3 reinforces the no-mesh stance: the
+  rendezvous stays the return-route registry)
+- event-script-over-code (consulted - D2 boundary: the token/progress loop is
+  an in-function unit of work; a flow-task wrapper deferred until a
+  declarative use case appears)
+- eric-release-rhythm (consulted - revision branch prepared; PR creation and
+  merge are Eric's gates)
+- conv-squash-title-prefill-check (consulted - PR title handed off on its own
+  line in a code block)


### PR DESCRIPTION
## What

Revises `draft-design-specs/streaming-return-route.md` from DRAFT to DESIGN RATIFIED: the Q-series is resolved into decisions D1–D6 and the design sections are rewritten to the ratified — and simpler — shape. Segments are individually keyed values (`SETEX segment:{cid}:{seq}`, consecutive seq from 1, `eof`/`exception` as the last sequence) drained by the UI pod in sequence order; a new lightweight producer API (`StreamResponder`) lets the responding server post segments directly to Redis; the facade is an interceptor behind a `stream: true` endpoint. The experiment plan is now broker-free (embedded Redis / redis-standalone only).

## Why

Eric answered the six open questions: D1 pub/sub stays wake-up-only (store-first); D2 no Event Script composition — the typical consumer is a UI app on an SSE-enabled REST endpoint; D3 Kafka is decoupled, Redis is the sole transport of the streaming return path — which eliminates both hard problems of the first draft (the partition-ordering contract and at-least-once duplicates); D4 no re-drain mechanism, Redis expiry serves the purpose; D5 no fan-out; D6 the sequence number is the retrieval index, so per-seq keys replace the Redis Stream and MAXLEN/trim policy dissolve.

**One nuance flagged for review (§3.5 / D4):** the spec keeps a *single* final drain at edge idle expiry — the streaming analogue of the shipped one-shot "final read before timeout" cornerstone, so a dropped final notification still completes the render. It is a last-chance read on the failure path, not the rejected periodic sweeper — strike it if Q4 is to be taken literally.

Design only — no code in this PR. Next gate: experiment E1 (coordinator + responder primitives).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)