### PR TITLE
design spec: D8 unification and the no-backward-compat ruling (completes #367)

### DIFF
--- a/draft-design-specs/streaming-return-route.md
+++ b/draft-design-specs/streaming-return-route.md
@@ -227,10 +227,11 @@ paths that already remove on every other exit: `awaitResponse`'s `finally`, and 
 exhaustive, so a completed-but-unawaited entry cannot leak. The existing await-by-cid
 test pins the behavior.
 
-**Migration note (release-notes item):** the Redis key shape changes — an old pod GETs
-`response:{cid}` while a new pod pushes to `queue:{cid}` — so in-flight cross-version
-requests during a rolling upgrade time out (408) until the fleet converges. Bounded to
-the upgrade window, and called out deliberately while the module is young.
+**No backward-compatibility issue (Eric's ruling):** the Redis key shape changes, but
+sync-over-async's use case is near real-time — rendezvous keys live for seconds and
+nothing persists across versions, so there is no state to migrate. At worst, a rolling
+upgrade re-times a handful of in-flight cross-version requests (408), indistinguishable
+from ordinary timeout behavior.
 
 ## 5. Contracts and invariants
 
@@ -316,9 +317,11 @@ the use-case discussion (§2).
   for one message and for a list of messages: `response:{cid}` retires, `deliver` posts
   a terminal entry, the recovery paths unify, and duplicate delivery becomes
   structurally impossible. Requires the complete-in-place adjustment in
-  `PendingRequests` (§4.7) and carries the rolling-upgrade migration note. The
-  acceptance proof is the existing one-shot regression suite passing unchanged on the
-  unified mechanism — the degenerate case shown to be truly degenerate.
+  `PendingRequests` (§4.7). No backward-compatibility concern: the use case is near
+  real-time, so rendezvous state is ephemeral and nothing persists across versions
+  (Eric's ruling). The acceptance proof is the existing one-shot regression suite
+  passing unchanged on the unified mechanism — the degenerate case shown to be truly
+  degenerate.
 
 ## 9. Experiment plan (E-series)
 

--- a/draft-design-specs/streaming-return-route.md
+++ b/draft-design-specs/streaming-return-route.md
@@ -4,7 +4,9 @@
 answered by Eric the same day (decisions D1–D6, §8), then refined once more after the
 driving use cases were articulated: **D7 removes the sequence number entirely — a Redis
 List per cid replaces the per-seq keys** (supersedes D6's mechanism, keeps its
-no-MAXLEN ruling). Next gate: experiment E1.
+no-MAXLEN ruling) — and **D8 unifies the module: the one-shot path adopts the same list
+mechanism**, so one message and a list of messages ride one store (`response:{cid}`
+retires; `deliver` becomes a terminal post). Next gate: experiment E1.
 **Blueprint:** serves `bp-agent-orchestration` (Q8 second half — graph-run streaming)
 → serves `vision-mercury-composable`.
 **Repo scope:** `extensions/sync-over-async` only. Java-only like the extension itself
@@ -39,7 +41,9 @@ look it up and wake the right subscriber. This spec generalizes that return rout
 *one response* to *a sequence of segments with a terminal signal*. By decision D3, the
 segments ride **Redis only** — the producing server posts them straight into the return
 route, so the streaming path has no broker dependency at all (the request leg reaches
-the backend however the application likes).
+the backend however the application likes). And by decision D8 the generalization folds
+back onto the original: a one-shot response is the **degenerate stream** — a queue whose
+first entry is terminal — so the module keeps one storage mechanism, not two.
 
 ## 2. Driving use cases (Eric, 2026-09-12)
 
@@ -92,7 +96,7 @@ drained or its TTL expires.
 |-----|------|---------|----------|
 | `request:{cid}` | string (unchanged) | the originating pod's return channel | streaming rendezvous: `sync.stream.ttl.seconds` (session-scale — an SSE notification channel outlives a one-shot's route window); eagerly deleted on close |
 | `queue:{cid}` | Redis List (new) | one entry per segment: compact JSON `{"type":"data\|eof\|exception","name":"<optional SSE event name>","body":...}` | `EXPIRE sync.stream.ttl.seconds`, refreshed on every `RPUSH`; a fully drained list ceases to exist on its own |
-| `response:{cid}` | string | one-shot only — unused on the streaming path | unchanged |
+| `response:{cid}` | string | **retired (D8)** — the one-shot path posts its single terminal entry to `queue:{cid}` instead | replaced; the one-shot queue's TTL comes from the existing `sync.response.ttl.seconds` |
 
 There is **no sequence number** (D7). Ordering, where required, comes from *how* the
 producer posts (§5, contract 2), and reads are destructive pops, so the consumer keeps
@@ -106,8 +110,9 @@ the UI side is stalled, and that window is bounded by the TTL, not by a trim pol
 
 ### 4.3 Coordinator additions (`ReturnRouteCoordinator`)
 
-The existing class gains a streaming sibling for each one-shot member; nothing existing
-changes behavior.
+The existing class gains a streaming sibling for each one-shot member — and by D8 the
+one-shot members keep their signatures while re-platforming onto the same queue
+underneath (§4.7).
 
 | One-shot (today) | Streaming (new) | Notes |
 |------------------|-----------------|-------|
@@ -192,6 +197,41 @@ confirmation.)
 | `sync.stream.ttl.seconds` | `1800` | TTL of a streaming rendezvous's route key and of `queue:{cid}` (refreshed on every post) — the crash safety net, sized for session-scale SSE channels; eager deletes do the real cleanup |
 | `sync.max.pending.streams` | `1000` | per-pod ceiling on concurrently open streams (the reply-lane pool of 500 is the natural upper bound per pod) |
 
+The one-shot path's existing keys are untouched: `sync.response.ttl.seconds` now sets
+the queue TTL for a one-shot `deliver`, and `sync.route.ttl.seconds` still governs its
+route.
+
+### 4.7 One mechanism for both — the one-shot path adopts the list (D8)
+
+A one-shot response is the degenerate stream: a queue whose first entry is terminal. So
+the one-shot path re-platforms onto the same store:
+
+- `deliver(cid, payload)` keeps its signature and becomes, internally, a post of one
+  terminal entry with the one-shot's own TTL (`sync.response.ttl.seconds`);
+  `response:{cid}` and its SETEX/GET path retire.
+- The signal handler always drains the queue; the only difference is the consumer — a
+  one-shot cid's first entry completes the pending future, a stream's entries feed the
+  sink until terminal.
+- The one-shot "final read before timeout" and the streaming "final drain at idle
+  expiry" become literally the same operation — one recovery cornerstone, two callers.
+- Duplicate delivery becomes structurally impossible (the second drain pops nothing),
+  where today it relies on `complete()` being idempotent.
+
+One behavioral adjustment makes this correct — the **early-arrival path**. Today, a
+response landing between `sync.prepare` and `sync.await` completes and removes the
+pending future, and `awaitResponse` recovers by re-reading `response:{cid}` (GET is
+non-destructive). Under destructive pops that Redis re-read disappears, so
+`PendingRequests.complete()` completes the future **in place** and removal moves to the
+paths that already remove on every other exit: `awaitResponse`'s `finally`, and the
+`abort(cid)` the flow's exception handler already calls on the fail-fast path — together
+exhaustive, so a completed-but-unawaited entry cannot leak. The existing await-by-cid
+test pins the behavior.
+
+**Migration note (release-notes item):** the Redis key shape changes — an old pod GETs
+`response:{cid}` while a new pod pushes to `queue:{cid}` — so in-flight cross-version
+requests during a rolling upgrade time out (408) until the fleet converges. Bounded to
+the upgrade window, and called out deliberately while the module is young.
+
 ## 5. Contracts and invariants
 
 1. **Store-first, notify-after (D1).** A segment is appended before its wake-up is
@@ -272,6 +312,13 @@ the use-case discussion (§2).
   from Redis's per-connection command ordering. So nothing is stamped: `RPUSH` to
   `queue:{cid}`, destructive `LPOP` drains, ordering by posting discipline (§5,
   contract 2), and the channel may be closed by either side. Supersedes D6's mechanism.
+- **D8 — The one-shot path adopts the list mechanism (Eric, 2026-09-12).** One store
+  for one message and for a list of messages: `response:{cid}` retires, `deliver` posts
+  a terminal entry, the recovery paths unify, and duplicate delivery becomes
+  structurally impossible. Requires the complete-in-place adjustment in
+  `PendingRequests` (§4.7) and carries the rolling-upgrade migration note. The
+  acceptance proof is the existing one-shot regression suite passing unchanged on the
+  unified mechanism — the degenerate case shown to be truly degenerate.
 
 ## 9. Experiment plan (E-series)
 
@@ -281,7 +328,10 @@ the use-case discussion (§2).
   concurrent producers (order-free), terminal entry from a *non-originating* producer
   closing the channel, orphan stop, missed-notification healing (suppress a publish,
   verify the next drain recovers), final drain at idle expiry, capacity rejection,
-  duplicate wake-up idempotence.
+  duplicate wake-up idempotence — **plus the D8 acceptance gate: the entire existing
+  one-shot regression suite (module and demo flows) passes unchanged on the unified
+  mechanism**, with the early-arrival await-by-cid test proving the complete-in-place
+  semantics.
 - **E2 — Single-JVM end-to-end.** Both use cases behind `stream: true` endpoints (no
   broker anywhere): a chat-style render (N ordered segments + `eof`, verified in exact
   order with `curl -N`) and a notification channel (several posting services, UI-side

--- a/memory/open-threads/thread-ot-streaming-return-route.md
+++ b/memory/open-threads/thread-ot-streaming-return-route.md
@@ -25,8 +25,9 @@
   response is the degenerate stream (first entry terminal); `response:{cid}` retires,
   deliver() ≡ terminal post, one drain path, final-read == final-drain; requires
   PendingRequests.complete-in-place (early-arrival path survives destructive pops;
-  removal via awaitResponse finally + abort, exhaustive); rolling-upgrade key-shape
-  migration note for release notes; acceptance = existing one-shot suite unchanged.
+  removal via awaitResponse finally + abort, exhaustive); no backward-compat issue —
+  near-real-time state, nothing persists across versions (Eric's ruling); acceptance =
+  existing one-shot suite unchanged.
   One nuance awaiting Eric's confirmation: a single final drain at edge idle expiry
   (the one-shot "final read before timeout" analogue). Serves
   [[bp-agent-orchestration]] Q8 second half (graph-run streaming); inherits

--- a/memory/open-threads/thread-ot-streaming-return-route.md
+++ b/memory/open-threads/thread-ot-streaming-return-route.md
@@ -21,8 +21,14 @@
   session-scale TTL 1800s default). Per-seq keys would collide across uncoordinated
   producers; a single sequential producer gets ordering free from Redis per-connection
   command order. Producer contract = post-in-order, no header stamping, no per-cid
-  state. One nuance awaiting Eric's confirmation: a single final drain at edge idle
-  expiry (the one-shot "final read before timeout" analogue). Serves
+  state. **D8 (same day): the one-shot path adopts the list mechanism** — a one-shot
+  response is the degenerate stream (first entry terminal); `response:{cid}` retires,
+  deliver() ≡ terminal post, one drain path, final-read == final-drain; requires
+  PendingRequests.complete-in-place (early-arrival path survives destructive pops;
+  removal via awaitResponse finally + abort, exhaustive); rolling-upgrade key-shape
+  migration note for release notes; acceptance = existing one-shot suite unchanged.
+  One nuance awaiting Eric's confirmation: a single final drain at edge idle expiry
+  (the one-shot "final read before timeout" analogue). Serves
   [[bp-agent-orchestration]] Q8 second half (graph-run streaming); inherits
   [[soa-transport-neutral-cid]]. Next: E1 (coordinator + responder primitives,
   embedded-Redis unit tests).

--- a/memory/open-threads/thread-ot-streaming-return-route.md
+++ b/memory/open-threads/thread-ot-streaming-return-route.md
@@ -13,7 +13,9 @@
   (new `StreamResponder` producer API; kills the ordering contract and the duplicate
   question); D4 no re-drain, TTL expiry is the cleanup; D5 no fan-out; D6 **per-seq keys
   `segment:{cid}:{seq}` replace the Redis Stream** (seq = retrieval index; MAXLEN/trim
-  dissolve). **Refined to D7 same day** (log 2026-09-12-044817) after Eric articulated
+  dissolve). **Refined to D7 same day** (log 2026-09-12-044817; D7 merged via PR #367, squash
+  `04603fdd` — its title says "D7 and D8" but a merge race caught the D7-only branch;
+  D8 + the compat ruling follow in the next PR) after Eric articulated
   the driving use cases (event notification: SEVERAL backends post to one SSE session,
   unordered, either side closes; AI chat: one sequential source, strict order): **no
   sequence number at all — a Redis List per cid** (`RPUSH queue:{cid}` store-first,

--- a/memory/sessions/2026-09-12-044817.md
+++ b/memory/sessions/2026-09-12-044817.md
@@ -62,6 +62,20 @@ worst re-times a few in-flight requests (the earlier migration-note framing
 was withdrawn accordingly). D8 acceptance gate: the existing one-shot
 regression suite passes unchanged on the unified mechanism.
 
+**Merge race and recovery.** Eric created PR #367 from the FIRST pushed
+branch (`design/streaming-return-route-redis-list`, D7 only) using the
+second handoff's title, and merged it before the superseding branch was
+noticed — so squash `04603fdd` says "D7 and D8" but contains D7 only, and
+the unified branch's four commits (D8 pair + ruling pair) were stranded in
+conflict against it. Recovery: verified main == redis-list tip exactly, then
+cherry-picked the four commits onto fresh main as
+`design/srr-d8-unification` (applied cleanly; final content byte-identical
+to the stranded tip) — the follow-up PR completes the D8 half of #367's
+title. Stale branches (redis-list, unified) deleted local and remote.
+Durable lesson: when a PR handoff is superseded before the PR exists,
+DELETE the superseded remote branch immediately — leaving it up until
+close-out is exactly what allows the wrong-branch PR.
+
 ## Memory References
 
 - ot-streaming-return-route (thread updated - D7 recorded, use cases captured)

--- a/memory/sessions/2026-09-12-044817.md
+++ b/memory/sessions/2026-09-12-044817.md
@@ -55,10 +55,12 @@ designed around: the EARLY-ARRIVAL path (response lands between sync.prepare
 and sync.await) relied on non-destructive GET of response:{cid} — fix is
 PendingRequests.complete() completing the future IN PLACE, removal moving to
 awaitResponse's finally + the existing abort() (exhaustive, no leak); the
-await-by-cid test pins it. Migration note recorded: key-shape change means
-cross-version in-flight requests during a rolling upgrade time out until the
-fleet converges (release-notes item). D8 acceptance gate: the existing
-one-shot regression suite passes unchanged on the unified mechanism.
+await-by-cid test pins it. Eric's ruling on the key-shape change: NO
+backward-compatibility issue — the use case is near real-time, rendezvous
+keys live for seconds, nothing persists across versions; a rolling upgrade at
+worst re-times a few in-flight requests (the earlier migration-note framing
+was withdrawn accordingly). D8 acceptance gate: the existing one-shot
+regression suite passes unchanged on the unified mechanism.
 
 ## Memory References
 

--- a/memory/sessions/2026-09-12-044817.md
+++ b/memory/sessions/2026-09-12-044817.md
@@ -42,6 +42,24 @@ non-originating-producer close test, both use cases in E2).
 Final-drain-at-idle-expiry nuance remains flagged for Eric's confirmation
 (unchanged from the D-series round).
 
+**Same session, next round — D8: the one-shot path adopts the list mechanism
+(commit `42b524b0`, same PR handoff).** After a Redis List semantics
+walkthrough (push/pop, destructive drain), Eric proposed unifying: "use list
+to simplify the current sync-over-async module so that the pub/sub for one
+message and a list of messages use the mechanism." Agreed with the framing
+that a one-shot response is the DEGENERATE STREAM (a queue whose first entry
+is terminal): response:{cid} retires, deliver() ≡ posting a terminal entry
+with sync.response.ttl.seconds, one drain path, final-read == final-drain,
+duplicate delivery structurally impossible. The one catch identified and
+designed around: the EARLY-ARRIVAL path (response lands between sync.prepare
+and sync.await) relied on non-destructive GET of response:{cid} — fix is
+PendingRequests.complete() completing the future IN PLACE, removal moving to
+awaitResponse's finally + the existing abort() (exhaustive, no leak); the
+await-by-cid test pins it. Migration note recorded: key-shape change means
+cross-version in-flight requests during a rolling upgrade time out until the
+fleet converges (release-notes item). D8 acceptance gate: the existing
+one-shot regression suite passes unchanged on the unified mechanism.
+
 ## Memory References
 
 - ot-streaming-return-route (thread updated - D7 recorded, use cases captured)


### PR DESCRIPTION
## What

The D8 half that PR #367's title promised but its merge did not capture (a merge race took the D7-only branch), recovered onto fresh main content-identical to the original commits:

- **D8 — the one-shot path adopts the list mechanism.** A one-shot response is the degenerate stream: a queue whose first entry is terminal. `response:{cid}` retires, `deliver()` becomes a terminal post with the one-shot's own TTL (`sync.response.ttl.seconds`), the signal handler always drains, and the one-shot "final read before timeout" and streaming "final drain at idle expiry" become one operation. Duplicate delivery becomes structurally impossible. One adjustment keeps the early-arrival path correct under destructive pops: `PendingRequests.complete()` completes the future in place, with removal on await/abort (exhaustive; the await-by-cid test pins it).
- **Backward-compatibility ruling folded in:** the Redis key shape changes, but sync-over-async's use case is near real-time — rendezvous keys live for seconds and nothing persists across versions, so there is no state to migrate; at worst a rolling upgrade re-times a few in-flight requests.

## Why

Once segments ride a Redis List (D7, merged in #367), keeping a second storage shape for the one-shot path means maintaining the special case alongside the general one. Unifying leaves the module with one store, one drain, one recovery cornerstone — "pub/sub for one message and a list of messages use the same mechanism." Acceptance gate: the existing one-shot regression suite passes unchanged on the unified mechanism.

Design only — no code in this PR. Next gate: experiment E1. (The single final drain at idle expiry remains flagged for confirmation.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)